### PR TITLE
SCRUM-838 - Add `transform init`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ release is connector-neutral.
 | `explore relationships [--verify]` | inferred + declared joins with confidences, plus notes on what inference examined; `--verify` measures each join with an aggregate overlap probe |
 | `explore map [--verify]` | writes/updates the `.dex/` map; prints a summary |
 | `explore query "<SELECT ...>"` | runs one agent-authored SELECT through the query firewall: columnar, capped result; values only from profiled, PII-cleared columns; requires the `.dex/` cache (`explore map` first) |
+| `transform init "<name>" --connector <c>` | bootstrap a dbt project skeleton (`dbt_project.yml`, `models/staging/` + `models/marts/`, a dev-only `profiles.yml`), reported as create diffs; refuses if any dbt project exists; the connector never defaults, so bare init errors (an explicit flag or a committed `connector:` in `.dex/config.yml` is required) |
 | `transform plan "<intent>" --edits-file <f>` | proposed dbt edits as diffs (nothing applied); `--scaffold <table>` adds a staging skeleton from the cache |
 | `transform apply <plan-id>` | writes diffs into the dbt project (a reviewable git diff); a human edit since planning returns `needs_confirmation`, never an overwrite |
 | `transform build --target dev` | cost preflight first; runs only with `--confirm` and a budget; prod-looking targets refused outright |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- `transform init "<name>" --connector <c>`: engine-owned dbt project bootstrap,
+  so an empty repo no longer hits a wall on step one. Renders a deterministic
+  skeleton (`dbt_project.yml`, `models/staging/` and `models/marts/`, a
+  project-local `profiles.yml` with a single duckdb `dev` target wired to the
+  known warehouse) and records `connector`, `dbt_project_dir`, and
+  `dbt_target: dev` in `.dex/config.yml`, all reported as create diffs. Strictly
+  additive: refuses wherever a dbt project already exists. Unlike the read-only
+  commands, init never falls back to a default connector (it bakes the connector
+  into the generated profile): `--connector` wins, a committed `connector:` in
+  `.dex/config.yml` is accepted and attributed in the envelope, and bare init is
+  an error listing the valid connectors. DuckDB is the supported connector
+  today; the cloud connectors return an actionable not-yet-supported error until
+  their dbt adapters ship.
+- Safety-spine coverage for init: refuses over an existing project, no connector
+  fall-through, the generated profile is dev-only with no prod-named target and
+  no secret-like keys, and the generated project round-trips through the loader
+  and a real gated `dbt build`.
+
+### Changed
+
+- `.dex/config.yml` writes now persist only fields that were explicitly loaded
+  or assigned, so the committed file records choices instead of every engine
+  default.
+
 ## [0.1.0a5] - 2026-07-03
 
 The authoring half of the loop goes live on DuckDB. `transform plan|apply|build`,

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -24,7 +24,7 @@ from . import envelope as env
 COMMAND_SURFACE: dict[str, list[str]] = {
     "connect": ["test"],
     "explore": ["inventory", "profile", "relationships", "map", "query"],
-    "transform": ["plan", "apply", "build"],
+    "transform": ["init", "plan", "apply", "build"],
     "semantic": ["define", "update"],
     "emit": ["dbt", "osi"],
     # maintain: keep the dbt project correct as the world drifts. `snapshot`
@@ -92,8 +92,9 @@ def _build_parser() -> argparse.ArgumentParser:
                     sp.add_argument(
                         "--verify", action="store_true", default=argparse.SUPPRESS
                     )
-                # transform plan takes the intent; apply takes the plan id.
-                if group == "transform" and name in {"plan", "apply"}:
+                # transform init takes the project name; plan the intent; apply
+                # the plan id.
+                if group == "transform" and name in {"init", "plan", "apply"}:
                     sp.add_argument("argument", nargs="?", default=None)
                 if group == "transform" and name == "plan":
                     # The agent-authored edits payload: a JSON file, or - for stdin.
@@ -156,6 +157,7 @@ def dispatch(args: argparse.Namespace) -> env.Envelope:
     # module serves them all. `emit osi` stays reserved for the dormant exporter,
     # and `viz preview` stays a stub until the Viz integration lands.
     transform_surface = {
+        ("transform", "init"),
         ("transform", "plan"),
         ("transform", "apply"),
         ("transform", "build"),
@@ -167,6 +169,7 @@ def dispatch(args: argparse.Namespace) -> env.Envelope:
         from .transform import commands as transform_cmds
 
         handlers = {
+            ("transform", "init"): transform_cmds.cmd_init,
             ("transform", "plan"): transform_cmds.cmd_plan,
             ("transform", "apply"): transform_cmds.cmd_apply,
             ("transform", "build"): transform_cmds.cmd_build,

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -76,9 +76,12 @@ def save_config(config: DexConfig, repo_root: Path | str = ".") -> Path:
     dex_dir = Path(repo_root) / DEX_DIR
     dex_dir.mkdir(parents=True, exist_ok=True)
     path = dex_dir / CONFIG_FILE
+    # Only fields that were loaded or assigned are written: the committed file
+    # stays a record of explicit choices, not a dump of every engine default.
     path.write_text(
         yaml.safe_dump(
-            config.model_dump(mode="json", exclude_none=True), sort_keys=False
+            config.model_dump(mode="json", exclude_unset=True, exclude_none=True),
+            sort_keys=False,
         ),
         encoding="utf-8",
     )

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -105,6 +105,19 @@ def content_hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+def discover_projects(repo_root: Path | str = ".") -> list[Path]:
+    """Every dbt project the search surface can see: the repo root itself, or
+    its immediate children. Shared by ``find_project`` and ``transform init``'s
+    already-exists refusal, so the two can never disagree."""
+
+    root = Path(repo_root)
+    if (root / PROJECT_FILE).is_file():
+        return [root]
+    if not root.is_dir():
+        return []
+    return sorted(child for child in root.iterdir() if (child / PROJECT_FILE).is_file())
+
+
 def find_project(repo_root: Path | str = ".") -> Path:
     """Locate the dbt project: the repo root itself, or a unique child directory.
 
@@ -113,13 +126,7 @@ def find_project(repo_root: Path | str = ".") -> Path:
     """
 
     root = Path(repo_root)
-    if (root / PROJECT_FILE).is_file():
-        return root
-    candidates = (
-        sorted(child for child in root.iterdir() if (child / PROJECT_FILE).is_file())
-        if root.is_dir()
-        else []
-    )
+    candidates = discover_projects(root)
     if len(candidates) == 1:
         return candidates[0]
     if not candidates:

--- a/packages/dex-core/src/exmergo_dex_core/transform/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/__init__.py
@@ -2,17 +2,19 @@
 and the semantic layer (dbt semantic models / MetricFlow YAML).
 
 ``commands`` holds the CLI orchestrators; the sibling modules are the engine they
-drive: ``plans`` (propose/apply as reviewable diffs), ``validate`` (per-kind edit
-checks), ``build`` (gated dev-target dbt builds), ``semantic`` (MetricFlow YAML),
-and ``scaffold`` (deterministic staging skeletons). The Viz preview is not part
-of this engine: it is a separate product surface and stays a stub here.
+drive: ``init`` (dbt project bootstrap), ``plans`` (propose/apply as reviewable
+diffs), ``validate`` (per-kind edit checks), ``build`` (gated dev-target dbt
+builds), ``semantic`` (MetricFlow YAML), and ``scaffold`` (deterministic staging
+skeletons). The Viz preview is not part of this engine: it is a separate product
+surface and stays a stub here.
 
 The engine entry points are re-exported here so callers address the capability,
 not its file layout: ``transform.plan(...)``, ``transform.apply(...)``,
-``transform.build(...)``.
+``transform.build(...)``, ``transform.init_project(...)``.
 """
 
 from .build import ProdTargetRefusedError, assert_dev_target, build
+from .init import InitError, InitResult, init_project
 from .plans import (
     EditKind,
     PlanEdit,
@@ -26,6 +28,8 @@ from .plans import (
 
 __all__ = [
     "EditKind",
+    "InitError",
+    "InitResult",
     "PlanEdit",
     "PlanError",
     "PlanNotFoundError",
@@ -35,5 +39,6 @@ __all__ = [
     "apply",
     "assert_dev_target",
     "build",
+    "init_project",
     "plan",
 ]

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -26,6 +26,49 @@ from . import semantic as semantic_mod
 from .plans import EditKind, PlanEdit, PlanStore
 
 
+def cmd_init(args: argparse.Namespace) -> env.Envelope:
+    from ..config import load_config
+    from . import init as init_mod
+
+    repo_root = command_args.repo_root(args)
+
+    # Init bakes the connector into the generated profiles.yml, so the engine-wide
+    # DuckDB fall-through is deliberately not used here: an explicit --connector
+    # wins, a connector: committed in .dex/config.yml is accepted (and attributed),
+    # and bare init is an error. Misconfiguration that works is the worst kind.
+    connector = getattr(args, "connector", None)
+    connector_source = "flag"
+    if not connector:
+        config = load_config(repo_root)
+        if config is not None and "connector" in config.model_fields_set:
+            connector, connector_source = config.connector, "config"
+    if not connector:
+        return env.error(
+            "transform init needs an explicit connector and never defaults: pass "
+            "--connector <" + "|".join(init_mod.VALID_CONNECTORS) + "> or declare "
+            "connector: in .dex/config.yml"
+        )
+
+    result = init_mod.init_project(
+        getattr(args, "argument", None) or "",
+        connector,
+        path=getattr(args, "path", None),
+        repo_root=repo_root,
+    )
+    return env.ok(
+        {
+            "project_name": result.project_name,
+            "project_dir": result.project_dir,
+            "connector": result.connector,
+            "connector_source": connector_source,
+            "created": result.created,
+            "next": "run `explore map` if you have not yet, then propose staging "
+            "models with `transform plan --scaffold <table>`",
+        },
+        diffs=result.diffs,
+    )
+
+
 def cmd_plan(args: argparse.Namespace) -> env.Envelope:
     intent = getattr(args, "argument", None) or ""
     edits = _edits_from_payload(getattr(args, "edits_file", None))

--- a/packages/dex-core/src/exmergo_dex_core/transform/init.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/init.py
@@ -1,0 +1,200 @@
+"""dbt project bootstrap: the deterministic skeleton behind `transform init`.
+
+Bootstrap is engine work, not agent freehand, because the generated
+``profiles.yml`` is safety-relevant: it defines the build targets, and the
+dev-target-only invariant depends on its shape. Engine-owned init guarantees a
+single ``dev`` default, never a prod-named target, and never a persisted secret,
+identically on every agent surface.
+
+Init is strictly additive: it refuses to run where any dbt project already
+exists, so propose-don't-impose holds by construction. And unlike the read-only
+commands, it never falls back to a default connector: the connector is baked
+into the generated profile's ``type:``, and a silent DuckDB default in a
+warehouse shop would produce a project that parses and builds locally yet is
+wrong. The caller must resolve the connector explicitly before calling in.
+
+Per-connector profile rendering sits behind a small dispatch so cloud renderers
+can slot in alongside their dbt adapters without touching the command; today
+only DuckDB renders, and the others raise an actionable error.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+from ..cache import DEX_DIR
+from ..config import CONFIG_FILE, DexConfig, DuckDBTarget, load_config, save_config
+from ..dbt_project import PROFILES_FILE, PROJECT_FILE, discover_projects
+from ..diffs import file_diff
+
+VALID_CONNECTORS = ("duckdb", "snowflake", "bigquery", "databricks", "postgres")
+
+
+class InitError(Exception):
+    pass
+
+
+class InitResult(BaseModel):
+    project_name: str
+    # Relative to the repo root; also what gets pinned as dbt_project_dir.
+    project_dir: str
+    connector: str
+    created: list[str] = Field(default_factory=list)
+    diffs: list[dict[str, Any]] = Field(default_factory=list)
+
+
+def sanitize_project_name(raw: str) -> str:
+    """Reduce free-form input to a valid dbt project name (lowercase,
+    underscores, no leading digit)."""
+
+    name = re.sub(r"[^a-z0-9_]+", "_", (raw or "").lower()).strip("_")
+    if not name:
+        raise InitError(
+            "transform init needs a project name, e.g. `transform init analytics`"
+        )
+    if name[0].isdigit():
+        name = f"_{name}"
+    return name
+
+
+def init_project(
+    name: str,
+    connector: str,
+    *,
+    path: str | None = None,
+    repo_root: Path | str = ".",
+) -> InitResult:
+    """Render a fresh dbt project skeleton and record the choices in config.
+
+    Creates ``<name>/dbt_project.yml``, ``models/staging/`` and ``models/marts/``
+    (kept non-empty with ``.gitkeep``), and a project-local ``profiles.yml`` with
+    a single ``dev`` target; then writes ``connector``, ``dbt_project_dir``, and
+    ``dbt_target: dev`` back to ``.dex/config.yml`` so the choice is explicit
+    once and ambient for every later command. Everything written is returned as
+    reviewable diffs.
+    """
+
+    root = Path(repo_root)
+    if connector not in VALID_CONNECTORS:
+        raise InitError(
+            f"unknown connector '{connector}'; valid connectors: "
+            + ", ".join(VALID_CONNECTORS)
+        )
+    render_profile = _PROFILE_RENDERERS.get(connector)
+    if render_profile is None:
+        raise InitError(
+            f"connector '{connector}' is not yet supported for init; DuckDB is "
+            "the supported path today (`transform init <name> --connector duckdb`)"
+        )
+
+    project_name = sanitize_project_name(name)
+    existing = discover_projects(root)
+    if existing:
+        raise InitError(
+            "a dbt project already exists ("
+            + ", ".join(str(p / PROJECT_FILE) for p in existing)
+            + "); init is strictly additive and never touches an existing project"
+        )
+
+    config = load_config(root) or DexConfig()
+    profiles_text = render_profile(project_name, path, config, root)
+
+    files: dict[str, str] = {
+        f"{project_name}/{PROJECT_FILE}": _project_yaml(project_name),
+        f"{project_name}/{PROFILES_FILE}": profiles_text,
+        f"{project_name}/models/staging/.gitkeep": "",
+        f"{project_name}/models/marts/.gitkeep": "",
+    }
+    collisions = sorted(rel for rel in files if (root / rel).exists())
+    if collisions:
+        raise InitError(
+            "refusing to overwrite existing files: "
+            + ", ".join(collisions)
+            + "; init only creates, never replaces"
+        )
+
+    config.connector = connector
+    config.dbt_project_dir = project_name
+    config.dbt_target = "dev"
+
+    config_rel = f"{DEX_DIR}/{CONFIG_FILE}"
+    config_path = root / config_rel
+    old_config = (
+        config_path.read_text(encoding="utf-8") if config_path.is_file() else None
+    )
+
+    diffs = [file_diff(rel, None, content) for rel, content in files.items()]
+    for rel, content in files.items():
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    save_config(config, root)
+    diffs.append(
+        file_diff(config_rel, old_config, config_path.read_text(encoding="utf-8"))
+    )
+
+    created = list(files) + ([config_rel] if old_config is None else [])
+    return InitResult(
+        project_name=project_name,
+        project_dir=project_name,
+        connector=connector,
+        created=created,
+        diffs=diffs,
+    )
+
+
+# --- per-connector profile renderers -------------------------------------------
+
+
+def _duckdb_profile(
+    project_name: str, path: str | None, config: DexConfig, root: Path
+) -> str:
+    """A single dbt-duckdb ``dev`` target wired to the warehouse dex already
+    knows. Also records the resolved path in ``config.duckdb`` so later commands
+    inherit it."""
+
+    raw = path or (config.duckdb.path if config.duckdb else None)
+    if not raw:
+        raise InitError(
+            "no DuckDB warehouse path to wire the dev target to: pass --path "
+            "<warehouse.duckdb> or set duckdb.path in .dex/config.yml "
+            "(`explore map --path ...` is the usual first step)"
+        )
+    warehouse = Path(raw)
+    if not warehouse.is_absolute():
+        # profiles.yml paths resolve against dbt's working directory, which is
+        # not the repo root; an absolute path keeps the target unambiguous.
+        warehouse = (root / warehouse).resolve()
+    config.duckdb = DuckDBTarget(path=str(warehouse))
+    return yaml.safe_dump(
+        {
+            project_name: {
+                "target": "dev",
+                "outputs": {"dev": {"type": "duckdb", "path": str(warehouse)}},
+            }
+        },
+        sort_keys=False,
+    )
+
+
+_PROFILE_RENDERERS: dict[str, Callable[[str, str | None, DexConfig, Path], str]] = {
+    "duckdb": _duckdb_profile,
+}
+
+
+def _project_yaml(project_name: str) -> str:
+    return yaml.safe_dump(
+        {
+            "name": project_name,
+            "version": "1.0.0",
+            "profile": project_name,
+            "model-paths": ["models"],
+        },
+        sort_keys=False,
+    )

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -221,6 +221,71 @@ def test_apply_refuses_to_overwrite_a_human_edit(dbt_project_dir: Path):
     assert model.read_text(encoding="utf-8") == "select 99 as id -- hand-tuned\n"
 
 
+# `transform init` sits across families 1 and 4: the profile it generates is
+# what the dev-target-only rule later reads, and bootstrap must stay strictly
+# additive with no silent connector default.
+
+
+def test_init_refuses_where_a_project_already_exists(dbt_project_dir: Path):
+    # Bootstrap is strictly additive: anywhere find_project would discover a
+    # project, init refuses, so it can never clobber hand-written work.
+    from exmergo_dex_core import transform
+
+    repo = dbt_project_dir.parent
+    with pytest.raises(transform.InitError):
+        transform.init_project(
+            "fresh", "duckdb", path=str(repo / "warehouse.duckdb"), repo_root=repo
+        )
+
+
+def test_init_never_falls_through_to_a_default_connector(tmp_path: Path, capsys):
+    # Init bakes the connector into a durable artifact (the generated
+    # profiles.yml), so the engine-wide DuckDB default does not apply: bare init
+    # errors and creates nothing.
+    import json
+
+    from exmergo_dex_core.cli import main
+
+    rc = main(["--repo-root", str(tmp_path), "transform", "init", "analytics"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["status"] == "error"
+    assert "--connector" in payload["errors"][0]
+    assert not (tmp_path / "analytics").exists()
+
+
+def test_init_profile_is_dev_only_with_no_secrets(tmp_path: Path):
+    # The generated profiles.yml is why bootstrap is engine-owned: a single dev
+    # default target, nothing prod-named, and no secret-like keys anywhere.
+    import yaml
+
+    from exmergo_dex_core import transform
+
+    transform.init_project(
+        "analytics", "duckdb", path=str(tmp_path / "w.duckdb"), repo_root=tmp_path
+    )
+    profiles = yaml.safe_load(
+        (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
+    )
+    profile = profiles["analytics"]
+    assert profile["target"] == "dev"
+    assert set(profile["outputs"]) == {"dev"}
+    # The envelope sanitizer doubles as the secret-key scanner here.
+    env.sanitize(env.ok(profiles))
+
+
+def test_init_project_round_trips_through_the_loader(tmp_path: Path):
+    from exmergo_dex_core import dbt_project, transform
+
+    transform.init_project(
+        "analytics", "duckdb", path=str(tmp_path / "w.duckdb"), repo_root=tmp_path
+    )
+    view = dbt_project.load(dbt_project.find_project(tmp_path))
+    assert view.project_name == "analytics"
+    assert view.profile_name == "analytics"
+    assert dbt_project.resolve_target(tmp_path / "analytics").name == "dev"
+
+
 # --- Family 5: credentials and raw rows never enter stdout data ---------------
 
 

--- a/packages/dex-core/tests/transform/test_init.py
+++ b/packages/dex-core/tests/transform/test_init.py
@@ -1,0 +1,242 @@
+"""`transform init`: engine-owned dbt bootstrap. Strictly additive, and the
+connector never falls through to a default."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from exmergo_dex_core.cli import main
+
+CONNECTORS = ("duckdb", "snowflake", "bigquery", "databricks", "postgres")
+
+
+def _run(argv: list[str], capsys) -> tuple[int, dict]:
+    rc = main(argv)
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1, "exactly one line on stdout"
+    return rc, json.loads(out)
+
+
+def _init_argv(repo: Path, *extra: str, name: str = "analytics") -> list[str]:
+    return ["--repo-root", str(repo), "transform", "init", name, *extra]
+
+
+def test_init_bootstraps_a_project_end_to_end(
+    duckdb_file: Path, tmp_path: Path, capsys
+):
+    rc, envelope = _run(
+        _init_argv(tmp_path, "--connector", "duckdb", "--path", str(duckdb_file)),
+        capsys,
+    )
+    assert rc == 0, envelope
+    assert envelope["status"] == "ok"
+    assert envelope["data"]["project_name"] == "analytics"
+    assert envelope["data"]["project_dir"] == "analytics"
+    assert envelope["data"]["connector"] == "duckdb"
+    assert envelope["data"]["connector_source"] == "flag"
+
+    project = tmp_path / "analytics"
+    assert (project / "dbt_project.yml").is_file()
+    assert (project / "profiles.yml").is_file()
+    assert (project / "models" / "staging").is_dir()
+    assert (project / "models" / "marts").is_dir()
+
+    ops = {d["path"]: d["op"] for d in envelope["diffs"]}
+    assert ops["analytics/dbt_project.yml"] == "create"
+    assert ops["analytics/profiles.yml"] == "create"
+    assert ops[".dex/config.yml"] == "create"
+
+    config = yaml.safe_load(
+        (tmp_path / ".dex" / "config.yml").read_text(encoding="utf-8")
+    )
+    assert config["connector"] == "duckdb"
+    assert config["dbt_project_dir"] == "analytics"
+    assert config["dbt_target"] == "dev"
+    assert config["duckdb"]["path"] == str(duckdb_file)
+
+    profiles = yaml.safe_load((project / "profiles.yml").read_text(encoding="utf-8"))
+    assert profiles["analytics"]["target"] == "dev"
+    assert set(profiles["analytics"]["outputs"]) == {"dev"}
+    assert profiles["analytics"]["outputs"]["dev"] == {
+        "type": "duckdb",
+        "path": str(duckdb_file),
+    }
+
+
+def test_init_makes_the_choices_ambient_for_the_composed_flow(
+    duckdb_file: Path, tmp_path: Path, capsys
+):
+    # After init, explore map and transform plan need no flags: the warehouse
+    # path and the project dir both come from the config init wrote back.
+    rc, _ = _run(
+        _init_argv(tmp_path, "--connector", "duckdb", "--path", str(duckdb_file)),
+        capsys,
+    )
+    assert rc == 0
+
+    rc, envelope = _run(["--repo-root", str(tmp_path), "explore", "map"], capsys)
+    assert rc == 0, envelope
+    assert envelope["status"] == "ok"
+
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "stage customers",
+            "--scaffold",
+            "customers",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+    assert envelope["status"] == "ok"
+    assert "models/staging/stg_customers.sql" in envelope["data"]["paths"]
+
+
+def test_bare_init_without_a_connector_is_refused(tmp_path: Path, capsys):
+    rc, envelope = _run(_init_argv(tmp_path), capsys)
+    assert rc == 1
+    assert envelope["status"] == "error"
+    for connector in CONNECTORS:
+        assert connector in envelope["errors"][0]
+    assert not (tmp_path / "analytics").exists()
+
+
+def test_config_declared_connector_is_accepted_and_attributed(
+    duckdb_file: Path, tmp_path: Path, capsys
+):
+    (tmp_path / ".dex").mkdir()
+    (tmp_path / ".dex" / "config.yml").write_text(
+        f"connector: duckdb\nduckdb:\n  path: {duckdb_file}\n", encoding="utf-8"
+    )
+    rc, envelope = _run(_init_argv(tmp_path), capsys)
+    assert rc == 0, envelope
+    assert envelope["data"]["connector"] == "duckdb"
+    assert envelope["data"]["connector_source"] == "config"
+    ops = {d["path"]: d["op"] for d in envelope["diffs"]}
+    assert ops[".dex/config.yml"] == "update"
+
+
+def test_init_refuses_when_a_project_exists_at_the_repo_root(
+    duckdb_file: Path, tmp_path: Path, capsys
+):
+    (tmp_path / "dbt_project.yml").write_text("name: existing\n", encoding="utf-8")
+    rc, envelope = _run(
+        _init_argv(tmp_path, "--connector", "duckdb", "--path", str(duckdb_file)),
+        capsys,
+    )
+    assert rc == 1
+    assert "already exists" in envelope["errors"][0]
+
+
+def test_init_refuses_when_a_project_exists_in_a_child_dir(
+    dbt_project_dir: Path, duckdb_file: Path, tmp_path: Path, capsys
+):
+    rc, envelope = _run(
+        _init_argv(
+            tmp_path,
+            "--connector",
+            "duckdb",
+            "--path",
+            str(duckdb_file),
+            name="fresh",
+        ),
+        capsys,
+    )
+    assert rc == 1
+    assert "already exists" in envelope["errors"][0]
+    assert str(dbt_project_dir) in envelope["errors"][0]
+    assert not (tmp_path / "fresh").exists()
+
+
+@pytest.mark.parametrize(
+    "connector", ["snowflake", "bigquery", "databricks", "postgres"]
+)
+def test_cloud_connectors_error_actionably(tmp_path: Path, capsys, connector: str):
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", connector), capsys)
+    assert rc == 1
+    message = envelope["errors"][0]
+    assert connector in message
+    assert "not yet supported" in message
+    assert "duckdb" in message.lower()
+
+
+def test_unknown_connector_lists_the_valid_ones(tmp_path: Path, capsys):
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "sqlite"), capsys)
+    assert rc == 1
+    for connector in CONNECTORS:
+        assert connector in envelope["errors"][0]
+
+
+def test_project_name_is_sanitized(duckdb_file: Path, tmp_path: Path, capsys):
+    rc, envelope = _run(
+        _init_argv(
+            tmp_path,
+            "--connector",
+            "duckdb",
+            "--path",
+            str(duckdb_file),
+            name="My Analytics!",
+        ),
+        capsys,
+    )
+    assert rc == 0, envelope
+    assert envelope["data"]["project_name"] == "my_analytics"
+    assert (tmp_path / "my_analytics" / "dbt_project.yml").is_file()
+
+
+@pytest.mark.parametrize("name", ["", "!!!"])
+def test_unusable_project_name_is_refused(tmp_path: Path, capsys, name: str):
+    rc, envelope = _run(
+        _init_argv(tmp_path, "--connector", "duckdb", name=name), capsys
+    )
+    assert rc == 1
+    assert "name" in envelope["errors"][0]
+
+
+def test_missing_warehouse_path_errors_actionably(tmp_path: Path, capsys):
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "duckdb"), capsys)
+    assert rc == 1
+    assert "--path" in envelope["errors"][0]
+    assert not (tmp_path / "analytics").exists()
+
+
+def test_init_scaffold_apply_build_round_trips(
+    duckdb_file: Path, tmp_path: Path, capsys
+):
+    # The composed flow on a bare repo: init, map, scaffold, apply, then a real
+    # gated dev build against the generated profiles.yml.
+    pytest.importorskip("dbt.cli.main")
+    repo = ["--repo-root", str(tmp_path)]
+
+    rc, _ = _run(
+        _init_argv(tmp_path, "--connector", "duckdb", "--path", str(duckdb_file)),
+        capsys,
+    )
+    assert rc == 0
+    rc, _ = _run([*repo, "explore", "map"], capsys)
+    assert rc == 0
+    rc, envelope = _run(
+        [*repo, "transform", "plan", "stage customers", "--scaffold", "customers"],
+        capsys,
+    )
+    assert rc == 0, envelope
+    rc, envelope = _run(
+        [*repo, "transform", "apply", envelope["data"]["plan_id"]], capsys
+    )
+    assert rc == 0, envelope
+    assert envelope["data"]["written"]
+
+    rc, envelope = _run(
+        [*repo, "transform", "build", "--target", "dev", "--confirm"], capsys
+    )
+    assert rc == 0, envelope
+    assert envelope["status"] == "ok"
+    assert envelope["data"]["success"] is True
+    assert "stg_customers" in {n["name"] for n in envelope["data"]["nodes"]}

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -36,6 +36,8 @@ dex explore profile <objects>     -> column profiles + PII flags + candidate key
 dex explore relationships         -> inferred + declared joins with confidences + inference notes
 dex explore map                   -> write/update the .dex cache; print a summary
 dex explore query "<SELECT ...>"  -> run one agent-authored SELECT through the query firewall
+dex transform init "<name>"       -> bootstrap a dbt project skeleton; requires an explicit
+                                     --connector (never defaults); refuses if a project exists
 dex transform plan "<intent>"     -> proposed dbt edits as diffs (nothing applied yet)
 dex transform apply <plan-id>     -> write diffs into the dbt project (a reviewable git diff)
 dex transform build --target dev  -> cost preflight FIRST; runs only with --confirm and a budget
@@ -70,6 +72,22 @@ must parse; semantic YAML must satisfy MetricFlow's schemas), pins it to the
 sha256 of the file it would change, computes the diffs, and stores the plan under
 `.dex/plans/<plan-id>.json`. Nothing touches the dbt project until an apply.
 
+- `transform init "<name>" --connector <duckdb|snowflake|bigquery|databricks|postgres>`
+  bootstraps a dbt project when none exists: `dbt_project.yml`, `models/staging/`
+  and `models/marts/`, and a project-local `profiles.yml` with a single `dev`
+  target wired to the warehouse dex already knows (`--path`, or `duckdb.path` in
+  `.dex/config.yml`). It is strictly additive (any existing dbt project is a
+  refusal, so nothing is ever overwritten), and everything created is reported
+  as `create` diffs. **Init never defaults the connector**: the engine-wide
+  fall-through to DuckDB is safe for read-only commands but wrong here, because
+  init bakes the connector into the generated profile. `--connector` wins, a
+  `connector:` already committed in `.dex/config.yml` is accepted (the envelope
+  names which source was used), and bare init is an error listing the valid
+  connectors. On success init writes `connector`, `dbt_project_dir`, and
+  `dbt_target: dev` back to `.dex/config.yml`, so the choice is made once and is
+  ambient for every later command. DuckDB is the supported connector today; the
+  cloud connectors are accepted by the contract but return an actionable
+  not-yet-supported error until their dbt adapters ship.
 - `transform plan` also accepts `--scaffold <table>` (repeatable): a
   deterministic staging skeleton (`stg_<table>.sql` plus per-model YAML with key
   tests and PII flags in column `meta`) generated from the `.dex/` cache.

--- a/skills/explore/evals/evals.json
+++ b/skills/explore/evals/evals.json
@@ -17,6 +17,7 @@
       "Run a quick query to check whether order dates have any gaps."
     ],
     "negative": [
+      "Set up a dbt project in this repo.",
       "Build a staging model for the orders table.",
       "Refactor this dbt model and add tests.",
       "Define a revenue metric on top of fct_orders.",

--- a/skills/maintain/evals/evals.json
+++ b/skills/maintain/evals/evals.json
@@ -13,6 +13,7 @@
     "negative": [
       "What's in this warehouse and which tables matter?",
       "Profile the events table and flag PII.",
+      "Set up a dbt project in this repo.",
       "Build a staging model for raw orders.",
       "Define a revenue metric on top of fct_orders."
     ]

--- a/skills/transform/SKILL.md
+++ b/skills/transform/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: transform
-description: Use this to author and change a dbt project: write or refactor dbt model SQL from staging to marts, add tests and docs in schema.yml, manage dependencies, and define or update the semantic layer (dbt semantic models / MetricFlow: entities, dimensions, measures, metrics). Trigger it for requests like "build a staging model for this table", "refactor this model", "add tests to this model", "create a mart for X", "define a revenue metric", or "add a dimension to this entity". Every change is a reviewable diff to the dbt project; any warehouse build is dev-target only, gated, and cost-surfaced first. Do not use it to explore or profile a warehouse (use explore) or to detect drift and reconcile a project that has fallen out of sync (use maintain).
+description: Use this to author and change a dbt project: bootstrap a new dbt project in a repo that has none (`transform init`), write or refactor dbt model SQL from staging to marts, add tests and docs in schema.yml, manage dependencies, and define or update the semantic layer (dbt semantic models / MetricFlow: entities, dimensions, measures, metrics). Trigger it for requests like "set up a dbt project in this repo", "build a staging model for this table", "refactor this model", "add tests to this model", "create a mart for X", "define a revenue metric", or "add a dimension to this entity". Every change is a reviewable diff to the dbt project; any warehouse build is dev-target only, gated, and cost-surfaced first. Do not use it to explore or profile a warehouse (use explore) or to detect drift and reconcile a project that has fallen out of sync (use maintain).
 ---
 
 # Transform
@@ -32,6 +32,26 @@ and stores the proposal as a plan. Hand content over with `--edits-file <path>`
 `semantic define|update`, which imply it). Model SQL must be a single read-only
 SELECT once its jinja is stripped; semantic YAML is validated against
 MetricFlow's schemas.
+
+### Bootstrapping a project
+
+If no dbt project exists in the repo, offer `transform init` before anything
+else: `transform plan` needs a project to edit. Ask the user for the project
+name and **confirm the connector with them**, then run:
+
+```bash
+uv run "${CLAUDE_SKILL_DIR}/scripts/run.py" transform init "<name>" --connector <c>
+```
+
+The engine renders the whole skeleton (`dbt_project.yml`, `models/staging/` and
+`models/marts/`, a `profiles.yml` with a single `dev` target and no secrets) and
+records `connector`, `dbt_project_dir`, and `dbt_target: dev` in
+`.dex/config.yml`; do not hand-write these files yourself. Init never assumes a
+connector: it errors rather than defaulting, so always pass the user's confirmed
+choice (a `connector:` already committed in `.dex/config.yml` also counts).
+DuckDB needs a warehouse path (`--path`, or the `duckdb.path` config); it is the
+supported connector today, and the cloud connectors return an actionable
+not-yet-supported error. Init refuses if any dbt project already exists.
 
 ### dbt SQL models
 

--- a/skills/transform/evals/evals.json
+++ b/skills/transform/evals/evals.json
@@ -2,6 +2,7 @@
   "skill_name": "transform",
   "triggering": {
     "positive": [
+      "Set up a dbt project in this repo.",
       "Build a staging model for the raw orders table.",
       "Refactor stg_customers and add not_null and unique tests.",
       "Create a marts model that joins orders and customers.",
@@ -43,6 +44,18 @@
     },
     {
       "id": 2,
+      "prompt": "This repo has no dbt project yet. Set one up so I can start building staging models from my DuckDB warehouse.",
+      "expected_output": "A dbt project skeleton bootstrapped via `transform init` with an explicitly confirmed connector, reported as create diffs; nothing hand-written by the agent.",
+      "files": [],
+      "assertions": [
+        "`transform init` never runs without an explicit connector (a flag or a committed connector: in .dex/config.yml); the agent confirms the choice with the user rather than assuming one",
+        "The skeleton is engine-rendered, not agent-freehand (no hand-written dbt_project.yml or profiles.yml)",
+        "The generated profiles.yml has a single dev target, no prod-named target, and no secrets",
+        "Everything created is reported as reviewable create diffs, and an existing dbt project is never overwritten"
+      ]
+    },
+    {
+      "id": 3,
       "prompt": "Define a revenue metric and a couple of dimensions on top of my orders mart as dbt semantic models.",
       "expected_output": "Semantic-layer edits written as dbt semantic models (MetricFlow YAML) in the dbt project, presented as a reviewable diff.",
       "files": [],


### PR DESCRIPTION
## What this changes

`transform init` initializes the dbt project.
Additionally, a connector flag (i.e. `duckdb` or `bigquery`) needs to be added so that the correct dependencies get installed.

## Related issues

Closes: https://github.com/exmergo/dex/issues/17

## Easter Egg
First PR under 1k lines of code 👀 