### PR TITLE
SCRUM-855: Harden BigQuery and dbt (post dogfood)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ release is connector-neutral.
 
 | Subcommand | Returns |
 |---|---|
-| `connect test` | capabilities, dialect, `read_only: true` |
+| `connect test` | capabilities, dialect, `read_only: true`; DuckDB takes `--path`, BigQuery takes `--project`/`--dataset` convenience overrides (never written to config) |
 | `explore inventory [--rank]` | ranked object summary (counts, sizes; no rows) |
 | `explore profile <objects>` | column profiles + PII flags (column, category, confidence) + candidate keys, grain, data-quality warnings |
 | `explore relationships [--verify]` | inferred + declared joins with confidences, plus notes on what inference examined; `--verify` measures each join with an aggregate overlap probe |
@@ -74,9 +74,11 @@ engine does not care which skill fronts a subcommand.
 
 Authored content reaches the engine through `--edits-file <path>` (or `-` for
 stdin): a JSON payload of `{"edits": [{"path", "kind", "content"}, ...]}` with
-`kind` one of `model_sql`, `schema_yml`, `semantic_yml`. The engine validates,
-diffs, and stores the plan under `.dex/plans/`; nothing touches the dbt project
-until `transform apply`. See `references/command-contract.md`.
+`kind` one of `model_sql`, `schema_yml`, `semantic_yml`, or `packages_yml` (the
+guarded way to author the project-root `packages.yml`/`dependencies.yml`, so
+declaring a dbt package is a reviewable diff too). The engine validates, diffs,
+and stores the plan under `.dex/plans/`; nothing touches the dbt project until
+`transform apply`. See `references/command-contract.md`.
 
 ### The envelope
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,59 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-07-05
+
+Hardening pass from the first billed-connector dogfooding sessions (BigQuery):
+the full explore, transform, and maintain loop on a real warehouse.
+
+### Added
+
+- `packages_yml` edit kind: author the project-root `packages.yml` (or
+  `dependencies.yml`) through the normal `transform plan`/`apply` contract, so
+  declaring a dbt package dependency is a reviewable, hash-pinned diff like every
+  other edit instead of a hand-written file outside the guardrail. The edit must
+  carry a `packages:` or `dependencies:` list; writes stay confined to the dbt
+  project (arbitrary project-root files are still refused).
+- `connect test --project` and `--dataset` (repeatable) for BigQuery: convenience
+  overrides of the config target, applied in memory only (never written to
+  `.dex/config.yml`), so a first smoke test works before a `bigquery:` block
+  exists. They mirror DuckDB's `--path`.
+
+### Changed
+
+- `explore map` folds same-lineage duplicate relationships when a dev/replica
+  dataset is mapped alongside its source. A replica's models mirror source
+  entities and keys, which otherwise inflated one real foreign key into source,
+  replica, and cross-dataset lookalike edges; the canonical (source-schema) edge
+  is kept, the duplicates are dropped, and the summary notes how many objects
+  mirror source lineage. The replica schema is recognized from
+  `bigquery.dev_dataset` or structurally (a matching entity and column set in a
+  second schema).
+- The query firewall's PII refusal now points at an unflagged column that
+  plausibly carries the same readable value (for example `inventory_items.product_name`
+  when `products.name` is flagged), computed from the cache. The flag itself is
+  never weakened and no value is ever surfaced; only the guidance improves.
+
+### Fixed
+
+- dbt subprocess path doubling: with a relative `dbt_project_dir`, `--project-dir`
+  and `--profiles-dir` resolved a second time against the already-pinned cwd
+  (`project/project`), which broke `transform build` and the `semantic define`
+  parse gate on a clean project. The engine now passes absolute dbt CLI paths, so
+  a relative project dir no longer needs a hand-edit to an absolute path.
+- BigQuery cost estimates now fold in the per-query billing floor (10 MiB per
+  referenced table). The dry-run estimate summed raw scanned bytes and ignored
+  the floor, so on small data (and fan-out commands like `maintain check`) it read
+  far below what must be approved and produced a ladder of budget rejections. The
+  surfaced estimate now reflects what BigQuery will bill, so the budget the agent
+  proposes clears in one step.
+- `maintain` no longer reports phantom dimension-cardinality drift from an
+  approximate baseline. It compares an exact current count against the snapshot's
+  distinct count, which for a low-cardinality categorical dimension is a
+  HyperLogLog estimate; a delta within the sketch's error band is now suppressed
+  as noise (the band scales with cardinality, so a genuine new category at low
+  cardinality still fires, and an exact baseline still fires on any change).
+
 ## [0.1.2] - 2026-07-04
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -419,7 +419,12 @@ class BigQueryAdapter:
         """Dry-run every aggregate batch profiling would issue and sum the
         bytes, per table and in total. Free: metadata GETs and dry-run jobs
         bill nothing. Partition-filter tables contribute zero because they
-        will not be queried."""
+        will not be queried.
+
+        Each batch is one billed query over one table, so its cost is floored
+        to the per-query minimum: on small tables the raw scan is a fraction of
+        what BigQuery actually bills, and an unfloored estimate would send the
+        agent into a ladder of budget rejections."""
 
         per_table: dict[str, float] = {}
         for identifier in identifiers:
@@ -438,7 +443,7 @@ class BigQueryAdapter:
                     sample_percent=sample_percent,
                 )
                 try:
-                    total += self._dry_run(sql)
+                    total += max(self._dry_run(sql), float(_MIN_BILLED_BYTES))
                 except self._api_exceptions.BadRequest:
                     self._note(
                         identifier,
@@ -449,9 +454,37 @@ class BigQueryAdapter:
         return sum(per_table.values()), per_table
 
     def query_estimate(self, sql: str) -> float:
-        """The dry-run byte estimate for one firewall-approved query."""
+        """The dry-run byte estimate for one firewall-approved query, floored to
+        what BigQuery will actually bill (the per-referenced-table minimum), so
+        the estimate the agent budgets against is not decorative on small data."""
 
-        return self._dry_run(assert_select_only(sql, dialect=self.dialect))
+        checked = assert_select_only(sql, dialect=self.dialect)
+        return max(self._dry_run(checked), self._min_billed_floor(checked))
+
+    def _min_billed_floor(self, sql: str) -> float:
+        """BigQuery bills at least ``_MIN_BILLED_BYTES`` per table a query
+        references. The floor for one query is that minimum times its distinct
+        table references, so a two-table join floors at twice a single scan."""
+
+        return float(self._referenced_table_count(sql) * _MIN_BILLED_BYTES)
+
+    def _referenced_table_count(self, sql: str) -> int:
+        """Distinct physical tables a query reads, for the billing floor. A parse
+        failure falls back to one table (the estimate only ever floors upward, so
+        under-counting is the safe direction to be wrong)."""
+
+        try:
+            import sqlglot
+            from sqlglot import expressions as sqlglot_exp
+
+            parsed = sqlglot.parse_one(sql, read=self.dialect)
+        except Exception:
+            return 1
+        tables = {
+            ".".join(part for part in (t.catalog, t.db, t.name) if part)
+            for t in parsed.find_all(sqlglot_exp.Table)
+        }
+        return max(len(tables), 1)
 
     # --- execution (the single billed door) -----------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -57,6 +57,11 @@ def _sub_connection_options() -> argparse.ArgumentParser:
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--connector", default=argparse.SUPPRESS)
     common.add_argument("--path", default=argparse.SUPPRESS)
+    # BigQuery's equivalent of --path: a convenience smoke-test override for the
+    # project and dataset allowlist, so `connect test` works before a
+    # .dex/config.yml bigquery block exists. Nothing is written to config.
+    common.add_argument("--project", default=argparse.SUPPRESS)
+    common.add_argument("--dataset", action="append", default=argparse.SUPPRESS)
     common.add_argument("--repo-root", default=argparse.SUPPRESS)
     common.add_argument("--confirm", action="store_true", default=argparse.SUPPRESS)
     common.add_argument("--budget", type=float, default=argparse.SUPPRESS)
@@ -71,6 +76,8 @@ def _build_parser() -> argparse.ArgumentParser:
     # Real defaults live on the top-level parser so every namespace has them.
     parser.add_argument("--connector", default=None)
     parser.add_argument("--path", default=None)
+    parser.add_argument("--project", default=None)
+    parser.add_argument("--dataset", action="append", default=None)
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--confirm", action="store_true")
     parser.add_argument("--budget", type=float, default=None)

--- a/packages/dex-core/src/exmergo_dex_core/command_args.py
+++ b/packages/dex-core/src/exmergo_dex_core/command_args.py
@@ -30,6 +30,8 @@ def open_from_args(args: argparse.Namespace) -> Adapter:
     return open_adapter(
         connector=getattr(args, "connector", None),
         path=getattr(args, "path", None),
+        project=getattr(args, "project", None),
+        datasets=getattr(args, "dataset", None),
         repo_root=repo_root(args),
         budget=getattr(args, "budget", None),
         confirmed=getattr(args, "confirm", False),
@@ -104,6 +106,8 @@ def project_dir(args: argparse.Namespace) -> Path:
 
     root = repo_root(args)
     config = load_config(root)
+    # Absolute so downstream dbt subprocess calls (which pin cwd to this dir)
+    # never re-resolve a relative --project-dir against it and double the path.
     if config and config.dbt_project_dir:
-        return Path(root) / config.dbt_project_dir
-    return find_project(root)
+        return (Path(root) / config.dbt_project_dir).resolve()
+    return find_project(root).resolve()

--- a/packages/dex-core/src/exmergo_dex_core/connect.py
+++ b/packages/dex-core/src/exmergo_dex_core/connect.py
@@ -33,6 +33,8 @@ def open_adapter(
     *,
     connector: str | None = None,
     path: str | None = None,
+    project: str | None = None,
+    datasets: list[str] | None = None,
     repo_root: str | Path = ".",
     budget: float | None = None,
     confirmed: bool = False,
@@ -41,9 +43,10 @@ def open_adapter(
     """Resolve the connection target and return an open, read-only adapter.
 
     Resolution order: explicit arguments win, then ``.dex/config.yml``. For
-    DuckDB the only input is a file path. ``budget``/``confirmed`` feed the
-    cost gate on billed connectors and are ignored by free ones; ``command``
-    labels ledger entries.
+    DuckDB the only input is a file path; for BigQuery ``project``/``datasets``
+    are convenience overrides of the config target (never written back).
+    ``budget``/``confirmed`` feed the cost gate on billed connectors and are
+    ignored by free ones; ``command`` labels ledger entries.
     """
 
     config = load_config(repo_root) or DexConfig()
@@ -59,7 +62,13 @@ def open_adapter(
 
     if connector == "bigquery":
         return _open_bigquery(
-            config, repo_root, budget=budget, confirmed=confirmed, command=command
+            config,
+            repo_root,
+            budget=budget,
+            confirmed=confirmed,
+            command=command,
+            project_override=project,
+            dataset_override=datasets,
         )
 
     # The remaining cloud connectors are not yet implemented.
@@ -73,8 +82,19 @@ def _open_bigquery(
     budget: float | None,
     confirmed: bool,
     command: str | None,
+    project_override: str | None = None,
+    dataset_override: list[str] | None = None,
 ):
     target = config.bigquery or BigQueryTarget()
+    if project_override or dataset_override:
+        # A command-line override of the committed target, applied in memory
+        # only: a smoke test should not silently rewrite .dex/config.yml.
+        updates: dict = {}
+        if project_override:
+            updates["project"] = project_override
+        if dataset_override:
+            updates["datasets"] = dataset_override
+        target = target.model_copy(update=updates)
     credentials, adc_project, principal_type = _default_credentials()
     project = resolve_bigquery_project(
         target, os.environ, adc_project, repo_root=repo_root

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -35,6 +35,11 @@ PROJECT_FILE = "dbt_project.yml"
 PROFILES_FILE = "profiles.yml"
 MANIFEST_PATH = Path("target") / "manifest.json"
 
+# dbt project-root manifests dex may author outside the model paths. They declare
+# package dependencies (not model content), so the editing surface widens by
+# exactly these two known files, never to arbitrary root files.
+_ALLOWED_ROOT_FILES = frozenset({"packages.yml", "dependencies.yml"})
+
 
 class DbtProjectError(Exception):
     pass
@@ -346,6 +351,10 @@ def contained_path(root: Path, rel_path: str, model_paths: list[str]) -> Path:
         raise DbtProjectError(f"edit path must be project-relative: '{rel_path}'")
     resolved = (root / candidate).resolve()
     root_resolved = root.resolve()
+    # The dbt package manifests live at the project root, so they are allowed by
+    # name (still inside the project, still not an arbitrary escape).
+    if resolved.parent == root_resolved and resolved.name in _ALLOWED_ROOT_FILES:
+        return root / candidate
     for model_path in model_paths:
         base = (root_resolved / model_path).resolve()
         if resolved == base or base in resolved.parents:

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -283,6 +283,18 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         command_args.stamp_spend(envelope, adapter)
     finally:
         adapter.close()
+    # Fold same-lineage duplicates before they reach the cache: a dev/replica
+    # dataset mapped alongside its source otherwise inflates one real foreign key
+    # into source, replica, and cross-dataset lookalike edges.
+    dev_schemas = frozenset(
+        name
+        for name in [config.bigquery.dev_dataset if config.bigquery else None]
+        if name
+    )
+    inferred, folded_edges, mirrored_objects = rel_mod.fold_replica_relationships(
+        profiled, inferred, dev_schemas
+    )
+
     declared = rel_mod.declared_relationships(repo_root)
     relationships = declared + inferred
 
@@ -316,6 +328,12 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         notes.append(
             f"carried forward {carried} prior profile(s) for objects not "
             "re-profiled this run; per-dataset profiled_at marks their age"
+        )
+    if folded_edges > 0:
+        notes.append(
+            f"folded {folded_edges} same-lineage duplicate relationship(s); "
+            f"{mirrored_objects} object(s) mirror source lineage (a dev/replica "
+            "dataset mapped alongside its source)"
         )
 
     pii_columns = sum(1 for d in profiled for c in d.columns if c.pii is not None)

--- a/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
@@ -127,6 +127,108 @@ def infer_relationships(datasets: list[Dataset]) -> list[Relationship]:
     return relationships
 
 
+def fold_replica_relationships(
+    datasets: list[Dataset],
+    relationships: list[Relationship],
+    dev_schemas: frozenset[str] = frozenset(),
+) -> tuple[list[Relationship], int, int]:
+    """Fold same-lineage duplicate joins that appear when a dev/replica dataset is
+    mapped alongside its source.
+
+    A replica's models mirror source entities and keys, so one real foreign key
+    inflates into the source edge, the replica edge, and cross-dataset lookalike
+    edges. Returns ``(kept, folded_count, mirrored_object_count)``.
+
+    A replica schema is one whose short name is in ``dev_schemas`` or one that
+    structurally mirrors another (the same layer-stripped entity and column set
+    living in a second schema). With no replica in scope nothing is folded, so a
+    single-dataset map is untouched. Within each lineage signature that a replica
+    edge participates in, the canonical (source-schema) edge is kept and the
+    duplicates are dropped.
+    """
+
+    def schema_of(identifier: str) -> str:
+        return identifier.rsplit(".", 1)[0]
+
+    def bare(identifier: str) -> str:
+        return identifier.rsplit(".", 1)[-1]
+
+    def is_dev(schema: str) -> bool:
+        return schema.rsplit(".", 1)[-1] in dev_schemas
+
+    # An entity+columns fingerprint held by more than one schema is a mirrored
+    # entity; a dev schema is a replica by declaration even without a structural
+    # twin in scope.
+    schemas_by_fingerprint: dict[tuple[str, frozenset[str]], set[str]] = {}
+    tables_per_schema: dict[str, int] = {}
+    present_schemas: set[str] = set()
+    for dataset in datasets:
+        schema = schema_of(dataset.identifier)
+        present_schemas.add(schema)
+        key = (
+            _entity(bare(dataset.identifier)),
+            frozenset(c.name.lower() for c in dataset.columns),
+        )
+        schemas_by_fingerprint.setdefault(key, set()).add(schema)
+        if dataset.object_type == "table":
+            tables_per_schema[schema] = tables_per_schema.get(schema, 0) + 1
+
+    mirrored_schemas: set[str] = {s for s in present_schemas if is_dev(s)}
+    for schemas in schemas_by_fingerprint.values():
+        if len(schemas) > 1:
+            mirrored_schemas |= schemas
+    if not mirrored_schemas:
+        return relationships, 0, 0
+
+    # Canonical schema: prefer a non-dev schema, then the one with the most base
+    # tables (a source has tables where a replica has staging views), then name.
+    canonical = min(
+        mirrored_schemas,
+        key=lambda s: (is_dev(s), -tables_per_schema.get(s, 0), s),
+    )
+    replica_schemas = mirrored_schemas - {canonical}
+    mirrored_object_count = sum(
+        1 for d in datasets if schema_of(d.identifier) in replica_schemas
+    )
+
+    def replica_endpoints(rel: Relationship) -> int:
+        return sum(
+            schema_of(endpoint) in replica_schemas
+            for endpoint in (rel.from_dataset, rel.to_dataset)
+        )
+
+    def signature(rel: Relationship) -> tuple:
+        return (
+            _entity(bare(rel.from_dataset)),
+            tuple(c.lower() for c in rel.from_columns),
+            _entity(bare(rel.to_dataset)),
+            tuple(c.lower() for c in rel.to_columns),
+        )
+
+    groups: dict[tuple, list[Relationship]] = {}
+    for rel in relationships:
+        groups.setdefault(signature(rel), []).append(rel)
+
+    kept: list[Relationship] = []
+    folded = 0
+    for members in groups.values():
+        if len(members) == 1 or not any(replica_endpoints(r) for r in members):
+            kept.extend(members)
+            continue
+        best = min(
+            members,
+            key=lambda r: (
+                replica_endpoints(r),
+                -(r.confidence or 0.0),
+                r.from_dataset,
+                r.to_dataset,
+            ),
+        )
+        kept.append(best)
+        folded += len(members) - 1
+    return kept, folded, mirrored_object_count
+
+
 def fk_candidate_count(datasets: list[Dataset]) -> int:
     """How many profiled columns look like foreign keys. Reported alongside the
     inference result so an empty relationships array is distinguishable from

--- a/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
@@ -24,6 +24,7 @@ trusted to agent frugality) and records which cache tables the query touches.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 import sqlglot
@@ -103,6 +104,59 @@ _QUERY_ROOTS = tuple(
 _Outputs = dict[str, set[str]]
 _Source = Dataset | dict
 
+# Warehouse-layer prefixes stripped before entity matching, so stg_products and
+# products share the entity "product" when suggesting an unflagged twin column.
+_LAYER_PREFIX = re.compile(r"^(raw|stg|src|dim|fct|fact|mart|int)_", re.IGNORECASE)
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_STRING_TYPE_HINTS = ("CHAR", "TEXT", "STRING", "VARCHAR")
+
+
+def _normalize_name(name: str) -> str:
+    return _CAMEL_BOUNDARY.sub("_", name).lower()
+
+
+def _is_string_type(data_type: str) -> bool:
+    upper = data_type.upper()
+    return any(hint in upper for hint in _STRING_TYPE_HINTS)
+
+
+def _entity_of(table: str) -> str:
+    """The entity a table name denotes: layer prefix stripped, naively
+    singularized (products -> product), lowered."""
+
+    stripped = _LAYER_PREFIX.sub("", table).lower()
+    if stripped.endswith("s") and not stripped.endswith("ss"):
+        stripped = stripped[:-1]
+    return stripped
+
+
+def recovery_hints(offending: list[str], cache: DexCache) -> list[str]:
+    """Unflagged string columns that plausibly carry the same readable value as a
+    refused PII column, so a refusal points at a lawful alternative instead of a
+    dead end (for example ``inventory_items.product_name`` for a flagged
+    ``products.name``). Column names only; no value is ever read. The flag itself
+    is never weakened, only the guidance around it."""
+
+    suggestions: set[str] = set()
+    for entry in offending:
+        table_col = entry.split(" (", 1)[0]
+        table, _, column = table_col.rpartition(".")
+        entity = _entity_of(table)
+        base = _normalize_name(column)
+        if not entity or not base:
+            continue
+        target = f"{entity}_{base}"
+        for dataset in cache.datasets:
+            short = dataset.identifier.rsplit(".", 1)[-1]
+            for col in dataset.columns:
+                if col.pii is not None or not _is_string_type(col.data_type):
+                    continue
+                normalized = _normalize_name(col.name)
+                tokens = set(normalized.split("_"))
+                if normalized == target or {entity, base} <= tokens:
+                    suggestions.add(f"{short}.{col.name}")
+    return sorted(suggestions)
+
 
 def inspect_query(
     sql: str,
@@ -133,13 +187,21 @@ def inspect_query(
 
     offending = sorted({flag for taint in outputs.values() for flag in taint})
     if offending:
-        raise QueryRefusedError(
+        message = (
             "the projection would carry values from PII-flagged column(s): "
             + "; ".join(offending)
             + ". Use a measuring aggregate over them (COUNT, "
             "APPROX_COUNT_DISTINCT, AVG(LENGTH(...))), or drop them from the "
             "output. PII values never cross the envelope."
         )
+        hints = recovery_hints(offending, cache)
+        if hints:
+            message += (
+                " An unflagged column may carry the same readable value: "
+                + ", ".join(hints)
+                + "."
+            )
+        raise QueryRefusedError(message)
 
     new_sql, row_cap, capped = _apply_limit(root, limits.max_rows, dialect)
     return InspectedQuery(

--- a/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
@@ -43,6 +43,14 @@ _VOLUME_HIGH_DROP = 0.50
 
 _SEVERITY_ORDER = {"high": 0, "medium": 1, "low": 2}
 
+# A dimension-cardinality baseline is often an approximate (HyperLogLog) count:
+# explore escalates only near-unique columns to an exact COUNT(DISTINCT), so a
+# low-cardinality categorical dimension keeps its sketch estimate in the
+# snapshot. A delta within the sketch's error band is noise, not drift, and must
+# not fire a finding against an exact current count. Retroactively re-measuring
+# the historical baseline is impossible, so deltas inside this band are gated.
+_APPROX_CARDINALITY_TOLERANCE = 0.02
+
 
 class DriftFinding(BaseModel):
     """One detected drift.
@@ -707,6 +715,19 @@ def cardinality_drift(
             after = counts.get(check.column)
             if after is None or after == check.baseline_distinct:
                 continue
+            # An approximate baseline wobbling within its sketch error is noise:
+            # the current count is exact, but the historical one was not, so a
+            # small delta is indistinguishable from HLL variance and would be a
+            # phantom finding. A delta beyond the band still fires (its direction
+            # and rough size are real), keeping the ~ marker and exact: false.
+            if not check.baseline_exact:
+                # The band scales with the baseline (the sketch's error is
+                # relative), with no floor: at a handful of distinct values it is
+                # zero, so a genuine new category still fires; at thousands it is
+                # tens, absorbing HLL wobble.
+                band = round(_APPROX_CARDINALITY_TOLERANCE * check.baseline_distinct)
+                if abs(after - check.baseline_distinct) <= band:
+                    continue
             marker = "" if check.baseline_exact else "~"
             direction = "widened" if after > check.baseline_distinct else "narrowed"
             sm = models_by_name.get(check.semantic_model)

--- a/packages/dex-core/src/exmergo_dex_core/transform/build.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/build.py
@@ -114,7 +114,10 @@ def build(
 
     if project_dir is None:
         raise DbtRunError("no dbt project directory resolved for the build")
-    project = Path(project_dir)
+    # Absolute so --project-dir/--profiles-dir cannot resolve a second time
+    # against the cwd we pin below: a relative project dir would otherwise
+    # double (dbt would look for project/project and fail).
+    project = Path(project_dir).resolve()
 
     seeding_warning = _check_dev_database(project, target)
 
@@ -144,7 +147,7 @@ def build(
         "--project-dir",
         str(project),
         "--profiles-dir",
-        str(profiles_dir(project)),
+        str(profiles_dir(project).resolve()),
         "--log-format",
         "json",
     ]
@@ -226,7 +229,9 @@ def shadow_parse(
     passed; non-empty messages are the parse errors.
     """
 
-    project = Path(project_dir)
+    # Absolute so --profiles-dir (pointing at the real project) does not
+    # resolve against the shadow tempdir we pin as cwd below.
+    project = Path(project_dir).resolve()
     try:
         executable = _dbt_executable()
     except DbtRunError:
@@ -268,7 +273,7 @@ def shadow_parse(
             "--project-dir",
             str(shadow),
             "--profiles-dir",
-            str(profiles),
+            str(profiles.resolve()),
             "--log-format",
             "json",
         ]
@@ -324,7 +329,8 @@ def deps(
     it runs after the target check and the cost gate anyway.
     """
 
-    project = Path(project_dir)
+    # Absolute so --project-dir does not double against the pinned cwd.
+    project = Path(project_dir).resolve()
     argv = [
         _dbt_executable(),
         "deps",

--- a/packages/dex-core/src/exmergo_dex_core/transform/plans.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/plans.py
@@ -51,6 +51,9 @@ class EditKind(str, Enum):
     MODEL_SQL = "model_sql"
     SCHEMA_YML = "schema_yml"
     SEMANTIC_YML = "semantic_yml"
+    # A dbt project-root manifest, not a model-path file: authoring it brings
+    # dependency declaration inside the plan/apply guardrail like every other edit.
+    PACKAGES_YML = "packages_yml"
 
 
 class PlanEdit(Edit):

--- a/packages/dex-core/src/exmergo_dex_core/transform/validate.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/validate.py
@@ -78,4 +78,11 @@ def validate_edit(edit: PlanEdit) -> list[str]:
             from .semantic import validate_semantic_yaml
 
             warnings.extend(validate_semantic_yaml(edit.path, parsed))
+        elif edit.kind is EditKind.PACKAGES_YML and not (
+            parsed.get("packages") or parsed.get("dependencies")
+        ):
+            raise EditValidationError(
+                f"{edit.path}: a packages manifest needs a 'packages:' (or "
+                "'dependencies:') list"
+            )
     return warnings

--- a/packages/dex-core/tests/adapters/test_connect_bigquery.py
+++ b/packages/dex-core/tests/adapters/test_connect_bigquery.py
@@ -10,6 +10,8 @@ import pytest
 
 pytest.importorskip("google.cloud.bigquery")
 
+from google.cloud import bigquery
+
 from exmergo_dex_core.adapters import get_adapter, get_dialect
 from exmergo_dex_core.adapters.bigquery import BigQueryAdapter
 from exmergo_dex_core.config import BigQueryTarget
@@ -140,13 +142,52 @@ def test_dry_run_precedes_every_execution(fake_bq_client):
     assert [c.dry_run for c in fake_bq_client.query_calls] == [True, False]
 
 
-def test_estimate_is_the_dry_run_figure(fake_bq_client):
+def test_estimate_floors_at_the_billing_minimum(fake_bq_client):
+    # customers is 5000 bytes, well under BigQuery's 10 MiB per-table minimum;
+    # the estimate reports what will be billed, not the raw scan, so the agent
+    # budgets against a truthful number instead of hitting a rejection ladder.
     adapter = make_adapter(fake_bq_client)
     estimate = adapter.query_estimate(
         "SELECT COUNT(*) FROM `test-proj`.`shop`.`customers`"
     )
-    assert estimate == 5_000  # the table's num_bytes, priced by the fake
+    assert estimate == 10 * MB
     assert [c.dry_run for c in fake_bq_client.query_calls] == [True]
+
+
+def test_estimate_is_the_raw_scan_when_it_exceeds_the_floor():
+    from fakes.bigquery import FakeBigQueryClient, FakeTable
+
+    big = FakeTable(
+        project="test-proj",
+        dataset_id="shop",
+        table_id="huge",
+        schema=[bigquery.SchemaField("id", "INTEGER")],
+        num_rows=1,
+        num_bytes=20 * MB,
+    )
+    client = FakeBigQueryClient(project="test-proj", tables=[big])
+    adapter = make_adapter(client)
+    estimate = adapter.query_estimate("SELECT COUNT(*) FROM `test-proj`.`shop`.`huge`")
+    assert estimate == 20 * MB  # above the floor, the raw dry-run figure wins
+
+
+def test_query_estimate_floors_per_referenced_table(fake_bq_client):
+    # A two-table join is billed at least the minimum per table, so the floor is
+    # twice a single scan even though the raw dry-run of both is a few KB.
+    adapter = make_adapter(fake_bq_client)
+    estimate = adapter.query_estimate(
+        "SELECT COUNT(*) FROM `test-proj`.`shop`.`customers` c "
+        "JOIN `test-proj`.`shop`.`events` e ON c.id = e.id"
+    )
+    assert estimate == 2 * 10 * MB
+
+
+def test_profile_estimate_floors_each_batch_at_the_billing_minimum(fake_bq_client):
+    adapter = make_adapter(fake_bq_client)
+    total, per_table = adapter.profile_estimate(["test-proj.shop.customers"])
+    # One batch over one table: the raw 5000-byte scan floors to the minimum.
+    assert per_table["test-proj.shop.customers"] == 10 * MB
+    assert total == 10 * MB
 
 
 def test_every_executed_job_carries_maximum_bytes_billed(fake_bq_client):
@@ -342,10 +383,11 @@ def test_profile_estimate_sums_free_dry_runs(fake_bq_client):
     total, per_table = adapter.profile_estimate(
         ["test-proj.shop.customers", "test-proj.shop.events", "test-proj.logs.requests"]
     )
-    assert per_table["test-proj.shop.customers"] == 5_000
-    assert per_table["test-proj.shop.events"] == 50_000
+    # Each queryable table is one below-floor batch, so both floor to the minimum.
+    assert per_table["test-proj.shop.customers"] == 10 * MB
+    assert per_table["test-proj.shop.events"] == 10 * MB
     assert per_table["test-proj.logs.requests"] == 0.0  # unqueryable, skipped
-    assert total == 55_000
+    assert total == 20 * MB
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
 
@@ -459,3 +501,55 @@ def test_project_falls_back_to_dbt_profiles(dbt_project_dir: Path):
         BigQueryTarget(), {}, None, repo_root=dbt_project_dir.parent
     )
     assert resolved == "from-dbt"
+
+
+def test_connect_test_parses_project_and_dataset_flags():
+    # The first-attempt flags a user reaches for must not be rejected as
+    # unrecognized args (the discoverability defect).
+    from exmergo_dex_core.cli import _build_parser
+
+    args = _build_parser().parse_args(
+        [
+            "connect",
+            "test",
+            "--connector",
+            "bigquery",
+            "--project",
+            "p",
+            "--dataset",
+            "d1",
+            "--dataset",
+            "d2",
+        ]
+    )
+    assert args.project == "p"
+    assert args.dataset == ["d1", "d2"]
+
+
+def test_project_and_dataset_flags_override_the_config_target(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    import exmergo_dex_core.connect as connect_mod
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        connect_mod, "_default_credentials", lambda: (None, None, "user")
+    )
+
+    def fake_get_adapter(name, **kwargs):
+        captured.update(kwargs)
+        captured["name"] = name
+        return SimpleNamespace(name=name, close=lambda: None)
+
+    monkeypatch.setattr(connect_mod, "get_adapter", fake_get_adapter)
+
+    connect_mod.open_adapter(
+        connector="bigquery",
+        project="cli-proj",
+        datasets=["ds_a", "ds_b"],
+        repo_root=tmp_path,  # no .dex/config.yml here
+    )
+    assert captured["name"] == "bigquery"
+    assert captured["project"] == "cli-proj"
+    assert captured["target"].project == "cli-proj"
+    assert captured["target"].datasets == ["ds_a", "ds_b"]

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -99,8 +99,9 @@ def test_unconfirmed_profile_returns_needs_confirmation(
     )
     assert envelope.status.value == "needs_confirmation"
     assert envelope.cost.paradigm is Paradigm.BYTES_SCANNED
-    assert envelope.cost.estimate == 5_000
-    assert envelope.data["per_table_bytes"] == {"test-proj.shop.customers": 5_000}
+    # The single below-floor batch is priced at the per-query billing minimum.
+    assert envelope.cost.estimate == 10 * MB
+    assert envelope.data["per_table_bytes"] == {"test-proj.shop.customers": 10 * MB}
     assert "--confirm" in envelope.data["hint"]
     # Nothing executed: only free metadata and dry-runs happened.
     assert all(c.dry_run for c in fake_bq_client.query_calls)
@@ -123,7 +124,7 @@ def test_confirmed_profile_runs_and_stamps_spend(
     )
     assert envelope.status.value == "ok"
     assert envelope.data["datasets"][0]["identifier"] == "test-proj.shop.customers"
-    assert envelope.cost.estimate == 5_000
+    assert envelope.cost.estimate == 10 * MB  # floored preflight estimate
     assert envelope.cost.ceiling == 100 * MB
     # The aggregate batch plus the exact-distinct escalation (optional spend
     # inside the confirmed budget): both scans land in the ledger.
@@ -137,8 +138,9 @@ def test_unconfirmed_map_estimates_selected_objects(
     route_adapter(fake_bq_client)
     envelope = explore_cmds.cmd_map(_args(tmp_path, subcommand="map"))
     assert envelope.status.value == "needs_confirmation"
-    # logs.requests needs a partition filter, so it contributes zero.
-    assert envelope.cost.estimate == 55_000
+    # customers and events each floor to the per-query minimum; logs.requests
+    # needs a partition filter, so it contributes zero.
+    assert envelope.cost.estimate == 2 * 10 * MB
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
 
@@ -187,7 +189,8 @@ def test_unconfirmed_query_returns_estimate_and_logs(
         )
     )
     assert envelope.status.value == "needs_confirmation"
-    assert envelope.cost.estimate == 5_000
+    # Single-table query, floored to the per-query billing minimum.
+    assert envelope.cost.estimate == 10 * MB
     log_lines = (tmp_path / ".dex" / "queries.jsonl").read_text().splitlines()
     assert json.loads(log_lines[-1])["decision"] == "needs_confirmation"
 

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -18,6 +18,7 @@ from exmergo_dex_core.explore.relationships import (
     data_quality_notes,
     detect_grain,
     fk_candidate_count,
+    fold_replica_relationships,
     infer_relationships,
 )
 
@@ -143,6 +144,99 @@ def test_ambiguous_all_caps_id_suffix_is_not_a_fk():
         rows=1,
     )
     assert fk_candidate_count([ds]) == 2
+
+
+# --- same-lineage / replica folding --------------------------------------------
+
+
+def _mirror_world() -> list[Dataset]:
+    """A source schema and a dev/replica schema holding the same entities: the
+    shape that inflated one foreign key into several edges in the field."""
+
+    return [
+        _ds(
+            "db.main.orders",
+            [_col("id", distinct=3, unique=True), _col("customer_id", distinct=2)],
+            rows=3,
+        ),
+        _ds("db.main.customers", [_col("id", distinct=2, unique=True)], rows=2),
+        _ds(
+            "db.dbt_dev.stg_orders",
+            [_col("id", distinct=3, unique=True), _col("customer_id", distinct=2)],
+            rows=3,
+        ),
+        _ds("db.dbt_dev.dim_customers", [_col("id", distinct=2, unique=True)], rows=2),
+    ]
+
+
+def test_replica_dataset_duplicate_edges_are_folded():
+    datasets = _mirror_world()
+    rels = infer_relationships(datasets)
+    assert len(rels) == 4  # source, replica, and two cross-dataset lookalikes
+
+    kept, folded, mirrored = fold_replica_relationships(
+        datasets, rels, frozenset({"dbt_dev"})
+    )
+    assert folded == 3
+    assert len(kept) == 1
+    # The kept edge is the source-schema one, named by the dev_dataset config.
+    assert kept[0].from_dataset == "db.main.orders"
+    assert kept[0].to_dataset == "db.main.customers"
+    assert mirrored == 2  # the two dbt_dev objects
+
+
+def test_fold_detects_mirror_structurally_without_config():
+    datasets = _mirror_world()
+    rels = infer_relationships(datasets)
+    kept, folded, mirrored = fold_replica_relationships(datasets, rels)
+    # No dev_schemas passed: structural mirror detection still collapses the
+    # duplicates (canonical chosen deterministically).
+    assert folded == 3
+    assert len(kept) == 1
+    assert mirrored == 2
+
+
+def test_fold_is_a_noop_without_a_mirror():
+    datasets = [
+        _ds(
+            "db.main.orders",
+            [_col("id", distinct=3, unique=True), _col("customer_id", distinct=2)],
+            rows=3,
+        ),
+        _ds("db.main.customers", [_col("id", distinct=2, unique=True)], rows=2),
+    ]
+    rels = infer_relationships(datasets)
+    kept, folded, mirrored = fold_replica_relationships(
+        datasets, rels, frozenset({"dbt_dev"})
+    )
+    assert kept == rels
+    assert folded == 0
+    assert mirrored == 0
+
+
+def test_map_folds_mirrored_lineage_and_notes_it(tmp_path: Path, capsys):
+    duckdb = pytest.importorskip("duckdb")
+    db = tmp_path / "mirror.duckdb"
+    conn = duckdb.connect(str(db))
+    conn.execute("CREATE TABLE orders (id INTEGER, customer_id INTEGER)")
+    conn.execute("INSERT INTO orders VALUES (1, 1), (2, 2), (3, 1)")
+    conn.execute("CREATE TABLE customers (id INTEGER)")
+    conn.execute("INSERT INTO customers VALUES (1), (2)")
+    conn.execute("CREATE SCHEMA dbt_dev")
+    conn.execute("CREATE TABLE dbt_dev.stg_orders (id INTEGER, customer_id INTEGER)")
+    conn.execute("INSERT INTO dbt_dev.stg_orders VALUES (1, 1), (2, 2), (3, 1)")
+    conn.execute("CREATE TABLE dbt_dev.dim_customers (id INTEGER)")
+    conn.execute("INSERT INTO dbt_dev.dim_customers VALUES (1), (2)")
+    conn.close()
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    payload = _run(
+        ["explore", "map", "--path", str(db), "--repo-root", str(repo)], capsys
+    )
+    assert any("mirror source lineage" in n for n in payload["data"]["notes"])
+    # One real foreign key survives instead of the inflated cross-schema fan-out.
+    assert payload["data"]["relationship_count"] <= 2
 
 
 # --- grain and data-quality notes ----------------------------------------------

--- a/packages/dex-core/tests/guards/test_query_firewall.py
+++ b/packages/dex-core/tests/guards/test_query_firewall.py
@@ -125,6 +125,49 @@ def test_refusal_names_column_category_and_fix(cache: DexCache):
     assert "COUNT" in message  # the fix
 
 
+@pytest.fixture
+def twin_cache() -> DexCache:
+    """A flagged entity-name column with an unflagged equivalent one table over,
+    the shape that made the firewall a dead end in the field."""
+
+    return DexCache(
+        datasets=[
+            Dataset(
+                identifier="db.main.PRODUCTS",
+                columns=[
+                    ColumnProfile(name="ID", data_type="INTEGER"),
+                    ColumnProfile(
+                        name="NAME",
+                        data_type="VARCHAR",
+                        pii=PIIFlag(category="name", confidence=0.6),
+                    ),
+                ],
+            ),
+            Dataset(
+                identifier="db.main.INVENTORY_ITEMS",
+                columns=[
+                    ColumnProfile(name="ID", data_type="INTEGER"),
+                    ColumnProfile(name="PRODUCT_NAME", data_type="VARCHAR"),
+                ],
+            ),
+        ]
+    )
+
+
+def test_pii_refusal_points_to_an_unflagged_equivalent_column(twin_cache: DexCache):
+    message = _refusal("SELECT NAME FROM PRODUCTS", twin_cache)
+    assert "PRODUCTS.NAME" in message  # still refused, flag intact
+    assert "INVENTORY_ITEMS.PRODUCT_NAME" in message  # the lawful alternative
+    assert "unflagged column may carry" in message
+
+
+def test_pii_refusal_without_a_twin_still_refuses_cleanly(cache: DexCache):
+    message = _refusal("SELECT NAME FROM RAW_HOSTS", cache)
+    assert "RAW_HOSTS.NAME" in message
+    assert "COUNT" in message  # the fix is still named
+    assert "unflagged column may carry" not in message  # no false suggestion
+
+
 # --- refused: shape, resolution, and introspection -------------------------------
 
 

--- a/packages/dex-core/tests/maintain/test_billed_handshake.py
+++ b/packages/dex-core/tests/maintain/test_billed_handshake.py
@@ -148,8 +148,9 @@ def test_unconfirmed_grain_returns_the_dry_run_estimate(
     envelope = maintain_cmds.cmd_grain(_args(tmp_path, "grain"))
     assert envelope.status.value == "needs_confirmation"
     assert envelope.cost.paradigm is Paradigm.BYTES_SCANNED
-    assert envelope.cost.estimate == 5_000
-    assert envelope.data["per_table_bytes"] == {"test-proj.shop.customers": 5_000}
+    # The single-table distinct-count scan floors to the per-query minimum.
+    assert envelope.cost.estimate == 10 * MB
+    assert envelope.data["per_table_bytes"] == {"test-proj.shop.customers": 10 * MB}
     assert "--confirm" in envelope.data["hint"]
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
@@ -207,7 +208,7 @@ def test_unconfirmed_check_is_two_phase(fake_bq_client, route_adapter, tmp_path)
     # with the estimate for the scanning axes.
     codes = {f["code"] for f in envelope.data["findings"]}
     assert "column_dropped" in codes
-    assert envelope.data["estimated_bytes"] == 5_000
+    assert envelope.data["estimated_bytes"] == 10 * MB
     assert any("free" in note for note in envelope.data["notes"])
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
@@ -230,3 +231,70 @@ def test_confirmed_check_completes_the_scanning_axes(
     assert envelope.data["axes"]["grain"] == 0
     report = DexStore(tmp_path).load_drift()
     assert {"schema", "volume", "grain"} <= set(report.axes)
+
+
+def _seed_two_keyed_tables(tmp_path: Path) -> None:
+    now = datetime.now(UTC).isoformat()
+
+    def keyed(identifier: str, rows: int, byte_size: int) -> Dataset:
+        return Dataset(
+            identifier=identifier,
+            row_count=rows,
+            byte_size=byte_size,
+            columns=[
+                ColumnProfile(
+                    name="id",
+                    data_type="INTEGER",
+                    nullable=False,
+                    null_fraction=0.0,
+                    distinct_count=rows,
+                    distinct_count_exact=True,
+                    is_unique=True,
+                )
+            ],
+            candidate_keys=[["id"]],
+            grain=["id"],
+            profiled_at=now,
+        )
+
+    DexStore(tmp_path).save_snapshot(
+        Snapshot(
+            created_at=now,
+            connector="bigquery",
+            warehouse=WarehouseBaseline(
+                datasets=[
+                    keyed("test-proj.shop.customers", 100, 5_000),
+                    keyed("test-proj.shop.events", 1_000, 50_000),
+                ]
+            ),
+            warehouse_from="cache",
+        )
+    )
+
+
+def test_check_fanout_estimate_reflects_per_query_floor(
+    fake_bq_client, route_adapter, tmp_path
+):
+    """A fan-out check over two tables estimates 2x the per-query floor, not the
+    few KB of raw scan; confirming with exactly that budget then runs without the
+    per-statement floor rejecting a statement (the reject-ladder the estimate
+    used to cause)."""
+
+    _seed_two_keyed_tables(tmp_path)
+    route_adapter(fake_bq_client)
+
+    unconfirmed = maintain_cmds.cmd_check(_args(tmp_path, "check"))
+    assert unconfirmed.status.value == "needs_confirmation"
+    assert unconfirmed.data["estimated_bytes"] == 2 * 10 * MB
+
+    fake_bq_client.row_resolver = lambda sql: [{"d_0": 100}]
+    route_adapter(fake_bq_client)
+    confirmed = maintain_cmds.cmd_check(
+        _args(
+            tmp_path,
+            "check",
+            confirm=True,
+            budget=float(unconfirmed.data["estimated_bytes"]),
+        )
+    )
+    assert confirmed.status.value == "ok"

--- a/packages/dex-core/tests/maintain/test_semantic.py
+++ b/packages/dex-core/tests/maintain/test_semantic.py
@@ -4,10 +4,100 @@ dimension cardinality. No dimension value ever reaches the envelope."""
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
+
+from exmergo_dex_core.maintain.drift import CardinalityCheck, cardinality_drift
 
 from .conftest import SEMANTIC_YAML
 
 SEMANTIC_PATH = "models/marts/orders_semantic.yml"
+
+
+class _StubAdapter:
+    """Just the surface cardinality_drift touches: the object exists, its column
+    is live, and an exact distinct count is returned for it."""
+
+    dialect = "duckdb"
+
+    def __init__(self, identifier: str, columns: list[str], exact: dict[str, int]):
+        self._identifier = identifier
+        self._columns = columns
+        self._exact = exact
+
+    def list_objects(self):
+        return [SimpleNamespace(identifier=self._identifier)]
+
+    def table_metadata(self, identifier: str):
+        cols = [SimpleNamespace(name=name) for name in self._columns]
+        return SimpleNamespace(identifier=identifier), cols
+
+    def exact_distinct_counts(self, identifier: str, columns: list[str]) -> dict:
+        return {c: self._exact[c] for c in columns if c in self._exact}
+
+
+def _semantic():
+    model = SimpleNamespace(
+        name="orders", model_ref="stg_orders", measures={"order_count": "order_id"}
+    )
+    return SimpleNamespace(semantic_models=[model], metrics=[])
+
+
+def _check(identifier: str, baseline: int, *, exact: bool) -> CardinalityCheck:
+    return CardinalityCheck(
+        identifier=identifier,
+        column="status",
+        dimension="status",
+        semantic_model="orders",
+        baseline_distinct=baseline,
+        baseline_exact=exact,
+    )
+
+
+def test_approximate_cardinality_wobble_within_error_band_is_not_drift():
+    # The field phantom: an approximate baseline of 2757 versus an exact 2756 is
+    # HLL noise (0.04%), well inside the sketch's error band, so no finding fires.
+    identifier = "test.shop.dim_products"
+    adapter = _StubAdapter(identifier, ["status"], {"status": 2756})
+    findings = cardinality_drift(
+        adapter, [_check(identifier, 2757, exact=False)], _semantic()
+    )
+    assert findings == []
+
+
+def test_real_cardinality_change_beyond_the_band_still_fires():
+    identifier = "test.shop.dim_products"
+    adapter = _StubAdapter(identifier, ["status"], {"status": 3200})
+    findings = cardinality_drift(
+        adapter, [_check(identifier, 2757, exact=False)], _semantic()
+    )
+    assert len(findings) == 1
+    assert findings[0].code == "dimension_cardinality_changed"
+    assert findings[0].exact is False
+    assert findings[0].data["distinct_after"] == 3200
+
+
+def test_small_dimension_delta_of_one_is_not_swallowed_by_the_band():
+    # At a handful of distinct values the band is zero, so a genuine new category
+    # (5 -> 6) fires even off an approximate baseline: the gate suppresses noise,
+    # not real low-cardinality changes.
+    identifier = "test.shop.stg_orders"
+    adapter = _StubAdapter(identifier, ["status"], {"status": 6})
+    findings = cardinality_drift(
+        adapter, [_check(identifier, 5, exact=False)], _semantic()
+    )
+    assert len(findings) == 1
+    assert findings[0].data["distinct_after"] == 6
+
+
+def test_exact_baseline_fires_on_any_change():
+    # An exact baseline is proof, so even a delta of one is real drift.
+    identifier = "test.shop.dim_products"
+    adapter = _StubAdapter(identifier, ["status"], {"status": 2756})
+    findings = cardinality_drift(
+        adapter, [_check(identifier, 2757, exact=True)], _semantic()
+    )
+    assert len(findings) == 1
+    assert findings[0].exact is True
 
 
 def test_clean_project_reports_no_semantic_drift(maintain_repo):

--- a/packages/dex-core/tests/transform/test_apply.py
+++ b/packages/dex-core/tests/transform/test_apply.py
@@ -59,6 +59,50 @@ def test_apply_round_trip(dbt_project_dir: Path, tmp_path: Path, capsys):
     assert json.loads(plan_file.read_text())["applied_at"] is not None
 
 
+def test_apply_writes_packages_yml_at_project_root(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    payload_file = tmp_path / "packages-edit.json"
+    payload_file.write_text(
+        json.dumps(
+            {
+                "edits": [
+                    {
+                        "path": "packages.yml",
+                        "kind": "packages_yml",
+                        "content": "packages:\n  - package: dbt-labs/dbt_utils\n"
+                        "    version: 1.1.1\n",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "add dbt_utils",
+            "--edits-file",
+            str(payload_file),
+        ],
+        capsys,
+    )
+    assert rc == 0 and envelope["status"] == "ok"
+    plan_id = envelope["data"]["plan_id"]
+
+    rc, envelope = _run(
+        ["--repo-root", str(tmp_path), "transform", "apply", plan_id], capsys
+    )
+    assert rc == 0 and envelope["status"] == "ok"
+    assert envelope["data"]["written"] == ["packages.yml"]
+    manifest = dbt_project_dir / "packages.yml"
+    assert manifest.is_file()
+    assert "dbt_utils" in manifest.read_text(encoding="utf-8")
+
+
 def test_apply_unknown_plan_is_a_clean_error(
     dbt_project_dir: Path, tmp_path: Path, capsys
 ):

--- a/packages/dex-core/tests/transform/test_build.py
+++ b/packages/dex-core/tests/transform/test_build.py
@@ -300,6 +300,94 @@ def test_relative_profile_path_resolves_against_project(
     assert not (elsewhere / "dev-rel.duckdb").exists()
 
 
+def test_build_paths_are_absolute_from_a_relative_project_dir(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """A relative project dir must not double against the cwd we pin. dbt resolves
+    --project-dir against the process cwd, and the runner pins that cwd to the
+    project; a relative --project-dir would resolve to project/project and fail."""
+
+    import subprocess
+
+    build_module = importlib.import_module("exmergo_dex_core.transform.build")
+    captured: dict = {}
+
+    def runner(argv: list[str]):
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0, stdout="", stderr=""
+        )
+
+    monkeypatch.chdir(tmp_path)
+    summary, _cost = build_module.build(
+        "analytics",  # relative to the pinned cwd (tmp_path)
+        target="dev",
+        confirmed=True,
+        runner=runner,
+    )
+    assert summary["success"] is True
+
+    argv = captured["argv"]
+    project_arg = Path(argv[argv.index("--project-dir") + 1])
+    profiles_arg = Path(argv[argv.index("--profiles-dir") + 1])
+    assert project_arg.is_absolute()
+    assert profiles_arg.is_absolute()
+    assert project_arg == dbt_project_dir.resolve()
+    # The doubling bug would have produced .../analytics/analytics.
+    assert project_arg.parent.name != "analytics"
+
+
+def test_shadow_parse_profiles_dir_is_absolute_from_a_relative_project(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """The define-time parse gate had the same doubling on --profiles-dir: its cwd
+    is an absolute shadow tempdir, so a relative --profiles-dir pointing at the
+    real project would resolve against the shadow and fail."""
+
+    pytest.importorskip("dbt.cli.main")
+    import subprocess
+
+    build_module = importlib.import_module("exmergo_dex_core.transform.build")
+    captured: dict = {}
+
+    def runner(argv: list[str]):
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0, stdout="", stderr=""
+        )
+
+    monkeypatch.chdir(tmp_path)
+    result = build_module.shadow_parse("analytics", [], target="dev", runner=runner)
+    assert result["available"] is True
+
+    argv = captured["argv"]
+    assert Path(argv[argv.index("--project-dir") + 1]).is_absolute()
+    assert Path(argv[argv.index("--profiles-dir") + 1]).is_absolute()
+
+
+def test_relative_project_dir_builds_without_path_doubling(
+    dbt_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """End-to-end proof of the blocking defect: a config-pinned relative
+    dbt_project_dir and a relative repo-root build green, no 'Path ... does not
+    exist' from a doubled --project-dir."""
+
+    pytest.importorskip("dbt.cli.main")
+    dex_dir = tmp_path / ".dex"
+    dex_dir.mkdir()
+    (dex_dir / "config.yml").write_text(
+        "dbt_project_dir: analytics\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+    rc, envelope = _run(
+        ["--repo-root", ".", "transform", "build", "--target", "dev", "--confirm"],
+        capsys,
+    )
+    assert rc == 0, envelope
+    assert envelope["status"] == "ok"
+    assert envelope["data"]["success"] is True
+
+
 # --- billed connectors (BigQuery): the ceiling binds, spend is ledgered --------
 
 
@@ -403,3 +491,37 @@ def test_billed_build_sums_bytes_billed_into_the_ledger(
     entry = json_mod.loads(ledger[-1])
     assert entry["command"] == "transform build"
     assert entry["billed_bytes"] == 3000
+
+
+def test_billed_build_failure_names_the_real_error_in_errors(
+    dbt_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """The failure-path envelope on the billed connector: the real dbt message
+    rides in errors, not buried in warnings (guards the sanitized-failure fix on
+    the bytes_scanned paradigm)."""
+
+    msg = "Database Error in model x: Access Denied on dataset dbt_dev"
+    _fake_runner_factory(
+        monkeypatch,
+        returncode=1,
+        stdout=json.dumps({"info": {"level": "error", "msg": msg}}),
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--connector",
+            "bigquery",
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+            "--budget",
+            "100000000",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert envelope["status"] == "error"
+    assert envelope["errors"][0] == f"dbt build failed: {msg}"

--- a/packages/dex-core/tests/transform/test_dbt_project.py
+++ b/packages/dex-core/tests/transform/test_dbt_project.py
@@ -197,6 +197,31 @@ def test_write_edits_refuses_absolute_paths(dbt_project_dir: Path, tmp_path: Pat
         write_edits([edit], dbt_project_dir)
 
 
+@pytest.mark.parametrize("manifest", ["packages.yml", "dependencies.yml"])
+def test_write_edits_allows_dbt_package_manifests_at_root(
+    dbt_project_dir: Path, manifest: str
+):
+    edit = Edit(
+        path=manifest,
+        new_content="packages:\n  - package: dbt-labs/dbt_utils\n    version: 1.1.1\n",
+        old_content_hash=None,
+    )
+    result = write_edits([edit], dbt_project_dir)
+    assert result.written == [manifest]
+    assert (dbt_project_dir / manifest).is_file()
+
+
+@pytest.mark.parametrize("root_file", ["profiles.yml", "dbt_project.yml", "random.yml"])
+def test_write_edits_still_refuses_other_root_files(
+    dbt_project_dir: Path, root_file: str
+):
+    # The carve-out is exactly the two package manifests, not project-root files
+    # in general.
+    edit = Edit(path=root_file, new_content="x: 1\n", old_content_hash=None)
+    with pytest.raises(DbtProjectError):
+        write_edits([edit], dbt_project_dir)
+
+
 def test_profiles_dir_env_override(
     dbt_project_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/packages/dex-core/tests/transform/test_plan.py
+++ b/packages/dex-core/tests/transform/test_plan.py
@@ -63,6 +63,62 @@ def test_plan_from_edits_file(dbt_project_dir: Path, tmp_path: Path, capsys):
     assert not (dbt_project_dir / "models/staging/stg_orders.yml").exists()
 
 
+def test_plan_packages_yml_at_project_root(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    payload = _write_payload(
+        tmp_path,
+        [
+            {
+                "path": "packages.yml",
+                "kind": "packages_yml",
+                "content": "packages:\n  - package: dbt-labs/dbt_utils\n"
+                "    version: 1.1.1\n",
+            }
+        ],
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "add dbt_utils",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 0 and envelope["status"] == "ok"
+    assert envelope["data"]["paths"] == ["packages.yml"]
+    assert envelope["diffs"][0]["op"] == "create"
+    # Propose-don't-impose: still nothing written until apply.
+    assert not (dbt_project_dir / "packages.yml").exists()
+
+
+def test_plan_packages_yml_requires_a_packages_key(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    payload = _write_payload(
+        tmp_path,
+        [{"path": "packages.yml", "kind": "packages_yml", "content": "nope: true\n"}],
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "bad packages",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 1 and envelope["status"] == "error"
+    assert "packages" in envelope["errors"][0]
+
+
 def test_plan_reads_stdin(dbt_project_dir: Path, tmp_path: Path, capsys, monkeypatch):
     payload = json.dumps(
         {

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -77,11 +77,16 @@ hands it over via `--edits-file <path>` (or `-` for stdin), a JSON payload:
 ```
 
 `kind` is one of `model_sql`, `schema_yml`, `semantic_yml` (optional on
-`semantic define|update`, which imply `semantic_yml`). The engine validates each
-edit (model SQL must be a single read-only SELECT once jinja is stripped; YAML
-must parse; semantic YAML must satisfy MetricFlow's schemas), pins it to the
-sha256 of the file it would change, computes the diffs, and stores the plan under
-`.dex/plans/<plan-id>.json`. Nothing touches the dbt project until an apply.
+`semantic define|update`, which imply `semantic_yml`), or `packages_yml`. The
+engine validates each edit (model SQL must be a single read-only SELECT once
+jinja is stripped; YAML must parse; semantic YAML must satisfy MetricFlow's
+schemas; a `packages_yml` edit must carry a `packages:` or `dependencies:` list
+and targets the project-root `packages.yml` or `dependencies.yml`), pins it to
+the sha256 of the file it would change, computes the diffs, and stores the plan
+under `.dex/plans/<plan-id>.json`. Nothing touches the dbt project until an
+apply. `packages_yml` is the guarded way to declare dbt package dependencies: a
+reviewable diff like any other edit, then `transform deps` (or the automatic
+deps step in `transform build`) installs them.
 
 - `transform init "<name>" --connector <duckdb|snowflake|bigquery|databricks|postgres>`
   bootstraps a dbt project when none exists: `dbt_project.yml`, `models/staging/`
@@ -159,7 +164,9 @@ re-map carry their prior profiles forward (`carried_forward_count`), each
 stamped with its own `profiled_at`.
 
 Global flags (shared resolution path): `--connector`, `--path` (DuckDB),
-`--repo-root`, `--confirm`, `--budget`.
+`--project` and `--dataset` (BigQuery convenience overrides of the config
+target, repeatable `--dataset`; never written back to config, so `connect test`
+works before a `bigquery:` block exists), `--repo-root`, `--confirm`, `--budget`.
 
 ## The query firewall
 

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -39,7 +39,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "0.1.2"
+DEX_CORE_VERSION = "0.1.3"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -39,7 +39,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "0.1.2"
+DEX_CORE_VERSION = "0.1.3"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -39,7 +39,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "0.1.2"
+DEX_CORE_VERSION = "0.1.3"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
## What this changes

Finetune (BigQuery)
- cost guard
- connect test
- same-lineage duplicate relationships

Finetune (dbt)
- path resolution bugs

Finetune (generic)
- maintain: no more approximate counts for dimensionality drift. Add small percentage error band to avoid noisy detections

## Related issues

Closes: https://github.com/exmergo/dex/issues/26
