### PR TITLE
SCRUM-790: Snowflake Connector

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-      # bigquery is included so the BigQuery unit tests and safety families run
-      # here (they are offline against a fake client, but they importorskip on
-      # the client library; without the extra they would silently skip).
-      - name: Sync (duckdb + bigquery + dev extras)
-        run: uv sync --extra duckdb --extra bigquery --extra dev --python ${{ matrix.python-version }}
+      # The cloud extras are included so their unit tests and safety families
+      # run here (they are offline against fake clients, but they importorskip
+      # on the client libraries; without the extras they would silently skip).
+      - name: Sync (duckdb + bigquery + snowflake + dev extras)
+        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra dev --python ${{ matrix.python-version }}
       - name: Tier-1 unit tests
         run: uv run pytest -q
 
@@ -48,8 +48,8 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-      - name: Sync (duckdb + bigquery + dev extras)
-        run: uv sync --extra duckdb --extra bigquery --extra dev
+      - name: Sync (duckdb + bigquery + snowflake + dev extras)
+        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra dev
       - name: Safety-critical assertions
         run: uv run pytest -q tests/test_safety_spine.py
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,17 +1,22 @@
 name: Integration
 
-# Live BigQuery, authenticated via Workload Identity Federation (OIDC, no
-# stored keys, matching the release workflow's Trusted Publishing stance).
+# Live cloud connectors, authenticated via workload identity federation (OIDC,
+# no stored keys, matching the release workflow's Trusted Publishing stance).
 # Deliberately NOT a merge or release gate: ci.yml stays deterministic and
 # fork-runnable; this workflow answers "does the connector still work against
-# the real service" on main and on a schedule. The suite reads public datasets,
-# writes only to the TTL'd scratch dataset, and caps every query at
-# DEX_TEST_BQ_MAX_BYTES, so a worst-case run costs cents.
+# the real service" on main and on a schedule. Each suite reads shared/public
+# sample data, writes only to its scratch scope, and caps every statement
+# (bytes on BigQuery, seconds on Snowflake), so a worst-case run costs cents.
 #
-# One-time GCP setup (documented in CONTRIBUTING.md): a Workload Identity Pool
-# with a GitHub OIDC provider whose attribute condition restricts it to this
-# repository, and a service account holding roles/bigquery.jobUser on the
-# project plus roles/bigquery.dataEditor on the scratch dataset only.
+# One-time setup (documented in CONTRIBUTING.md):
+#   BigQuery: scripts/setup_bigquery_ci.sh (Workload Identity Pool provider
+#   pinned to this repo + environment; service account with jobUser on the
+#   project and dataEditor on the scratch dataset only).
+#   Snowflake: scripts/setup_snowflake_ci.sh (a SERVICE user whose
+#   WORKLOAD_IDENTITY accepts only GitHub OIDC tokens minted for this repo's
+#   snowflake-integration environment; a least-privilege role on the pinned
+#   X-Small warehouse and the transient scratch database; a resource monitor
+#   as the hard monthly cost backstop).
 on:
   push:
     branches: [main]
@@ -25,10 +30,10 @@ on:
 permissions:
   contents: read
 
-# One run at a time: the scratch dataset is shared, and serializing runs caps
+# One run at a time: the scratch scopes are shared, and serializing runs caps
 # worst-case concurrent spend.
 concurrency:
-  group: bigquery-integration
+  group: cloud-integration
   cancel-in-progress: false
 
 jobs:
@@ -68,4 +73,49 @@ jobs:
       - name: Sync (bigquery + duckdb + dev extras)
         run: uv sync --extra bigquery --extra duckdb --extra dev
       - name: Live BigQuery integration suite
-        run: uv run pytest tests/integration -q
+        run: uv run pytest tests/integration -q -m bigquery
+
+  snowflake:
+    if: github.repository == 'exmergo/dex'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # The environment carries the Snowflake variables and, via its deployment
+    # branch policy (main only), refuses this job to a workflow modified on a
+    # branch before the token is minted. The Snowflake-side pin mirrors it:
+    # the DEX_CI service user accepts only tokens whose subject names this
+    # repo + environment.
+    environment: snowflake-integration
+    permissions:
+      contents: read
+      id-token: write # OIDC for Snowflake workload identity; no stored keys.
+    defaults:
+      run:
+        working-directory: packages/dex-core
+    env:
+      DEX_TEST_SNOWFLAKE_DATABASE: DEX_CI
+      DEX_TEST_SNOWFLAKE_WAREHOUSE: DEX_CI_WH
+      DEX_TEST_SNOWFLAKE_MAX_SECONDS: "60"
+      SNOWFLAKE_ACCOUNT: ${{ vars.DEX_TEST_SNOWFLAKE_ACCOUNT }}
+      SNOWFLAKE_USER: ${{ vars.DEX_TEST_SNOWFLAKE_USER }}
+      SNOWFLAKE_AUTHENTICATOR: WORKLOAD_IDENTITY
+      SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER: OIDC
+    steps:
+      - uses: actions/checkout@v4
+      # Mint the GitHub OIDC token Snowflake validates (audience pinned to
+      # what the service user's OIDC_AUDIENCE_LIST expects) and hand it to the
+      # connector through the same SNOWFLAKE_* discovery path the engine uses
+      # everywhere: no CI special-casing.
+      - name: Mint GitHub OIDC token for Snowflake
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const token = await core.getIDToken('snowflakecomputing.com')
+            core.setSecret(token)
+            core.exportVariable('SNOWFLAKE_TOKEN', token)
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync (snowflake + duckdb + dev extras)
+        run: uv sync --extra snowflake --extra duckdb --extra dev
+      - name: Live Snowflake integration suite
+        run: uv run pytest tests/integration -q -m snowflake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      # bigquery stays in the gate: the BigQuery safety families importorskip
-      # on the client library, and a release gate that silently skips
+      # The cloud extras stay in the gate: their safety families importorskip
+      # on the client libraries, and a release gate that silently skips
       # safety-critical assertions is a hole, not a speedup.
-      - name: Sync (duckdb + bigquery + dev extras)
-        run: uv sync --extra duckdb --extra bigquery --extra dev
+      - name: Sync (duckdb + bigquery + snowflake + dev extras)
+        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra dev
       - name: Tier-1 + safety-critical gate
         run: uv run pytest -q
       # A safety-assertion regression blocks the release regardless of pass-rate;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ release is connector-neutral.
 
 | Subcommand | Returns |
 |---|---|
-| `connect test` | capabilities, dialect, `read_only: true`; DuckDB takes `--path`, BigQuery takes `--project`/`--dataset` convenience overrides (never written to config) |
+| `connect test` | capabilities, dialect, `read_only: true`; DuckDB takes `--path`, BigQuery takes `--project`/`--dataset` convenience overrides (never written to config); Snowflake reports the pinned warehouse and its credit rate |
 | `explore inventory [--rank]` | ranked object summary (counts, sizes; no rows) |
 | `explore profile <objects>` | column profiles + PII flags (column, category, confidence) + candidate keys, grain, data-quality warnings |
 | `explore relationships [--verify]` | inferred + declared joins with confidences, plus notes on what inference examined; `--verify` measures each join with an aggregate overlap probe |
@@ -90,14 +90,19 @@ Every command prints exactly one JSON object and nothing else:
 
 Cost is a preflight estimate surfaced **before** any spend. Any command that
 would spend requires an explicit `--confirm` and a session budget: on a billed
-connector (BigQuery today) the first call returns `needs_confirmation` with a
-free dry-run byte estimate, and the same command is re-issued with
-`--confirm --budget <bytes>` once the user has agreed to the spend. Actual
-billed bytes come back under `data.spend` and accumulate in the
-`.dex/spend.jsonl` ledger. Credentials never appear in `data` (BigQuery
-authenticates via discovered Application Default Credentials, never a pasted
-key), and result values appear only in `explore query`'s columnar payload
-after the query firewall has cleared them.
+connector (BigQuery and Snowflake today) the first call returns
+`needs_confirmation` with a free estimate, and the same command is re-issued
+with `--confirm --budget <magnitude>` once the user has agreed to the spend.
+The magnitude is paradigm-relative: **bytes** on BigQuery (an exact free
+dry-run figure), **warehouse-seconds** on Snowflake (a heuristic labeled
+`estimate_quality: "heuristic"`, with a credit translation alongside; the
+budget still binds exactly via a server-side statement timeout). Actual spend
+comes back under `data.spend` (`bytes_billed` or `seconds_billed`) and
+accumulates in the `.dex/spend.jsonl` ledger per connector. Credentials never
+appear in `data` (BigQuery authenticates via discovered Application Default
+Credentials, Snowflake via a discovered `connections.toml` entry, environment,
+or dbt profile; never a pasted key), and result values appear only in
+`explore query`'s columnar payload after the query firewall has cleared them.
 
 ## Guardrails (non-negotiable, enforced in the engine)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-07-06
+
+### Added
+
+- **Snowflake connector**, the second billed cloud connector and the first on
+  the compute-time paradigm. Explore, transform, and maintain run against
+  Snowflake with the same guardrails as BigQuery, adapted to the cost
+  inversion (metadata is free via SHOW commands; scans bill warehouse time):
+  - Connection discovery, never prompting: a `connections.toml` entry pinned
+    by `snowflake.connection_name`, the default connection, `SNOWFLAKE_*`
+    environment variables (including workload-identity tokens, the keyless CI
+    path), or a dbt profile. Only a coarse auth method is surfaced.
+  - Warehouse-seconds budgets (`--budget`, `budget.ceiling`,
+    `budget.session_ceiling`) with the credit translation shown on every cost
+    surface, and dollars when `snowflake.credit_price_usd` is configured.
+    Estimates are an honestly labeled heuristic (`estimate_quality:
+    "heuristic"`; Snowflake has no dry-run) floored by the 60-second resume
+    minimum on a suspended warehouse; the budget is hard-enforced regardless
+    by a per-statement server-side `STATEMENT_TIMEOUT_IN_SECONDS`. Actual
+    wall-clock seconds land in the `.dex/spend.jsonl` ledger as
+    `billed_seconds`, kept separate from byte entries so paradigms never sum
+    together.
+  - Strict warehouse pinning: billed statements run only on
+    `snowflake.warehouse`; a connection-default warehouse is never spent on.
+    Every session is tagged `QUERY_TAG = 'dex'`.
+  - Free-path inventory and profiling estimation from SHOW metadata; batched
+    aggregate profiling with semi-structured degradation (VARIANT, OBJECT,
+    ARRAY, GEOGRAPHY) and opt-in `SAMPLE SYSTEM` above
+    `snowflake.max_full_profile_bytes`.
+  - `transform init --connector snowflake`: a dbt-snowflake dev profile from
+    the discovered connection (key-pair as a path, SSO as externalbrowser, a
+    password only as an `env_var` reference, never a value), writing to a
+    dedicated `dev_database.dev_schema` refused as a source, one thread, on
+    the pinned warehouse. `transform build` accounts per-node execution time
+    into the ledger.
+  - The `[snowflake]` extra now carries `dbt-snowflake` and requires
+    `snowflake-connector-python>=3.17` (workload-identity support).
+  - Testing per the established billed-connector template: a stateful fake
+    connection with simulated timing and real connector error types,
+    safety-spine extensions across all five families for the compute-time
+    paradigm, an env-gated live integration suite (`DEX_TEST_SNOWFLAKE_*`)
+    against `SNOWFLAKE_SAMPLE_DATA`, and a scheduled keyless CI job
+    (Snowflake workload identity federation, GitHub OIDC). One-time
+    provisioning automated by `scripts/setup_snowflake_ci.sh`.
+
 ## [0.1.3] - 2026-07-05
 
 Hardening pass from the first billed-connector dogfooding sessions (BigQuery):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ uv run pytest
 ```
 
 Everything is deterministic and free: no cloud account is needed. The live
-BigQuery integration tests under `tests/integration/` collect as skipped with
+cloud integration tests under `tests/integration/` collect as skipped with
 the enabling variables named in the skip reason.
 
 ## Live BigQuery integration tests
@@ -68,6 +68,43 @@ variables, not secrets, on purpose: with WIF there is no credential to hide,
 the values are identifiers, and unmasked values make auth failures debuggable.
 The workflow is deliberately not a merge or release gate; forks skip it and
 can point the suite at their own project with the same environment variables.
+
+## Live Snowflake integration tests
+
+The same `tests/integration/` directory carries the Snowflake suite:
+connection discovery, the warehouse-seconds handshake with its credit
+translation, the over-ceiling refusal, a firewalled query, and a dbt build
+into the scratch database. It reads `SNOWFLAKE_SAMPLE_DATA` (shared data,
+free storage), bills warehouse time to the pinned X-Small only, and caps
+every statement at `DEX_TEST_SNOWFLAKE_MAX_SECONDS` (default 60), so a
+worst-case run costs cents; the account's resource monitor is the hard
+monthly backstop no bug can outspend.
+
+One-time setup is automated by `scripts/setup_snowflake_ci.sh` (run by a
+maintainer with an ACCOUNTADMIN `snow` connection): the `DEX_CI_WH` X-Small
+warehouse (60s auto-suspend, statement timeout, resource monitor), the
+transient zero-retention `DEX_CI` database, the least-privilege `DEX_CI_ROLE`
+(read samples, write scratch only: the grant-level enforcement of "dex never
+writes outside the dev target"), a workload-identity CI user, a key-pair dev
+user with a local `dex-ci` connection, and the GitHub environment with its
+variables.
+
+Run the suite locally against the `dex-ci` connection:
+
+```
+DEX_TEST_SNOWFLAKE_CONNECTION=dex-ci DEX_TEST_SNOWFLAKE_DATABASE=DEX_CI \
+    uv run pytest tests/integration -q -m snowflake
+```
+
+In CI the same suite runs from `.github/workflows/integration.yml`,
+authenticated via Snowflake workload identity federation (OIDC, no stored
+keys): the `DEX_CI` service user's `WORKLOAD_IDENTITY` accepts only GitHub
+OIDC tokens whose subject names this repository's `snowflake-integration`
+environment, whose deployment branch policy restricts it to `main`. The job
+mints the token itself and hands it to the connector through the ordinary
+`SNOWFLAKE_*` discovery path; `DEX_TEST_SNOWFLAKE_ACCOUNT` and
+`DEX_TEST_SNOWFLAKE_USER` are environment variables, not secrets, for the
+same debuggability reason as the BigQuery job.
 
 ## Agent evals (`evals/`)
 

--- a/README.md
+++ b/README.md
@@ -42,29 +42,33 @@ intent.
 
 ## Connectors
 
-Cloud warehouse: **BigQuery** (live), **Snowflake**, **Databricks**. Operational
-database: **PostgreSQL**. Embedded analytical: **DuckDB** (the zero-credential
-on-ramp, and the engine behind the eval and benchmark suites). Each client library
-is behind an optional extra, so the DuckDB on-ramp installs only `duckdb` and
-`sqlglot`; BigQuery installs with `exmergo-dex-core[bigquery]`. To pull every
+Cloud warehouse: **BigQuery** (live), **Snowflake** (live), **Databricks**.
+Operational database: **PostgreSQL**. Embedded analytical: **DuckDB** (the
+zero-credential on-ramp, and the engine behind the eval and benchmark suites).
+Each client library is behind an optional extra, so the DuckDB on-ramp installs
+only `duckdb` and `sqlglot`; the cloud connectors install with
+`exmergo-dex-core[bigquery]` or `exmergo-dex-core[snowflake]`. To pull every
 connector at once, install `exmergo-dex-core[all]`.
 
-BigQuery authenticates through Application Default Credentials (run
-`gcloud auth application-default login`); dex discovers credentials, it never
-asks for keys. Every scan is estimated with a free dry-run and confirmed before
-it spends, capped server-side with `maximum_bytes_billed`, and recorded in a
-local spend ledger.
+Cloud credentials are discovered, never asked for: BigQuery through
+Application Default Credentials (`gcloud auth application-default login`),
+Snowflake through `connections.toml`, `SNOWFLAKE_*` env, or a dbt profile.
+Every scan is estimated and confirmed before it spends, capped server-side
+(`maximum_bytes_billed` on BigQuery; a per-statement statement timeout on
+Snowflake, where budgets are warehouse-seconds with credits shown alongside),
+and recorded in a local spend ledger.
 
 ## Status
 
 **v0.1 is the full ETM loop on DuckDB**, with no cloud credentials required:
 explore, transform, and now **maintain** (drift detection and reconcile across
 schema, volume, grain, and semantic axes). **Explore, transform, and maintain
-also run on BigQuery**, the first cloud connector: credential discovery via ADC,
-bytes-scanned cost guards with a confirm-before-spend handshake, and
-dev-dataset-only dbt builds via dbt-bigquery. Snowflake, Databricks, and
-PostgreSQL land next as v0.2 completes; published benchmark scores (ADE-bench
-uplift and cost/turn efficiency, Spider2.0-DBT) land with v0.3.
+also run on BigQuery and Snowflake**, the first two cloud connectors, each with
+credential discovery, cost guards with a confirm-before-spend handshake
+(bytes-scanned on BigQuery, warehouse-seconds on Snowflake), and dev-target-only
+dbt builds. Databricks and PostgreSQL land next as v0.2 completes; published
+benchmark scores (ADE-bench uplift and cost/turn efficiency, Spider2.0-DBT)
+land with v0.3.
 
 ## Beyond Claude Code
 
@@ -120,6 +124,13 @@ credentials:
   and the `gcp-integration` environment with its variables), automated by
   `scripts/setup_bigquery_ci.sh`; background in `CONTRIBUTING.md` under "Live
   BigQuery integration tests".
+- **Snowflake integration CI:** one-time Snowflake and GitHub setup (a
+  workload-identity service user pinned to this repo's
+  `snowflake-integration` environment, a least-privilege role, the pinned
+  X-Small `DEX_CI_WH` warehouse with a resource-monitor backstop, the
+  transient `DEX_CI` scratch database, and a key-pair dev user with a local
+  `dex-ci` connection for running the live suite while developing), automated
+  by `scripts/setup_snowflake_ci.sh`.
 
 ## License
 

--- a/packages/dex-core/README.md
+++ b/packages/dex-core/README.md
@@ -13,7 +13,7 @@ every change is a reviewable diff.
 ## Install
 
 ```
-pip install "exmergo-dex-core[duckdb]"
+pip install "exmergo-dex-core"
 ```
 
 Connector client libraries live behind extras, so the zero-credential DuckDB
@@ -71,6 +71,19 @@ capped server-side by `maximum_bytes_billed` and recorded in a local
 dbt-bigquery, which the `[bigquery]` extra carries. See
 [`references/bigquery.md`](../../references/bigquery.md).
 
+Snowflake: connects through discovered credentials (`connections.toml`,
+`SNOWFLAKE_*` env, or a dbt profile; dex never asks for or persists a
+password). The cost inversion from BigQuery: metadata is free (SHOW commands,
+no warehouse), while scans bill warehouse time, so budgets are
+**warehouse-seconds** with credits shown alongside. Estimates are an honestly
+labeled heuristic (Snowflake has no dry-run), floored by the 60-second resume
+minimum on a cold warehouse; the budget is hard-enforced anyway by a
+per-statement server-side `STATEMENT_TIMEOUT_IN_SECONDS`, and actual seconds
+land in the same `.dex/spend.jsonl` ledger. Billed work runs only on the
+warehouse the config pins. dbt builds go to a dedicated dev database.schema
+via dbt-snowflake, which the `[snowflake]` extra carries. See
+[`references/snowflake.md`](../../references/snowflake.md).
+
 Maintain detects drift against the `.dex/` snapshot on four axes and proposes
 the fix: schema (structure), volume (freshness), grain (uniqueness and fanout),
 and semantic (definitions, dangling references, and dimension cardinality).
@@ -81,8 +94,8 @@ connectors the metadata axes (schema, volume, references) stay free while the
 scanning axes (grain, dimension cardinality) take the `--confirm --budget`
 handshake, so `check` is two-phase.
 
-The remaining cloud connectors (Snowflake, Databricks, PostgreSQL) and the Viz
-preview report `not_implemented` until they land.
+The remaining cloud connectors (Databricks, PostgreSQL) and the Viz preview
+report `not_implemented` until they land.
 
 ## License
 

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -41,7 +41,10 @@ dex = "exmergo_dex_core.cli:main"
 # pure explore-only install would need; a separate lighter explore extra can be
 # split out later if that tradeoff matters.)
 duckdb = ["duckdb>=1", "sqlglot>=25", "dbt-duckdb>=1.9"]
-snowflake = ["snowflake-connector-python>=3", "sqlglot>=25"]
+# 3.17 is the floor for workload-identity auth (the keyless CI path). Like
+# [duckdb], the extra carries the dbt adapter so transform can build against a
+# Snowflake dev target with one install.
+snowflake = ["snowflake-connector-python>=3.17", "sqlglot>=25", "dbt-snowflake>=1.9"]
 # Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
 # transform can build against a BigQuery dev target with one install.
 bigquery = ["google-cloud-bigquery>=3", "sqlglot>=25", "dbt-bigquery>=1.9"]
@@ -84,6 +87,7 @@ addopts = "--import-mode=importlib"
 # doubles under tests/fakes/ need an explicit path entry to be importable.
 pythonpath = ["tests"]
 markers = [
-  "integration: hits a live warehouse; gated on DEX_TEST_BQ_* environment variables",
+  "integration: hits a live warehouse; gated on DEX_TEST_* environment variables",
   "bigquery: BigQuery-specific integration tests",
+  "snowflake: Snowflake-specific integration tests",
 ]

--- a/packages/dex-core/src/exmergo_dex_core/adapters/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/__init__.py
@@ -1,4 +1,5 @@
-"""Connector adapters. DuckDB and BigQuery are real; the rest are stubs.
+"""Connector adapters. DuckDB, BigQuery, and Snowflake are real; the rest are
+stubs.
 
 ``get_adapter`` is the single entry point so callers never import a connector
 client directly; the client libraries stay behind their extras and are imported
@@ -33,7 +34,11 @@ def get_adapter(connector: str, **kwargs: Any):
         from .bigquery import BigQueryAdapter
 
         return BigQueryAdapter(**kwargs)
-    if connector in {"snowflake", "databricks", "postgres"}:
+    if connector == "snowflake":
+        from .snowflake import SnowflakeAdapter
+
+        return SnowflakeAdapter(**kwargs)
+    if connector in {"databricks", "postgres"}:
         raise NotImplementedError(f"the '{connector}' adapter is not yet implemented")
     raise ValueError(f"unknown connector '{connector}'")
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -534,7 +534,7 @@ class BigQueryAdapter:
         cap, wait for completion (bounded when a timeout is given), account the
         actual billed bytes, and return (job, row iterator)."""
 
-        cap = self.cost_gate.max_bytes_for_statement()
+        cap = self.cost_gate.remaining_for_statement()
         if cap is not None and cap < _MIN_BILLED_BYTES:
             raise OverCeilingError(
                 f"the remaining budget ({cap} bytes) is below BigQuery's "

--- a/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
@@ -1,10 +1,846 @@
-"""The snowflake adapter (stub). Not yet implemented: metadata model, SQLGlot
-dialect, cheap-metadata path, and the connector-specific cost strategy
-(credits, warehouse size by time).
+"""The Snowflake adapter: the first compute-time billed connector.
+
+The cost inversion from BigQuery: metadata is cheap (SHOW commands run on the
+cloud-services layer with no warehouse), while any data scan costs warehouse
+runtime. So inventory, ``connect test``, and all schema facts stay free, and
+the guarded quantity is warehouse-seconds, not bytes.
+
+Snowflake has no dry-run, so estimates are a documented heuristic (table bytes
+over a conservative per-size scan rate, floored at the 60-second resume
+minimum when the warehouse is suspended) and every envelope that carries one
+says so. The server-side backstop is a per-statement
+``STATEMENT_TIMEOUT_IN_SECONDS`` set to the remaining budget before each billed
+statement, so a wrong estimate cannot overrun the ceiling: Snowflake kills the
+statement. Actual spend is wall-clock seconds per statement (which includes
+any resume time this statement caused, the honest attribution), recorded to
+the ledger as ``billed_seconds``.
+
+Read-only is enforced in depth: the SELECT-only guard in the snowflake dialect
+on every data statement through one execution door, an adapter that issues no
+mutating statements (SHOW / SELECT / session parameters only), and the
+documented read-only role grants. Billed statements run only on the warehouse
+``.dex/config.yml`` pins; a connection-level default warehouse is never
+spent on.
 """
 
 from __future__ import annotations
 
-# Cost paradigm for this connector: credits, warehouse size by time.
+import json
+import time
+from collections.abc import Callable
+from typing import Any
+
+from ..config import SnowflakeTarget
+from ..envelope import Paradigm
+from ..guards.cost_guard import CostGate, OverCeilingError
+from ..guards.sql_guard import assert_select_only
+from .base import ColumnAggregate, ColumnMeta, ObjectMeta, QueryResult, json_safe
+
 PARADIGM = "compute_time"
 DIALECT = "snowflake"
+
+# Columns are profiled in batches so one statement against a very wide table
+# does not balloon (up to 4 expressions per column).
+_COLUMN_BATCH = 50
+
+# Snowflake bills at least 60 seconds each time a suspended warehouse resumes,
+# regardless of query duration. Estimates against a suspended warehouse carry
+# this floor once so the quoted number is what the account will actually see.
+_RESUME_MINIMUM_SECONDS = 60.0
+
+# The estimate heuristic: a deliberately conservative X-Small scan rate.
+# Larger sizes scale it by their credit multiple (they bill proportionally
+# more per second but scan proportionally faster, so estimated *seconds*
+# shrink while estimated *credits* stay comparable).
+_XSMALL_SCAN_BYTES_PER_SECOND = 50 * 1024 * 1024
+
+# Every billed statement estimates at least this much: even a metadata-served
+# result costs a moment of a running warehouse.
+_MIN_STATEMENT_SECONDS = 1.0
+
+# Credits per hour by warehouse size (Gen1 standard). Keyed by the normalized
+# size token from SHOW WAREHOUSES. Gen2 warehouses bill a multiplier on top
+# (1.35 on AWS/GCP, 1.25 on Azure); the cloud is not cheaply knowable, so the
+# conservative 1.35 is applied and the translation is labeled approximate.
+_CREDITS_PER_HOUR = {
+    "XSMALL": 1.0,
+    "SMALL": 2.0,
+    "MEDIUM": 4.0,
+    "LARGE": 8.0,
+    "XLARGE": 16.0,
+    "2XLARGE": 32.0,
+    "3XLARGE": 64.0,
+    "4XLARGE": 128.0,
+    "5XLARGE": 256.0,
+    "6XLARGE": 512.0,
+}
+_GEN2_MULTIPLIER = 1.35
+
+# Semi-structured and spatial types: no distinct estimate, no min/max, only a
+# non-null count (COUNT works on all of them; the others do not).
+_NESTED_TYPE_PREFIXES = (
+    "VARIANT",
+    "OBJECT",
+    "ARRAY",
+    "GEOGRAPHY",
+    "GEOMETRY",
+    "VECTOR",
+)
+
+_ESTIMATE_QUALITY_NOTE = (
+    "Snowflake has no dry-run: the estimate is a heuristic (table bytes over a "
+    "conservative scan rate); the confirmed budget is still hard-enforced by a "
+    "per-statement server-side timeout"
+)
+
+
+class SnowflakeConnectionError(Exception):
+    """Raised when the pinned warehouse (or a queried object) cannot be
+    resolved. The message always names the fix, never a credential."""
+
+
+class SnowflakeAdapter:
+    """Holds one Snowflake connection plus the cost gate for one command.
+
+    ``connection`` is injectable (class DI) so unit tests drive a fake; the
+    real connection is built by ``connect.py`` from discovered parameters.
+    Credentials live only inside this process and are never surfaced.
+    ``clock`` is injectable so the fake can simulate statement duration; it is
+    what actual billed seconds are measured with.
+    """
+
+    name = "snowflake"
+    dialect = DIALECT
+    paradigm = Paradigm.COMPUTE_TIME
+
+    def __init__(
+        self,
+        *,
+        connection: Any,
+        cost_gate: CostGate,
+        target: SnowflakeTarget | None = None,
+        account: str | None = None,
+        auth_method: str = "unknown",
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self._conn = connection
+        self.cost_gate = cost_gate
+        self.target = target or SnowflakeTarget()
+        self.account = account
+        self.auth_method = auth_method
+        self._clock = clock
+        # Imported lazily (the caller constructed the connection, so the
+        # library is present); the error types drive refusal translation.
+        from snowflake.connector import errors as sf_errors
+
+        self._sf_errors = sf_errors
+        # SHOW results are cached per command: the estimate pass and the
+        # confirmed run share table facts, and each SHOW is free but a
+        # round-trip.
+        self._objects: dict[str, dict] = {}
+        self._columns: dict[str, list[ColumnMeta]] = {}
+        self._inventory_loaded = False
+        self._warehouse_info: dict | None = None
+        self._notes: dict[str, list[str]] = {}
+        # The 60s resume minimum is charged once per command, by whichever
+        # billed statement runs first.
+        self._resume_floor_pending: bool | None = None
+        self._session_prepared = False
+
+    # --- capabilities (free) ---------------------------------------------------
+
+    def capabilities(self) -> dict[str, object]:
+        # SHOW DATABASES is the live probe: cloud-services layer, no warehouse,
+        # and it fails on a stale or underprivileged credential.
+        databases = self._database_scope()
+        caps: dict[str, object] = {
+            "connector": self.name,
+            "dialect": self.dialect,
+            "read_only": True,
+            "paradigm": self.paradigm.value,
+            "account": self.account,
+            "auth_method": self.auth_method,
+            "database_count": len(databases),
+            "required_grants": [
+                "USAGE on the pinned warehouse",
+                "USAGE + SELECT (or IMPORTED PRIVILEGES) on source databases",
+            ],
+        }
+        cost = self.cost_gate.cost()
+        budget: dict[str, object] = {
+            "ceiling_seconds": cost.ceiling,
+            "session_spent_today_seconds": self.cost_gate.session_spent,
+        }
+        if self.target.warehouse:
+            info = self._warehouse()
+            budget["warehouse"] = {
+                "name": info["name"],
+                "size": info["size"],
+                "credits_per_hour": info["credits_per_hour"],
+                "state": info["state"],
+            }
+            if cost.ceiling is not None:
+                budget["ceiling_credits"] = self._to_credits(cost.ceiling)
+        else:
+            caps["warnings"] = [
+                "no snowflake.warehouse pinned in .dex/config.yml; metadata "
+                "commands work, but nothing that scans will run until one is set"
+            ]
+        caps["budget"] = budget
+        return caps
+
+    # --- introspection (free SHOW metadata; no warehouse, no billing) ----------
+
+    def list_objects(self, *, include_views: bool = True) -> list[ObjectMeta]:
+        self._load_inventory()
+        objects = [
+            self._object_meta(entry)
+            for entry in self._objects.values()
+            if include_views or entry["object_type"] != "view"
+        ]
+        objects.sort(key=lambda o: o.identifier)
+        return objects
+
+    def table_metadata(self, identifier: str) -> tuple[ObjectMeta, list[ColumnMeta]]:
+        self._load_inventory()
+        entry = self._objects.get(identifier) or self._objects.get(identifier.upper())
+        if entry is None:
+            raise SnowflakeConnectionError(
+                f"object '{identifier}' not found in the configured scope; "
+                "check snowflake.databases in .dex/config.yml"
+            )
+        return self._object_meta(entry), self._column_metas(entry["identifier"])
+
+    def table_notes(self, identifier: str) -> list[str]:
+        """Data-quality notes the profiling run accumulated for one object
+        (sampling degradation, skipped escalations). Merged into the dataset's
+        ``data_quality`` by the profile engine."""
+
+        return list(self._notes.get(identifier, []))
+
+    def _load_inventory(self) -> None:
+        if self._inventory_loaded:
+            return
+        for scope in self._scopes():
+            in_clause = self._scope_clause(scope)
+            for row in self._show(f"SHOW TABLES {in_clause}"):
+                self._register(row, "table")
+            for row in self._show(f"SHOW VIEWS {in_clause}"):
+                self._register(row, "view")
+            # One SHOW COLUMNS per scope (not per table) keeps inventory a
+            # handful of round-trips. SHOW output is capped at 10K rows, which
+            # a db.schema allowlist keeps comfortably distant.
+            by_table: dict[str, list[ColumnMeta]] = {}
+            for row in self._show(f"SHOW COLUMNS {in_clause}"):
+                identifier = self._identifier_of(row)
+                columns = by_table.setdefault(identifier, [])
+                columns.append(
+                    ColumnMeta(
+                        name=str(row["column_name"]),
+                        data_type=self._render_type(str(row["data_type"])),
+                        nullable=self._column_nullable(str(row["data_type"])),
+                        ordinal=len(columns),
+                    )
+                )
+            self._columns.update(by_table)
+        for identifier, columns in self._columns.items():
+            if identifier in self._objects:
+                self._objects[identifier]["column_count"] = len(columns)
+        self._inventory_loaded = True
+
+    def _register(self, row: dict, object_type: str) -> None:
+        identifier = self._identifier_of(row)
+        # SHOW TABLES row/byte counts are metadata-maintained and free; views
+        # have no stored rows (their count arrives via profiling).
+        rows = row.get("rows") if object_type == "table" else None
+        size = row.get("bytes") if object_type == "table" else None
+        self._objects[identifier] = {
+            "identifier": identifier,
+            "object_type": object_type,
+            "schema": str(row["schema_name"]),
+            "name": str(row["name"]),
+            "row_count": int(rows) if rows is not None else None,
+            "byte_size": int(size) if size is not None else None,
+            "column_count": 0,
+        }
+
+    @staticmethod
+    def _identifier_of(row: dict) -> str:
+        name = row.get("table_name") or row.get("name")
+        return f"{row['database_name']}.{row['schema_name']}.{name}"
+
+    @staticmethod
+    def _object_meta(entry: dict) -> ObjectMeta:
+        return ObjectMeta(
+            identifier=entry["identifier"],
+            object_type=entry["object_type"],
+            schema=entry["schema"],
+            name=entry["name"],
+            row_count=entry["row_count"],
+            byte_size=entry["byte_size"],
+            column_count=entry["column_count"],
+        )
+
+    def _column_metas(self, identifier: str) -> list[ColumnMeta]:
+        columns = self._columns.get(identifier)
+        if columns is None:
+            columns = []
+            rows = self._show(f"SHOW COLUMNS IN TABLE {self._quote(identifier)}")
+            for ordinal, row in enumerate(rows):
+                columns.append(
+                    ColumnMeta(
+                        name=str(row["column_name"]),
+                        data_type=self._render_type(str(row["data_type"])),
+                        nullable=self._column_nullable(str(row["data_type"])),
+                        ordinal=ordinal,
+                    )
+                )
+            self._columns[identifier] = columns
+        return columns
+
+    @staticmethod
+    def _render_type(data_type_json: str) -> str:
+        """SHOW COLUMNS carries the type as a JSON document; surface its type
+        token (TEXT, FIXED, VARIANT, ...) rather than the raw JSON."""
+
+        try:
+            parsed = json.loads(data_type_json)
+            return str(parsed.get("type", data_type_json))
+        except (json.JSONDecodeError, AttributeError):
+            return data_type_json
+
+    @staticmethod
+    def _column_nullable(data_type_json: str) -> bool:
+        try:
+            return bool(json.loads(data_type_json).get("nullable", True))
+        except (json.JSONDecodeError, AttributeError):
+            return True
+
+    def _scopes(self) -> list[str]:
+        """The allowlist entries in scope (``db`` or ``db.schema``), or every
+        database the role can see when no allowlist is configured. The
+        account-internal SNOWFLAKE database is never a source."""
+
+        if self.target.databases:
+            return sorted({entry.upper() for entry in self.target.databases})
+        return sorted(
+            str(row["name"]).upper()
+            for row in self._show("SHOW DATABASES")
+            if str(row["name"]).upper() != "SNOWFLAKE"
+        )
+
+    def _database_scope(self) -> list[str]:
+        """Distinct databases in scope; also the live credential probe (SHOW
+        DATABASES round-trips even when an allowlist is configured)."""
+
+        visible = {str(row["name"]).upper() for row in self._show("SHOW DATABASES")}
+        if not self.target.databases:
+            return sorted(visible - {"SNOWFLAKE"})
+        return sorted({entry.split(".")[0].upper() for entry in self.target.databases})
+
+    def _scope_clause(self, scope: str) -> str:
+        if "." in scope:
+            db, schema = scope.split(".", 1)
+            return f"IN SCHEMA {_quote_ident(db)}.{_quote_ident(schema)}"
+        return f"IN DATABASE {_quote_ident(scope)}"
+
+    # --- the warehouse and the credit translation -------------------------------
+
+    def _warehouse(self) -> dict:
+        """The pinned warehouse's facts (size, state, credit rate), fetched
+        free via SHOW WAREHOUSES and cached per command. Refuses when the
+        config pins nothing or the pin does not resolve: dex never spends on a
+        warehouse the config does not name."""
+
+        if self._warehouse_info is not None:
+            return self._warehouse_info
+        pinned = self.target.warehouse
+        if not pinned:
+            raise SnowflakeConnectionError(
+                "no warehouse pinned: set snowflake.warehouse in "
+                ".dex/config.yml (dex never spends on a connection-default "
+                "warehouse)"
+            )
+        rows = self._show(f"SHOW WAREHOUSES LIKE '{_escape_literal(pinned)}'")
+        if not rows:
+            raise SnowflakeConnectionError(
+                f"warehouse '{pinned}' not found or not granted; create it or "
+                "grant USAGE to this role, or pin a different "
+                "snowflake.warehouse in .dex/config.yml"
+            )
+        row = rows[0]
+        size_token = str(row.get("size", "")).upper().replace("-", "").replace(" ", "")
+        credits = _CREDITS_PER_HOUR.get(size_token)
+        generation = str(row.get("resource_constraint") or "")
+        gen2 = "GEN_2" in generation.upper()
+        if credits is not None and gen2:
+            credits *= _GEN2_MULTIPLIER
+        self._warehouse_info = {
+            "name": str(row.get("name", pinned)),
+            "size": str(row.get("size", "unknown")),
+            "state": str(row.get("state", "unknown")).upper(),
+            "credits_per_hour": credits,
+            "gen2": gen2,
+        }
+        return self._warehouse_info
+
+    def _to_credits(self, seconds: float) -> float | None:
+        info = self._warehouse_info or (
+            self._warehouse() if self.target.warehouse else None
+        )
+        if not info or info.get("credits_per_hour") is None:
+            return None
+        return round(seconds * info["credits_per_hour"] / 3600.0, 6)
+
+    def describe_estimate(
+        self, estimate: float, per_table: dict[str, float] | None = None
+    ) -> dict:
+        """The compute-time handshake payload: seconds are the binding number,
+        credits (and dollars when the price is configured) ride alongside as
+        the familiar translation."""
+
+        data: dict[str, object] = {
+            "estimated_seconds": estimate,
+            "estimate_quality": "heuristic",
+            "hint": (
+                "review the estimate, then re-run with --confirm --budget "
+                "<seconds> (the ceiling in warehouse-seconds; the same number "
+                "becomes the server-side statement timeout)"
+            ),
+            "notes": [_ESTIMATE_QUALITY_NOTE],
+        }
+        if per_table:
+            data["per_table_seconds"] = per_table
+        credits = self._to_credits(estimate)
+        if credits is not None:
+            info = self._warehouse_info or {}
+            data["estimated_credits"] = credits
+            data["credit_rate"] = {
+                "warehouse": info.get("name"),
+                "size": info.get("size"),
+                "credits_per_hour": info.get("credits_per_hour"),
+                "approximate": bool(info.get("gen2")),
+            }
+            if self.target.credit_price_usd is not None:
+                data["estimated_usd"] = round(credits * self.target.credit_price_usd, 4)
+        return data
+
+    def spend_display(self) -> dict:
+        """Credit translation of actual seconds, merged into ``data.spend``."""
+
+        summary: dict[str, object] = {}
+        credits = self._to_credits(self.cost_gate.spend_summary()["seconds_billed"])
+        if credits is not None:
+            summary["credits_billed"] = credits
+            if self.target.credit_price_usd is not None:
+                summary["usd_billed"] = round(credits * self.target.credit_price_usd, 4)
+        return summary
+
+    # --- estimation (free; feeds the confirm handshake) -------------------------
+
+    def profile_estimate(
+        self, identifiers: list[str]
+    ) -> tuple[float, dict[str, float]]:
+        """The heuristic warehouse-seconds estimate for profiling: per table,
+        its bytes over the size-scaled scan rate times the number of aggregate
+        batches; plus the 60-second resume minimum once when the warehouse is
+        currently suspended. Free: everything comes from SHOW metadata."""
+
+        per_table: dict[str, float] = {}
+        for identifier in identifiers:
+            meta, columns = self.table_metadata(identifier)
+            batches = max((len(columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
+            per_table[identifier] = batches * self._scan_seconds(meta.byte_size)
+        total = sum(per_table.values()) + self._resume_floor()
+        return total, per_table
+
+    def query_estimate(self, sql: str) -> float:
+        """The heuristic estimate for one firewall-approved query: the summed
+        bytes of every referenced table over the scan rate, plus the resume
+        minimum when the warehouse is suspended."""
+
+        checked = assert_select_only(sql, dialect=self.dialect)
+        return self._statement_estimate(checked) + self._resume_floor()
+
+    def _statement_estimate(self, sql: str) -> float:
+        total_bytes = 0
+        known = 0
+        self._load_inventory()
+        for identifier in self._referenced_tables(sql):
+            entry = self._objects.get(identifier.upper())
+            if entry and entry["byte_size"] is not None:
+                total_bytes += entry["byte_size"]
+                known += 1
+        if known == 0:
+            return _MIN_STATEMENT_SECONDS
+        return self._scan_seconds(total_bytes)
+
+    def _scan_seconds(self, byte_size: int | None) -> float:
+        if not byte_size:
+            return _MIN_STATEMENT_SECONDS
+        # Bigger warehouses scan proportionally faster; the size multiple is
+        # the credit rate stripped of any Gen2 billing markup (Gen2 bills more
+        # per second without scanning proportionally more).
+        size_factor = 1.0
+        info = self._warehouse_info
+        if info and info.get("credits_per_hour"):
+            size_factor = info["credits_per_hour"]
+            if info.get("gen2"):
+                size_factor /= _GEN2_MULTIPLIER
+        rate = _XSMALL_SCAN_BYTES_PER_SECOND * max(size_factor, 1.0)
+        return max(byte_size / rate, _MIN_STATEMENT_SECONDS)
+
+    def _resume_floor(self) -> float:
+        """60 once when the pinned warehouse is suspended (each resume bills a
+        60-second minimum), else 0. Cached: one command resumes at most once."""
+
+        if self._resume_floor_pending is None:
+            if not self.target.warehouse:
+                self._resume_floor_pending = False
+            else:
+                self._resume_floor_pending = self._warehouse()["state"] != "STARTED"
+        return _RESUME_MINIMUM_SECONDS if self._resume_floor_pending else 0.0
+
+    def _referenced_tables(self, sql: str) -> set[str]:
+        try:
+            import sqlglot
+            from sqlglot import expressions as sqlglot_exp
+
+            parsed = sqlglot.parse_one(sql, read=self.dialect)
+        except Exception:
+            return set()
+        return {
+            ".".join(part for part in (t.catalog, t.db, t.name) if part)
+            for t in parsed.find_all(sqlglot_exp.Table)
+        }
+
+    # --- profiling (billed; every statement estimated and gated) ----------------
+
+    def column_aggregates(
+        self,
+        identifier: str,
+        columns: list[ColumnMeta],
+        *,
+        safe_min_max: set[str] | None = None,
+    ) -> list[ColumnAggregate]:
+        safe = safe_min_max or set()
+        meta, _ = self.table_metadata(identifier)
+        sample_percent = self._sample_percent(identifier, meta.byte_size)
+        results: list[ColumnAggregate] = []
+        for start in range(0, len(columns), _COLUMN_BATCH):
+            batch = columns[start : start + _COLUMN_BATCH]
+            sql, plan = self._build_aggregate_sql(
+                identifier, batch, safe, sample_percent=sample_percent
+            )
+            rows, labels = self._execute(
+                sql, estimate=self._scan_seconds(meta.byte_size)
+            )
+            values = dict(zip(labels, rows[0], strict=True))
+            results.extend(
+                self._read_aggregates(values, plan, sampled=sample_percent is not None)
+            )
+        return results
+
+    def _sample_percent(self, identifier: str, byte_size: int | None) -> float | None:
+        threshold = self.target.max_full_profile_bytes
+        if threshold is None or not byte_size or byte_size <= threshold:
+            return None
+        percent = max(round(100.0 * threshold / byte_size, 2), 0.01)
+        self._note(
+            identifier,
+            f"profiled from a ~{percent}% block sample (table exceeds "
+            "snowflake.max_full_profile_bytes); counts and extremes are "
+            "approximate and uniqueness is not judged",
+        )
+        return percent
+
+    def _build_aggregate_sql(
+        self,
+        identifier: str,
+        columns: list[ColumnMeta],
+        safe: set[str],
+        *,
+        sample_percent: float | None = None,
+    ) -> tuple[str, list[tuple[int, ColumnMeta, bool, bool]]]:
+        # One aggregate statement per batch: COUNT(*) once, then per column a
+        # non-null count, an approximate distinct, and min/max only where
+        # allowed. Pure (no connection), so the SELECT-only property is
+        # testable offline. Semi-structured columns get the non-null count
+        # only (APPROX_COUNT_DISTINCT and MIN/MAX are invalid or meaningless
+        # on them).
+        select_parts = ["COUNT(*) AS n_total"]
+        plan: list[tuple[int, ColumnMeta, bool, bool]] = []
+        for i, col in enumerate(columns):
+            qcol = _quote_ident(col.name)
+            nested = self._is_nested(col.data_type)
+            select_parts.append(f"COUNT({qcol}) AS nn_{i}")
+            wants_distinct = not nested
+            if wants_distinct:
+                select_parts.append(f"APPROX_COUNT_DISTINCT({qcol}) AS nd_{i}")
+            wants_min_max = (col.name in safe) and not nested
+            if wants_min_max:
+                select_parts.append(f"MIN({qcol}) AS mn_{i}")
+                select_parts.append(f"MAX({qcol}) AS mx_{i}")
+            plan.append((i, col, wants_distinct, wants_min_max))
+        source = self._quote(identifier)
+        if sample_percent is not None:
+            source += f" SAMPLE SYSTEM ({sample_percent})"
+        # Interpolated parts are quoted identifiers and fixed aggregate
+        # keywords, never values; the result is guarded as a read-only SELECT.
+        sql = f"SELECT {', '.join(select_parts)} FROM {source}"  # noqa: S608
+        return assert_select_only(sql, dialect=self.dialect), plan
+
+    @staticmethod
+    def _is_nested(data_type: str) -> bool:
+        return data_type.upper().startswith(_NESTED_TYPE_PREFIXES)
+
+    @staticmethod
+    def _read_aggregates(
+        values: dict,
+        plan: list[tuple[int, ColumnMeta, bool, bool]],
+        *,
+        sampled: bool,
+    ) -> list[ColumnAggregate]:
+        n_total = int(values["n_total"])
+        aggregates: list[ColumnAggregate] = []
+        for i, col, wants_distinct, wants_min_max in plan:
+            nn = values.get(f"nn_{i}")
+            null_fraction = (
+                (1 - int(nn) / n_total) if nn is not None and n_total > 0 else None
+            )
+            distinct = (
+                int(values[f"nd_{i}"]) if wants_distinct and n_total > 0 else None
+            )
+            # Under sampling, counts describe the sample, so a uniqueness
+            # verdict would be unfounded either way.
+            is_unique = (
+                (distinct == int(nn) == n_total and n_total > 0)
+                if distinct is not None and nn is not None and not sampled
+                else None
+            )
+            aggregates.append(
+                ColumnAggregate(
+                    name=col.name,
+                    null_fraction=null_fraction,
+                    distinct_count=distinct,
+                    is_unique=is_unique,
+                    min_value=(
+                        json_safe(values.get(f"mn_{i}")) if wants_min_max else None
+                    ),
+                    max_value=(
+                        json_safe(values.get(f"mx_{i}")) if wants_min_max else None
+                    ),
+                )
+            )
+        return aggregates
+
+    def exact_distinct_counts(
+        self, identifier: str, columns: list[str]
+    ) -> dict[str, int]:
+        """Exact COUNT(DISTINCT) for near-unique columns, spent only within the
+        already-confirmed budget: when the remaining budget cannot cover the
+        extra scan, return nothing and let uniqueness verdicts stay
+        approximate. A metered adapter never self-escalates past its ceiling.
+        """
+
+        if not columns:
+            return {}
+        meta, _ = self.table_metadata(identifier)
+        estimate = self._scan_seconds(meta.byte_size)
+        if not self.cost_gate.try_charge(estimate):
+            self._note(
+                identifier,
+                "distinct-count escalation skipped: the remaining budget could "
+                "not cover the extra scan; uniqueness verdicts stay approximate",
+            )
+            return {}
+        select_parts = [
+            f"COUNT(DISTINCT {_quote_ident(name)}) AS d_{i}"
+            for i, name in enumerate(columns)
+        ]
+        sql = assert_select_only(
+            f"SELECT {', '.join(select_parts)} FROM {self._quote(identifier)}",  # noqa: S608
+            dialect=self.dialect,
+        )
+        rows, labels = self._run(sql)
+        values = dict(zip(labels, rows[0], strict=True))
+        return {name: int(values[f"d_{i}"]) for i, name in enumerate(columns)}
+
+    # --- execution (the single billed door) --------------------------------------
+
+    def run_query(
+        self,
+        sql: str,
+        *,
+        max_rows: int,
+        timeout_seconds: float,
+    ) -> QueryResult:
+        """Execute one firewall-approved SELECT, bounded in rows, wall time,
+        and warehouse-seconds (client preflight plus the server-side statement
+        timeout)."""
+
+        rows, labels, types = self._execute_query(
+            sql,
+            estimate=self._statement_estimate(sql) + self._resume_floor(),
+            timeout_seconds=timeout_seconds,
+            max_rows=max_rows,
+        )
+        return QueryResult(
+            columns=labels,
+            types=types,
+            cells=[[json_safe(v) for v in row] for row in rows[:max_rows]],
+            truncated=len(rows) > max_rows,
+        )
+
+    def _execute(self, sql: str, *, estimate: float) -> tuple[list, list[str]]:
+        """SELECT-only guard, heuristic charge, then the timeout-capped run."""
+
+        assert_select_only(sql, dialect=self.dialect)
+        self.cost_gate.charge(estimate + self._consume_resume_floor())
+        return self._run(sql)
+
+    def _execute_query(
+        self, sql: str, *, estimate: float, timeout_seconds: float, max_rows: int
+    ) -> tuple[list, list[str], list[str]]:
+        assert_select_only(sql, dialect=self.dialect)
+        self.cost_gate.charge(estimate)
+        self._consume_resume_floor()
+        cursor = self._billed_cursor()
+        started = self._clock()
+        try:
+            cursor.execute(sql, timeout=int(max(timeout_seconds, 1)))
+            rows = cursor.fetchmany(max_rows + 1)
+        except self._sf_errors.ProgrammingError as exc:
+            self._record_elapsed(started, cursor, sql)
+            raise self._translate(exc, timeout_seconds) from exc
+        self._record_elapsed(started, cursor, sql)
+        labels = [d[0].lower() for d in cursor.description]
+        types = [self._description_type(d) for d in cursor.description]
+        return rows, labels, types
+
+    def _run(self, sql: str) -> tuple[list, list[str]]:
+        """The single billed door past the gate: statement timeout set to the
+        remaining budget, wall-clock elapsed recorded to the ledger."""
+
+        cursor = self._billed_cursor()
+        started = self._clock()
+        try:
+            cursor.execute(sql)
+            rows = cursor.fetchall()
+        except self._sf_errors.ProgrammingError as exc:
+            self._record_elapsed(started, cursor, sql)
+            raise self._translate(exc, None) from exc
+        self._record_elapsed(started, cursor, sql)
+        labels = [d[0].lower() for d in cursor.description]
+        return rows, labels
+
+    def _billed_cursor(self):
+        """A cursor prepared for spend: warehouse pinned (strict), query tag
+        set, and the server-side statement timeout wound down to what remains
+        of the budget, so even a wrong heuristic cannot overrun the ceiling."""
+
+        info = self._warehouse()  # refuses when config pins no warehouse
+        remaining = self.cost_gate.remaining_for_statement()
+        if remaining is not None and remaining < 1:
+            raise OverCeilingError(
+                "the remaining budget is under one warehouse-second; raise "
+                "--budget or narrow the work"
+            )
+        cursor = self._conn.cursor()
+        if not self._session_prepared:
+            # Engine-built session statements, not agent SQL: the warehouse
+            # name comes from validated SHOW output and the tag is a constant.
+            cursor.execute(f"USE WAREHOUSE {_quote_ident(info['name'])}")
+            cursor.execute("ALTER SESSION SET QUERY_TAG = 'dex'")
+            self._session_prepared = True
+        if remaining is not None:
+            cursor.execute(
+                "ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = "
+                f"{max(int(remaining), 1)}"
+            )
+        return cursor
+
+    def _record_elapsed(self, started: float, cursor: Any, sql: str) -> None:
+        elapsed = max(self._clock() - started, 0.0)
+        self.cost_gate.record_billed(
+            elapsed,
+            job_id=getattr(cursor, "sfqid", None),
+            statement=sql,
+        )
+
+    def _consume_resume_floor(self) -> float:
+        """The first billed statement of a command carries the 60-second
+        resume charge when the warehouse was suspended; later ones do not."""
+
+        floor = self._resume_floor()
+        self._resume_floor_pending = False
+        return floor
+
+    def _translate(self, exc: Exception, timeout_seconds: float | None) -> Exception:
+        message = str(exc)
+        if "statement or warehouse timeout" in message.lower():
+            return OverCeilingError(
+                "the statement hit the server-side timeout derived from the "
+                "remaining budget (STATEMENT_TIMEOUT_IN_SECONDS); raise "
+                "--budget or narrow the work"
+            )
+        if timeout_seconds is not None and (
+            "canceled" in message.lower() or "cancelled" in message.lower()
+        ):
+            return TimeoutError(
+                f"query exceeded {timeout_seconds:g}s and was cancelled; "
+                "narrow it (tighter filter, fewer columns) and retry"
+            )
+        return exc
+
+    @staticmethod
+    def _description_type(description: Any) -> str:
+        type_code = description[1]
+        return str(getattr(type_code, "name", type_code))
+
+    # --- helpers ------------------------------------------------------------------
+
+    def _show(self, sql: str) -> list[dict]:
+        """Free metadata door: SHOW commands only, engine-built, served by the
+        cloud-services layer with no warehouse. Results come back as dicts
+        keyed by the (lowercase) SHOW column names."""
+
+        if not sql.upper().startswith("SHOW "):
+            raise ValueError("only SHOW statements pass through the metadata door")
+        cursor = self._conn.cursor()
+        cursor.execute(sql)
+        labels = [d[0].lower() for d in cursor.description]
+        return [dict(zip(labels, row, strict=True)) for row in cursor.fetchall()]
+
+    def _note(self, identifier: str, note: str) -> None:
+        notes = self._notes.setdefault(identifier, [])
+        if note not in notes:
+            notes.append(note)
+
+    @staticmethod
+    def _split(identifier: str) -> tuple[str, str, str]:
+        parts = identifier.rsplit(".", 2)
+        if len(parts) != 3:
+            raise ValueError(f"expected database.schema.table, got '{identifier}'")
+        return parts[0], parts[1], parts[2]
+
+    def _quote(self, identifier: str) -> str:
+        return ".".join(_quote_ident(p) for p in self._split(identifier))
+
+    def close(self) -> None:
+        close = getattr(self._conn, "close", None)
+        if close is not None:
+            close()
+
+
+def _quote_ident(name: str) -> str:
+    """Quote one identifier component with double quotes (preserving case,
+    which unquoted Snowflake identifiers would fold to upper), doubling
+    embedded quotes."""
+
+    escaped = name.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _escape_literal(value: str) -> str:
+    return value.replace("'", "''")

--- a/packages/dex-core/src/exmergo_dex_core/cache.py
+++ b/packages/dex-core/src/exmergo_dex_core/cache.py
@@ -272,8 +272,18 @@ class DexStore:
             handle.write(json.dumps(entry) + "\n")
         return path
 
-    def spend_since(self, cutoff_iso: str) -> float:
-        """Total `billed_bytes` recorded at or after ``cutoff_iso`` (ISO-8601).
+    def spend_since(
+        self,
+        cutoff_iso: str,
+        *,
+        field: str = "billed_bytes",
+        connector: str | None = None,
+    ) -> float:
+        """Total ``field`` recorded at or after ``cutoff_iso`` (ISO-8601).
+
+        ``field`` and ``connector`` keep paradigms separate: a session budget in
+        bytes must never absorb a seconds entry from another connector sharing
+        the ledger, so callers sum their own connector's own unit.
 
         String comparison is correct here because every `at` stamp is written
         by dex in the same UTC ISO format. Malformed lines are skipped rather
@@ -289,8 +299,10 @@ class DexStore:
                 entry = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            if connector is not None and entry.get("connector") != connector:
+                continue
             at = entry.get("at")
-            billed = entry.get("billed_bytes")
+            billed = entry.get(field)
             if (
                 isinstance(at, str)
                 and at >= cutoff_iso

--- a/packages/dex-core/src/exmergo_dex_core/command_args.py
+++ b/packages/dex-core/src/exmergo_dex_core/command_args.py
@@ -69,19 +69,28 @@ def billed_handshake(
     try:
         gate.preflight_command(estimate)
     except ConfirmationRequiredError as exc:
-        data: dict = {
-            "command": command,
-            "estimated_bytes": estimate,
-            "hint": (
-                "review the estimate, then re-run with --confirm --budget "
-                "<bytes> (the ceiling in bytes; 10000000000 is 10 GB, about "
-                "$0.06 on-demand)"
-            ),
-        }
-        if per_table:
-            data["per_table_bytes"] = per_table
+        # The payload speaks the connector's unit. An adapter that knows more
+        # than the raw magnitude (Snowflake's credit translation, its
+        # estimate-quality caveat) describes its own estimate; the bytes shape
+        # is the default the bytes-scanned connectors settled on.
+        describe = getattr(adapter, "describe_estimate", None)
+        if describe is not None:
+            data = {"command": command, **describe(estimate, per_table)}
+        else:
+            data = {
+                "command": command,
+                "estimated_bytes": estimate,
+                "hint": (
+                    "review the estimate, then re-run with --confirm --budget "
+                    "<bytes> (the ceiling in bytes; 10000000000 is 10 GB, about "
+                    "$0.06 on-demand)"
+                ),
+            }
+            if per_table:
+                data["per_table_bytes"] = per_table
         if notes:
-            data["notes"] = notes
+            data.setdefault("notes", [])
+            data["notes"] = [*data["notes"], *notes]
         return env.needs_confirmation(data, cost=exc.cost)
     return None
 
@@ -94,7 +103,11 @@ def stamp_spend(envelope: env.Envelope, adapter: Adapter) -> env.Envelope:
     gate = cost_gate(adapter)
     if gate is not None:
         envelope.cost = gate.cost()
-        envelope.data["spend"] = gate.spend_summary()
+        spend = gate.spend_summary()
+        display = getattr(adapter, "spend_display", None)
+        if display is not None:
+            spend.update(display())
+        envelope.data["spend"] = spend
     return envelope
 
 

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -61,6 +61,35 @@ class BigQueryTarget(BaseModel):
     max_full_profile_bytes: int | None = None
 
 
+class SnowflakeTarget(BaseModel):
+    """Non-secret Snowflake connection target. Credentials are never here: auth
+    is discovered at runtime by connect.py (connections.toml, SNOWFLAKE_* env,
+    or a dbt profile), and passwords or keys are never written or logged.
+
+    ``connection_name`` pins a ``connections.toml`` entry; unset means the
+    default connection, then the environment, then a dbt profile. ``warehouse``
+    is the pinned compute for every billed statement: dex refuses to spend on a
+    warehouse the config does not name, so a connection-level default can never
+    silently land work on oversized compute. ``databases`` is a source
+    allowlist (entries ``db`` or ``db.schema``); empty means every database the
+    role can see. ``dev_database``/``dev_schema`` are where dbt dev builds
+    write; the pair is refused as a source so reads and writes never share a
+    schema. ``max_full_profile_bytes`` opts large tables into sampled profiling
+    (SAMPLE SYSTEM) instead of a full scan. ``credit_price_usd`` is the
+    contract-specific dollar price of one credit; set it to see dollar figures
+    next to the credit translation (no API exposes it, so dex never guesses).
+    """
+
+    account: str | None = None
+    connection_name: str | None = None
+    warehouse: str | None = None
+    databases: list[str] = Field(default_factory=list)
+    dev_database: str | None = None
+    dev_schema: str | None = None
+    max_full_profile_bytes: int | None = None
+    credit_price_usd: float | None = None
+
+
 class QueryLimits(BaseModel):
     """Hard bounds on `explore query` results, enforced in the engine.
 
@@ -75,12 +104,14 @@ class QueryLimits(BaseModel):
 
 
 class DexConfig(BaseModel):
-    """The shape of ``.dex/config.yml``. DuckDB and BigQuery targets are wired;
-    the remaining cloud connector targets are not yet implemented."""
+    """The shape of ``.dex/config.yml``. DuckDB, BigQuery, and Snowflake
+    targets are wired; the remaining cloud connector targets are not yet
+    implemented."""
 
     connector: str = "duckdb"
     duckdb: DuckDBTarget | None = None
     bigquery: BigQueryTarget | None = None
+    snowflake: SnowflakeTarget | None = None
     dbt_target: str | None = None
     # Pins the dbt project directory (relative to the repo root) when discovery
     # would be ambiguous; by default the project is located automatically.

--- a/packages/dex-core/src/exmergo_dex_core/connect.py
+++ b/packages/dex-core/src/exmergo_dex_core/connect.py
@@ -5,13 +5,17 @@ engine process and never reach the agent. DuckDB is a local file path, opened
 read-only, no credentials. BigQuery discovers credentials ("discover, don't
 ask"): Application Default Credentials only, never a prompted or pasted key,
 with the project resolved from explicit config, the environment, the ADC
-default, or a dbt profile, in that order. Every discovery failure names the
-fix; nothing is ever prompted for.
+default, or a dbt profile, in that order. Snowflake discovers a connection the
+same way: a named ``connections.toml`` entry, the default connection, the
+``SNOWFLAKE_*`` environment (which is also how CI's workload-identity token
+arrives), or a dbt profile. Every discovery failure names the fix; nothing is
+ever prompted for.
 """
 
 from __future__ import annotations
 
 import os
+import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -19,7 +23,7 @@ import yaml
 
 from .adapters import get_adapter
 from .cache import DexStore
-from .config import BigQueryTarget, DexConfig, load_config
+from .config import BigQueryTarget, DexConfig, SnowflakeTarget, load_config
 from .envelope import Paradigm
 from .guards.cost_guard import CostGate
 
@@ -71,6 +75,11 @@ def open_adapter(
             dataset_override=datasets,
         )
 
+    if connector == "snowflake":
+        return _open_snowflake(
+            config, repo_root, budget=budget, confirmed=confirmed, command=command
+        )
+
     # The remaining cloud connectors are not yet implemented.
     return get_adapter(connector)
 
@@ -114,7 +123,7 @@ def _open_bigquery(
         paradigm=Paradigm.BYTES_SCANNED,
         ceiling=budget if budget is not None else config.budget.ceiling,
         session_ceiling=config.budget.session_ceiling,
-        session_spent=store.spend_since(utc_midnight),
+        session_spent=store.spend_since(utc_midnight, connector="bigquery"),
         confirmed=confirmed,
         connector="bigquery",
         command=command,
@@ -128,6 +137,257 @@ def _open_bigquery(
         credentials=credentials,
         principal_type=principal_type,
     )
+
+
+def _open_snowflake(
+    config: DexConfig,
+    repo_root: str | Path,
+    *,
+    budget: float | None,
+    confirmed: bool,
+    command: str | None,
+):
+    target = config.snowflake or SnowflakeTarget()
+    params, method = resolve_snowflake_connection(target, os.environ, repo_root)
+
+    try:
+        import snowflake.connector
+    except ImportError as exc:
+        raise CredentialDiscoveryError(
+            "the Snowflake client is not installed; install the connector "
+            "extra: exmergo-dex-core[snowflake]"
+        ) from exc
+
+    # The pinned warehouse rides on the session so free paths and dbt agree,
+    # but the adapter re-asserts the pin before anything billed regardless.
+    if target.warehouse:
+        params.setdefault("warehouse", target.warehouse)
+    params.setdefault("client_session_keep_alive", False)
+    connection = snowflake.connector.connect(**params)
+
+    store = DexStore(repo_root)
+    utc_midnight = (
+        datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
+    )
+    gate = CostGate(
+        paradigm=Paradigm.COMPUTE_TIME,
+        ceiling=budget if budget is not None else config.budget.ceiling,
+        session_ceiling=config.budget.session_ceiling,
+        session_spent=store.spend_since(
+            utc_midnight, field="billed_seconds", connector="snowflake"
+        ),
+        confirmed=confirmed,
+        connector="snowflake",
+        command=command,
+        record=store.append_spend_log,
+    )
+    return get_adapter(
+        "snowflake",
+        connection=connection,
+        cost_gate=gate,
+        target=target,
+        account=str(params.get("account") or "") or None,
+        auth_method=method,
+    )
+
+
+def resolve_snowflake_connection(
+    target: SnowflakeTarget,
+    env: dict | os._Environ,
+    repo_root: str | Path = ".",
+) -> tuple[dict, str]:
+    """Discover Snowflake connection parameters, never prompting.
+
+    Returns ``(params, auth_method)`` where ``params`` feeds
+    ``snowflake.connector.connect`` and ``auth_method`` is a coarse class safe
+    to surface (named_connection / default_connection / environment /
+    dbt_profile, suffixed with the credential kind); parameter values,
+    including any password or key a store legitimately holds, never leave the
+    engine process. Order: the config-pinned ``connections.toml`` entry, the
+    default connection, ``SNOWFLAKE_*`` environment variables (the CI path:
+    a workload-identity token arrives as SNOWFLAKE_TOKEN), then a dbt
+    profile's snowflake target. Every failure names the fix.
+    """
+
+    connections = _snowflake_connections(env)
+
+    if target.connection_name:
+        params = connections.get(target.connection_name)
+        if params is None:
+            raise CredentialDiscoveryError(
+                f"snowflake.connection_name '{target.connection_name}' not "
+                "found in connections.toml; run `snow connection add "
+                f"--connection-name {target.connection_name} ...` or fix the "
+                "name in .dex/config.yml"
+            )
+        return _normalize_connection(params, target), (
+            f"named_connection:{_credential_kind(params)}"
+        )
+
+    default_name = env.get("SNOWFLAKE_DEFAULT_CONNECTION_NAME") or connections.get(
+        "__default__"
+    )
+    if isinstance(default_name, str) and default_name in connections:
+        params = connections[default_name]
+        return _normalize_connection(params, target), (
+            f"default_connection:{_credential_kind(params)}"
+        )
+
+    if env.get("SNOWFLAKE_ACCOUNT") and env.get("SNOWFLAKE_USER"):
+        params = {
+            key: env[var]
+            for var, key in (
+                ("SNOWFLAKE_ACCOUNT", "account"),
+                ("SNOWFLAKE_USER", "user"),
+                ("SNOWFLAKE_PASSWORD", "password"),
+                ("SNOWFLAKE_AUTHENTICATOR", "authenticator"),
+                ("SNOWFLAKE_PRIVATE_KEY_FILE", "private_key_file"),
+                ("SNOWFLAKE_TOKEN", "token"),
+                ("SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER", "workload_identity_provider"),
+                ("SNOWFLAKE_ROLE", "role"),
+                ("SNOWFLAKE_WAREHOUSE", "warehouse"),
+                ("SNOWFLAKE_DATABASE", "database"),
+            )
+            if env.get(var)
+        }
+        return _normalize_connection(params, target), (
+            f"environment:{_credential_kind(params)}"
+        )
+
+    profile_params = _snowflake_from_dbt_profiles(repo_root)
+    if profile_params:
+        return _normalize_connection(profile_params, target), (
+            f"dbt_profile:{_credential_kind(profile_params)}"
+        )
+
+    raise CredentialDiscoveryError(
+        "no Snowflake connection discovered; add one with `snow connection "
+        "add` (then set snowflake.connection_name in .dex/config.yml), or "
+        "export SNOWFLAKE_ACCOUNT/SNOWFLAKE_USER plus a credential, or keep a "
+        "snowflake target in your dbt profiles.yml"
+    )
+
+
+def _normalize_connection(params: dict, target: SnowflakeTarget) -> dict:
+    normalized = dict(params)
+    if target.account:
+        normalized["account"] = target.account
+    if not normalized.get("account"):
+        raise CredentialDiscoveryError(
+            "the discovered Snowflake connection has no account identifier; "
+            "set snowflake.account in .dex/config.yml or fix the connection"
+        )
+    return normalized
+
+
+def _credential_kind(params: dict) -> str:
+    """The coarse credential class for the envelope; never a value."""
+
+    authenticator = str(params.get("authenticator", "")).upper()
+    if authenticator == "WORKLOAD_IDENTITY":
+        return "workload_identity"
+    if authenticator == "EXTERNALBROWSER":
+        return "sso_browser"
+    if (
+        params.get("private_key_file")
+        or params.get("private_key_path")
+        or params.get("private_key")
+    ):
+        return "key_pair"
+    if params.get("token"):
+        return "token"
+    if params.get("password"):
+        return "password"
+    return "unknown"
+
+
+def _snowflake_connections(env: dict | os._Environ) -> dict:
+    """Parse the Snowflake config stores the ``snow`` CLI and the Python
+    connector share. Returns name -> params, plus ``__default__`` naming the
+    configured default connection when one is declared.
+
+    Search order matches the connector: ``$SNOWFLAKE_HOME``, ``~/.snowflake``,
+    then the platform config dir. ``connections.toml`` holds top-level
+    connection tables; ``config.toml`` holds ``[connections.<name>]`` tables
+    and ``default_connection_name``.
+    """
+
+    candidates: list[Path] = []
+    snowflake_home = env.get("SNOWFLAKE_HOME")
+    if snowflake_home:
+        candidates.append(Path(snowflake_home))
+    candidates.append(Path.home() / ".snowflake")
+    candidates.append(_platform_config_dir())
+
+    connections: dict = {}
+    for directory in candidates:
+        connections_file = directory / "connections.toml"
+        config_file = directory / "config.toml"
+        try:
+            if connections_file.is_file():
+                parsed = tomllib.loads(connections_file.read_text(encoding="utf-8"))
+                for name, params in parsed.items():
+                    if isinstance(params, dict):
+                        connections.setdefault(name, params)
+            if config_file.is_file():
+                parsed = tomllib.loads(config_file.read_text(encoding="utf-8"))
+                for name, params in (parsed.get("connections") or {}).items():
+                    if isinstance(params, dict):
+                        connections.setdefault(name, params)
+                default = parsed.get("default_connection_name")
+                if isinstance(default, str):
+                    connections.setdefault("__default__", default)
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+    return connections
+
+
+def _platform_config_dir() -> Path:
+    import sys
+
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "snowflake"
+    return Path.home() / ".config" / "snowflake"
+
+
+def _snowflake_from_dbt_profiles(repo_root: str | Path) -> dict | None:
+    """Best-effort: the connection fields of a ``type: snowflake`` output in
+    the discovered dbt project's profiles. Any failure means "not found"."""
+
+    try:
+        from .dbt_project import PROFILES_FILE, find_project, profiles_dir
+
+        project_dir = find_project(repo_root)
+        profiles_path = profiles_dir(project_dir) / PROFILES_FILE
+        profiles = yaml.safe_load(profiles_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return None
+    for profile in profiles.values():
+        if not isinstance(profile, dict):
+            continue
+        for output in (profile.get("outputs") or {}).values():
+            if (
+                isinstance(output, dict)
+                and output.get("type") == "snowflake"
+                and output.get("account")
+            ):
+                params = {
+                    key: output[key]
+                    for key in (
+                        "account",
+                        "user",
+                        "password",
+                        "authenticator",
+                        "role",
+                        "warehouse",
+                        "database",
+                    )
+                    if output.get(key)
+                }
+                if output.get("private_key_path"):
+                    params["private_key_file"] = output["private_key_path"]
+                return params
+    return None
 
 
 def _default_credentials():

--- a/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
@@ -186,14 +186,26 @@ class CostGate:
             return False
         return True
 
-    def max_bytes_for_statement(self) -> int | None:
-        """The server-side cap for the next statement: what remains of the
-        effective ceiling after everything already charged."""
+    def remaining_for_statement(self) -> int | None:
+        """The server-side cap for the next statement, in the paradigm's unit
+        (bytes for ``maximum_bytes_billed``, seconds for a statement timeout):
+        what remains of the effective ceiling after everything already charged.
+        """
 
         ceiling = self.effective_ceiling()
         if ceiling is None:
             return None
         return max(int(ceiling - self._billed), 0)
+
+    def ledger_field(self) -> str:
+        """The ledger key actual spend is recorded under. Paradigm-specific so
+        a bytes total and a seconds total can never silently sum together."""
+
+        return (
+            "billed_seconds"
+            if self.paradigm is Paradigm.COMPUTE_TIME
+            else "billed_bytes"
+        )
 
     def record_billed(
         self, billed: float, *, job_id: str | None = None, statement: str = ""
@@ -209,7 +221,7 @@ class CostGate:
                     "at": datetime.now(UTC).isoformat(),
                     "connector": self.connector,
                     "command": self.command,
-                    "billed_bytes": billed,
+                    self.ledger_field(): billed,
                     "job_id": job_id,
                     "statement_sha256": hashlib.sha256(
                         statement.encode("utf-8")
@@ -238,9 +250,14 @@ class CostGate:
     def spend_summary(self) -> dict:
         """Actual spend for the envelope's ``data`` (the ``cost`` field stays a
         preflight estimate by contract). Key names deliberately avoid every
-        envelope-sanitizer pattern."""
+        envelope-sanitizer pattern and carry the paradigm's unit."""
 
+        key = (
+            "seconds_billed"
+            if self.paradigm is Paradigm.COMPUTE_TIME
+            else "bytes_billed"
+        )
         return {
-            "bytes_billed": self._billed,
+            key: self._billed,
             "session_spent_today": self.session_spent + self._billed,
         }

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -145,9 +145,10 @@ def cmd_build(args: argparse.Namespace) -> env.Envelope:
     budget = getattr(args, "budget", None)
     ceiling = budget if budget is not None else config.budget.ceiling
     connector = getattr(args, "connector", None) or config.connector
-    paradigm = (
-        Paradigm.BYTES_SCANNED if connector == "bigquery" else Paradigm.FREE_LOCAL
-    )
+    paradigm = {
+        "bigquery": Paradigm.BYTES_SCANNED,
+        "snowflake": Paradigm.COMPUTE_TIME,
+    }.get(connector, Paradigm.FREE_LOCAL)
 
     try:
         summary, cost = run_build(
@@ -172,7 +173,7 @@ def cmd_build(args: argparse.Namespace) -> env.Envelope:
 
     messages = summary.pop("messages", [])
     notes = summary.pop("notes", [])
-    if paradigm is not Paradigm.FREE_LOCAL:
+    if paradigm is Paradigm.BYTES_SCANNED:
         notes = [
             "dbt has no dry-run, so this build's scan size could not be "
             "estimated upfront; each statement was capped server-side by the "
@@ -181,7 +182,22 @@ def cmd_build(args: argparse.Namespace) -> env.Envelope:
         ]
         billed = summary.get("bytes_billed")
         if billed:
-            _record_build_spend(repo_root, connector, billed)
+            _record_build_spend(repo_root, connector, billed, "billed_bytes")
+    elif paradigm is Paradigm.COMPUTE_TIME:
+        notes = [
+            "dbt has no dry-run, so this build's warehouse time could not be "
+            "estimated upfront; the warehouse-level statement timeout and "
+            "auto-suspend are the server-side caps",
+            *notes,
+        ]
+        # dbt-snowflake reports no billing figure; per-node execution time is
+        # the honest warehouse-seconds actual.
+        seconds = sum(
+            float(node.get("execution_time") or 0) for node in summary.get("nodes", [])
+        )
+        if seconds:
+            summary["seconds_billed"] = seconds
+            _record_build_spend(repo_root, connector, seconds, "billed_seconds")
     if summary["success"]:
         return env.ok(summary, cost=cost, warnings=[*notes, *messages])
     # Agents triage from `errors` first, so the first real dbt message rides
@@ -245,9 +261,11 @@ def cmd_semantic_plan(args: argparse.Namespace) -> env.Envelope:
 # --- helpers -----------------------------------------------------------------
 
 
-def _record_build_spend(repo_root, connector: str, billed: float) -> None:
+def _record_build_spend(repo_root, connector: str, billed: float, field: str) -> None:
     """Account a billed dbt build in the `.dex/spend.jsonl` ledger, so builds
-    draw against the same session budget as explore scans."""
+    draw against the same session budget as explore scans. ``field`` carries
+    the connector's unit (bytes or seconds), matching what its cost gate
+    records."""
 
     from datetime import UTC, datetime
 
@@ -258,7 +276,7 @@ def _record_build_spend(repo_root, connector: str, billed: float) -> None:
             "at": datetime.now(UTC).isoformat(),
             "connector": connector,
             "command": "transform build",
-            "billed_bytes": float(billed),
+            field: float(billed),
             "job_id": None,
             "statement_sha256": None,
         }

--- a/packages/dex-core/src/exmergo_dex_core/transform/init.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/init.py
@@ -35,6 +35,7 @@ from ..config import (
     BigQueryTarget,
     DexConfig,
     DuckDBTarget,
+    SnowflakeTarget,
     load_config,
     save_config,
 )
@@ -97,9 +98,9 @@ def init_project(
     render_profile = _PROFILE_RENDERERS.get(connector)
     if render_profile is None:
         raise InitError(
-            f"connector '{connector}' is not yet supported for init; DuckDB and "
-            "BigQuery are the supported paths today (`transform init <name> "
-            "--connector duckdb|bigquery`)"
+            f"connector '{connector}' is not yet supported for init; DuckDB, "
+            "BigQuery, and Snowflake are the supported paths today "
+            "(`transform init <name> --connector duckdb|bigquery|snowflake`)"
         )
 
     project_name = sanitize_project_name(name)
@@ -261,9 +262,88 @@ def _resolve_init_project(target: BigQueryTarget, root: Path) -> str | None:
     return resolve_bigquery_project(target, os.environ, adc_project, repo_root=root)
 
 
+_DEFAULT_SF_DEV_SCHEMA = "DBT_DEV"
+
+
+def _snowflake_profile(
+    project_name: str, path: str | None, config: DexConfig, root: Path
+) -> str:
+    """A single dbt-snowflake ``dev`` target from the discovered connection,
+    with no secret ever rendered: key-pair auth becomes a ``private_key_path``
+    (a path, not a key), SSO stays ``externalbrowser``, and a password-based
+    connection renders an ``env_var`` reference. Writes go to a dedicated dev
+    database.schema, never to a source scope, on the pinned warehouse only."""
+
+    from ..connect import CredentialDiscoveryError, resolve_snowflake_connection
+
+    target = config.snowflake or SnowflakeTarget()
+    try:
+        params, _method = resolve_snowflake_connection(target, os.environ, root)
+    except CredentialDiscoveryError as exc:
+        raise InitError(str(exc)) from exc
+
+    if not target.warehouse:
+        raise InitError(
+            "no warehouse pinned: set snowflake.warehouse in .dex/config.yml "
+            "(dbt builds run only on the pinned warehouse, never a "
+            "connection default)"
+        )
+    dev_database = target.dev_database or params.get("database")
+    if not dev_database:
+        raise InitError(
+            "no dev database to write to: set snowflake.dev_database in "
+            ".dex/config.yml (a scratch database the role can write; source "
+            "databases stay read-only)"
+        )
+    dev_schema = target.dev_schema or _DEFAULT_SF_DEV_SCHEMA
+    dev_scope = f"{dev_database}.{dev_schema}".upper()
+    source_scopes = {entry.upper() for entry in target.databases}
+    if dev_scope in source_scopes:
+        raise InitError(
+            f"dev target '{dev_scope}' is also a source scope in "
+            "snowflake.databases; dbt builds must write where dex does not "
+            "read (set snowflake.dev_database/dev_schema to a dedicated pair)"
+        )
+
+    target.dev_database = str(dev_database)
+    target.dev_schema = dev_schema
+    config.snowflake = target
+
+    output: dict[str, Any] = {
+        "type": "snowflake",
+        "account": str(params["account"]),
+        "user": str(params.get("user", "")),
+        "role": str(params["role"]) if params.get("role") else None,
+        "warehouse": target.warehouse,
+        "database": str(dev_database),
+        "schema": dev_schema,
+        # One thread keeps the smallest warehouse from parallel bursts; the
+        # per-model runtime is the guarded quantity on compute-time billing.
+        "threads": 1,
+        "query_tag": "dex",
+    }
+    output = {k: v for k, v in output.items() if v is not None}
+
+    private_key = params.get("private_key_file") or params.get("private_key_path")
+    authenticator = str(params.get("authenticator", "")).upper()
+    if private_key:
+        output["private_key_path"] = str(private_key)
+    elif authenticator == "EXTERNALBROWSER":
+        output["authenticator"] = "externalbrowser"
+    else:
+        # Never persist a password or token: the profile reads it from the
+        # environment at dbt runtime instead (a Jinja reference, not a value).
+        output["password"] = "{{ env_var('SNOWFLAKE_PASSWORD') }}"  # noqa: S105
+    return yaml.safe_dump(
+        {project_name: {"target": "dev", "outputs": {"dev": output}}},
+        sort_keys=False,
+    )
+
+
 _PROFILE_RENDERERS: dict[str, Callable[[str, str | None, DexConfig, Path], str]] = {
     "duckdb": _duckdb_profile,
     "bigquery": _bigquery_profile,
+    "snowflake": _snowflake_profile,
 }
 
 

--- a/packages/dex-core/tests/adapters/test_connect_bigquery.py
+++ b/packages/dex-core/tests/adapters/test_connect_bigquery.py
@@ -446,7 +446,7 @@ def test_get_adapter_wires_bigquery(fake_bq_client):
 
 
 def test_remaining_cloud_connectors_still_stub():
-    for connector in ("snowflake", "databricks", "postgres"):
+    for connector in ("databricks", "postgres"):
         with pytest.raises(NotImplementedError):
             get_adapter(connector)
 

--- a/packages/dex-core/tests/adapters/test_connect_snowflake.py
+++ b/packages/dex-core/tests/adapters/test_connect_snowflake.py
@@ -1,0 +1,590 @@
+"""The Snowflake adapter against the stateful fake connection: metadata is
+free (SHOW commands, no warehouse), every billed statement is estimated and
+gated in warehouse-seconds, and the budget binds at both the client (charge)
+and the simulated server (statement timeout)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("snowflake.connector")
+
+from fakes.snowflake import FakeResult
+
+from exmergo_dex_core.adapters import get_adapter, get_dialect
+from exmergo_dex_core.adapters.snowflake import (
+    _RESUME_MINIMUM_SECONDS,
+    SnowflakeAdapter,
+    SnowflakeConnectionError,
+)
+from exmergo_dex_core.config import SnowflakeTarget
+from exmergo_dex_core.envelope import Paradigm
+from exmergo_dex_core.guards.cost_guard import (
+    ConfirmationRequiredError,
+    CostGate,
+    OverCeilingError,
+)
+
+
+def make_adapter(
+    connection,
+    *,
+    ceiling: float | None = 600.0,
+    confirmed: bool = True,
+    session_ceiling: float | None = None,
+    session_spent: float = 0.0,
+    record=None,
+    target: SnowflakeTarget | None = None,
+) -> SnowflakeAdapter:
+    gate = CostGate(
+        paradigm=Paradigm.COMPUTE_TIME,
+        ceiling=ceiling,
+        session_ceiling=session_ceiling,
+        session_spent=session_spent,
+        confirmed=confirmed,
+        connector="snowflake",
+        command="explore profile",
+        record=record,
+    )
+    return SnowflakeAdapter(
+        connection=connection,
+        cost_gate=gate,
+        target=target or SnowflakeTarget(warehouse="DEX_WH"),
+        account="TESTORG-TESTACCT",
+        auth_method="named_connection:key_pair",
+        clock=connection.clock,
+    )
+
+
+def data_statements(connection) -> list:
+    return connection.data_statements
+
+
+# --- metadata (free) ---------------------------------------------------------------
+
+
+def test_capabilities_shape_and_free(fake_sf_connection):
+    adapter = make_adapter(fake_sf_connection)
+    caps = adapter.capabilities()
+    assert caps["connector"] == "snowflake"
+    assert caps["dialect"] == "snowflake"
+    assert caps["read_only"] is True
+    assert caps["paradigm"] == "compute_time"
+    assert caps["account"] == "TESTORG-TESTACCT"
+    assert caps["auth_method"] == "named_connection:key_pair"
+    assert caps["database_count"] == 1  # SHOP
+    budget = caps["budget"]
+    assert budget["ceiling_seconds"] == 600.0
+    assert budget["warehouse"]["size"] == "X-Small"
+    assert budget["warehouse"]["credits_per_hour"] == 1.0
+    # 600 warehouse-seconds on an X-Small is a sixth of a credit.
+    assert budget["ceiling_credits"] == pytest.approx(600 / 3600, abs=1e-6)
+    # Capabilities is a free probe: SHOW commands only, no data statement.
+    assert data_statements(fake_sf_connection) == []
+
+
+def test_list_objects_uses_free_show_metadata_only(fake_sf_connection):
+    adapter = make_adapter(fake_sf_connection)
+    objects = adapter.list_objects()
+    assert [o.identifier for o in objects] == [
+        "SHOP.PUBLIC.CUSTOMERS",
+        "SHOP.PUBLIC.EVENTS",
+    ]
+    customers = next(o for o in objects if o.name == "CUSTOMERS")
+    assert customers.row_count == 100
+    assert customers.byte_size == 5_000_000_000
+    assert customers.column_count == 2
+    assert data_statements(fake_sf_connection) == []
+
+
+def test_database_allowlist_scopes_inventory(fake_sf_connection):
+    from fakes.snowflake import FakeSnowflakeTable
+
+    fake_sf_connection.tables.append(
+        FakeSnowflakeTable(
+            database="OTHER",
+            schema="PUBLIC",
+            name="NOISE",
+            columns=[("ID", "FIXED", True)],
+        )
+    )
+    adapter = make_adapter(
+        fake_sf_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=["SHOP.PUBLIC"]),
+    )
+    assert {o.schema for o in adapter.list_objects()} == {"PUBLIC"}
+    assert all(o.identifier.startswith("SHOP.") for o in adapter.list_objects())
+
+
+def test_table_metadata_parses_show_columns_types(fake_sf_connection):
+    adapter = make_adapter(fake_sf_connection)
+    meta, columns = adapter.table_metadata("SHOP.PUBLIC.EVENTS")
+    assert meta.identifier == "SHOP.PUBLIC.EVENTS"
+    by_name = {c.name: c for c in columns}
+    assert by_name["PAYLOAD"].data_type == "VARIANT"
+    assert by_name["LABELS"].data_type == "ARRAY"
+    assert by_name["ID"].nullable is True
+    id_col = next(
+        c for c in adapter.table_metadata("SHOP.PUBLIC.CUSTOMERS")[1] if c.name == "ID"
+    )
+    assert id_col.nullable is False
+
+
+# --- estimation (free) and the resume floor ------------------------------------------
+
+
+def test_profile_estimate_is_heuristic_and_carries_the_resume_floor(
+    fake_sf_connection,
+):
+    adapter = make_adapter(fake_sf_connection)
+    total, per_table = adapter.profile_estimate(["SHOP.PUBLIC.CUSTOMERS"])
+    # 5 GB over the conservative X-Small rate, one batch.
+    scan = per_table["SHOP.PUBLIC.CUSTOMERS"]
+    assert scan > 1.0
+    # DEX_WH is suspended, so the total carries the 60-second resume minimum.
+    assert total == pytest.approx(scan + _RESUME_MINIMUM_SECONDS)
+    assert data_statements(fake_sf_connection) == []
+
+
+def test_no_resume_floor_on_a_running_warehouse(fake_sf_connection):
+    fake_sf_connection.warehouses[0].state = "STARTED"
+    fake_sf_connection.warehouse_resumes_pending = False
+    adapter = make_adapter(fake_sf_connection)
+    total, per_table = adapter.profile_estimate(["SHOP.PUBLIC.CUSTOMERS"])
+    assert total == pytest.approx(per_table["SHOP.PUBLIC.CUSTOMERS"])
+
+
+def test_query_estimate_sums_referenced_tables(fake_sf_connection):
+    fake_sf_connection.warehouses[0].state = "STARTED"
+    fake_sf_connection.warehouse_resumes_pending = False
+    adapter = make_adapter(fake_sf_connection)
+    single = adapter.query_estimate('SELECT COUNT(*) FROM "SHOP"."PUBLIC"."CUSTOMERS"')
+    joined = adapter.query_estimate(
+        'SELECT COUNT(*) FROM "SHOP"."PUBLIC"."CUSTOMERS" c '
+        'JOIN "SHOP"."PUBLIC"."EVENTS" e ON c."ID" = e."ID"'
+    )
+    assert joined > single > 0
+
+
+def test_describe_estimate_translates_to_credits(fake_sf_connection):
+    adapter = make_adapter(
+        fake_sf_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", credit_price_usd=3.0),
+    )
+    described = adapter.describe_estimate(360.0, {"SHOP.PUBLIC.CUSTOMERS": 360.0})
+    assert described["estimated_seconds"] == 360.0
+    assert described["estimate_quality"] == "heuristic"
+    assert described["estimated_credits"] == pytest.approx(0.1)
+    assert described["estimated_usd"] == pytest.approx(0.3)
+    assert described["per_table_seconds"] == {"SHOP.PUBLIC.CUSTOMERS": 360.0}
+    assert "--budget" in described["hint"] and "seconds" in described["hint"]
+    assert any("no dry-run" in note for note in described["notes"])
+
+
+# --- the billed door -----------------------------------------------------------------
+
+
+def test_unconfirmed_execution_is_refused_before_any_run(fake_sf_connection):
+    adapter = make_adapter(fake_sf_connection, confirmed=False)
+    with pytest.raises(ConfirmationRequiredError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert data_statements(fake_sf_connection) == []
+
+
+def test_over_ceiling_refused_client_side_without_execution(fake_sf_connection):
+    # The 50 GB events table estimates far beyond a 5-second ceiling.
+    adapter = make_adapter(fake_sf_connection, ceiling=5.0)
+    with pytest.raises(OverCeilingError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "SHOP"."PUBLIC"."EVENTS"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert data_statements(fake_sf_connection) == []
+
+
+def test_billed_statements_run_on_the_pinned_warehouse_with_query_tag(
+    fake_sf_connection,
+):
+    fake_sf_connection.row_resolver = lambda sql: [{"n": 1}]
+    adapter = make_adapter(fake_sf_connection)
+    # The suspended warehouse's 60s resume counts toward the wall clock, so
+    # the timeout must sit above it.
+    adapter.run_query(
+        'SELECT COUNT(*) AS n FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+        max_rows=10,
+        timeout_seconds=200,
+    )
+    assert any('USE WAREHOUSE "DEX_WH"' in u for u in fake_sf_connection.used)
+    assert fake_sf_connection.session_parameters["QUERY_TAG"] == "dex"
+
+
+def test_no_pinned_warehouse_refuses_billed_work_with_the_fix(fake_sf_connection):
+    adapter = make_adapter(fake_sf_connection, target=SnowflakeTarget())
+    with pytest.raises(SnowflakeConnectionError) as exc_info:
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert "snowflake.warehouse" in str(exc_info.value)
+    assert data_statements(fake_sf_connection) == []
+
+
+def test_missing_warehouse_refuses_with_the_fix(fake_sf_connection):
+    adapter = make_adapter(
+        fake_sf_connection, target=SnowflakeTarget(warehouse="NOPE_WH")
+    )
+    with pytest.raises(SnowflakeConnectionError) as exc_info:
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert "NOPE_WH" in str(exc_info.value)
+
+
+def test_every_billed_statement_carries_the_remaining_budget_as_timeout(
+    fake_sf_connection,
+):
+    fake_sf_connection.row_resolver = lambda sql: [{"n": 1}]
+    adapter = make_adapter(fake_sf_connection, ceiling=300.0)
+    adapter.run_query(
+        'SELECT COUNT(*) AS n FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+        max_rows=10,
+        timeout_seconds=200,
+    )
+    executed = data_statements(fake_sf_connection)
+    assert executed
+    for statement in executed:
+        assert statement.session_timeout is not None
+        assert statement.session_timeout <= 300
+
+
+def test_server_side_timeout_translates_when_the_estimate_drifts(fake_sf_connection):
+    from fakes.snowflake import FakeResult
+
+    # The estimate says seconds; the statement 'runs' far longer than the
+    # remaining budget, and the simulated server kills it at the timeout.
+    fake_sf_connection.warehouses[0].state = "STARTED"
+    fake_sf_connection.warehouse_resumes_pending = False
+    fake_sf_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n": 1}], seconds=10_000.0
+    )
+    adapter = make_adapter(fake_sf_connection, ceiling=200.0)
+    with pytest.raises(OverCeilingError) as exc_info:
+        adapter.run_query(
+            'SELECT COUNT(*) AS n FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+            max_rows=10,
+            timeout_seconds=100_000,
+        )
+    assert "budget" in str(exc_info.value)
+
+
+def test_wall_timeout_translates_to_timeout_error(fake_sf_connection):
+    fake_sf_connection.warehouses[0].state = "STARTED"
+    fake_sf_connection.warehouse_resumes_pending = False
+    fake_sf_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n": 1}], seconds=50.0
+    )
+    adapter = make_adapter(fake_sf_connection, ceiling=10_000.0)
+    with pytest.raises(TimeoutError):
+        adapter.run_query(
+            'SELECT COUNT(*) AS n FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+            max_rows=10,
+            timeout_seconds=5,
+        )
+
+
+def test_actual_seconds_land_in_the_ledger(fake_sf_connection):
+    entries: list[dict] = []
+    fake_sf_connection.warehouses[0].state = "STARTED"
+    fake_sf_connection.warehouse_resumes_pending = False
+    fake_sf_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n": 1}], seconds=2.5
+    )
+    adapter = make_adapter(fake_sf_connection, record=entries.append)
+    adapter.run_query(
+        'SELECT COUNT(*) AS n FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+        max_rows=10,
+        timeout_seconds=30,
+    )
+    assert len(entries) == 1
+    assert entries[0]["billed_seconds"] == pytest.approx(2.5)
+    assert entries[0]["connector"] == "snowflake"
+    assert entries[0]["job_id"].startswith("fake-query")
+    assert "SELECT" not in str(entries[0].values())
+
+
+def test_resume_time_is_billed_to_the_first_statement(fake_sf_connection):
+    entries: list[dict] = []
+    fake_sf_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n": 1}], seconds=1.0
+    )
+    adapter = make_adapter(fake_sf_connection, record=entries.append)
+    adapter.run_query(
+        'SELECT COUNT(*) AS n FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+        max_rows=10,
+        timeout_seconds=200,
+    )
+    # The suspended warehouse resumed: 60s minimum + 1s of work on the clock.
+    assert entries[0]["billed_seconds"] == pytest.approx(61.0)
+
+
+def test_session_remainder_binds_across_commands(fake_sf_connection):
+    adapter = make_adapter(
+        fake_sf_connection,
+        ceiling=600.0,
+        session_ceiling=100.0,
+        session_spent=99.5,
+    )
+    with pytest.raises(OverCeilingError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert data_statements(fake_sf_connection) == []
+
+
+def test_run_query_truncates_and_shapes_columnar(fake_sf_connection):
+    fake_sf_connection.warehouses[0].state = "STARTED"
+    fake_sf_connection.warehouse_resumes_pending = False
+    fake_sf_connection.row_resolver = lambda sql: [{"id": i} for i in range(5)]
+    adapter = make_adapter(fake_sf_connection)
+    result = adapter.run_query(
+        'SELECT "ID" AS id FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+        max_rows=3,
+        timeout_seconds=30,
+    )
+    assert result.columns == ["id"]
+    assert result.cells == [[0], [1], [2]]
+    assert result.truncated is True
+
+
+# --- profiling -----------------------------------------------------------------------
+
+
+def _aggregate_resolver(sql: str):
+    values = {"n_total": 100}
+    for i in range(10):
+        values[f"nn_{i}"] = 100
+        values[f"nd_{i}"] = 100 if i == 0 else 40
+        values[f"mn_{i}"] = 1
+        values[f"mx_{i}"] = 100
+    return [values]
+
+
+def test_column_aggregates_profile_scalar_columns(fake_sf_connection):
+    fake_sf_connection.row_resolver = _aggregate_resolver
+    adapter = make_adapter(fake_sf_connection, ceiling=100_000.0)
+    _meta, columns = adapter.table_metadata("SHOP.PUBLIC.CUSTOMERS")
+    aggs = {
+        a.name: a
+        for a in adapter.column_aggregates(
+            "SHOP.PUBLIC.CUSTOMERS", columns, safe_min_max={"ID"}
+        )
+    }
+    assert aggs["ID"].is_unique is True
+    assert aggs["ID"].min_value == 1
+    assert aggs["EMAIL"].min_value is None  # not in safe_min_max
+    executed = data_statements(fake_sf_connection)
+    assert len(executed) == 1
+    assert "APPROX_COUNT_DISTINCT" in executed[0].sql
+
+
+def test_semi_structured_columns_degrade_to_non_null_counts(fake_sf_connection):
+    fake_sf_connection.row_resolver = _aggregate_resolver
+    adapter = make_adapter(fake_sf_connection, ceiling=100_000.0)
+    _meta, columns = adapter.table_metadata("SHOP.PUBLIC.EVENTS")
+    aggs = {
+        a.name: a
+        for a in adapter.column_aggregates(
+            "SHOP.PUBLIC.EVENTS", columns, safe_min_max=set()
+        )
+    }
+    sql = data_statements(fake_sf_connection)[0].sql
+    assert 'COUNT("PAYLOAD")' in sql
+    assert 'APPROX_COUNT_DISTINCT("PAYLOAD")' not in sql
+    assert 'APPROX_COUNT_DISTINCT("LABELS")' not in sql
+    assert aggs["PAYLOAD"].distinct_count is None
+    assert aggs["PAYLOAD"].null_fraction == 0.0
+
+
+def test_sampling_kicks_in_above_the_threshold_and_voids_uniqueness(
+    fake_sf_connection,
+):
+    fake_sf_connection.row_resolver = _aggregate_resolver
+    adapter = make_adapter(
+        fake_sf_connection,
+        ceiling=100_000.0,
+        target=SnowflakeTarget(warehouse="DEX_WH", max_full_profile_bytes=1_000_000),
+    )
+    _meta, columns = adapter.table_metadata("SHOP.PUBLIC.EVENTS")
+    aggs = adapter.column_aggregates("SHOP.PUBLIC.EVENTS", columns, safe_min_max=set())
+    sql = data_statements(fake_sf_connection)[0].sql
+    assert "SAMPLE SYSTEM" in sql
+    assert all(a.is_unique is None for a in aggs)
+    assert any(
+        "block sample" in note for note in adapter.table_notes("SHOP.PUBLIC.EVENTS")
+    )
+
+
+def test_exact_distinct_counts_degrade_when_budget_cannot_cover(fake_sf_connection):
+    fake_sf_connection.row_resolver = lambda sql: [{"d_0": 100}]
+    adapter = make_adapter(fake_sf_connection, ceiling=100.0)
+    adapter.cost_gate.charge(99.5)
+    result = adapter.exact_distinct_counts("SHOP.PUBLIC.CUSTOMERS", ["ID"])
+    assert result == {}
+    assert any(
+        "escalation skipped" in note
+        for note in adapter.table_notes("SHOP.PUBLIC.CUSTOMERS")
+    )
+    assert data_statements(fake_sf_connection) == []
+
+
+# --- factory and dialect --------------------------------------------------------
+
+
+def test_get_adapter_wires_snowflake(fake_sf_connection):
+    gate = CostGate(
+        paradigm=Paradigm.COMPUTE_TIME,
+        ceiling=600.0,
+        session_ceiling=None,
+        session_spent=0.0,
+        confirmed=True,
+        connector="snowflake",
+    )
+    adapter = get_adapter(
+        "snowflake",
+        connection=fake_sf_connection,
+        cost_gate=gate,
+        target=SnowflakeTarget(warehouse="DEX_WH"),
+    )
+    assert adapter.name == "snowflake"
+    adapter.close()
+    assert fake_sf_connection.closed is True
+
+
+def test_get_dialect_resolves_snowflake():
+    assert get_dialect("snowflake") == "snowflake"
+
+
+# --- connection discovery (connect.py) ----------------------------------------------
+
+
+def test_discovery_order_and_coarse_method(tmp_path: Path, monkeypatch):
+    from exmergo_dex_core import connect as connect_mod
+    from exmergo_dex_core.connect import resolve_snowflake_connection
+
+    connections = {
+        "dex-ci": {
+            "account": "TESTORG-TESTACCT",
+            "user": "DEX_DEV",
+            "authenticator": "SNOWFLAKE_JWT",
+            "private_key_file": "/keys/k.p8",
+        },
+        "other": {"account": "A", "user": "U", "password": "hunter2"},
+    }
+    monkeypatch.setattr(
+        connect_mod, "_snowflake_connections", lambda env: dict(connections)
+    )
+
+    params, method = resolve_snowflake_connection(
+        SnowflakeTarget(connection_name="dex-ci"), {}, tmp_path
+    )
+    assert params["account"] == "TESTORG-TESTACCT"
+    assert method == "named_connection:key_pair"
+
+    # The default connection is used when config pins nothing.
+    connections["__default__"] = "other"
+    _params, method = resolve_snowflake_connection(SnowflakeTarget(), {}, tmp_path)
+    assert method == "default_connection:password"
+
+    # Environment (the CI workload-identity path) when no toml store matches.
+    monkeypatch.setattr(connect_mod, "_snowflake_connections", lambda env: {})
+    env = {
+        "SNOWFLAKE_ACCOUNT": "TESTORG-TESTACCT",
+        "SNOWFLAKE_USER": "DEX_CI",
+        "SNOWFLAKE_AUTHENTICATOR": "WORKLOAD_IDENTITY",
+        "SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER": "OIDC",
+        "SNOWFLAKE_TOKEN": "not-a-real-token",
+    }
+    params, method = resolve_snowflake_connection(SnowflakeTarget(), env, tmp_path)
+    assert method == "environment:workload_identity"
+    assert params["authenticator"] == "WORKLOAD_IDENTITY"
+    assert params["workload_identity_provider"] == "OIDC"
+
+
+def test_discovery_failure_names_the_fixes(tmp_path: Path, monkeypatch):
+    from exmergo_dex_core import connect as connect_mod
+    from exmergo_dex_core.connect import (
+        CredentialDiscoveryError,
+        resolve_snowflake_connection,
+    )
+
+    monkeypatch.setattr(connect_mod, "_snowflake_connections", lambda env: {})
+    with pytest.raises(CredentialDiscoveryError) as exc_info:
+        resolve_snowflake_connection(SnowflakeTarget(), {}, tmp_path)
+    message = str(exc_info.value)
+    assert "snow connection add" in message
+    assert "SNOWFLAKE_ACCOUNT" in message
+
+    with pytest.raises(CredentialDiscoveryError) as exc_info:
+        resolve_snowflake_connection(
+            SnowflakeTarget(connection_name="missing"), {}, tmp_path
+        )
+    assert "missing" in str(exc_info.value)
+
+
+def test_discovery_falls_back_to_dbt_profiles(dbt_project_dir: Path, monkeypatch):
+    from exmergo_dex_core import connect as connect_mod
+    from exmergo_dex_core.connect import resolve_snowflake_connection
+
+    monkeypatch.setattr(connect_mod, "_snowflake_connections", lambda env: {})
+    profiles = dbt_project_dir / "profiles.yml"
+    profiles.write_text(
+        "dex_test:\n"
+        "  target: dev\n"
+        "  outputs:\n"
+        "    dev:\n"
+        "      type: snowflake\n"
+        "      account: FROM-DBT\n"
+        "      user: DBT_USER\n"
+        "      private_key_path: /keys/dbt.p8\n"
+        "      warehouse: WH\n"
+        "      database: DB\n"
+        "      schema: DEV\n",
+        encoding="utf-8",
+    )
+    params, method = resolve_snowflake_connection(
+        SnowflakeTarget(), {}, dbt_project_dir.parent
+    )
+    assert params["account"] == "FROM-DBT"
+    assert params["private_key_file"] == "/keys/dbt.p8"
+    assert method == "dbt_profile:key_pair"
+
+
+def test_connections_toml_parsing(tmp_path: Path):
+    from exmergo_dex_core.connect import _snowflake_connections
+
+    home = tmp_path / "sfhome"
+    home.mkdir()
+    (home / "connections.toml").write_text(
+        '[dex-ci]\naccount = "ORG-ACCT"\nuser = "DEX_DEV"\n', encoding="utf-8"
+    )
+    (home / "config.toml").write_text(
+        'default_connection_name = "dex-ci"\n'
+        '[connections.admin]\naccount = "ORG-ACCT"\nuser = "ADMIN"\n',
+        encoding="utf-8",
+    )
+    connections = _snowflake_connections({"SNOWFLAKE_HOME": str(home)})
+    assert connections["dex-ci"]["user"] == "DEX_DEV"
+    assert connections["admin"]["user"] == "ADMIN"
+    assert connections["__default__"] == "dex-ci"

--- a/packages/dex-core/tests/conftest.py
+++ b/packages/dex-core/tests/conftest.py
@@ -88,6 +88,53 @@ def fake_bq_client():
 
 
 @pytest.fixture
+def fake_sf_connection():
+    """The standard populated fake Snowflake connection (see
+    tests/fakes/snowflake.py).
+
+    Requires the real snowflake-connector-python library (the [snowflake]
+    extra) for its error types; skipped when absent, but CI and the release
+    gate install the extra, so the Snowflake safety families run everywhere
+    that matters. The DEX_WH warehouse starts SUSPENDED so resume-minimum
+    behavior is on by default; tests that want a warm warehouse flip its state.
+    """
+
+    pytest.importorskip("snowflake.connector")
+    from fakes.snowflake import (
+        FakeSnowflakeConnection,
+        FakeSnowflakeTable,
+        FakeWarehouse,
+    )
+
+    tables = [
+        FakeSnowflakeTable(
+            database="SHOP",
+            schema="PUBLIC",
+            name="CUSTOMERS",
+            columns=[("ID", "FIXED", False), ("EMAIL", "TEXT", True)],
+            rows=100,
+            bytes=5_000_000_000,  # 5 GB -> a non-trivial seconds estimate
+        ),
+        FakeSnowflakeTable(
+            database="SHOP",
+            schema="PUBLIC",
+            name="EVENTS",
+            columns=[
+                ("ID", "FIXED", True),
+                ("PAYLOAD", "VARIANT", True),
+                ("LABELS", "ARRAY", True),
+            ],
+            rows=1_000,
+            bytes=50_000_000_000,  # 50 GB
+        ),
+    ]
+    return FakeSnowflakeConnection(
+        tables=tables,
+        warehouses=[FakeWarehouse(name="DEX_WH", size="X-Small", state="SUSPENDED")],
+    )
+
+
+@pytest.fixture
 def dbt_project_dir(tmp_path: Path) -> Path:
     """A minimal dbt project with a project-local profiles.yml.
 

--- a/packages/dex-core/tests/fakes/snowflake.py
+++ b/packages/dex-core/tests/fakes/snowflake.py
@@ -1,0 +1,306 @@
+"""A stateful fake of the snowflake-connector-python surface dex uses.
+
+Behavioral, not a mock: it records every statement in order, serves SHOW
+metadata from a table registry, simulates per-statement duration by advancing
+an injectable clock (the adapter measures wall-clock elapsed through the same
+clock, so timing assertions are deterministic), tracks the session parameters
+the adapter sets, and enforces ``STATEMENT_TIMEOUT_IN_SECONDS`` the way the
+service does: a real ``ProgrammingError`` naming the statement timeout, raised
+at execute, with the elapsed time capped at the timeout (a killed statement
+still bills what ran). Tests assert against observable behavior (statement
+ordering, session state, ledger effects), not call signatures.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from snowflake.connector import errors as sf_errors
+
+# Statements with no registered duration run this long on the fake clock.
+DEFAULT_STATEMENT_SECONDS = 0.5
+
+
+class FakeClock:
+    """The adapter's injectable clock; the fake connection advances it by each
+    statement's simulated duration."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+@dataclass
+class FakeSnowflakeTable:
+    database: str
+    schema: str
+    name: str
+    # (column_name, type_token, nullable); type_token as in SHOW COLUMNS
+    # data_type JSON, e.g. "FIXED", "TEXT", "VARIANT".
+    columns: list[tuple[str, str, bool]]
+    rows: int = 0
+    bytes: int = 0
+    kind: str = "table"
+
+    @property
+    def identifier(self) -> str:
+        return f"{self.database}.{self.schema}.{self.name}"
+
+    @property
+    def quoted(self) -> str:
+        return ".".join(f'"{part}"' for part in (self.database, self.schema, self.name))
+
+
+@dataclass
+class FakeWarehouse:
+    name: str
+    size: str = "X-Small"
+    state: str = "SUSPENDED"
+    resource_constraint: str = ""
+
+
+@dataclass
+class FakeStatement:
+    sql: str
+    timeout: int | None
+    session_timeout: int | None
+
+
+@dataclass
+class FakeResult:
+    """What one executed SELECT returns: dict rows keyed by (lowercase) alias,
+    plus how long the statement 'runs' on the fake clock."""
+
+    rows: list[dict]
+    seconds: float = DEFAULT_STATEMENT_SECONDS
+
+
+class FakeCursor:
+    def __init__(self, conn: FakeSnowflakeConnection):
+        self._conn = conn
+        self._rows: list[tuple] = []
+        self.description: list[tuple] = []
+        self.sfqid = None
+
+    def execute(self, sql: str, timeout: int | None = None):
+        self._conn.execute_count += 1
+        self.sfqid = f"fake-query-{self._conn.execute_count}"
+        upper = sql.strip().upper()
+
+        if upper.startswith("ALTER SESSION SET"):
+            self._record(sql, timeout)
+            self._apply_session_parameter(sql)
+            return self
+        if upper.startswith("USE "):
+            self._record(sql, timeout)
+            self._conn.used.append(sql)
+            return self
+        if upper.startswith("SHOW "):
+            self._record(sql, timeout)
+            self._serve_show(sql)
+            return self
+
+        # A data statement: simulate duration, enforce the session timeout the
+        # way the service does (kill and bill what ran).
+        result = self._conn.resolve(sql)
+        self._record(sql, timeout)
+        session_timeout = self._conn.session_parameters.get(
+            "STATEMENT_TIMEOUT_IN_SECONDS"
+        )
+        seconds = result.seconds
+        if self._conn.warehouse_resumes_pending:
+            # First data statement after a suspended start pays the resume.
+            seconds += self._conn.resume_seconds
+            self._conn.warehouse_resumes_pending = False
+        if session_timeout is not None and seconds > session_timeout:
+            self._conn.clock.now += float(session_timeout)
+            raise sf_errors.ProgrammingError(
+                msg=(
+                    f"Statement reached its statement or warehouse timeout of "
+                    f"{session_timeout} second(s) and was canceled."
+                ),
+                errno=604,
+            )
+        if timeout is not None and seconds > timeout:
+            self._conn.clock.now += float(timeout)
+            raise sf_errors.ProgrammingError(msg="SQL execution canceled", errno=604)
+        self._conn.clock.now += seconds
+        keys = list(result.rows[0].keys()) if result.rows else []
+        self.description = [
+            (key, "FIXED", None, None, None, None, True) for key in keys
+        ]
+        self._rows = [tuple(row[key] for key in keys) for row in result.rows]
+        return self
+
+    def fetchall(self) -> list[tuple]:
+        return list(self._rows)
+
+    def fetchmany(self, size: int) -> list[tuple]:
+        return list(self._rows[:size])
+
+    # --- internals -------------------------------------------------------------
+
+    def _record(self, sql: str, timeout: int | None) -> None:
+        self._conn.statements.append(
+            FakeStatement(
+                sql=sql,
+                timeout=timeout,
+                session_timeout=self._conn.session_parameters.get(
+                    "STATEMENT_TIMEOUT_IN_SECONDS"
+                ),
+            )
+        )
+
+    def _apply_session_parameter(self, sql: str) -> None:
+        # ALTER SESSION SET <PARAM> = <value>
+        try:
+            assignment = sql.split("SET", 1)[1]
+            key, value = assignment.split("=", 1)
+            key = key.strip().upper()
+            value = value.strip().strip("'")
+            self._conn.session_parameters[key] = (
+                int(value) if value.isdigit() else value
+            )
+        except (IndexError, ValueError):
+            pass
+
+    def _serve_show(self, sql: str) -> None:
+        upper = sql.strip().upper()
+        if upper.startswith("SHOW DATABASES"):
+            names = sorted({t.database for t in self._conn.tables})
+            self._emit([{"name": name} for name in names])
+        elif upper.startswith("SHOW WAREHOUSES"):
+            like = self._like_pattern(sql)
+            rows = [
+                {
+                    "name": w.name,
+                    "size": w.size,
+                    "state": w.state,
+                    "resource_constraint": w.resource_constraint,
+                }
+                for w in self._conn.warehouses
+                if like is None or w.name.upper() == like.upper()
+            ]
+            self._emit(rows)
+        elif upper.startswith("SHOW TABLES") or upper.startswith("SHOW VIEWS"):
+            kind = "table" if upper.startswith("SHOW TABLES") else "view"
+            rows = [
+                {
+                    "name": t.name,
+                    "database_name": t.database,
+                    "schema_name": t.schema,
+                    "rows": t.rows,
+                    "bytes": t.bytes,
+                }
+                for t in self._scoped(sql)
+                if t.kind == kind
+            ]
+            self._emit(rows)
+        elif upper.startswith("SHOW COLUMNS"):
+            rows = []
+            for t in self._scoped(sql):
+                for col, type_token, nullable in t.columns:
+                    rows.append(
+                        {
+                            "table_name": t.name,
+                            "database_name": t.database,
+                            "schema_name": t.schema,
+                            "column_name": col,
+                            "data_type": (
+                                f'{{"type":"{type_token}",'
+                                f'"nullable":{str(nullable).lower()}}}'
+                            ),
+                        }
+                    )
+            self._emit(rows)
+        else:
+            self._emit([])
+
+    def _scoped(self, sql: str) -> list[FakeSnowflakeTable]:
+        upper = sql.upper()
+        tables = sorted(self._conn.tables, key=lambda t: t.identifier)
+        if " IN SCHEMA " in upper:
+            scope = sql[upper.index(" IN SCHEMA ") + len(" IN SCHEMA ") :].strip()
+            db, schema = (part.strip('"') for part in scope.split(".", 1))
+            return [
+                t
+                for t in tables
+                if t.database.upper() == db.upper()
+                and t.schema.upper() == schema.upper()
+            ]
+        if " IN DATABASE " in upper:
+            scope = sql[upper.index(" IN DATABASE ") + len(" IN DATABASE ") :].strip()
+            db = scope.strip('"')
+            return [t for t in tables if t.database.upper() == db.upper()]
+        if " IN TABLE " in upper:
+            scope = sql[upper.index(" IN TABLE ") + len(" IN TABLE ") :].strip()
+            ident = scope.replace('"', "")
+            return [t for t in tables if t.identifier.upper() == ident.upper()]
+        return tables
+
+    @staticmethod
+    def _like_pattern(sql: str) -> str | None:
+        upper = sql.upper()
+        if "LIKE" not in upper:
+            return None
+        return sql[upper.index("LIKE") + 4 :].strip().strip("'")
+
+    def _emit(self, rows: list[dict]) -> None:
+        keys = list(rows[0].keys()) if rows else ["name"]
+        self.description = [(key, "TEXT", None, None, None, None, True) for key in keys]
+        self._rows = [tuple(row[key] for key in keys) for row in rows]
+
+
+class FakeSnowflakeConnection:
+    """Simulates exactly the connection surface the adapter touches; anything
+    else raises AttributeError, which is the point (the adapter must not grow
+    calls the fake does not vouch for)."""
+
+    def __init__(
+        self,
+        *,
+        tables: list[FakeSnowflakeTable] | None = None,
+        warehouses: list[FakeWarehouse] | None = None,
+        clock: FakeClock | None = None,
+        row_resolver: Callable[[str], FakeResult | list[dict]] | None = None,
+        resume_seconds: float = 60.0,
+    ):
+        self.tables = tables or []
+        self.warehouses = warehouses or [FakeWarehouse(name="DEX_WH")]
+        self.clock = clock or FakeClock()
+        self.row_resolver = row_resolver
+        self.resume_seconds = resume_seconds
+        self.statements: list[FakeStatement] = []
+        self.used: list[str] = []
+        self.session_parameters: dict[str, Any] = {}
+        self.execute_count = 0
+        self.closed = False
+        # Set when the (single) fake warehouse starts suspended: the first
+        # data statement pays the resume on the clock.
+        self.warehouse_resumes_pending = any(
+            w.state != "STARTED" for w in self.warehouses
+        )
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
+
+    def resolve(self, sql: str) -> FakeResult:
+        if self.row_resolver is None:
+            return FakeResult(rows=[])
+        resolved = self.row_resolver(sql)
+        return resolved if isinstance(resolved, FakeResult) else FakeResult(resolved)
+
+    def close(self) -> None:
+        self.closed = True
+
+    # --- convenience for assertions ---------------------------------------------
+
+    @property
+    def data_statements(self) -> list[FakeStatement]:
+        return [
+            s for s in self.statements if s.sql.strip().upper().startswith("SELECT")
+        ]

--- a/packages/dex-core/tests/guards/test_cost_guard.py
+++ b/packages/dex-core/tests/guards/test_cost_guard.py
@@ -117,9 +117,9 @@ def test_gate_session_remainder_binds_when_tighter():
 
 def test_gate_max_bytes_tracks_actual_billing():
     gate = _gate(ceiling=1_000.0)
-    assert gate.max_bytes_for_statement() == 1_000
+    assert gate.remaining_for_statement() == 1_000
     gate.record_billed(400.0, statement="SELECT 1")
-    assert gate.max_bytes_for_statement() == 600
+    assert gate.remaining_for_statement() == 600
 
 
 def test_gate_ledger_entries_carry_hashes_never_sql():

--- a/packages/dex-core/tests/integration/conftest.py
+++ b/packages/dex-core/tests/integration/conftest.py
@@ -1,18 +1,26 @@
-"""Live BigQuery integration: real ADC, real jobs, real (tiny) bills.
+"""Live cloud integration: real credentials, real jobs, real (tiny) bills.
 
-Skipped unless the environment opts in, so the default suite stays
-deterministic and free for contributors without GCP. To run locally:
+Each connector's tests are skipped unless its environment opts in, so the
+default suite stays deterministic and free for contributors without cloud
+accounts.
+
+BigQuery (bills to DEX_TEST_BQ_PROJECT; every query capped at
+DEX_TEST_BQ_MAX_BYTES, default 100 MB, so a worst-case bug costs cents; reads
+public datasets, writes only to the TTL'd scratch dataset):
 
     gcloud auth application-default login
     DEX_TEST_BQ_PROJECT=<your-project> DEX_TEST_BQ_DATASET=dex_ci \
         uv run pytest tests/integration -q
 
-Billing goes to DEX_TEST_BQ_PROJECT. Every query is capped at
-DEX_TEST_BQ_MAX_BYTES (default 100 MB), so a worst-case bug costs cents; the
-suite reads public datasets (bigquery-public-data) and writes only to the
-scratch dataset, which should be provisioned with a default table TTL:
+Snowflake (bills warehouse time on the pinned X-Small; every statement capped
+at DEX_TEST_SNOWFLAKE_MAX_SECONDS, default 60; reads SNOWFLAKE_SAMPLE_DATA,
+writes only to the transient scratch database; the account-level resource
+monitor is the hard backstop). Auth comes from a connections.toml entry
+locally or SNOWFLAKE_* env in CI (scripts/setup_snowflake_ci.sh provisions
+both):
 
-    bq mk --dataset --default_table_expiration 86400 <project>:dex_ci
+    DEX_TEST_SNOWFLAKE_CONNECTION=dex-ci DEX_TEST_SNOWFLAKE_DATABASE=DEX_CI \
+        uv run pytest tests/integration -q
 """
 
 from __future__ import annotations
@@ -25,9 +33,31 @@ REQUIRED_ENV = ("DEX_TEST_BQ_PROJECT", "DEX_TEST_BQ_DATASET")
 
 MAX_BYTES = int(os.environ.get("DEX_TEST_BQ_MAX_BYTES", str(100 * 1024 * 1024)))
 
+SF_MAX_SECONDS = float(os.environ.get("DEX_TEST_SNOWFLAKE_MAX_SECONDS", "60"))
+
+
+def _snowflake_enabled() -> bool:
+    return bool(
+        os.environ.get("DEX_TEST_SNOWFLAKE_DATABASE")
+        and (
+            os.environ.get("DEX_TEST_SNOWFLAKE_CONNECTION")
+            or (
+                os.environ.get("SNOWFLAKE_ACCOUNT") and os.environ.get("SNOWFLAKE_USER")
+            )
+        )
+    )
+
 
 @pytest.fixture(autouse=True)
-def _require_bigquery_env():
+def _require_cloud_env(request):
+    if request.node.get_closest_marker("snowflake"):
+        if not _snowflake_enabled():
+            pytest.skip(
+                "Snowflake integration disabled: set DEX_TEST_SNOWFLAKE_DATABASE "
+                "plus DEX_TEST_SNOWFLAKE_CONNECTION (or SNOWFLAKE_ACCOUNT/USER)"
+            )
+        pytest.importorskip("snowflake.connector")
+        return
     missing = [name for name in REQUIRED_ENV if not os.environ.get(name)]
     if missing:
         pytest.skip(f"BigQuery integration disabled: set {', '.join(missing)}")
@@ -42,3 +72,18 @@ def bq_project() -> str:
 @pytest.fixture
 def bq_scratch_dataset() -> str:
     return os.environ["DEX_TEST_BQ_DATASET"]
+
+
+@pytest.fixture
+def sf_scratch_database() -> str:
+    return os.environ["DEX_TEST_SNOWFLAKE_DATABASE"]
+
+
+@pytest.fixture
+def sf_connection_name() -> str | None:
+    return os.environ.get("DEX_TEST_SNOWFLAKE_CONNECTION")
+
+
+@pytest.fixture
+def sf_warehouse() -> str:
+    return os.environ.get("DEX_TEST_SNOWFLAKE_WAREHOUSE", "DEX_CI_WH")

--- a/packages/dex-core/tests/integration/test_snowflake_connect.py
+++ b/packages/dex-core/tests/integration/test_snowflake_connect.py
@@ -1,0 +1,74 @@
+"""Live `connect test` against Snowflake: connection discovery, capabilities
+envelope, and the sanitizer, end to end. Free: capabilities issues SHOW
+commands only, which run on the cloud-services layer with no warehouse."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from exmergo_dex_core.cli import main
+
+pytestmark = [pytest.mark.integration, pytest.mark.snowflake]
+
+SAMPLE_SCOPE = "SNOWFLAKE_SAMPLE_DATA.TPCH_SF1"
+
+
+def seed_repo(
+    root: Path,
+    scratch_database: str,
+    warehouse: str,
+    connection_name: str | None,
+    *,
+    databases: list[str] | None = None,
+    budget: float | None = None,
+) -> None:
+    snowflake: dict = {
+        "warehouse": warehouse,
+        "databases": databases if databases is not None else [SAMPLE_SCOPE],
+        "dev_database": scratch_database,
+    }
+    if connection_name:
+        snowflake["connection_name"] = connection_name
+    config: dict = {"connector": "snowflake", "snowflake": snowflake}
+    if budget is not None:
+        config["budget"] = {"ceiling": budget}
+    (root / ".dex").mkdir(parents=True, exist_ok=True)
+    (root / ".dex" / "config.yml").write_text(yaml.safe_dump(config), encoding="utf-8")
+
+
+def run_cli(argv: list[str], capsys) -> tuple[int, dict]:
+    rc = main(argv)
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1, "exactly one envelope line on stdout"
+    return rc, json.loads(out)
+
+
+def test_connect_test_discovers_connection_and_reports_read_only(
+    tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
+):
+    seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
+    rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
+    assert rc == 0, envelope
+    data = envelope["data"]
+    assert data["connector"] == "snowflake"
+    assert data["dialect"] == "snowflake"
+    assert data["read_only"] is True
+    assert data["paradigm"] == "compute_time"
+    assert data["budget"]["warehouse"]["name"].upper() == sf_warehouse.upper()
+    assert data["budget"]["warehouse"]["credits_per_hour"] is not None
+    assert envelope["cost"]["paradigm"] == "compute_time"
+    # The auth method is coarse; no identity, password, or key crosses.
+    payload = json.dumps(envelope)
+    assert data["auth_method"].split(":")[0] in {
+        "named_connection",
+        "default_connection",
+        "environment",
+        "dbt_profile",
+    }
+    user = os.environ.get("SNOWFLAKE_USER", "\x00never")
+    assert user not in payload

--- a/packages/dex-core/tests/integration/test_snowflake_explore.py
+++ b/packages/dex-core/tests/integration/test_snowflake_explore.py
@@ -1,0 +1,154 @@
+"""Live explore against Snowflake sample data: free inventory, the confirm
+handshake with a heuristic seconds estimate (credits alongside), the
+over-ceiling refusal (free), and a firewalled query. Reads only
+SNOWFLAKE_SAMPLE_DATA; warehouse time bills to the pinned X-Small, capped per
+statement by the suite's second ceiling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.cache import ColumnProfile, Dataset, DexCache, DexStore
+
+from .conftest import SF_MAX_SECONDS
+from .test_snowflake_connect import SAMPLE_SCOPE, run_cli, seed_repo
+
+pytestmark = [pytest.mark.integration, pytest.mark.snowflake]
+
+REGION = f"{SAMPLE_SCOPE}.REGION"  # 5 rows: the cheapest possible scan
+# Deliberately large (TPCH SF1000 lineitem is ~170 GB): its heuristic estimate
+# must blow any sane test budget, proving the refusal live at zero cost.
+HUGE_SCOPE = "SNOWFLAKE_SAMPLE_DATA.TPCH_SF1000"
+HUGE = f"{HUGE_SCOPE}.LINEITEM"
+
+
+def test_inventory_is_free_and_ranked(
+    tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
+):
+    seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
+    rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "inventory", "--rank"], capsys
+    )
+    assert rc == 0, envelope
+    identifiers = {o["identifier"] for o in envelope["data"]["objects"]}
+    assert REGION in identifiers
+    assert envelope["cost"]["paradigm"] == "compute_time"
+    assert envelope["cost"]["estimate"] in (0.0, None)
+
+
+def test_profile_handshake_then_confirmed_run(
+    tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
+):
+    seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
+    root = str(tmp_path)
+
+    rc, first = run_cli(["--repo-root", root, "explore", "profile", "REGION"], capsys)
+    assert rc == 0
+    assert first["status"] == "needs_confirmation"
+    estimate = first["cost"]["estimate"]
+    assert estimate > 0
+    assert first["data"]["estimate_quality"] == "heuristic"
+    assert "seconds" in first["data"]["hint"]
+    # The credit translation rides alongside the binding seconds figure.
+    assert first["data"]["estimated_credits"] > 0
+    assert first["data"]["per_table_seconds"][REGION] > 0
+
+    budget = max(estimate * 2, SF_MAX_SECONDS)
+    rc, second = run_cli(
+        [
+            "--repo-root",
+            root,
+            "explore",
+            "profile",
+            "REGION",
+            "--confirm",
+            "--budget",
+            str(budget),
+        ],
+        capsys,
+    )
+    assert rc == 0, second
+    assert second["status"] == "ok"
+    dataset = second["data"]["datasets"][0]
+    assert dataset["identifier"] == REGION
+    columns = {c["name"] for c in dataset["columns"]}
+    assert {"R_REGIONKEY", "R_NAME", "R_COMMENT"} <= columns
+    # The estimate the agent confirmed is what the envelope reports; actual
+    # spend (wall seconds) is in data.spend and the ledger.
+    assert second["cost"]["estimate"] == pytest.approx(estimate, rel=0.5)
+    spend = second["data"]["spend"]
+    assert spend["seconds_billed"] >= 0
+    ledger = (tmp_path / ".dex" / "spend.jsonl").read_text().splitlines()
+    assert ledger, "billed commands always leave a ledger entry"
+
+
+def test_over_ceiling_refusal_is_live_and_free(
+    tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
+):
+    seed_repo(
+        tmp_path,
+        sf_scratch_database,
+        sf_warehouse,
+        sf_connection_name,
+        databases=[HUGE_SCOPE],
+    )
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "explore",
+            "profile",
+            "LINEITEM",
+            "--confirm",
+            "--budget",
+            "2",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert envelope["status"] == "error"
+    assert "ceiling" in envelope["errors"][0]
+    # Refused at the estimate stage: no ledger, no spend.
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
+
+
+def test_firewalled_query_round_trip(
+    tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
+):
+    seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
+    # The firewall's PII policy is computed from the cache; seed it directly
+    # (the cache is a non-canonical artifact) so this test scans once, not twice.
+    DexStore(tmp_path).save_cache(
+        DexCache(
+            datasets=[
+                Dataset(
+                    identifier=REGION,
+                    columns=[
+                        ColumnProfile(name="R_REGIONKEY", data_type="FIXED"),
+                        ColumnProfile(name="R_NAME", data_type="TEXT"),
+                        ColumnProfile(name="R_COMMENT", data_type="TEXT"),
+                    ],
+                )
+            ]
+        )
+    )
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "explore",
+            "query",
+            f"SELECT COUNT(*) AS n FROM {REGION}",  # noqa: S608 (test SQL, fixed table)
+            "--confirm",
+            "--budget",
+            # Covers the 60s resume minimum when the warehouse is cold: the
+            # estimate honestly includes it, so the budget must too.
+            str(SF_MAX_SECONDS + 90),
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+    assert envelope["data"]["cells"] == [[5]]
+    assert envelope["data"]["spend"]["seconds_billed"] >= 0

--- a/packages/dex-core/tests/integration/test_snowflake_transform.py
+++ b/packages/dex-core/tests/integration/test_snowflake_transform.py
@@ -1,0 +1,121 @@
+"""Live transform against Snowflake: init a project wired to the transient
+scratch database, plan and apply a trivial model, then a confirmed dev build
+via dbt-snowflake. Writes land only in the scratch database (grants enforce
+it: the CI role can write there and nowhere else); the database is transient
+with zero retention, so anything teardown misses stores nothing durable."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from .conftest import SF_MAX_SECONDS
+from .test_snowflake_connect import run_cli, seed_repo
+
+pytestmark = [pytest.mark.integration, pytest.mark.snowflake]
+
+MODEL_NAME = "dex_probe"
+
+
+def test_init_plan_apply_build_into_the_scratch_database(
+    tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
+):
+    pytest.importorskip("dbt.adapters.snowflake")
+    root = str(tmp_path)
+    seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
+
+    rc, envelope = run_cli(
+        ["--repo-root", root, "transform", "init", "analytics"], capsys
+    )
+    assert rc == 0, envelope
+    profiles = yaml.safe_load(
+        (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
+    )
+    dev = profiles["analytics"]["outputs"]["dev"]
+    assert dev["type"] == "snowflake"
+    assert dev["warehouse"] == sf_warehouse
+    assert dev["database"] == sf_scratch_database
+    assert dev["schema"] == "DBT_DEV"
+    assert dev["threads"] == 1
+    # Discovery renders auth without persisting a secret value.
+    assert "password" not in dev or "env_var" in str(dev.get("password"))
+
+    edits_file = tmp_path / "edits.json"
+    edits_file.write_text(
+        json.dumps(
+            {
+                "edits": [
+                    {
+                        "path": f"models/staging/{MODEL_NAME}.sql",
+                        "kind": "model_sql",
+                        "content": "select 1 as id\n",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc, planned = run_cli(
+        [
+            "--repo-root",
+            root,
+            "transform",
+            "plan",
+            "probe model",
+            "--edits-file",
+            str(edits_file),
+        ],
+        capsys,
+    )
+    assert rc == 0, planned
+    rc, applied = run_cli(["--repo-root", root, "transform", "apply"], capsys)
+    assert rc == 0, applied
+
+    rc, built = run_cli(
+        [
+            "--repo-root",
+            root,
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+            "--budget",
+            str(SF_MAX_SECONDS * 10),  # a dbt build resumes the warehouse
+        ],
+        capsys,
+    )
+    assert rc == 0, built
+    assert built["status"] == "ok"
+    statuses = {n["name"]: n["status"] for n in built["data"]["nodes"]}
+    assert statuses.get(MODEL_NAME) == "success"
+    # Warehouse time is accounted: the compute-time build records seconds.
+    assert built["data"].get("seconds_billed", 0) >= 0
+
+    # The relation exists exactly where the dev target points, then
+    # best-effort cleanup; the transient database is the backstop.
+    import snowflake.connector
+
+    from exmergo_dex_core.config import SnowflakeTarget
+    from exmergo_dex_core.connect import resolve_snowflake_connection
+
+    params, _method = resolve_snowflake_connection(
+        SnowflakeTarget(connection_name=sf_connection_name), os.environ, tmp_path
+    )
+    conn = snowflake.connector.connect(**params)
+    try:
+        cursor = conn.cursor()
+        # dbt's default materialization is a view, so match any object kind.
+        cursor.execute(
+            f"SHOW OBJECTS LIKE '{MODEL_NAME.upper()}' IN SCHEMA "
+            f'"{sf_scratch_database}"."DBT_DEV"'
+        )
+        assert cursor.fetchall(), "the built model must exist in the dev schema"
+        relation = f'"{sf_scratch_database}"."DBT_DEV"."{MODEL_NAME.upper()}"'
+        cursor.execute(f"DROP VIEW IF EXISTS {relation}")
+    finally:
+        conn.close()

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -641,6 +641,226 @@ def test_bigquery_spend_ledger_holds_no_sql_or_values(tmp_path: Path, fake_bq_cl
     assert entry["statement_sha256"]
 
 
+# --- Snowflake: the compute-time connector exercises every family ---------------
+#
+# These run against the fake connection (tests/fakes/snowflake.py):
+# deterministic, offline, free. They importorskip on the [snowflake] extra,
+# which CI and the release gate install, so trimming that extra from a
+# workflow would silently skip release-blocking families; keep
+# `--extra snowflake` in ci.yml and release.yml.
+
+
+def _sf_adapter(fake_sf_connection, *, ceiling=600.0, confirmed=True):
+    from exmergo_dex_core.adapters.snowflake import SnowflakeAdapter
+    from exmergo_dex_core.config import SnowflakeTarget
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    gate = CostGate(
+        paradigm=env.Paradigm.COMPUTE_TIME,
+        ceiling=ceiling,
+        session_ceiling=None,
+        session_spent=0.0,
+        confirmed=confirmed,
+        connector="snowflake",
+    )
+    return SnowflakeAdapter(
+        connection=fake_sf_connection,
+        cost_gate=gate,
+        target=SnowflakeTarget(warehouse="DEX_WH"),
+        account="TESTORG-TESTACCT",
+        auth_method="named_connection:key_pair",
+        clock=fake_sf_connection.clock,
+    )
+
+
+def test_snowflake_generated_sql_is_select_only(fake_sf_connection):
+    # Family 1: every data statement the adapter generates passes the
+    # SELECT-only guard in the snowflake dialect (asserted at build time).
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    adapter = _sf_adapter(fake_sf_connection)
+    _meta, columns = adapter.table_metadata("SHOP.PUBLIC.CUSTOMERS")
+    sql, _plan = adapter._build_aggregate_sql("SHOP.PUBLIC.CUSTOMERS", columns, {"ID"})
+    assert sql.lstrip().upper().startswith("SELECT")
+    assert assert_select_only(sql, dialect="snowflake") == sql
+
+
+def test_select_only_guard_rejects_snowflake_writes_and_ddl():
+    # Family 1: Snowflake DML/DDL, stage/data movement, and multi-statement
+    # forms are all refused when parsed in the snowflake dialect.
+    from exmergo_dex_core.guards.sql_guard import NotSelectOnlyError, assert_select_only
+
+    for bad in (
+        "CREATE TABLE t AS SELECT 1",
+        "MERGE INTO d.t USING d.s ON FALSE WHEN NOT MATCHED THEN INSERT VALUES (1)",
+        "TRUNCATE TABLE d.t",
+        "SELECT 1; SELECT 2",
+        "DELETE FROM d.t WHERE TRUE",
+        "COPY INTO @mystage/x FROM (SELECT 1)",
+        "CALL d.proc()",
+        "ALTER WAREHOUSE wh SET WAREHOUSE_SIZE = 'X-Large'",
+    ):
+        with pytest.raises(NotSelectOnlyError):
+            assert_select_only(bad, dialect="snowflake")
+
+
+def test_snowflake_unconfirmed_scan_never_executes(fake_sf_connection):
+    # Family 2: the strict handshake. Without --confirm nothing runs on the
+    # warehouse (estimation is free SHOW metadata, so there is nothing to bill).
+    from exmergo_dex_core.guards.cost_guard import ConfirmationRequiredError
+
+    adapter = _sf_adapter(fake_sf_connection, confirmed=False)
+    with pytest.raises(ConfirmationRequiredError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert fake_sf_connection.data_statements == []
+
+
+def test_snowflake_confirmed_run_without_a_ceiling_is_refused(fake_sf_connection):
+    # Family 2: nothing executes unbudgeted; confirmation cannot stand in for
+    # a ceiling on a billed paradigm.
+    from exmergo_dex_core.guards.cost_guard import CostGuardError
+
+    adapter = _sf_adapter(fake_sf_connection, ceiling=None, confirmed=True)
+    with pytest.raises(CostGuardError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert fake_sf_connection.data_statements == []
+
+
+def test_snowflake_over_ceiling_cannot_be_confirmed_through(fake_sf_connection):
+    # Family 2: over-ceiling blocks first, even fully confirmed.
+    from exmergo_dex_core.guards.cost_guard import OverCeilingError
+
+    adapter = _sf_adapter(fake_sf_connection, ceiling=2.0, confirmed=True)
+    with pytest.raises(OverCeilingError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "SHOP"."PUBLIC"."EVENTS"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert fake_sf_connection.data_statements == []
+
+
+def test_snowflake_every_executed_statement_is_server_capped(fake_sf_connection):
+    # Family 2: defense in depth past the client-side gate; a wrong heuristic
+    # cannot overrun the budget because the statement timeout kills it.
+    fake_sf_connection.row_resolver = lambda sql: [{"n": 1}]
+    adapter = _sf_adapter(fake_sf_connection)
+    adapter.run_query(
+        'SELECT COUNT(*) AS n FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+        max_rows=10,
+        timeout_seconds=200,
+    )
+    executed = fake_sf_connection.data_statements
+    assert executed
+    assert all(s.session_timeout is not None for s in executed)
+
+
+def test_query_firewall_blocks_snowflake_value_carrying_shapes():
+    # Family 3: PII stays flagged-not-surfaced under the snowflake dialect,
+    # including Snowflake's own value-carrying aggregates and casts.
+    from exmergo_dex_core.config import QueryLimits
+    from exmergo_dex_core.guards.query_firewall import (
+        QueryRefusedError,
+        inspect_query,
+    )
+
+    cache = _firewall_cache()
+    for bad in (
+        "SELECT ANY_VALUE(email) FROM db.main.customers",
+        "SELECT ARRAY_AGG(email) FROM db.main.customers",
+        "SELECT LISTAGG(email, ',') FROM db.main.customers",
+        "SELECT TO_JSON(email) FROM db.main.customers",
+    ):
+        with pytest.raises(QueryRefusedError):
+            inspect_query(bad, cache, QueryLimits(), dialect="snowflake")
+    # Measuring stays allowed in the snowflake dialect too.
+    inspect_query(
+        "SELECT COUNT(DISTINCT email) FROM db.main.customers",
+        cache,
+        QueryLimits(),
+        dialect="snowflake",
+    )
+
+
+def test_snowflake_capabilities_pass_the_sanitizer(fake_sf_connection, capsys):
+    # Family 5: the capabilities payload carries a coarse auth method, never
+    # an identity, password, or key, and survives the sanitizer end to end.
+    adapter = _sf_adapter(fake_sf_connection)
+    caps = adapter.capabilities()
+    env.emit(env.ok(caps))
+    out = capsys.readouterr().out
+    assert out
+    assert "@" not in out  # no user identity
+    assert caps["auth_method"].split(":")[0] in {
+        "named_connection",
+        "default_connection",
+        "environment",
+        "dbt_profile",
+        "unknown",
+    }
+
+
+def test_snowflake_spend_ledger_holds_no_sql_or_values(
+    tmp_path: Path, fake_sf_connection
+):
+    # Family 5: the audit trail is second counts and statement hashes only.
+    import json
+
+    from exmergo_dex_core.cache import DexStore
+
+    store = DexStore(tmp_path)
+    fake_sf_connection.row_resolver = lambda sql: [{"n": 1}]
+    adapter = _sf_adapter(fake_sf_connection)
+    adapter.cost_gate._record = store.append_spend_log
+    adapter.run_query(
+        'SELECT COUNT(*) AS n FROM "SHOP"."PUBLIC"."CUSTOMERS"',
+        max_rows=10,
+        timeout_seconds=200,
+    )
+    lines = (tmp_path / ".dex" / "spend.jsonl").read_text().splitlines()
+    entry = json.loads(lines[-1])
+    assert "SELECT" not in json.dumps(entry)
+    assert entry["billed_seconds"] > 0
+    assert entry["statement_sha256"]
+
+
+def test_ledgers_never_mix_paradigms(tmp_path: Path):
+    # Family 2 (cross-connector): a bytes session budget must not absorb a
+    # seconds entry and vice versa; each connector sums only its own unit.
+    from exmergo_dex_core.cache import DexStore
+
+    store = DexStore(tmp_path)
+    store.append_spend_log(
+        {
+            "at": "2026-07-05T00:00:01+00:00",
+            "connector": "bigquery",
+            "billed_bytes": 5000,
+        }
+    )
+    store.append_spend_log(
+        {
+            "at": "2026-07-05T00:00:02+00:00",
+            "connector": "snowflake",
+            "billed_seconds": 42.0,
+        }
+    )
+    assert store.spend_since("2026-07-05T00:00:00+00:00", connector="bigquery") == 5000
+    assert (
+        store.spend_since(
+            "2026-07-05T00:00:00+00:00", field="billed_seconds", connector="snowflake"
+        )
+        == 42.0
+    )
+
+
 # --- Maintain: drift detection and reconcile exercise every family -------------
 #
 # Detection is read-only against data and writes only to `.dex/`; only reconcile

--- a/packages/dex-core/tests/transform/test_init.py
+++ b/packages/dex-core/tests/transform/test_init.py
@@ -155,7 +155,7 @@ def test_init_refuses_when_a_project_exists_in_a_child_dir(
     assert not (tmp_path / "fresh").exists()
 
 
-@pytest.mark.parametrize("connector", ["snowflake", "databricks", "postgres"])
+@pytest.mark.parametrize("connector", ["databricks", "postgres"])
 def test_cloud_connectors_error_actionably(tmp_path: Path, capsys, connector: str):
     rc, envelope = _run(_init_argv(tmp_path, "--connector", connector), capsys)
     assert rc == 1
@@ -163,6 +163,96 @@ def test_cloud_connectors_error_actionably(tmp_path: Path, capsys, connector: st
     assert connector in message
     assert "not yet supported" in message
     assert "duckdb" in message.lower()
+
+
+def _seed_snowflake_config(repo: Path, **target) -> None:
+    (repo / ".dex").mkdir(parents=True, exist_ok=True)
+    (repo / ".dex" / "config.yml").write_text(
+        yaml.safe_dump({"snowflake": target}), encoding="utf-8"
+    )
+
+
+def _patch_snowflake_discovery(monkeypatch, params: dict):
+    # The renderer resolves the connection at call time from connect.py, so
+    # patching there keeps the real rendering logic under test.
+    import exmergo_dex_core.connect as connect_mod
+
+    monkeypatch.setattr(
+        connect_mod,
+        "resolve_snowflake_connection",
+        lambda target, env, root: (params, "named_connection:key_pair"),
+    )
+
+
+def test_init_snowflake_bootstraps_a_project(tmp_path: Path, capsys, monkeypatch):
+    _seed_snowflake_config(
+        tmp_path,
+        warehouse="DEX_WH",
+        dev_database="SCRATCH",
+        databases=["SHOP"],
+    )
+    _patch_snowflake_discovery(
+        monkeypatch,
+        {
+            "account": "TESTORG-TESTACCT",
+            "user": "DEX_DEV",
+            "private_key_file": "/keys/k.p8",
+            "role": "DEX_ROLE",
+        },
+    )
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "snowflake"), capsys)
+    assert rc == 0, envelope
+    assert envelope["data"]["connector"] == "snowflake"
+    profile = yaml.safe_load(
+        (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
+    )
+    output = profile["analytics"]["outputs"]["dev"]
+    assert output["type"] == "snowflake"
+    assert output["account"] == "TESTORG-TESTACCT"
+    assert output["warehouse"] == "DEX_WH"
+    assert output["database"] == "SCRATCH"
+    assert output["schema"] == "DBT_DEV"
+    assert output["threads"] == 1
+    assert output["query_tag"] == "dex"
+    # Key-pair auth renders as a path, never a key or password value.
+    assert output["private_key_path"] == "/keys/k.p8"
+    assert "password" not in output
+
+
+def test_init_snowflake_refuses_unpinned_warehouse_and_source_collision(
+    tmp_path: Path, capsys, monkeypatch
+):
+    _patch_snowflake_discovery(
+        monkeypatch, {"account": "A", "user": "U", "password": "x"}
+    )
+    _seed_snowflake_config(tmp_path, dev_database="SCRATCH")
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "snowflake"), capsys)
+    assert rc == 1
+    assert "snowflake.warehouse" in envelope["errors"][0]
+
+    _seed_snowflake_config(
+        tmp_path,
+        warehouse="DEX_WH",
+        dev_database="SHOP",
+        dev_schema="PUBLIC",
+        databases=["SHOP.PUBLIC"],
+    )
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "snowflake"), capsys)
+    assert rc == 1
+    assert "source" in envelope["errors"][0]
+
+
+def test_init_snowflake_never_persists_a_password(tmp_path: Path, capsys, monkeypatch):
+    _patch_snowflake_discovery(
+        monkeypatch,
+        {"account": "A", "user": "U", "password": "hunter2-never-rendered"},
+    )
+    _seed_snowflake_config(tmp_path, warehouse="DEX_WH", dev_database="SCRATCH")
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "snowflake"), capsys)
+    assert rc == 0, envelope
+    rendered = (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
+    assert "hunter2" not in rendered
+    assert "env_var" in rendered and "SNOWFLAKE_PASSWORD" in rendered
 
 
 def _seed_bigquery_config(repo: Path, **target) -> None:

--- a/packages/dex-core/uv.lock
+++ b/packages/dex-core/uv.lock
@@ -84,6 +84,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.35"
 source = { registry = "https://pypi.org/simple" }
@@ -113,11 +122,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577, upload-time = "2025-01-31T02:16:47.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393, upload-time = "2025-01-31T02:16:45.015Z" },
 ]
 
 [[package]]
@@ -584,6 +593,23 @@ wheels = [
 ]
 
 [[package]]
+name = "dbt-snowflake"
+version = "1.11.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "agate" },
+    { name = "certifi" },
+    { name = "dbt-adapters" },
+    { name = "dbt-common" },
+    { name = "dbt-core" },
+    { name = "snowflake-connector-python", extra = ["secure-local-storage"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/80/b5a779b9a92cc2607cc37a929febab4b3484fbd0ee374c44baeea721d11e/dbt_snowflake-1.11.6.tar.gz", hash = "sha256:e975b53eb94528648cc88d8046518529d4c5bd7f488783d90b99342cf3dca549", size = 151654, upload-time = "2026-06-24T10:04:11.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/05/5dccc0f173d385f78fac43dcd93b6ecb7e7f5e38597f35d9169202b26a2f/dbt_snowflake-1.11.6-py3-none-any.whl", hash = "sha256:88af2d2f6991a176316ffac1ec8ffbd70c5aeac2813e81037d72abd9b642e4ce", size = 82339, upload-time = "2026-06-24T10:04:10.017Z" },
+]
+
+[[package]]
 name = "deepdiff"
 version = "8.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -672,6 +698,7 @@ all = [
     { name = "databricks-sql-connector" },
     { name = "dbt-bigquery" },
     { name = "dbt-duckdb" },
+    { name = "dbt-snowflake" },
     { name = "duckdb" },
     { name = "google-cloud-bigquery" },
     { name = "psycopg", extra = ["binary"] },
@@ -702,6 +729,7 @@ postgres = [
     { name = "sqlglot" },
 ]
 snowflake = [
+    { name = "dbt-snowflake" },
     { name = "snowflake-connector-python" },
     { name = "sqlglot" },
 ]
@@ -716,6 +744,8 @@ requires-dist = [
     { name = "dbt-bigquery", marker = "extra == 'bigquery'", specifier = ">=1.9" },
     { name = "dbt-duckdb", marker = "extra == 'all'", specifier = ">=1.9" },
     { name = "dbt-duckdb", marker = "extra == 'duckdb'", specifier = ">=1.9" },
+    { name = "dbt-snowflake", marker = "extra == 'all'", specifier = ">=1.9" },
+    { name = "dbt-snowflake", marker = "extra == 'snowflake'", specifier = ">=1.9" },
     { name = "duckdb", marker = "extra == 'all'", specifier = ">=1" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=1" },
     { name = "google-cloud-bigquery", marker = "extra == 'all'", specifier = ">=3" },
@@ -726,8 +756,8 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pyyaml", specifier = ">=6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.19" },
-    { name = "snowflake-connector-python", marker = "extra == 'all'", specifier = ">=3" },
-    { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3" },
+    { name = "snowflake-connector-python", marker = "extra == 'all'", specifier = ">=3.17" },
+    { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.17" },
     { name = "sqlglot", marker = "extra == 'all'", specifier = ">=25" },
     { name = "sqlglot", marker = "extra == 'bigquery'", specifier = ">=25" },
     { name = "sqlglot", marker = "extra == 'databricks'", specifier = ">=25" },
@@ -1161,6 +1191,51 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1219,6 +1294,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -2205,6 +2298,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2476,6 +2578,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2547,6 +2662,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/c6/2b367aa04fb6f6d8e6da22908dd8f61f49ba613306648a2b35b61fb70cd4/snowflake_connector_python-4.6.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:676162cd45df744aa966483960d34bf204cdcae87cecad77fba970f1c2fd570d", size = 2845398, upload-time = "2026-05-28T13:01:44.538Z" },
     { url = "https://files.pythonhosted.org/packages/b7/94/ec61dfbad2d70131c46605a52487733bc98e2d7b26ddd32334f1c4db104d/snowflake_connector_python-4.6.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:eab420406a38ebc059100bb1faa55d7d6306bb224cefadb739ec3cafeff65384", size = 2874335, upload-time = "2026-05-28T13:01:46.742Z" },
     { url = "https://files.pythonhosted.org/packages/af/de/0a816b9877948f60071a5852b1b97a4605475fce4704f04f89d7ca9f43f2/snowflake_connector_python-4.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:9dd8689123a7e7b873db0846f2d92745a02062b16665d20634fbaf34a9c88e7a", size = 5446341, upload-time = "2026-05-28T13:02:16.985Z" },
+]
+
+[package.optional-dependencies]
+secure-local-storage = [
+    { name = "keyring" },
 ]
 
 [[package]]

--- a/references/snowflake.md
+++ b/references/snowflake.md
@@ -1,7 +1,130 @@
-# Connector: Snowflake (stub)
+# Connector: Snowflake
 
-Not yet implemented. The dominant dbt and AE warehouse. Cost paradigm: credits
-(warehouse size times time), so minimize warehouse runtime, not bytes. Auth
-discovered (never asked) from `connections.toml`, key-pair (RSA), SSO
-(externalbrowser), the dbt `profiles.yml` Snowflake target, and `SNOWFLAKE_*` env.
-Namespace: `database.schema.table`.
+The first compute-time billed connector. Namespace: `database.schema.table`.
+Cost paradigm: **warehouse-seconds** (credits shown alongside). Read-only
+against data, enforced in depth.
+
+## Authentication: discover, don't ask
+
+The engine discovers a connection at runtime and never prompts for or persists
+a password. Discovery order:
+
+1. `snowflake.connection_name` in `.dex/config.yml`, naming a
+   `~/.snowflake/connections.toml` entry (the store the `snow` CLI writes)
+2. the default connection (`default_connection_name` in `config.toml`, or
+   `SNOWFLAKE_DEFAULT_CONNECTION_NAME`)
+3. `SNOWFLAKE_*` environment variables (`SNOWFLAKE_ACCOUNT` +
+   `SNOWFLAKE_USER` plus a credential; this is also how CI's
+   workload-identity token arrives: `SNOWFLAKE_AUTHENTICATOR=WORKLOAD_IDENTITY`,
+   `SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER=OIDC`, `SNOWFLAKE_TOKEN=<jwt>`)
+4. the `account` of a `type: snowflake` target in a discovered dbt
+   `profiles.yml`
+
+Key-pair, SSO (`externalbrowser`), password, token, and workload-identity
+credentials all work; only the coarse method (for example
+`named_connection:key_pair`) is ever surfaced. Identities, passwords, and key
+material never cross the envelope. Every discovery failure names the fix.
+
+## Config
+
+```yaml
+# .dex/config.yml
+connector: snowflake
+snowflake:
+  connection_name: dex-ci        # a connections.toml entry; optional
+  warehouse: DEX_CI_WH           # REQUIRED for anything billed; the pin is strict
+  databases:                     # source allowlist; empty means all visible
+    - SNOWFLAKE_SAMPLE_DATA.TPCH_SF1   # db or db.schema entries
+  dev_database: DEX_CI           # where dbt dev builds write (never a source)
+  dev_schema: DBT_DEV            # default DBT_DEV
+  max_full_profile_bytes: null   # opt-in SAMPLE threshold for huge tables
+  credit_price_usd: null         # your contract price; set it to see dollars
+budget:
+  ceiling: 300                   # per-command warehouse-seconds; --budget overrides
+  session_ceiling: 3600          # cumulative seconds per UTC day
+```
+
+**The warehouse pin is strict.** Billed statements run only on
+`snowflake.warehouse`; a connection-level default warehouse is never spent on,
+and a missing or unpinned warehouse refuses with the fix named. Pin the
+smallest warehouse that works (X-Small with 60s auto-suspend is the intended
+shape; `scripts/setup_snowflake_ci.sh` provisions exactly that plus a resource
+monitor as the hard monthly backstop).
+
+## Cost model: the inversion from BigQuery
+
+On BigQuery, metadata is free and scans bill by bytes. On Snowflake the rule
+flips: metadata is cheap (SHOW commands run on the cloud-services layer with
+no warehouse), while any data scan costs warehouse runtime. So dex guards
+**warehouse-seconds**, not bytes.
+
+- **Free:** `connect test`, `explore inventory`, all schema and row/byte
+  metadata (SHOW commands, no `INFORMATION_SCHEMA` scans), estimation, and
+  `maintain check` (drift detection reads metadata only).
+- **Billed:** profiling aggregates, `explore query`, relationship verification
+  probes, and `transform build`.
+
+Budgets (`budget.ceiling`, `--budget`, `budget.session_ceiling`) are
+warehouse-seconds: the number you budget is the number the server enforces.
+Every cost surface also carries the translation to **credits**
+(`seconds x credits_per_hour / 3600`, rate from the warehouse's size and
+generation via `SHOW WAREHOUSES`; Gen2 rates are marked approximate), and to
+dollars when `snowflake.credit_price_usd` is set. dex never guesses a dollar
+price: no API exposes your contract rate.
+
+**Estimates are a heuristic, honestly labeled.** Snowflake has no dry-run, so
+the estimate is derived from table bytes over a conservative scan rate, and
+every handshake payload carries `estimate_quality: "heuristic"`. The estimate
+also floors in the **60-second resume minimum** when the pinned warehouse is
+suspended (Snowflake bills at least 60 seconds per resume), so a two-second
+probe against a cold warehouse is quoted at what the account will actually
+see.
+
+**The budget is hard-enforced regardless of estimate quality.** Before every
+billed statement the session's `STATEMENT_TIMEOUT_IN_SECONDS` is set to the
+remaining budget, so a wrong heuristic cannot overrun the ceiling: Snowflake
+kills the statement and dex reports the over-ceiling refusal. Actual spend is
+wall-clock seconds per statement (including any resume the statement caused),
+recorded to `.dex/spend.jsonl` as `billed_seconds` and summed into the daily
+session ceiling. Every session is tagged `QUERY_TAG = 'dex'` for attribution.
+
+The handshake is the same strict two-step as every billed connector: a
+scanning command without `--confirm` returns `needs_confirmation` carrying the
+seconds estimate (per table where relevant) and its credit translation;
+re-issue with `--confirm --budget <seconds>`. Nothing executes unconfirmed or
+without a ceiling, and an estimate over the ceiling is refused outright.
+
+## Read-only, enforced in depth
+
+- Every data statement passes the SELECT-only guard parsed in the snowflake
+  dialect through one execution door (DML, DDL, `COPY INTO`, `CALL`,
+  `ALTER`, and multi-statement forms all refuse).
+- The adapter issues no mutating statements: SHOW commands, SELECTs, and
+  session parameters only.
+- The documented grant shape is a least-privilege role: USAGE on the pinned
+  warehouse, read (or `IMPORTED PRIVILEGES`) on source databases, and write
+  only on the dedicated dev database (`scripts/setup_snowflake_ci.sh` creates
+  this shape).
+- dbt dev builds write to `dev_database.dev_schema`, which is refused as a
+  source, and the generated profile pins the warehouse and one thread.
+
+## Profiling behavior
+
+Profiling is batched aggregates (COUNT, APPROX_COUNT_DISTINCT, min/max only
+for engine-cleared safe columns), never row values. Semi-structured and
+spatial columns (VARIANT, OBJECT, ARRAY, GEOGRAPHY, GEOMETRY, VECTOR) degrade
+to non-null counts. Tables above `snowflake.max_full_profile_bytes` are
+profiled from a block sample (`SAMPLE SYSTEM`), noted, with uniqueness not
+judged. Exact distinct-count escalation spends only inside the confirmed
+budget and degrades to approximate verdicts with a note when the remainder
+cannot cover it.
+
+## Testing
+
+Offline: a stateful fake connection (`tests/fakes/snowflake.py`) that records
+statement ordering, simulates timing on an injected clock, and enforces the
+statement timeout with the connector's real error types. Live: an env-gated
+integration suite (`DEX_TEST_SNOWFLAKE_*`) reading `SNOWFLAKE_SAMPLE_DATA`
+and writing only to the transient scratch database, run in CI on a schedule
+via workload identity federation (no stored keys), never as a merge or
+release gate.

--- a/scripts/setup_snowflake_ci.sh
+++ b/scripts/setup_snowflake_ci.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# One-time provisioning for the Snowflake connector: the local dev/test loop
+# and the live integration suite (.github/workflows/integration.yml). Run by a
+# maintainer whose `snow` CLI connection can use ACCOUNTADMIN and with gh
+# authenticated against the repository.
+#
+# What it sets up, keyless wherever the platform allows it:
+#   - DEX_CI_WH: an X-Small warehouse, 60s auto-suspend, statement timeout;
+#     the only warehouse dex CI and dev runs are granted
+#   - DEX_CI_MONITOR: a resource monitor that SUSPENDs the warehouse at its
+#     monthly credit quota (the hard cost backstop; nothing dex does can
+#     outspend it)
+#   - DEX_CI: a TRANSIENT scratch database with zero time-travel retention
+#     (the only place dex may write; transient means no fail-safe storage)
+#   - DEX_CI_ROLE: read on SNOWFLAKE_SAMPLE_DATA plus write on the scratch
+#     database only (the grant-level enforcement of "dex never writes outside
+#     the dev target")
+#   - DEX_CI user: a SERVICE user authenticated by Workload Identity
+#     Federation (GitHub OIDC), pinned to this repository and to the
+#     snowflake-integration environment; no key or password is ever created
+#     or stored for CI
+#   - DEX_DEV user: a SERVICE user with a locally generated RSA key pair plus
+#     a `dex-ci` entry in ~/.snowflake/connections.toml, for running the live
+#     integration suite while developing
+#   - the GitHub environment (deployments restricted to main) carrying the
+#     two variables the workflow reads
+#
+# Everything account-specific is a parameter, so nothing private lives in this
+# script. Idempotent: safe to re-run; existing resources are left in place and
+# the WIF pinning is refreshed.
+#
+# Usage:
+#   scripts/setup_snowflake_ci.sh <account-identifier> [snow-connection-name]
+#
+# <account-identifier> is the ORGNAME-ACCOUNTNAME form (shown by
+# `snow connection list` or SELECT CURRENT_ORGANIZATION_NAME() || '-' ||
+# CURRENT_ACCOUNT_NAME()). The optional second argument names the maintainer's
+# admin `snow` connection; the default connection is used otherwise.
+#
+# Overrides via environment: DEX_CI_REPO (owner/name),
+# DEX_CI_CREDIT_QUOTA (monthly credits before the monitor suspends, default 5),
+# DEX_CI_STATEMENT_TIMEOUT (warehouse-level seconds, default 600).
+
+set -euo pipefail
+
+ACCOUNT="${1:-}"
+ADMIN_CONN="${2:-}"
+if [[ -z "$ACCOUNT" ]]; then
+  echo "usage: $0 <account-identifier> [snow-connection-name]" >&2
+  exit 1
+fi
+
+REPO="${DEX_CI_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+CREDIT_QUOTA="${DEX_CI_CREDIT_QUOTA:-5}"
+STATEMENT_TIMEOUT="${DEX_CI_STATEMENT_TIMEOUT:-600}"
+WAREHOUSE="DEX_CI_WH"
+MONITOR="DEX_CI_MONITOR"
+DATABASE="DEX_CI"
+ROLE="DEX_CI_ROLE"
+CI_USER="DEX_CI"
+DEV_USER="DEX_DEV"
+GH_ENV="snowflake-integration"
+DEV_CONN_NAME="dex-ci"
+KEY_DIR="${HOME}/.snowflake/keys"
+KEY_FILE="${KEY_DIR}/dex_dev_rsa_key.p8"
+
+SNOW=(snow sql)
+if [[ -n "$ADMIN_CONN" ]]; then
+  SNOW=(snow sql -c "$ADMIN_CONN")
+fi
+sql() { "${SNOW[@]}" -q "USE ROLE ACCOUNTADMIN; $1"; }
+
+echo "== dex Snowflake setup =="
+echo "   account:     ${ACCOUNT}"
+echo "   repository:  ${REPO}"
+echo "   warehouse:   ${WAREHOUSE} (X-Small, auto-suspend 60s, timeout ${STATEMENT_TIMEOUT}s)"
+echo "   monitor:     ${MONITOR} (${CREDIT_QUOTA} credits/month, suspends)"
+echo "   database:    ${DATABASE} (transient, retention 0)"
+echo "   role:        ${ROLE}"
+echo "   ci user:     ${CI_USER} (WIF: GitHub OIDC, env ${GH_ENV})"
+echo "   dev user:    ${DEV_USER} (key pair, connection '${DEV_CONN_NAME}')"
+echo
+
+echo "-- Warehouse (the only compute dex is granted; suspended until used)"
+sql "CREATE WAREHOUSE IF NOT EXISTS ${WAREHOUSE}
+       WAREHOUSE_SIZE = 'XSMALL'
+       AUTO_SUSPEND = 60
+       AUTO_RESUME = TRUE
+       INITIALLY_SUSPENDED = TRUE
+       STATEMENT_TIMEOUT_IN_SECONDS = ${STATEMENT_TIMEOUT}
+       COMMENT = 'dex integration and dev; capped by ${MONITOR}';"
+
+echo "-- Resource monitor (the hard backstop: suspends the warehouse at quota)"
+sql "CREATE RESOURCE MONITOR IF NOT EXISTS ${MONITOR}
+       WITH CREDIT_QUOTA = ${CREDIT_QUOTA}
+       FREQUENCY = MONTHLY
+       START_TIMESTAMP = IMMEDIATELY
+       TRIGGERS ON 80 PERCENT DO NOTIFY
+                ON 100 PERCENT DO SUSPEND_IMMEDIATE;
+     ALTER WAREHOUSE ${WAREHOUSE} SET RESOURCE_MONITOR = ${MONITOR};"
+
+echo "-- Scratch database (transient + zero retention: no fail-safe or"
+echo "   time-travel storage cost; crashed runs leave nothing that bills)"
+sql "CREATE TRANSIENT DATABASE IF NOT EXISTS ${DATABASE}
+       DATA_RETENTION_TIME_IN_DAYS = 0
+       COMMENT = 'dex integration scratch; safe to drop';"
+
+echo "-- Sample data (shared TPC-H; storage is free, mounted if absent)"
+sql "CREATE DATABASE IF NOT EXISTS SNOWFLAKE_SAMPLE_DATA
+       FROM SHARE SFC_SAMPLES.SAMPLE_DATA;"
+
+echo "-- Role and grants (read samples; write scratch only)"
+sql "CREATE ROLE IF NOT EXISTS ${ROLE};
+     GRANT USAGE ON WAREHOUSE ${WAREHOUSE} TO ROLE ${ROLE};
+     GRANT IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE_SAMPLE_DATA TO ROLE ${ROLE};
+     GRANT ALL PRIVILEGES ON DATABASE ${DATABASE} TO ROLE ${ROLE};
+     GRANT ALL PRIVILEGES ON ALL SCHEMAS IN DATABASE ${DATABASE} TO ROLE ${ROLE};
+     GRANT ALL PRIVILEGES ON FUTURE SCHEMAS IN DATABASE ${DATABASE} TO ROLE ${ROLE};"
+
+echo "-- CI service user (Workload Identity Federation, pinned to ${REPO} + ${GH_ENV})"
+# CREATE IF NOT EXISTS then ALTER keeps re-runs idempotent while refreshing
+# the pinning if the repository or environment name ever changes. The subject
+# condition is the load-bearing line: only tokens GitHub mints for this
+# repository's snowflake-integration environment are accepted.
+sql "CREATE USER IF NOT EXISTS ${CI_USER}
+       TYPE = SERVICE
+       DEFAULT_ROLE = ${ROLE}
+       DEFAULT_WAREHOUSE = ${WAREHOUSE}
+       DEFAULT_NAMESPACE = ${DATABASE}
+       COMMENT = 'dex integration CI (GitHub Actions via workload identity)';
+     ALTER USER ${CI_USER} SET WORKLOAD_IDENTITY = (
+       TYPE = OIDC
+       ISSUER = 'https://token.actions.githubusercontent.com'
+       SUBJECT = 'repo:${REPO}:environment:${GH_ENV}'
+       OIDC_AUDIENCE_LIST = ('snowflakecomputing.com')
+     );
+     GRANT ROLE ${ROLE} TO USER ${CI_USER};"
+
+echo "-- Local dev service user (key pair; the key never leaves this machine)"
+sql "CREATE USER IF NOT EXISTS ${DEV_USER}
+       TYPE = SERVICE
+       DEFAULT_ROLE = ${ROLE}
+       DEFAULT_WAREHOUSE = ${WAREHOUSE}
+       DEFAULT_NAMESPACE = ${DATABASE}
+       COMMENT = 'dex local development (key-pair auth)';
+     GRANT ROLE ${ROLE} TO USER ${DEV_USER};"
+
+if [[ -f "$KEY_FILE" ]]; then
+  echo "   key ${KEY_FILE} already exists; reusing it"
+else
+  mkdir -p "$KEY_DIR"
+  (umask 077 && openssl genrsa 2048 2>/dev/null \
+    | openssl pkcs8 -topk8 -inform PEM -nocrypt -out "$KEY_FILE")
+  echo "   generated ${KEY_FILE}"
+fi
+# Snowflake wants the base64 body only, without the PEM armor lines.
+PUBLIC_KEY=$(openssl rsa -in "$KEY_FILE" -pubout 2>/dev/null | grep -v '^-----' | tr -d '\n')
+sql "ALTER USER ${DEV_USER} SET RSA_PUBLIC_KEY = '${PUBLIC_KEY}';"
+
+echo "-- Local snow connection '${DEV_CONN_NAME}' (used by the integration suite)"
+if snow connection list 2>/dev/null | grep -q "$DEV_CONN_NAME"; then
+  echo "   connection ${DEV_CONN_NAME} already exists"
+else
+  snow connection add --connection-name "$DEV_CONN_NAME" \
+    --account "$ACCOUNT" --user "$DEV_USER" \
+    --authenticator SNOWFLAKE_JWT --private-key-file "$KEY_FILE" \
+    --role "$ROLE" --warehouse "$WAREHOUSE" --database "$DATABASE" \
+    --no-interactive
+fi
+
+echo "-- GitHub environment (deployments restricted to main)"
+printf '{ "deployment_branch_policy": { "protected_branches": false, "custom_branch_policies": true } }' \
+  | gh api -X PUT "repos/${REPO}/environments/${GH_ENV}" --input - >/dev/null
+# Adding the same branch policy twice errors; tolerate re-runs.
+gh api -X POST "repos/${REPO}/environments/${GH_ENV}/deployment-branch-policies" \
+  -f name=main >/dev/null 2>&1 || echo "   branch policy for main already present"
+
+echo "-- GitHub environment variables (identifiers, not secrets: WIF stores no credential)"
+gh variable set DEX_TEST_SNOWFLAKE_ACCOUNT --repo "$REPO" --env "$GH_ENV" --body "$ACCOUNT"
+gh variable set DEX_TEST_SNOWFLAKE_USER --repo "$REPO" --env "$GH_ENV" --body "$CI_USER"
+
+echo
+echo "== Done. Verify with:"
+echo "   snow connection test -c ${DEV_CONN_NAME}"
+echo "   snow sql -c ${DEV_CONN_NAME} -q \"SELECT COUNT(*) FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.ORDERS\""
+echo "== The second query resumes ${WAREHOUSE}; it auto-suspends after 60s and"
+echo "   ${MONITOR} suspends it for the month at ${CREDIT_QUOTA} credits."

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -39,7 +39,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "0.1.3"
+DEX_CORE_VERSION = "0.1.4"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -39,7 +39,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "0.1.3"
+DEX_CORE_VERSION = "0.1.4"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -39,7 +39,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "0.1.3"
+DEX_CORE_VERSION = "0.1.4"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
## What this changes

Added Snowflake connector.
Small interface change: `dex` now supports 2 different billing paradigms:
- `compute_time` (currently: Snowflake uses this)
- `bytes_billed` (currently: BigQuery uses this)

Added integration tests against a real Snowflake data warehouse.

## Related issues

Closes: https://github.com/exmergo/dex/issues/28