### PR TITLE
Hotfix: Fix failing Integration Tests (Snowflake)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,19 @@ the full explore, transform, and maintain loop on a real warehouse.
   as noise (the band scales with cardinality, so a genuine new category at low
   cardinality still fires, and an exact baseline still fires on any change).
 
+- `transform init --connector snowflake` on a workload-identity connection
+  now refuses with the working alternatives named (key-pair or SSO via
+  `snowflake.connection_name`) instead of rendering a profile that references
+  a `SNOWFLAKE_PASSWORD` that cannot exist. Stable dbt-snowflake does not
+  support workload identity yet; the engine paths (explore, maintain, query)
+  are unaffected. Surfaced by the first scheduled Snowflake integration run,
+  where the whole suite authenticates keylessly.
+- The live `connect test` assertion that no identity crosses the envelope now
+  checks identity-shaped keys and credential values instead of a raw username
+  substring, which false-positived when the CI username (`DEX_CI`) was a
+  substring of the scratch database and warehouse names the envelope
+  legitimately reports.
+
 ## [0.1.2] - 2026-07-04
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/transform/init.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/init.py
@@ -330,6 +330,20 @@ def _snowflake_profile(
         output["private_key_path"] = str(private_key)
     elif authenticator == "EXTERNALBROWSER":
         output["authenticator"] = "externalbrowser"
+    elif authenticator == "WORKLOAD_IDENTITY" or (
+        params.get("token") and not params.get("password")
+    ):
+        # Stable dbt-snowflake cannot authenticate via workload identity or a
+        # raw OIDC token (support is upstream but unreleased), so a rendered
+        # profile would fail every build with an opaque auth error. Refuse
+        # with the working alternatives instead.
+        raise InitError(
+            "the discovered Snowflake connection authenticates via workload "
+            "identity, which dbt-snowflake does not support yet; for dbt "
+            "builds use a key-pair or SSO connection (snow connection add "
+            "with --private-key-file or --authenticator externalbrowser) and "
+            "pin it via snowflake.connection_name in .dex/config.yml"
+        )
     else:
         # Never persist a password or token: the profile reads it from the
         # environment at dbt runtime instead (a Jinja reference, not a value).

--- a/packages/dex-core/tests/integration/test_snowflake_connect.py
+++ b/packages/dex-core/tests/integration/test_snowflake_connect.py
@@ -62,13 +62,36 @@ def test_connect_test_discovers_connection_and_reports_read_only(
     assert data["budget"]["warehouse"]["name"].upper() == sf_warehouse.upper()
     assert data["budget"]["warehouse"]["credits_per_hour"] is not None
     assert envelope["cost"]["paradigm"] == "compute_time"
-    # The auth method is coarse; no identity, password, or key crosses.
-    payload = json.dumps(envelope)
+    # The auth method is coarse; no identity, password, or key crosses. A raw
+    # substring check on the username would false-positive whenever the user
+    # is a substring of a legitimate identifier (in CI the DEX_CI user matches
+    # the DEX_CI database and DEX_CI_WH warehouse), so assert on the actual
+    # invariants: no identity-shaped key anywhere, and no credential value.
     assert data["auth_method"].split(":")[0] in {
         "named_connection",
         "default_connection",
         "environment",
         "dbt_profile",
     }
-    user = os.environ.get("SNOWFLAKE_USER", "\x00never")
-    assert user not in payload
+    assert not _identity_keys(data)
+    payload = json.dumps(envelope)
+    for secret in (
+        os.environ.get("SNOWFLAKE_TOKEN"),
+        os.environ.get("SNOWFLAKE_PASSWORD"),
+    ):
+        assert not secret or secret not in payload
+
+
+def _identity_keys(value, path="data") -> list[str]:
+    """Every key in the payload that names an identity or credential."""
+
+    hits: list[str] = []
+    if isinstance(value, dict):
+        for key, sub in value.items():
+            if str(key).lower() in {"user", "username", "login", "login_name"}:
+                hits.append(f"{path}.{key}")
+            hits.extend(_identity_keys(sub, f"{path}.{key}"))
+    elif isinstance(value, list):
+        for i, sub in enumerate(value):
+            hits.extend(_identity_keys(sub, f"{path}[{i}]"))
+    return hits

--- a/packages/dex-core/tests/integration/test_snowflake_transform.py
+++ b/packages/dex-core/tests/integration/test_snowflake_transform.py
@@ -25,6 +25,12 @@ def test_init_plan_apply_build_into_the_scratch_database(
     tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
 ):
     pytest.importorskip("dbt.adapters.snowflake")
+    if os.environ.get("SNOWFLAKE_AUTHENTICATOR", "").upper() == "WORKLOAD_IDENTITY":
+        # Stable dbt-snowflake cannot authenticate via workload identity, so
+        # `transform init` deliberately refuses such a connection. The build
+        # path is exercised by the local key-pair run; unskip once
+        # dbt-snowflake ships workload-identity support and init renders it.
+        pytest.skip("dbt builds need a durable credential; WIF not yet in dbt")
     root = str(tmp_path)
     seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
 

--- a/packages/dex-core/tests/transform/test_init.py
+++ b/packages/dex-core/tests/transform/test_init.py
@@ -242,6 +242,29 @@ def test_init_snowflake_refuses_unpinned_warehouse_and_source_collision(
     assert "source" in envelope["errors"][0]
 
 
+def test_init_snowflake_refuses_workload_identity_with_the_fix(
+    tmp_path: Path, capsys, monkeypatch
+):
+    # dbt-snowflake cannot authenticate via workload identity yet, so a
+    # rendered profile would fail every build; init must refuse actionably.
+    _patch_snowflake_discovery(
+        monkeypatch,
+        {
+            "account": "A",
+            "user": "U",
+            "authenticator": "WORKLOAD_IDENTITY",
+            "token": "not-a-real-token",
+        },
+    )
+    _seed_snowflake_config(tmp_path, warehouse="DEX_WH", dev_database="SCRATCH")
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "snowflake"), capsys)
+    assert rc == 1
+    message = envelope["errors"][0]
+    assert "workload identity" in message
+    assert "connection_name" in message
+    assert not (tmp_path / "analytics").exists()
+
+
 def test_init_snowflake_never_persists_a_password(tmp_path: Path, capsys, monkeypatch):
     _patch_snowflake_discovery(
         monkeypatch,

--- a/references/snowflake.md
+++ b/references/snowflake.md
@@ -25,6 +25,12 @@ credentials all work; only the coarse method (for example
 `named_connection:key_pair`) is ever surfaced. Identities, passwords, and key
 material never cross the envelope. Every discovery failure names the fix.
 
+One caveat: workload identity covers the engine (explore, maintain, query)
+but not dbt builds, because stable dbt-snowflake does not support it yet.
+`transform init` refuses a workload-identity connection and names the
+alternatives (key-pair or SSO); the refusal lifts once dbt-snowflake ships
+support.
+
 ## Config
 
 ```yaml


### PR DESCRIPTION
Improve Snowflake integration: enforce workload identity refusal for unsupported dbt builds and enhance identity checks

## What this changes

Fixes the two failures from the first scheduled Snowflake integration run,
where the whole suite authenticates keylessly via workload identity.

- `transform init --connector snowflake` on a workload-identity connection now
  refuses with the working alternatives named (key-pair or SSO pinned via
  `snowflake.connection_name`) instead of rendering a profile that references
  a `SNOWFLAKE_PASSWORD` that cannot exist. Stable dbt-snowflake does not
  support workload identity yet (upstream support is merged for 1.12, still in
  beta); the engine paths (explore, maintain, query) are unaffected. The CI
  transform test skips visibly under `WORKLOAD_IDENTITY`; the dbt-build path
  stays covered by the local key-pair run.
- The live `connect test` no-identity-leak assertion now checks
  identity-shaped keys and credential values instead of a raw username
  substring, which false-positived when the CI username (`DEX_CI`) is a
  substring of the scratch database and warehouse names the envelope
  legitimately reports.

Also documents the workload-identity caveat in `references/snowflake.md`.

Verified: 496 unit tests green; live suite 6/6 with the key-pair connection;
re-run with `SNOWFLAKE_AUTHENTICATOR=WORKLOAD_IDENTITY` reproduces the CI
shape (5 passed, 1 skipped with the documented reason).

## Related issues

Closes: https://github.com/exmergo/dex/issues/30