### PR TITLE
PostgreSQL connector

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,13 +30,13 @@ body:
     id: connector
     attributes:
       label: Connector
-      description: Which connector were you using? DuckDB and BigQuery are implemented today.
+      description: Which connector were you using? DuckDB, BigQuery, Snowflake, and PostgreSQL are implemented today.
       options:
         - DuckDB
         - BigQuery
-        - Snowflake (not yet implemented)
+        - Snowflake
+        - PostgreSQL
         - Databricks (not yet implemented)
-        - PostgreSQL (not yet implemented)
         - Not connector-specific
     validations:
       required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       # The cloud extras are included so their unit tests and safety families
       # run here (they are offline against fake clients, but they importorskip
       # on the client libraries; without the extras they would silently skip).
-      - name: Sync (duckdb + bigquery + snowflake + dev extras)
-        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra dev --python ${{ matrix.python-version }}
+      - name: Sync (duckdb + bigquery + snowflake + postgres + dev extras)
+        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra postgres --extra dev --python ${{ matrix.python-version }}
       - name: Tier-1 unit tests
         run: uv run pytest -q
 
@@ -48,8 +48,8 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-      - name: Sync (duckdb + bigquery + snowflake + dev extras)
-        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra dev
+      - name: Sync (duckdb + bigquery + snowflake + postgres + dev extras)
+        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra postgres --extra dev
       - name: Safety-critical assertions
         run: uv run pytest -q tests/test_safety_spine.py
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,8 @@ name: Integration
 # fork-runnable; this workflow answers "does the connector still work against
 # the real service" on main and on a schedule. Each suite reads shared/public
 # sample data, writes only to its scratch scope, and caps every statement
-# (bytes on BigQuery, seconds on Snowflake), so a worst-case run costs cents.
+# (bytes on BigQuery, seconds on Snowflake and Postgres), so a worst-case run
+# costs cents.
 #
 # One-time setup (documented in CONTRIBUTING.md):
 #   BigQuery: scripts/setup_bigquery_ci.sh (Workload Identity Pool provider
@@ -17,6 +18,11 @@ name: Integration
 #   snowflake-integration environment; a least-privilege role on the pinned
 #   X-Small warehouse and the transient scratch database; a resource monitor
 #   as the hard monthly cost backstop).
+#   Postgres: no setup at all. The operational-database connector runs against
+#   a service container seeded from scripts/postgres_seed.sql (the same seed
+#   scripts/setup_postgres_dev.sh applies locally): free, keyless, and
+#   fork-runnable by construction, kept here for pattern parity with the other
+#   connectors rather than as a cost decision.
 on:
   push:
     branches: [main]
@@ -119,3 +125,47 @@ jobs:
         run: uv sync --extra snowflake --extra duckdb --extra dev
       - name: Live Snowflake integration suite
         run: uv run pytest tests/integration -q -m snowflake
+
+  postgres:
+    # No repository gate and no environment: the target is a job-local service
+    # container, so there is nothing to authenticate against and nothing a
+    # fork could spend.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: packages/dex-core
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DEX_TEST_PG_DSN: postgresql://dex_ro:dex_ro@localhost:5432/dex_dogfood
+      DEX_TEST_PG_DEV_PASSWORD: dbt_dev
+    steps:
+      - uses: actions/checkout@v4
+      # The same seed the local dogfood container uses; psql ships on
+      # ubuntu-latest runners.
+      - name: Seed the service container
+        working-directory: .
+        run: |
+          PGPASSWORD=postgres psql -h localhost -U postgres -v ON_ERROR_STOP=1 \
+            -c "DROP DATABASE IF EXISTS dex_dogfood WITH (FORCE)" \
+            -c "CREATE DATABASE dex_dogfood"
+          PGPASSWORD=postgres psql -h localhost -U postgres -d dex_dogfood \
+            -v ON_ERROR_STOP=1 -f scripts/postgres_seed.sql
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync (postgres + duckdb + dev extras)
+        run: uv sync --extra postgres --extra duckdb --extra dev
+      - name: Live Postgres integration suite
+        run: uv run pytest tests/integration -q -m postgres

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
       # The cloud extras stay in the gate: their safety families importorskip
       # on the client libraries, and a release gate that silently skips
       # safety-critical assertions is a hole, not a speedup.
-      - name: Sync (duckdb + bigquery + snowflake + dev extras)
-        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra dev
+      - name: Sync (duckdb + bigquery + snowflake + postgres + dev extras)
+        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra postgres --extra dev
       - name: Tier-1 + safety-critical gate
         run: uv run pytest -q
       # A safety-assertion regression blocks the release regardless of pass-rate;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,20 +89,24 @@ Every command prints exactly one JSON object and nothing else:
 ```
 
 Cost is a preflight estimate surfaced **before** any spend. Any command that
-would spend requires an explicit `--confirm` and a session budget: on a billed
-connector (BigQuery and Snowflake today) the first call returns
-`needs_confirmation` with a free estimate, and the same command is re-issued
-with `--confirm --budget <magnitude>` once the user has agreed to the spend.
-The magnitude is paradigm-relative: **bytes** on BigQuery (an exact free
-dry-run figure), **warehouse-seconds** on Snowflake (a heuristic labeled
-`estimate_quality: "heuristic"`, with a credit translation alongside; the
-budget still binds exactly via a server-side statement timeout). Actual spend
-comes back under `data.spend` (`bytes_billed` or `seconds_billed`) and
-accumulates in the `.dex/spend.jsonl` ledger per connector. Credentials never
-appear in `data` (BigQuery authenticates via discovered Application Default
-Credentials, Snowflake via a discovered `connections.toml` entry, environment,
-or dbt profile; never a pasted key), and result values appear only in
-`explore query`'s columnar payload after the query firewall has cleared them.
+would spend requires an explicit `--confirm` and a session budget: on a
+metered connector (BigQuery, Snowflake, and Postgres today) the first call
+returns `needs_confirmation` with a free estimate, and the same command is
+re-issued with `--confirm --budget <magnitude>` once the user has agreed to
+the spend. The magnitude is paradigm-relative: **bytes** on BigQuery (an
+exact free dry-run figure), **warehouse-seconds** on Snowflake (a heuristic
+labeled `estimate_quality: "heuristic"`, with a credit translation alongside),
+**database-seconds** on Postgres (nothing is billed in dollars; the guarded
+quantity is load on the operational database, estimated free via EXPLAIN). On
+both time paradigms the budget still binds exactly via a server-side
+statement timeout. Actual spend comes back under `data.spend` (`bytes_billed`
+or `seconds_billed`) and accumulates in the `.dex/spend.jsonl` ledger per
+connector. Credentials never appear in `data` (BigQuery authenticates via
+discovered Application Default Credentials, Snowflake via a discovered
+`connections.toml` entry, environment, or dbt profile, Postgres via
+`pg_service.conf`, `DATABASE_URL`, the `PG*` environment, or a dbt profile;
+never a pasted key), and result values appear only in `explore query`'s
+columnar payload after the query firewall has cleared them.
 
 ## Guardrails (non-negotiable, enforced in the engine)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,66 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **PostgreSQL connector**, the operational-database connector and the first
+  on the db-load paradigm. Explore, transform, and maintain run against
+  Postgres with the same guardrails as the billed connectors, adapted to what
+  the paradigm actually protects (no dollars are billed; the guarded quantity
+  is load on a production primary, in database-seconds):
+  - Connection discovery, never prompting: a `pg_service.conf` entry pinned by
+    `postgres.service`, `DATABASE_URL`, the `PG*` environment (resolved
+    natively by libpq, including `~/.pgpass`), the committed non-secret
+    `postgres.host`/`dbname` config target, or a dbt profile. Only a coarse
+    auth method is surfaced; DSNs and passwords never cross the envelope.
+  - Database-seconds budgets (`--budget`, `budget.ceiling`,
+    `budget.session_ceiling`) through the same strict confirm handshake as the
+    billed connectors. Query estimates come from the genuinely free planner
+    preflight (`EXPLAIN (FORMAT JSON)`, so index-served queries are not quoted
+    as full scans) and profile estimates from relation sizes, both honestly
+    labeled `estimate_quality: "heuristic"`; the budget is hard-enforced
+    regardless by a per-statement server-side `statement_timeout`. Actual
+    wall-clock seconds land in the `.dex/spend.jsonl` ledger as
+    `billed_seconds`. Sessions connect as `application_name = 'dex'`.
+  - Read-only in depth: `default_transaction_read_only = on` on every session
+    (autocommit, so no idle-in-transaction holds back vacuum), the SELECT-only
+    guard in the postgres dialect through one execution door, an adapter that
+    issues only catalog SELECTs / EXPLAIN / session SETs, and a documented
+    least-privilege role shape.
+  - Profiling that is deliberately light on the primary: one cheap single-pass
+    aggregate batch (counts, nulls, safe min/max); distinct counts come free
+    from `pg_stats.n_distinct` (never the value-carrying statistics columns),
+    and near-unique keys escalate to exact `COUNT(DISTINCT)` inside the
+    confirmed budget. The escalation scan also upgrades `reltuples` estimates
+    to exact row counts, so uniqueness proofs and `maintain grain` verdicts
+    never fabricate duplicates from a stale planner estimate. `json`/`jsonb`,
+    arrays, `bytea`, and geometric types degrade to non-null counts; tables
+    above `postgres.max_full_profile_bytes` profile from `TABLESAMPLE SYSTEM`.
+  - `transform init --connector postgres`: a dbt-postgres dev profile from the
+    discovered connection (password only as an `env_var('PGPASSWORD')`
+    reference, never a value), writing to a dedicated `dev_schema` refused as
+    a source, one thread. `transform build` injects the ceiling as
+    `PGOPTIONS="-c statement_timeout=<ceiling>s"` (dbt has no dry-run; the
+    per-statement cap is the binding cost control) and accounts per-node
+    execution time into the ledger.
+  - The `[postgres]` extra now carries `dbt-postgres`.
+  - Testing per the established connector template: a stateful fake connection
+    (catalog + pg_stats registry, size-derived EXPLAIN costs, simulated timing,
+    psycopg's real `QueryCanceled` on timeout), safety-spine extensions across
+    all five families for the db-load paradigm, and an env-gated live
+    integration suite (`DEX_TEST_PG_DSN`) against the seeded database from
+    `scripts/postgres_seed.sql`. No cloud setup script: CI runs the suite
+    against a free, keyless `postgres:16` service container, and
+    `scripts/setup_postgres_dev.sh` stands up the same seeded database locally
+    in Docker.
+
+### Fixed
+
+- `explore map` replica folding now recognizes the Snowflake and Postgres dev
+  schemas (`snowflake.dev_schema`, `postgres.dev_schema`); previously only
+  BigQuery's `dev_dataset` fed the fold, so a mapped Snowflake dev schema
+  could inflate one real foreign key into duplicate edges.
+
 ## [0.1.4] - 2026-07-06
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,31 @@ mints the token itself and hands it to the connector through the ordinary
 `DEX_TEST_SNOWFLAKE_USER` are environment variables, not secrets, for the
 same debuggability reason as the BigQuery job.
 
+## Live PostgreSQL integration tests
+
+The same `tests/integration/` directory carries the Postgres suite:
+connection discovery, the database-seconds handshake, the over-ceiling
+refusal, PII flag-not-surface, relationship inference on a deliberately
+undeclared foreign key, a firewalled query, and a dbt build into the
+dedicated dev schema. Unlike the cloud suites it bills nothing and needs no
+cloud account: the target is a local Docker container seeded from
+`scripts/postgres_seed.sql`, with a read-only `dex_ro` role for the engine
+and a `dbt_dev` role that can write only the dev schema.
+
+Stand the container up and run the suite locally:
+
+```
+scripts/setup_postgres_dev.sh
+DEX_TEST_PG_DSN=postgresql://dex_ro:dex_ro@localhost:5433/dex_dogfood \
+    DEX_TEST_PG_DEV_PASSWORD=dbt_dev uv run pytest tests/integration -q -m postgres
+```
+
+In CI the same suite runs from `.github/workflows/integration.yml` against a
+`postgres:16` service container seeded from the same SQL: free, keyless, and
+fork-runnable, kept in the integration workflow for pattern parity with the
+cloud connectors rather than as a cost decision. There is no
+`setup_postgres_ci.sh`; there is nothing to provision.
+
 ## Agent evals (`evals/`)
 
 The Tier-2 agent-eval harness lives at the repo root in `evals/`, separate from

--- a/README.md
+++ b/README.md
@@ -43,30 +43,32 @@ intent.
 ## Connectors
 
 Cloud warehouse: **BigQuery** (live), **Snowflake** (live), **Databricks**.
-Operational database: **PostgreSQL**. Embedded analytical: **DuckDB** (the
-zero-credential on-ramp, and the engine behind the eval and benchmark suites).
-Each client library is behind an optional extra, so the DuckDB on-ramp installs
-only `duckdb` and `sqlglot`; the cloud connectors install with
-`exmergo-dex-core[bigquery]` or `exmergo-dex-core[snowflake]`. To pull every
-connector at once, install `exmergo-dex-core[all]`.
+Operational database: **PostgreSQL** (live). Embedded analytical: **DuckDB**
+(the zero-credential on-ramp, and the engine behind the eval and benchmark
+suites). Each client library is behind an optional extra, so the DuckDB
+on-ramp installs only `duckdb` and `sqlglot`; the other connectors install
+with `exmergo-dex-core[bigquery]`, `[snowflake]`, or `[postgres]`. To pull
+every connector at once, install `exmergo-dex-core[all]`.
 
-Cloud credentials are discovered, never asked for: BigQuery through
-Application Default Credentials (`gcloud auth application-default login`),
-Snowflake through `connections.toml`, `SNOWFLAKE_*` env, or a dbt profile.
-Every scan is estimated and confirmed before it spends, capped server-side
-(`maximum_bytes_billed` on BigQuery; a per-statement statement timeout on
-Snowflake, where budgets are warehouse-seconds with credits shown alongside),
-and recorded in a local spend ledger.
+Credentials are discovered, never asked for: BigQuery through Application
+Default Credentials (`gcloud auth application-default login`), Snowflake
+through `connections.toml`, `SNOWFLAKE_*` env, or a dbt profile, Postgres
+through `pg_service.conf`, `DATABASE_URL`, the `PG*` environment, or a dbt
+profile. Every scan is estimated and confirmed before it spends, capped
+server-side (`maximum_bytes_billed` on BigQuery; a per-statement statement
+timeout on Snowflake and Postgres, whose budgets are warehouse-seconds with
+credits alongside and database-seconds respectively), and recorded in a local
+spend ledger.
 
 ## Status
 
 **v0.1 is the full ETM loop on DuckDB**, with no cloud credentials required:
 explore, transform, and now **maintain** (drift detection and reconcile across
 schema, volume, grain, and semantic axes). **Explore, transform, and maintain
-also run on BigQuery and Snowflake**, the first two cloud connectors, each with
-credential discovery, cost guards with a confirm-before-spend handshake
-(bytes-scanned on BigQuery, warehouse-seconds on Snowflake), and dev-target-only
-dbt builds. Databricks and PostgreSQL land next as v0.2 completes; published
+also run on BigQuery, Snowflake, and PostgreSQL**, each with credential
+discovery, cost guards with a confirm-before-spend handshake (bytes-scanned on
+BigQuery, warehouse-seconds on Snowflake, database-seconds on Postgres), and
+dev-target-only dbt builds. Databricks lands next as v0.2 completes; published
 benchmark scores (ADE-bench uplift and cost/turn efficiency, Spider2.0-DBT)
 land with v0.3.
 

--- a/packages/dex-core/README.md
+++ b/packages/dex-core/README.md
@@ -84,6 +84,21 @@ warehouse the config pins. dbt builds go to a dedicated dev database.schema
 via dbt-snowflake, which the `[snowflake]` extra carries. See
 [`references/snowflake.md`](../../references/snowflake.md).
 
+PostgreSQL: the operational-database connector. Connects through discovered
+credentials (`pg_service.conf`, `DATABASE_URL`, the `PG*` environment, or a
+dbt profile; dex never asks for or persists a password). Nothing is billed in
+dollars; the guarded quantity is load on what is often a production primary,
+so budgets are **database-seconds** through the same confirm handshake. Query
+estimates come from the genuinely free planner preflight (`EXPLAIN`), profile
+estimates from relation sizes, both labeled heuristic; the budget is
+hard-enforced anyway by a per-statement server-side `statement_timeout`, and
+actual seconds land in the same ledger. The session is read-only at the
+server (`default_transaction_read_only = on`), profiling leans on the
+planner's own statistics instead of scanning distincts, and dbt builds go to
+a dedicated dev schema via dbt-postgres, which the `[postgres]` extra
+carries, with the ceiling injected as a statement timeout through
+`PGOPTIONS`. See [`references/postgres.md`](../../references/postgres.md).
+
 Maintain detects drift against the `.dex/` snapshot on four axes and proposes
 the fix: schema (structure), volume (freshness), grain (uniqueness and fanout),
 and semantic (definitions, dangling references, and dimension cardinality).
@@ -94,8 +109,8 @@ connectors the metadata axes (schema, volume, references) stay free while the
 scanning axes (grain, dimension cardinality) take the `--confirm --budget`
 handshake, so `check` is two-phase.
 
-The remaining cloud connectors (Databricks, PostgreSQL) and the Viz preview
-report `not_implemented` until they land.
+The remaining cloud connector (Databricks) and the Viz preview report
+`not_implemented` until they land.
 
 ## License
 

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -49,7 +49,9 @@ snowflake = ["snowflake-connector-python>=3.17", "sqlglot>=25", "dbt-snowflake>=
 # transform can build against a BigQuery dev target with one install.
 bigquery = ["google-cloud-bigquery>=3", "sqlglot>=25", "dbt-bigquery>=1.9"]
 databricks = ["databricks-sql-connector>=3", "databricks-sdk>=0.30", "sqlglot>=25"]
-postgres = ["psycopg[binary]>=3", "sqlglot>=25"]
+# Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
+# transform can build against a Postgres dev schema with one install.
+postgres = ["psycopg[binary]>=3", "sqlglot>=25", "dbt-postgres>=1.9"]
 # One command for users who want every connector at once (e.g. driving multiple
 # warehouses). Self-references the connector extras so their client lists stay
 # defined in exactly one place. Excludes dev, which is contributor tooling, not a
@@ -90,4 +92,5 @@ markers = [
   "integration: hits a live warehouse; gated on DEX_TEST_* environment variables",
   "bigquery: BigQuery-specific integration tests",
   "snowflake: Snowflake-specific integration tests",
+  "postgres: PostgreSQL-specific integration tests",
 ]

--- a/packages/dex-core/src/exmergo_dex_core/adapters/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/__init__.py
@@ -1,5 +1,5 @@
-"""Connector adapters. DuckDB, BigQuery, and Snowflake are real; the rest are
-stubs.
+"""Connector adapters. DuckDB, BigQuery, Snowflake, and Postgres are real;
+Databricks is a stub.
 
 ``get_adapter`` is the single entry point so callers never import a connector
 client directly; the client libraries stay behind their extras and are imported
@@ -38,7 +38,11 @@ def get_adapter(connector: str, **kwargs: Any):
         from .snowflake import SnowflakeAdapter
 
         return SnowflakeAdapter(**kwargs)
-    if connector in {"databricks", "postgres"}:
+    if connector == "postgres":
+        from .postgres import PostgresAdapter
+
+        return PostgresAdapter(**kwargs)
+    if connector == "databricks":
         raise NotImplementedError(f"the '{connector}' adapter is not yet implemented")
     raise ValueError(f"unknown connector '{connector}'")
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
@@ -1,10 +1,834 @@
-"""The postgres adapter (stub). Not yet implemented: metadata model, SQLGlot
-dialect, cheap-metadata path, and the connector-specific cost strategy
-(database load).
+"""The postgres adapter: the operational-database connector (db-load paradigm).
+
+Postgres bills no dollars; the guarded quantity is load on the database dex is
+pointed at, which is often a production OLTP primary. The budget is therefore
+denominated in database-seconds, and every billed statement is capped
+server-side by a ``statement_timeout`` wound down to what remains of the
+budget, so a wrong estimate cannot overrun the ceiling: Postgres kills the
+statement. Actual spend is wall-clock seconds per statement, recorded to the
+ledger as ``billed_seconds``.
+
+The cost split mirrors Snowflake's inversion, not BigQuery's: metadata is
+cheap (``pg_catalog`` lookups, no table scans), while any data scan loads the
+server. Inventory, ``connect test``, ``pg_stats`` reads, and ``EXPLAIN`` stay
+free; profiling aggregates, distinct-count escalations, and agent queries are
+metered. Unlike Snowflake, Postgres has a genuinely free planner preflight:
+query estimates come from ``EXPLAIN (FORMAT JSON)`` (which knows about
+indexes), translated to seconds through a conservative scan-rate heuristic and
+labeled as such.
+
+Profiling is deliberately light on the primary: the billed batch is one cheap
+single-pass scan (COUNT(*), per-column non-null counts, min/max only for
+engine-cleared safe columns), and distinct counts come free from the planner's
+own statistics (``pg_stats.n_distinct``, never the value-carrying histogram
+columns). Near-unique keys then escalate to an exact COUNT(DISTINCT) inside
+the confirmed budget through the standard escalation flow.
+
+Read-only is enforced in depth: ``default_transaction_read_only = on`` on the
+session, the SELECT-only guard in the postgres dialect on every data statement
+through one execution door, an adapter that issues no mutating statements
+(catalog SELECTs / EXPLAIN / session SETs only), and the documented
+least-privilege read-only role.
 """
 
 from __future__ import annotations
 
-# Cost paradigm for this connector: database load.
+import json
+import time
+from collections.abc import Callable
+from typing import Any
+
+from ..config import PostgresTarget
+from ..envelope import Paradigm
+from ..guards.cost_guard import CostGate, OverCeilingError
+from ..guards.sql_guard import assert_select_only
+from .base import ColumnAggregate, ColumnMeta, ObjectMeta, QueryResult, json_safe
+
 PARADIGM = "db_load"
 DIALECT = "postgres"
+
+# Columns are profiled in batches so one statement against a very wide table
+# does not balloon (up to 3 expressions per column).
+_COLUMN_BATCH = 50
+
+# The estimate heuristic: a deliberately conservative sequential scan rate.
+_SCAN_BYTES_PER_SECOND = 50 * 1024 * 1024
+
+# The planner's cost unit is calibrated so seq_page_cost = 1.0 is one page
+# read; translating plan cost through the page size errs conservative (CPU
+# cost components inflate the byte figure).
+_BYTES_PER_PLANNER_PAGE = 8192
+
+# Every billed statement estimates at least this much.
+_MIN_STATEMENT_SECONDS = 0.5
+
+# Types where distinct counts and min/max are invalid or meaningless: only a
+# non-null count is computed. Matched against format_type output (lowercase),
+# plus any array type by its [] suffix. The geometric types matter because
+# "point" contains "int", which the engine's numeric hint would otherwise
+# clear for min/max Postgres cannot order.
+_DEGRADED_TYPE_PREFIXES = (
+    "json",
+    "jsonb",
+    "bytea",
+    "xml",
+    "tsvector",
+    "tsquery",
+    "geometry",
+    "geography",
+    "point",
+    "line",
+    "lseg",
+    "box",
+    "path",
+    "polygon",
+    "circle",
+)
+
+_ESTIMATE_QUALITY_NOTE = (
+    "Postgres bills no dollars; the guarded quantity is load on the database, "
+    "expressed as database-seconds. Query estimates come from the free "
+    "planner (EXPLAIN); profile estimates from relation sizes. The confirmed "
+    "budget is hard-enforced per statement by a server-side statement_timeout"
+)
+
+
+class PostgresConnectionError(Exception):
+    """Raised when a queried object cannot be resolved in the configured
+    scope. The message always names the fix, never a credential."""
+
+
+class PostgresAdapter:
+    """Holds one Postgres connection plus the cost gate for one command.
+
+    ``connection`` is injectable (class DI) so unit tests drive a fake; the
+    real connection is built by ``connect.py`` from discovered parameters
+    (autocommit, ``application_name=dex``). Credentials live only inside this
+    process and are never surfaced. ``clock`` is injectable so the fake can
+    simulate statement duration; it is what actual billed seconds are
+    measured with.
+    """
+
+    name = "postgres"
+    dialect = DIALECT
+    paradigm = Paradigm.DB_LOAD
+
+    def __init__(
+        self,
+        *,
+        connection: Any,
+        cost_gate: CostGate,
+        target: PostgresTarget | None = None,
+        auth_method: str = "unknown",
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self._conn = connection
+        self.cost_gate = cost_gate
+        self.target = target or PostgresTarget()
+        self.auth_method = auth_method
+        self._clock = clock
+        # Imported lazily (the caller constructed the connection, so the
+        # library is present); the error types drive refusal translation.
+        from psycopg import errors as pg_errors
+
+        self._pg_errors = pg_errors
+        # Catalog results are cached per command: the estimate pass and the
+        # confirmed run share table facts, and each lookup is free but a
+        # round-trip.
+        self._objects: dict[str, dict] = {}
+        self._columns: dict[str, list[ColumnMeta]] = {}
+        self._stats: dict[str, dict[str, float]] = {}
+        self._exact_rows: dict[str, int] = {}
+        self._inventory_loaded = False
+        self._database: str | None = None
+        self._notes: dict[str, list[str]] = {}
+        self._session_prepared = False
+
+    # --- capabilities (free) ---------------------------------------------------
+
+    def capabilities(self) -> dict[str, object]:
+        # The probe round-trips to the server (current settings, not cached
+        # facts), so a stale or underprivileged credential fails here instead
+        # of reporting a healthy connection.
+        probe = self._catalog(
+            "SELECT current_database() AS db, "
+            "current_setting('server_version') AS server_version, "
+            "current_setting('default_transaction_read_only') AS read_only"
+        )[0]
+        self._database = str(probe["db"])
+        cost = self.cost_gate.cost()
+        return {
+            "connector": self.name,
+            "dialect": self.dialect,
+            "read_only": True,
+            "session_read_only": str(probe["read_only"]).lower() == "on",
+            "paradigm": self.paradigm.value,
+            "auth_method": self.auth_method,
+            "database": self._database,
+            "server_version": str(probe["server_version"]).split()[0],
+            "schema_count": len(self._schema_scope()),
+            "required_grants": [
+                "USAGE on source schemas and SELECT on their tables",
+                "write only on the dedicated dbt dev schema (transform build)",
+            ],
+            "budget": {
+                "ceiling_seconds": cost.ceiling,
+                "session_spent_today_seconds": self.cost_gate.session_spent,
+            },
+        }
+
+    # --- introspection (free pg_catalog metadata; no scans) --------------------
+
+    def list_objects(self, *, include_views: bool = True) -> list[ObjectMeta]:
+        self._load_inventory()
+        objects = [
+            self._object_meta(entry)
+            for entry in self._objects.values()
+            if include_views or entry["object_type"] != "view"
+        ]
+        objects.sort(key=lambda o: o.identifier)
+        return objects
+
+    def table_metadata(self, identifier: str) -> tuple[ObjectMeta, list[ColumnMeta]]:
+        self._load_inventory()
+        entry = self._objects.get(identifier)
+        if entry is None:
+            raise PostgresConnectionError(
+                f"object '{identifier}' not found in the configured scope; "
+                "check postgres.schemas in .dex/config.yml (identifiers are "
+                "database.schema.table against the connected database)"
+            )
+        return self._object_meta(entry), list(self._columns.get(identifier, []))
+
+    def table_notes(self, identifier: str) -> list[str]:
+        """Data-quality notes the profiling run accumulated for one object
+        (sampling degradation, skipped escalations, missing planner stats).
+        Merged into the dataset's ``data_quality`` by the profile engine."""
+
+        return list(self._notes.get(identifier, []))
+
+    def _load_inventory(self) -> None:
+        if self._inventory_loaded:
+            return
+        database = self._current_database()
+        allowed = set(self.target.schemas)
+        # relkind: r table, p partitioned table, f foreign table, m
+        # materialized view, v view. reltuples is the planner's estimate (-1
+        # means never analyzed); pg_total_relation_size is a catalog lookup,
+        # not a scan.
+        rows = self._catalog(
+            "SELECT n.nspname AS schema_name, c.relname AS object_name, "
+            "c.relkind AS kind, c.reltuples AS reltuples, "
+            "pg_catalog.pg_total_relation_size(c.oid) AS total_bytes "
+            "FROM pg_catalog.pg_class c "
+            "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE c.relkind IN ('r', 'p', 'f', 'm', 'v') "
+            "AND n.nspname <> 'information_schema' "
+            "AND n.nspname NOT LIKE 'pg\\_%'"
+        )
+        for row in rows:
+            schema = str(row["schema_name"])
+            if allowed and schema not in allowed:
+                continue
+            object_type = "view" if str(row["kind"]) in ("v", "m") else "table"
+            reltuples = float(row["reltuples"])
+            size = int(row["total_bytes"]) if row["total_bytes"] else None
+            identifier = f"{database}.{schema}.{row['object_name']}"
+            self._objects[identifier] = {
+                "identifier": identifier,
+                "object_type": object_type,
+                "schema": schema,
+                "name": str(row["object_name"]),
+                "row_count": int(reltuples) if reltuples >= 0 else None,
+                "byte_size": size if object_type == "table" or size else None,
+                "column_count": 0,
+            }
+        columns = self._catalog(
+            "SELECT n.nspname AS schema_name, c.relname AS object_name, "
+            "a.attname AS column_name, "
+            "pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type, "
+            "NOT a.attnotnull AS nullable "
+            "FROM pg_catalog.pg_attribute a "
+            "JOIN pg_catalog.pg_class c ON c.oid = a.attrelid "
+            "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE a.attnum > 0 AND NOT a.attisdropped "
+            "AND c.relkind IN ('r', 'p', 'f', 'm', 'v') "
+            "AND n.nspname <> 'information_schema' "
+            "AND n.nspname NOT LIKE 'pg\\_%' "
+            "ORDER BY n.nspname, c.relname, a.attnum"
+        )
+        for row in columns:
+            identifier = f"{database}.{row['schema_name']}.{row['object_name']}"
+            entry = self._objects.get(identifier)
+            if entry is None:
+                continue
+            metas = self._columns.setdefault(identifier, [])
+            metas.append(
+                ColumnMeta(
+                    name=str(row["column_name"]),
+                    data_type=str(row["data_type"]),
+                    nullable=bool(row["nullable"]),
+                    ordinal=len(metas),
+                )
+            )
+            entry["column_count"] = len(metas)
+        self._inventory_loaded = True
+
+    def _object_meta(self, entry: dict) -> ObjectMeta:
+        # An exact count from a profiling scan supersedes the planner estimate
+        # for the rest of the command, so uniqueness proofs and drift verdicts
+        # compare against real rows, not reltuples.
+        row_count = self._exact_rows.get(entry["identifier"], entry["row_count"])
+        return ObjectMeta(
+            identifier=entry["identifier"],
+            object_type=entry["object_type"],
+            schema=entry["schema"],
+            name=entry["name"],
+            row_count=row_count,
+            byte_size=entry["byte_size"],
+            column_count=entry["column_count"],
+        )
+
+    def _current_database(self) -> str:
+        if self._database is None:
+            row = self._catalog("SELECT current_database() AS db")[0]
+            self._database = str(row["db"])
+        return self._database
+
+    def _schema_scope(self) -> list[str]:
+        """The allowlisted schemas, or every visible non-system schema when no
+        allowlist is configured."""
+
+        if self.target.schemas:
+            return sorted(set(self.target.schemas))
+        rows = self._catalog(
+            "SELECT nspname FROM pg_catalog.pg_namespace "
+            "WHERE nspname <> 'information_schema' "
+            "AND nspname NOT LIKE 'pg\\_%'"
+        )
+        return sorted(str(row["nspname"]) for row in rows)
+
+    def _table_stats(self, identifier: str) -> dict[str, float]:
+        """Free per-table distinct estimates from the planner's statistics.
+
+        Reads only ``attname`` and ``n_distinct``, never the value-carrying
+        statistics columns (most_common_vals, histogram_bounds), so no row
+        value can cross this door.
+        """
+
+        if identifier not in self._stats:
+            _db, schema, table = self._split(identifier)
+            # Interpolated parts are escaped identifiers that came from the
+            # catalog itself, never values; the door only accepts SELECTs.
+            rows = self._catalog(
+                "SELECT attname, n_distinct FROM pg_catalog.pg_stats "  # noqa: S608
+                f"WHERE schemaname = '{_escape_literal(schema)}' "
+                f"AND tablename = '{_escape_literal(table)}'"
+            )
+            self._stats[identifier] = {
+                str(row["attname"]): float(row["n_distinct"])
+                for row in rows
+                if row["n_distinct"] is not None
+            }
+        return self._stats[identifier]
+
+    # --- estimation (free; feeds the confirm handshake) -------------------------
+
+    def profile_estimate(
+        self, identifiers: list[str]
+    ) -> tuple[float, dict[str, float]]:
+        """The heuristic database-seconds estimate for profiling: per table,
+        its bytes over a conservative scan rate times the number of aggregate
+        batches. Free: everything comes from catalog metadata."""
+
+        per_table: dict[str, float] = {}
+        for identifier in identifiers:
+            meta, columns = self.table_metadata(identifier)
+            batches = max((len(columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
+            per_table[identifier] = batches * self._scan_seconds(meta.byte_size)
+        return sum(per_table.values()), per_table
+
+    def query_estimate(self, sql: str) -> float:
+        """The estimate for one firewall-approved query, from the free planner
+        preflight (EXPLAIN knows about indexes, so a point lookup on a huge
+        table is not quoted as a full scan), falling back to summed
+        referenced-table bytes when the plan cannot be read."""
+
+        checked = assert_select_only(sql, dialect=self.dialect)
+        return self._statement_estimate(checked)
+
+    def _statement_estimate(self, sql: str) -> float:
+        cost = self._plan_cost(sql)
+        if cost is not None:
+            return max(
+                cost * _BYTES_PER_PLANNER_PAGE / _SCAN_BYTES_PER_SECOND,
+                _MIN_STATEMENT_SECONDS,
+            )
+        total_bytes = 0
+        known = 0
+        self._load_inventory()
+        for identifier in self._referenced_tables(sql):
+            entry = self._objects.get(identifier)
+            if entry and entry["byte_size"] is not None:
+                total_bytes += entry["byte_size"]
+                known += 1
+        if known == 0:
+            return _MIN_STATEMENT_SECONDS
+        return self._scan_seconds(total_bytes)
+
+    def _plan_cost(self, sql: str) -> float | None:
+        """Total planner cost of one SELECT via the free EXPLAIN door, or
+        ``None`` when the plan cannot be produced or read (the caller then
+        falls back to the size heuristic)."""
+
+        try:
+            rows = self._explain(sql)
+            document = rows[0][0]
+            if isinstance(document, str):
+                document = json.loads(document)
+            return float(document[0]["Plan"]["Total Cost"])
+        except Exception:
+            return None
+
+    def _scan_seconds(self, byte_size: int | None) -> float:
+        if not byte_size:
+            return _MIN_STATEMENT_SECONDS
+        return max(byte_size / _SCAN_BYTES_PER_SECOND, _MIN_STATEMENT_SECONDS)
+
+    def _referenced_tables(self, sql: str) -> set[str]:
+        try:
+            import sqlglot
+            from sqlglot import expressions as sqlglot_exp
+
+            parsed = sqlglot.parse_one(sql, read=self.dialect)
+        except Exception:
+            return set()
+        database = self._current_database()
+        identifiers = set()
+        for table in parsed.find_all(sqlglot_exp.Table):
+            parts = [p for p in (table.catalog, table.db, table.name) if p]
+            if len(parts) == 2:
+                parts.insert(0, database)
+            identifiers.add(".".join(parts))
+        return identifiers
+
+    def describe_estimate(
+        self, estimate: float, per_table: dict[str, float] | None = None
+    ) -> dict:
+        """The db-load handshake payload: database-seconds are the binding
+        number; there is no currency translation because nothing is billed."""
+
+        data: dict[str, object] = {
+            "estimated_seconds": estimate,
+            "estimate_quality": "heuristic",
+            "hint": (
+                "review the estimate, then re-run with --confirm --budget "
+                "<seconds> (the ceiling in database-seconds; the same number "
+                "becomes the server-side statement_timeout)"
+            ),
+            "notes": [_ESTIMATE_QUALITY_NOTE],
+        }
+        if per_table:
+            data["per_table_seconds"] = per_table
+        return data
+
+    def spend_display(self) -> dict:
+        """No currency translation exists for database load; the seconds in
+        the spend summary are the whole story."""
+
+        return {}
+
+    # --- profiling (billed; every statement estimated and gated) ----------------
+
+    def column_aggregates(
+        self,
+        identifier: str,
+        columns: list[ColumnMeta],
+        *,
+        safe_min_max: set[str] | None = None,
+    ) -> list[ColumnAggregate]:
+        safe = safe_min_max or set()
+        meta, _ = self.table_metadata(identifier)
+        sample_percent = self._sample_percent(identifier, meta.byte_size)
+        stats = self._table_stats(identifier)
+        results: list[ColumnAggregate] = []
+        for start in range(0, len(columns), _COLUMN_BATCH):
+            batch = columns[start : start + _COLUMN_BATCH]
+            sql, plan = self._build_aggregate_sql(
+                identifier, batch, safe, sample_percent=sample_percent
+            )
+            rows, labels = self._execute(
+                sql, estimate=self._scan_seconds(meta.byte_size)
+            )
+            values = dict(zip(labels, rows[0], strict=True))
+            n_total = int(values["n_total"])
+            if sample_percent is None:
+                self._exact_rows[identifier] = n_total
+            results.extend(
+                self._read_aggregates(
+                    values,
+                    plan,
+                    stats,
+                    row_basis=self._distinct_row_basis(identifier, meta),
+                    sampled=sample_percent is not None,
+                )
+            )
+        self._note_missing_stats(identifier, columns, stats)
+        return results
+
+    def _distinct_row_basis(self, identifier: str, meta: ObjectMeta) -> int | None:
+        """The whole-table row count negative ``n_distinct`` ratios scale by:
+        the exact count when a full scan produced one, else the planner
+        estimate."""
+
+        return self._exact_rows.get(identifier, meta.row_count)
+
+    def _sample_percent(self, identifier: str, byte_size: int | None) -> float | None:
+        threshold = self.target.max_full_profile_bytes
+        if threshold is None or not byte_size or byte_size <= threshold:
+            return None
+        percent = max(round(100.0 * threshold / byte_size, 2), 0.01)
+        self._note(
+            identifier,
+            f"profiled from a ~{percent}% block sample (table exceeds "
+            "postgres.max_full_profile_bytes); counts and extremes are "
+            "approximate and uniqueness is not judged",
+        )
+        return percent
+
+    def _build_aggregate_sql(
+        self,
+        identifier: str,
+        columns: list[ColumnMeta],
+        safe: set[str],
+        *,
+        sample_percent: float | None = None,
+    ) -> tuple[str, list[tuple[int, ColumnMeta, bool, bool]]]:
+        # One aggregate statement per batch, a single cheap pass: COUNT(*)
+        # once, then per column a non-null count and min/max only where
+        # allowed. Distinct counts deliberately do NOT scan here (they come
+        # free from pg_stats); COUNT(DISTINCT) across every column is exactly
+        # the sort/hash load a production primary should not carry. Pure (no
+        # connection), so the SELECT-only property is testable offline.
+        select_parts = ["COUNT(*) AS n_total"]
+        plan: list[tuple[int, ColumnMeta, bool, bool]] = []
+        for i, col in enumerate(columns):
+            qcol = _quote_ident(col.name)
+            degraded = self._is_degraded(col.data_type)
+            select_parts.append(f"COUNT({qcol}) AS nn_{i}")
+            wants_distinct = not degraded
+            wants_min_max = (col.name in safe) and not degraded
+            if wants_min_max:
+                select_parts.append(f"MIN({qcol}) AS mn_{i}")
+                select_parts.append(f"MAX({qcol}) AS mx_{i}")
+            plan.append((i, col, wants_distinct, wants_min_max))
+        source = self._quote(identifier)
+        if sample_percent is not None:
+            source += f" TABLESAMPLE SYSTEM ({sample_percent})"
+        # Interpolated parts are quoted identifiers and fixed aggregate
+        # keywords, never values; the result is guarded as a read-only SELECT.
+        sql = f"SELECT {', '.join(select_parts)} FROM {source}"  # noqa: S608
+        return assert_select_only(sql, dialect=self.dialect), plan
+
+    @staticmethod
+    def _is_degraded(data_type: str) -> bool:
+        lowered = data_type.lower()
+        return lowered.endswith("[]") or lowered.startswith(_DEGRADED_TYPE_PREFIXES)
+
+    @staticmethod
+    def _read_aggregates(
+        values: dict,
+        plan: list[tuple[int, ColumnMeta, bool, bool]],
+        stats: dict[str, float],
+        *,
+        row_basis: int | None,
+        sampled: bool,
+    ) -> list[ColumnAggregate]:
+        n_total = int(values["n_total"])
+        aggregates: list[ColumnAggregate] = []
+        for i, col, wants_distinct, wants_min_max in plan:
+            nn = values.get(f"nn_{i}")
+            null_fraction = (
+                (1 - int(nn) / n_total) if nn is not None and n_total > 0 else None
+            )
+            distinct: int | None = None
+            if wants_distinct and n_total > 0:
+                n_distinct = stats.get(col.name)
+                if n_distinct is not None:
+                    if n_distinct >= 0:
+                        distinct = int(n_distinct)
+                    elif row_basis is not None:
+                        # Negative n_distinct is a ratio of the row count
+                        # (-1 means "all rows distinct").
+                        distinct = round(-n_distinct * row_basis)
+            aggregates.append(
+                ColumnAggregate(
+                    name=col.name,
+                    null_fraction=null_fraction,
+                    # pg_stats estimates are never a uniqueness verdict; the
+                    # near-unique escalation proves keys with an exact scan.
+                    distinct_count=distinct,
+                    is_unique=None,
+                    min_value=(
+                        json_safe(values.get(f"mn_{i}")) if wants_min_max else None
+                    ),
+                    max_value=(
+                        json_safe(values.get(f"mx_{i}")) if wants_min_max else None
+                    ),
+                )
+            )
+        return aggregates
+
+    def _note_missing_stats(
+        self, identifier: str, columns: list[ColumnMeta], stats: dict[str, float]
+    ) -> None:
+        missing = [
+            col.name
+            for col in columns
+            if not self._is_degraded(col.data_type) and col.name not in stats
+        ]
+        if missing:
+            self._note(
+                identifier,
+                f"no planner statistics for {len(missing)} column(s); distinct "
+                "counts are unavailable until ANALYZE runs on this table",
+            )
+
+    def exact_distinct_counts(
+        self, identifier: str, columns: list[str]
+    ) -> dict[str, int]:
+        """Exact COUNT(DISTINCT) for near-unique columns, spent only within the
+        already-confirmed budget: when the remaining budget cannot cover the
+        extra scan, return nothing and let uniqueness verdicts stay
+        approximate. A metered adapter never self-escalates past its ceiling.
+        """
+
+        if not columns:
+            return {}
+        meta, _ = self.table_metadata(identifier)
+        estimate = self._scan_seconds(meta.byte_size)
+        if not self.cost_gate.try_charge(estimate):
+            self._note(
+                identifier,
+                "distinct-count escalation skipped: the remaining budget could "
+                "not cover the extra scan; uniqueness verdicts stay approximate",
+            )
+            return {}
+        # COUNT(*) rides along so the same scan also upgrades the planner's
+        # row estimate to an exact count (grain verdicts compare against it).
+        select_parts = ["COUNT(*) AS n_total"] + [
+            f"COUNT(DISTINCT {_quote_ident(name)}) AS d_{i}"
+            for i, name in enumerate(columns)
+        ]
+        sql = assert_select_only(
+            f"SELECT {', '.join(select_parts)} FROM {self._quote(identifier)}",  # noqa: S608
+            dialect=self.dialect,
+        )
+        rows, labels = self._run(sql)
+        values = dict(zip(labels, rows[0], strict=True))
+        self._exact_rows[identifier] = int(values["n_total"])
+        return {name: int(values[f"d_{i}"]) for i, name in enumerate(columns)}
+
+    # --- execution (the single billed door) --------------------------------------
+
+    def run_query(
+        self,
+        sql: str,
+        *,
+        max_rows: int,
+        timeout_seconds: float,
+    ) -> QueryResult:
+        """Execute one firewall-approved SELECT, bounded in rows, wall time,
+        and database-seconds (client preflight plus the server-side statement
+        timeout, whichever is tighter)."""
+
+        checked = assert_select_only(sql, dialect=self.dialect)
+        self.cost_gate.charge(self._statement_estimate(checked))
+        rows, labels, types = self._run_rows(
+            checked, timeout_seconds=timeout_seconds, fetch_rows=max_rows + 1
+        )
+        return QueryResult(
+            columns=labels,
+            types=types,
+            cells=[[json_safe(v) for v in row] for row in rows[:max_rows]],
+            truncated=len(rows) > max_rows,
+        )
+
+    def _execute(self, sql: str, *, estimate: float) -> tuple[list, list[str]]:
+        """SELECT-only guard, heuristic charge, then the timeout-capped run."""
+
+        assert_select_only(sql, dialect=self.dialect)
+        self.cost_gate.charge(estimate)
+        return self._run(sql)
+
+    def _run(self, sql: str) -> tuple[list, list[str]]:
+        rows, labels, _types = self._run_rows(sql)
+        return rows, labels
+
+    def _run_rows(
+        self,
+        sql: str,
+        *,
+        timeout_seconds: float | None = None,
+        fetch_rows: int | None = None,
+    ) -> tuple[list, list[str], list[str]]:
+        """The single billed door past the gate: the server-side
+        statement_timeout is wound down to what remains of the budget (or the
+        wall-clock limit when that is tighter), and wall-clock elapsed is
+        recorded to the ledger."""
+
+        cursor, budget_bound = self._billed_cursor(timeout_seconds)
+        started = self._clock()
+        try:
+            cursor.execute(sql)
+            rows = (
+                cursor.fetchmany(fetch_rows)
+                if fetch_rows is not None
+                else cursor.fetchall()
+            )
+        except self._pg_errors.QueryCanceled as exc:
+            self._record_elapsed(started, sql)
+            raise self._timeout_refusal(budget_bound, timeout_seconds) from exc
+        except self._pg_errors.ReadOnlySqlTransaction as exc:
+            self._record_elapsed(started, sql)
+            raise PostgresConnectionError(
+                "the statement attempted a write and the session is read-only "
+                "by construction; dex never mutates the database"
+            ) from exc
+        self._record_elapsed(started, sql)
+        labels = [str(d.name) for d in cursor.description]
+        types = [self._description_type(d) for d in cursor.description]
+        return rows, labels, types
+
+    def _billed_cursor(self, timeout_seconds: float | None) -> tuple[Any, bool]:
+        """A cursor prepared for spend: session read-only asserted, and the
+        server-side statement timeout wound down to what remains of the
+        budget, so even a wrong heuristic cannot overrun the ceiling. Returns
+        the cursor and whether the budget (not the wall clock) is the binding
+        bound."""
+
+        remaining = self.cost_gate.remaining_for_statement()
+        if remaining is not None and remaining < 1:
+            raise OverCeilingError(
+                "the remaining budget is under one database-second; raise "
+                "--budget or narrow the work"
+            )
+        self._ensure_session()
+        cursor = self._conn.cursor()
+        timeout_ms: int | None = None
+        budget_bound = False
+        if remaining is not None:
+            timeout_ms = int(remaining) * 1000
+            budget_bound = True
+        if timeout_seconds is not None:
+            wall_ms = int(max(timeout_seconds, 1) * 1000)
+            if timeout_ms is None or wall_ms < timeout_ms:
+                timeout_ms = wall_ms
+                budget_bound = False
+        if timeout_ms is not None:
+            # Engine-built session statement, not agent SQL: the value is a
+            # computed integer of milliseconds.
+            cursor.execute(f"SET statement_timeout = {timeout_ms}")
+        return cursor, budget_bound
+
+    def _timeout_refusal(
+        self, budget_bound: bool, timeout_seconds: float | None
+    ) -> Exception:
+        if budget_bound:
+            return OverCeilingError(
+                "the statement hit the server-side statement_timeout derived "
+                "from the remaining budget; raise --budget or narrow the work"
+            )
+        limit = f"{timeout_seconds:g}s" if timeout_seconds is not None else "its limit"
+        return TimeoutError(
+            f"query exceeded {limit} and was cancelled; narrow it (tighter "
+            "filter, fewer columns) and retry"
+        )
+
+    def _record_elapsed(self, started: float, sql: str) -> None:
+        elapsed = max(self._clock() - started, 0.0)
+        self.cost_gate.record_billed(elapsed, job_id=None, statement=sql)
+
+    def _ensure_session(self) -> None:
+        """Session preparation, once per command: reads stay reads even if a
+        later statement tried otherwise. Engine-built constants, not agent
+        SQL."""
+
+        if self._session_prepared:
+            return
+        cursor = self._conn.cursor()
+        cursor.execute("SET default_transaction_read_only = on")
+        self._session_prepared = True
+
+    @staticmethod
+    def _description_type(description: Any) -> str:
+        type_code = getattr(description, "type_code", None)
+        try:
+            from psycopg import postgres
+
+            info = postgres.types.get(type_code)
+        except Exception:
+            info = None
+        if info is not None:
+            return str(info.name)
+        return str(getattr(type_code, "name", type_code))
+
+    # --- helpers ------------------------------------------------------------------
+
+    def _catalog(self, sql: str) -> list[dict]:
+        """Free metadata door: engine-built catalog SELECTs only (pg_catalog
+        lookups and session settings, no table scans). Results come back as
+        dicts keyed by the column names."""
+
+        if not sql.lstrip().upper().startswith("SELECT"):
+            raise ValueError("only SELECT statements pass through the catalog door")
+        self._ensure_session()
+        cursor = self._conn.cursor()
+        cursor.execute(sql)
+        labels = [str(d.name) for d in cursor.description]
+        return [dict(zip(labels, row, strict=True)) for row in cursor.fetchall()]
+
+    def _explain(self, sql: str) -> list:
+        """Free planner door: the statement is guarded SELECT-only, then
+        prefixed with EXPLAIN here, so nothing but a plan request can pass."""
+
+        checked = assert_select_only(sql, dialect=self.dialect)
+        self._ensure_session()
+        cursor = self._conn.cursor()
+        cursor.execute(f"EXPLAIN (FORMAT JSON) {checked}")
+        return cursor.fetchall()
+
+    def _note(self, identifier: str, note: str) -> None:
+        notes = self._notes.setdefault(identifier, [])
+        if note not in notes:
+            notes.append(note)
+
+    @staticmethod
+    def _split(identifier: str) -> tuple[str, str, str]:
+        parts = identifier.rsplit(".", 2)
+        if len(parts) != 3:
+            raise ValueError(f"expected database.schema.table, got '{identifier}'")
+        return parts[0], parts[1], parts[2]
+
+    def _quote(self, identifier: str) -> str:
+        # A three-part reference is valid Postgres only against the connected
+        # database, which is exactly what the namespace guarantees.
+        return ".".join(_quote_ident(p) for p in self._split(identifier))
+
+    def close(self) -> None:
+        close = getattr(self._conn, "close", None)
+        if close is not None:
+            close()
+
+
+def _quote_ident(name: str) -> str:
+    """Quote one identifier component with double quotes (preserving case,
+    which unquoted Postgres identifiers would fold to lower), doubling
+    embedded quotes."""
+
+    escaped = name.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _escape_literal(value: str) -> str:
+    return value.replace("'", "''")

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -90,6 +90,34 @@ class SnowflakeTarget(BaseModel):
     credit_price_usd: float | None = None
 
 
+class PostgresTarget(BaseModel):
+    """Non-secret PostgreSQL connection target. Credentials are never here:
+    auth is discovered at runtime by connect.py (a pg_service.conf entry,
+    DATABASE_URL, PG* environment variables, or a dbt profile), and passwords
+    are supplied by PGPASSWORD, ``~/.pgpass``, or the service file, never by
+    this config.
+
+    ``service`` pins a ``pg_service.conf`` entry (the ``connection_name``
+    analogue); unset means DATABASE_URL, then the PG* environment, then a dbt
+    profile. ``host``/``port``/``dbname``/``user`` are an optional committed
+    non-secret target used only when no other source resolves. ``schemas`` is
+    a source allowlist of schema names inside the connected database; empty
+    means every non-system schema the role can see. ``dev_schema`` is where
+    dbt dev builds write, and is refused as a source so reads and writes never
+    share a schema. ``max_full_profile_bytes`` opts large tables into sampled
+    profiling (TABLESAMPLE SYSTEM) instead of a full scan.
+    """
+
+    service: str | None = None
+    host: str | None = None
+    port: int | None = None
+    dbname: str | None = None
+    user: str | None = None
+    schemas: list[str] = Field(default_factory=list)
+    dev_schema: str | None = None
+    max_full_profile_bytes: int | None = None
+
+
 class QueryLimits(BaseModel):
     """Hard bounds on `explore query` results, enforced in the engine.
 
@@ -104,14 +132,15 @@ class QueryLimits(BaseModel):
 
 
 class DexConfig(BaseModel):
-    """The shape of ``.dex/config.yml``. DuckDB, BigQuery, and Snowflake
-    targets are wired; the remaining cloud connector targets are not yet
+    """The shape of ``.dex/config.yml``. DuckDB, BigQuery, Snowflake, and
+    Postgres targets are wired; the Databricks target is not yet
     implemented."""
 
     connector: str = "duckdb"
     duckdb: DuckDBTarget | None = None
     bigquery: BigQueryTarget | None = None
     snowflake: SnowflakeTarget | None = None
+    postgres: PostgresTarget | None = None
     dbt_target: str | None = None
     # Pins the dbt project directory (relative to the repo root) when discovery
     # would be ambiguous; by default the project is located automatically.

--- a/packages/dex-core/src/exmergo_dex_core/connect.py
+++ b/packages/dex-core/src/exmergo_dex_core/connect.py
@@ -8,8 +8,10 @@ with the project resolved from explicit config, the environment, the ADC
 default, or a dbt profile, in that order. Snowflake discovers a connection the
 same way: a named ``connections.toml`` entry, the default connection, the
 ``SNOWFLAKE_*`` environment (which is also how CI's workload-identity token
-arrives), or a dbt profile. Every discovery failure names the fix; nothing is
-ever prompted for.
+arrives), or a dbt profile. Postgres follows suit: a config-pinned
+``pg_service.conf`` entry, ``DATABASE_URL``, the ``PG*`` environment (resolved
+natively by libpq, including ``~/.pgpass``), or a dbt profile. Every discovery
+failure names the fix; nothing is ever prompted for.
 """
 
 from __future__ import annotations
@@ -23,7 +25,13 @@ import yaml
 
 from .adapters import get_adapter
 from .cache import DexStore
-from .config import BigQueryTarget, DexConfig, SnowflakeTarget, load_config
+from .config import (
+    BigQueryTarget,
+    DexConfig,
+    PostgresTarget,
+    SnowflakeTarget,
+    load_config,
+)
 from .envelope import Paradigm
 from .guards.cost_guard import CostGate
 
@@ -77,6 +85,11 @@ def open_adapter(
 
     if connector == "snowflake":
         return _open_snowflake(
+            config, repo_root, budget=budget, confirmed=confirmed, command=command
+        )
+
+    if connector == "postgres":
+        return _open_postgres(
             config, repo_root, budget=budget, confirmed=confirmed, command=command
         )
 
@@ -386,6 +399,208 @@ def _snowflake_from_dbt_profiles(repo_root: str | Path) -> dict | None:
                 }
                 if output.get("private_key_path"):
                     params["private_key_file"] = output["private_key_path"]
+                return params
+    return None
+
+
+def _open_postgres(
+    config: DexConfig,
+    repo_root: str | Path,
+    *,
+    budget: float | None,
+    confirmed: bool,
+    command: str | None,
+):
+    target = config.postgres or PostgresTarget()
+    params, method = resolve_postgres_connection(target, os.environ, repo_root)
+
+    try:
+        import psycopg
+    except ImportError as exc:
+        raise CredentialDiscoveryError(
+            "the Postgres client is not installed; install the connector "
+            "extra: exmergo-dex-core[postgres]"
+        ) from exc
+
+    # autocommit keeps the session out of idle-in-transaction (which blocks
+    # vacuum on a production primary); application_name is the attribution
+    # tag, the QUERY_TAG analogue. The adapter additionally sets the session
+    # read-only before any statement runs.
+    connection = psycopg.connect(**params, autocommit=True, application_name="dex")
+
+    store = DexStore(repo_root)
+    utc_midnight = (
+        datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
+    )
+    gate = CostGate(
+        paradigm=Paradigm.DB_LOAD,
+        ceiling=budget if budget is not None else config.budget.ceiling,
+        session_ceiling=config.budget.session_ceiling,
+        session_spent=store.spend_since(
+            utc_midnight, field="billed_seconds", connector="postgres"
+        ),
+        confirmed=confirmed,
+        connector="postgres",
+        command=command,
+        record=store.append_spend_log,
+    )
+    return get_adapter(
+        "postgres",
+        connection=connection,
+        cost_gate=gate,
+        target=target,
+        auth_method=method,
+    )
+
+
+def resolve_postgres_connection(
+    target: PostgresTarget,
+    env: dict | os._Environ,
+    repo_root: str | Path = ".",
+) -> tuple[dict, str]:
+    """Discover Postgres connection parameters, never prompting.
+
+    Returns ``(params, auth_method)`` where ``params`` feeds
+    ``psycopg.connect`` and ``auth_method`` is a coarse class safe to surface
+    (config_service / database_url / environment / config_target /
+    dbt_profile, suffixed with the credential kind); parameter values,
+    including any password a store legitimately holds, never leave the engine
+    process. Order: the config-pinned ``pg_service.conf`` entry,
+    ``DATABASE_URL``, the ``PG*`` environment (resolved natively by libpq,
+    including ``~/.pgpass`` and ``PGSERVICE``), the committed non-secret
+    config target, then a dbt profile's postgres target. Every failure names
+    the fix.
+    """
+
+    if target.service:
+        service_params = _pg_service_params(target.service, env)
+        if service_params is None:
+            raise CredentialDiscoveryError(
+                f"postgres.service '{target.service}' not found in "
+                "pg_service.conf; add the entry (PGSERVICEFILE or "
+                "~/.pg_service.conf) or fix the name in .dex/config.yml"
+            )
+        # libpq resolves the service entry itself; the parsed fields above
+        # only validated existence and stay inside the engine.
+        return {"service": target.service}, (
+            f"config_service:{_pg_credential_kind(service_params)}"
+        )
+
+    url = env.get("DATABASE_URL")
+    if url:
+        params = _pg_url_params(url)
+        return {"conninfo": url}, f"database_url:{_pg_credential_kind(params)}"
+
+    if env.get("PGSERVICE"):
+        return {}, "environment:service_file"
+    if env.get("PGHOST") or env.get("PGDATABASE"):
+        # libpq reads the PG* variables (and ~/.pgpass) natively; passing no
+        # explicit params lets its own resolution rules apply.
+        kind = "password" if env.get("PGPASSWORD") else "external"
+        return {}, f"environment:{kind}"
+
+    if target.host or target.dbname:
+        params = {
+            key: value
+            for key, value in (
+                ("host", target.host),
+                ("port", target.port),
+                ("dbname", target.dbname),
+                ("user", target.user),
+            )
+            if value is not None
+        }
+        kind = "password" if env.get("PGPASSWORD") else "external"
+        return params, f"config_target:{kind}"
+
+    profile_params = _postgres_from_dbt_profiles(repo_root)
+    if profile_params:
+        return profile_params, f"dbt_profile:{_pg_credential_kind(profile_params)}"
+
+    raise CredentialDiscoveryError(
+        "no Postgres connection discovered; export DATABASE_URL (or PGHOST/"
+        "PGDATABASE and friends), or add a pg_service.conf entry and set "
+        "postgres.service in .dex/config.yml, or set postgres.host/dbname "
+        "there, or keep a postgres target in your dbt profiles.yml"
+    )
+
+
+def _pg_credential_kind(params: dict) -> str:
+    """The coarse credential class for the envelope; never a value. Anything
+    that is not an inline password is ``external`` (``~/.pgpass``, peer/trust
+    auth, SSL client certificates), deliberately coarse."""
+
+    return "password" if params.get("password") else "external"
+
+
+def _pg_url_params(url: str) -> dict:
+    """Parse a Postgres URL into libpq keywords, for classification only (the
+    URL itself is what gets passed to the driver). Failures mean "no fields",
+    never an error that could echo the URL."""
+
+    try:
+        from psycopg.conninfo import conninfo_to_dict
+
+        return {k: v for k, v in conninfo_to_dict(url).items() if v is not None}
+    except Exception:
+        return {}
+
+
+def _pg_service_params(service: str, env: dict | os._Environ) -> dict | None:
+    """The named entry of the pg_service.conf file, or ``None`` when the file
+    or entry is missing. Search order matches libpq: ``PGSERVICEFILE``, then
+    ``~/.pg_service.conf``. Parsed fields are used for existence validation
+    and credential classification only; they never leave the engine."""
+
+    import configparser
+
+    candidates: list[Path] = []
+    service_file = env.get("PGSERVICEFILE")
+    if service_file:
+        candidates.append(Path(service_file))
+    candidates.append(Path.home() / ".pg_service.conf")
+    for candidate in candidates:
+        if not candidate.is_file():
+            continue
+        parser = configparser.ConfigParser(interpolation=None)
+        try:
+            parser.read_string(candidate.read_text(encoding="utf-8"))
+        except (OSError, configparser.Error):
+            continue
+        if parser.has_section(service):
+            return dict(parser.items(service))
+    return None
+
+
+def _postgres_from_dbt_profiles(repo_root: str | Path) -> dict | None:
+    """Best-effort: the connection fields of a ``type: postgres`` output in
+    the discovered dbt project's profiles. Any failure means "not found"."""
+
+    try:
+        from .dbt_project import PROFILES_FILE, find_project, profiles_dir
+
+        project_dir = find_project(repo_root)
+        profiles_path = profiles_dir(project_dir) / PROFILES_FILE
+        profiles = yaml.safe_load(profiles_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return None
+    for profile in profiles.values():
+        if not isinstance(profile, dict):
+            continue
+        for output in (profile.get("outputs") or {}).values():
+            if (
+                isinstance(output, dict)
+                and output.get("type") == "postgres"
+                and output.get("host")
+            ):
+                params = {
+                    key: output[key]
+                    for key in ("host", "port", "user", "password", "sslmode")
+                    if output.get(key)
+                }
+                dbname = output.get("dbname") or output.get("database")
+                if dbname:
+                    params["dbname"] = dbname
                 return params
     return None
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -288,7 +288,11 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
     # into source, replica, and cross-dataset lookalike edges.
     dev_schemas = frozenset(
         name
-        for name in [config.bigquery.dev_dataset if config.bigquery else None]
+        for name in [
+            config.bigquery.dev_dataset if config.bigquery else None,
+            config.snowflake.dev_schema if config.snowflake else None,
+            config.postgres.dev_schema if config.postgres else None,
+        ]
         if name
     )
     inferred, folded_edges, mirrored_objects = rel_mod.fold_replica_relationships(

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -188,6 +188,12 @@ def profile(adapter: Adapter, identifiers: list[str]) -> list[Dataset]:
             a.name: a
             for a in adapter.column_aggregates(identifier, columns, safe_min_max=safe)
         }
+        # Re-read the metadata after the aggregate scan: adapters whose
+        # inventory row counts are planner estimates (Postgres reltuples)
+        # upgrade to the exact COUNT(*) the scan just paid for, so uniqueness
+        # proofs and the dataset row count are exact. Free everywhere (cached
+        # or trivially cheap on the other adapters).
+        meta, _ = adapter.table_metadata(identifier)
         aggregates = _escalate_near_unique(
             adapter, identifier, meta.row_count, aggregates
         )

--- a/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
@@ -203,7 +203,7 @@ class CostGate:
 
         return (
             "billed_seconds"
-            if self.paradigm is Paradigm.COMPUTE_TIME
+            if self.paradigm in (Paradigm.COMPUTE_TIME, Paradigm.DB_LOAD)
             else "billed_bytes"
         )
 
@@ -254,7 +254,7 @@ class CostGate:
 
         key = (
             "seconds_billed"
-            if self.paradigm is Paradigm.COMPUTE_TIME
+            if self.paradigm in (Paradigm.COMPUTE_TIME, Paradigm.DB_LOAD)
             else "bytes_billed"
         )
         return {

--- a/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
@@ -414,6 +414,14 @@ def grain_drift(
     findings: list[DriftFinding] = []
     for dataset, keys, row_count in plan.key_checks:
         distinct = adapter.exact_distinct_counts(dataset.identifier, keys)
+        # Re-read the metadata after the distinct scan: adapters whose
+        # inventory row counts are planner estimates (Postgres reltuples)
+        # upgrade to the exact COUNT(*) that scan carried, so an over-estimate
+        # can never fabricate duplicates on a genuinely unique key. Free
+        # everywhere (cached or trivially cheap on the other adapters).
+        live_meta, _ = adapter.table_metadata(dataset.identifier)
+        if live_meta.row_count is not None:
+            row_count = live_meta.row_count
         for key in keys:
             count = distinct.get(key)
             if count is None or count >= row_count:

--- a/packages/dex-core/src/exmergo_dex_core/transform/build.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/build.py
@@ -15,6 +15,7 @@ only a sanitized summary crosses the boundary. Node results come from dbt's own
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -157,7 +158,7 @@ def build(
     # cwd is pinned to the project dir so relative paths in profiles.yml (for
     # example a DuckDB `path: ./dev.duckdb`) resolve against the project, never
     # against whatever directory the caller happened to launch from.
-    run = runner or _default_runner(timeout, project)
+    run = runner or _default_runner(timeout, project, env=_build_env(paradigm, ceiling))
     completed = run(argv)
 
     summary = _summarize(project, target, completed)
@@ -371,7 +372,26 @@ def _dbt_executable() -> str:
     )
 
 
-def _default_runner(timeout: float, cwd: Path) -> Runner:
+def _build_env(paradigm: Paradigm, ceiling: float | None) -> dict[str, str] | None:
+    """Environment overrides for the dbt subprocess, or ``None`` to inherit.
+
+    On db-load gating (Postgres) the profile has no statement-timeout key, but
+    libpq honors ``PGOPTIONS``, so the ceiling becomes a per-statement
+    server-side ``statement_timeout`` — the ``maximum_bytes_billed`` analogue:
+    a build statement cannot load the database past the budget even though dbt
+    has no dry-run.
+    """
+
+    if paradigm is not Paradigm.DB_LOAD or ceiling is None:
+        return None
+    cap = f"-c statement_timeout={max(int(ceiling), 1)}s"
+    existing = os.environ.get("PGOPTIONS", "")
+    return {**os.environ, "PGOPTIONS": f"{existing} {cap}".strip()}
+
+
+def _default_runner(
+    timeout: float, cwd: Path, env: dict[str, str] | None = None
+) -> Runner:
     def run(argv: list[str]) -> subprocess.CompletedProcess:
         # The argv is engine-built (dbt executable + validated target/paths),
         # never raw user input, and shell=False.
@@ -382,6 +402,7 @@ def _default_runner(timeout: float, cwd: Path) -> Runner:
             timeout=timeout,
             check=False,
             cwd=str(cwd),
+            env=env,
         )
 
     return run

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -148,6 +148,7 @@ def cmd_build(args: argparse.Namespace) -> env.Envelope:
     paradigm = {
         "bigquery": Paradigm.BYTES_SCANNED,
         "snowflake": Paradigm.COMPUTE_TIME,
+        "postgres": Paradigm.DB_LOAD,
     }.get(connector, Paradigm.FREE_LOCAL)
 
     try:
@@ -192,6 +193,21 @@ def cmd_build(args: argparse.Namespace) -> env.Envelope:
         ]
         # dbt-snowflake reports no billing figure; per-node execution time is
         # the honest warehouse-seconds actual.
+        seconds = sum(
+            float(node.get("execution_time") or 0) for node in summary.get("nodes", [])
+        )
+        if seconds:
+            summary["seconds_billed"] = seconds
+            _record_build_spend(repo_root, connector, seconds, "billed_seconds")
+    elif paradigm is Paradigm.DB_LOAD:
+        notes = [
+            "dbt has no dry-run, so this build's database time could not be "
+            "estimated upfront; each statement was capped server-side by a "
+            "statement_timeout set to the ceiling (injected via PGOPTIONS)",
+            *notes,
+        ]
+        # dbt-postgres reports no billing figure; per-node execution time is
+        # the honest database-seconds actual.
         seconds = sum(
             float(node.get("execution_time") or 0) for node in summary.get("nodes", [])
         )

--- a/packages/dex-core/src/exmergo_dex_core/transform/init.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/init.py
@@ -14,8 +14,9 @@ warehouse shop would produce a project that parses and builds locally yet is
 wrong. The caller must resolve the connector explicitly before calling in.
 
 Per-connector profile rendering sits behind a small dispatch so cloud renderers
-can slot in alongside their dbt adapters without touching the command; DuckDB
-and BigQuery render today, and the others raise an actionable error.
+can slot in alongside their dbt adapters without touching the command; DuckDB,
+BigQuery, Snowflake, and Postgres render today, and the others raise an
+actionable error.
 """
 
 from __future__ import annotations
@@ -99,8 +100,9 @@ def init_project(
     if render_profile is None:
         raise InitError(
             f"connector '{connector}' is not yet supported for init; DuckDB, "
-            "BigQuery, and Snowflake are the supported paths today "
-            "(`transform init <name> --connector duckdb|bigquery|snowflake`)"
+            "BigQuery, Snowflake, and Postgres are the supported paths today "
+            "(`transform init <name> --connector "
+            "duckdb|bigquery|snowflake|postgres`)"
         )
 
     project_name = sanitize_project_name(name)
@@ -354,10 +356,126 @@ def _snowflake_profile(
     )
 
 
+_DEFAULT_PG_DEV_SCHEMA = "dbt_dev"
+
+
+def _postgres_profile(
+    project_name: str, path: str | None, config: DexConfig, root: Path
+) -> str:
+    """A single dbt-postgres ``dev`` target from the discovered connection,
+    with no secret ever rendered: the password is an ``env_var`` reference
+    (``PGPASSWORD``, empty default so ``~/.pgpass`` and peer auth still apply
+    at dbt runtime). Writes go to a dedicated dev schema, never to a source
+    schema dex reads from."""
+
+    from ..config import PostgresTarget
+    from ..connect import CredentialDiscoveryError, resolve_postgres_connection
+
+    target = config.postgres or PostgresTarget()
+    try:
+        _params, method = resolve_postgres_connection(target, os.environ, root)
+    except CredentialDiscoveryError as exc:
+        raise InitError(str(exc)) from exc
+
+    fields = _pg_connection_fields(target, method)
+    host = fields.get("host")
+    dbname = fields.get("dbname")
+    user = fields.get("user")
+    if not host or not dbname or not user:
+        missing = ", ".join(
+            name
+            for name, value in (("host", host), ("dbname", dbname), ("user", user))
+            if not value
+        )
+        raise InitError(
+            f"the discovered Postgres connection does not name {missing}, "
+            "which dbt-postgres requires; export DATABASE_URL with them (or "
+            "PGHOST/PGDATABASE/PGUSER), or complete the pg_service.conf entry"
+        )
+
+    dev_schema = target.dev_schema or _DEFAULT_PG_DEV_SCHEMA
+    if dev_schema in set(target.schemas):
+        raise InitError(
+            f"dev_schema '{dev_schema}' is also a source schema in "
+            "postgres.schemas; dbt builds must write where dex does not read "
+            "(set postgres.dev_schema to a dedicated schema)"
+        )
+
+    target.dev_schema = dev_schema
+    config.postgres = target
+
+    output: dict[str, Any] = {
+        "type": "postgres",
+        "host": str(host),
+        "port": int(fields.get("port") or 5432),
+        "user": str(user),
+        # Never persist a password: the profile reads it from the environment
+        # at dbt runtime (a Jinja reference, not a value); the empty default
+        # keeps ~/.pgpass and peer auth working when no variable is set.
+        "password": "{{ env_var('PGPASSWORD', '') }}",
+        "dbname": str(dbname),
+        "schema": dev_schema,
+        # One thread keeps the operational database from parallel bursts; the
+        # per-statement load is the guarded quantity on db-load gating.
+        "threads": 1,
+        "connect_timeout": 10,
+    }
+    if fields.get("sslmode"):
+        output["sslmode"] = str(fields["sslmode"])
+    return yaml.safe_dump(
+        {project_name: {"target": "dev", "outputs": {"dev": output}}},
+        sort_keys=False,
+    )
+
+
+def _pg_connection_fields(target: Any, method: str) -> dict:
+    """The non-secret connection fields of the source that won discovery, for
+    rendering into the profile. Values stay inside the engine except the ones
+    deliberately rendered (host/port/user/dbname/sslmode)."""
+
+    from ..connect import _pg_service_params, _pg_url_params
+
+    env = os.environ
+    source = method.split(":", 1)[0]
+    if source == "config_service" and target.service:
+        return _pg_service_params(target.service, env) or {}
+    if source == "database_url":
+        return _pg_url_params(env.get("DATABASE_URL", ""))
+    if source == "environment":
+        if env.get("PGSERVICE"):
+            return _pg_service_params(env["PGSERVICE"], env) or {}
+        return {
+            key: env[var]
+            for var, key in (
+                ("PGHOST", "host"),
+                ("PGPORT", "port"),
+                ("PGDATABASE", "dbname"),
+                ("PGUSER", "user"),
+                ("PGSSLMODE", "sslmode"),
+            )
+            if env.get(var)
+        }
+    if source == "config_target":
+        return {
+            key: value
+            for key, value in (
+                ("host", target.host),
+                ("port", target.port),
+                ("dbname", target.dbname),
+                ("user", target.user),
+            )
+            if value is not None
+        }
+    from ..connect import _postgres_from_dbt_profiles
+
+    return _postgres_from_dbt_profiles(".") or {}
+
+
 _PROFILE_RENDERERS: dict[str, Callable[[str, str | None, DexConfig, Path], str]] = {
     "duckdb": _duckdb_profile,
     "bigquery": _bigquery_profile,
     "snowflake": _snowflake_profile,
+    "postgres": _postgres_profile,
 }
 
 

--- a/packages/dex-core/tests/adapters/test_connect_bigquery.py
+++ b/packages/dex-core/tests/adapters/test_connect_bigquery.py
@@ -446,7 +446,7 @@ def test_get_adapter_wires_bigquery(fake_bq_client):
 
 
 def test_remaining_cloud_connectors_still_stub():
-    for connector in ("databricks", "postgres"):
+    for connector in ("databricks",):
         with pytest.raises(NotImplementedError):
             get_adapter(connector)
 

--- a/packages/dex-core/tests/adapters/test_connect_postgres.py
+++ b/packages/dex-core/tests/adapters/test_connect_postgres.py
@@ -1,0 +1,634 @@
+"""The Postgres adapter against the stateful fake connection: metadata is
+free (pg_catalog lookups, no scans), every billed statement is estimated and
+gated in database-seconds, and the budget binds at both the client (charge)
+and the simulated server (statement_timeout)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("psycopg")
+
+from fakes.postgres import FakePostgresTable, FakeResult
+
+from exmergo_dex_core.adapters import get_adapter, get_dialect
+from exmergo_dex_core.adapters.postgres import (
+    _MIN_STATEMENT_SECONDS,
+    _SCAN_BYTES_PER_SECOND,
+    PostgresAdapter,
+    PostgresConnectionError,
+)
+from exmergo_dex_core.config import PostgresTarget
+from exmergo_dex_core.connect import (
+    CredentialDiscoveryError,
+    resolve_postgres_connection,
+)
+from exmergo_dex_core.envelope import Paradigm
+from exmergo_dex_core.guards.cost_guard import (
+    ConfirmationRequiredError,
+    CostGate,
+    OverCeilingError,
+)
+
+
+def make_adapter(
+    connection,
+    *,
+    ceiling: float | None = 600.0,
+    confirmed: bool = True,
+    session_ceiling: float | None = None,
+    session_spent: float = 0.0,
+    record=None,
+    target: PostgresTarget | None = None,
+) -> PostgresAdapter:
+    gate = CostGate(
+        paradigm=Paradigm.DB_LOAD,
+        ceiling=ceiling,
+        session_ceiling=session_ceiling,
+        session_spent=session_spent,
+        confirmed=confirmed,
+        connector="postgres",
+        command="explore profile",
+        record=record,
+    )
+    return PostgresAdapter(
+        connection=connection,
+        cost_gate=gate,
+        target=target or PostgresTarget(),
+        auth_method="database_url:password",
+        clock=connection.clock,
+    )
+
+
+# --- metadata (free) ---------------------------------------------------------------
+
+
+def test_capabilities_shape_and_free(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection)
+    caps = adapter.capabilities()
+    assert caps["connector"] == "postgres"
+    assert caps["dialect"] == "postgres"
+    assert caps["read_only"] is True
+    assert caps["session_read_only"] is True  # the SET took effect on the fake
+    assert caps["paradigm"] == "db_load"
+    assert caps["auth_method"] == "database_url:password"
+    assert caps["database"] == "dexdb"
+    assert caps["server_version"] == "16.4"
+    assert caps["schema_count"] == 1  # shop
+    assert caps["budget"]["ceiling_seconds"] == 600.0
+    # Capabilities is a free probe: no data statement ran.
+    assert fake_pg_connection.data_statements == []
+
+
+def test_session_is_read_only_before_any_statement(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection)
+    adapter.list_objects()
+    first = fake_pg_connection.statements[0].sql.lower()
+    assert "set default_transaction_read_only = on" in first
+
+
+def test_list_objects_uses_free_catalog_metadata_only(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection)
+    objects = adapter.list_objects()
+    assert [o.identifier for o in objects] == [
+        "dexdb.shop.customers",
+        "dexdb.shop.events",
+    ]
+    customers = next(o for o in objects if o.name == "customers")
+    assert customers.row_count == 100
+    assert customers.byte_size == 5_000_000_000
+    assert customers.column_count == 4
+    assert fake_pg_connection.data_statements == []
+
+
+def test_unanalyzed_reltuples_reports_no_row_count(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection)
+    events_meta, _ = adapter.table_metadata("dexdb.shop.events")
+    assert events_meta.row_count is None  # reltuples -1: never analyzed
+
+
+def test_schema_allowlist_scopes_inventory(fake_pg_connection):
+    fake_pg_connection.tables.append(
+        FakePostgresTable(
+            schema="other",
+            name="noise",
+            columns=[("id", "bigint", True)],
+        )
+    )
+    adapter = make_adapter(fake_pg_connection, target=PostgresTarget(schemas=["shop"]))
+    assert {o.schema for o in adapter.list_objects()} == {"shop"}
+
+
+def test_views_carry_no_stored_size(fake_pg_connection):
+    fake_pg_connection.tables.append(
+        FakePostgresTable(
+            schema="shop",
+            name="v_totals",
+            columns=[("total", "numeric", True)],
+            kind="view",
+            reltuples=-1.0,
+            total_bytes=0,
+        )
+    )
+    adapter = make_adapter(fake_pg_connection)
+    meta, _ = adapter.table_metadata("dexdb.shop.v_totals")
+    assert meta.object_type == "view"
+    assert meta.row_count is None
+    assert meta.byte_size is None
+
+
+def test_unknown_object_names_the_fix(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection)
+    with pytest.raises(PostgresConnectionError, match=r"postgres\.schemas"):
+        adapter.table_metadata("dexdb.shop.missing")
+
+
+def test_get_adapter_constructs_postgres(fake_pg_connection):
+    gate = CostGate(
+        paradigm=Paradigm.DB_LOAD,
+        ceiling=10.0,
+        session_ceiling=None,
+        session_spent=0.0,
+        confirmed=True,
+        connector="postgres",
+    )
+    adapter = get_adapter("postgres", connection=fake_pg_connection, cost_gate=gate)
+    assert isinstance(adapter, PostgresAdapter)
+    assert get_dialect("postgres") == "postgres"
+
+
+# --- estimation (free) --------------------------------------------------------------
+
+
+def test_profile_estimate_scales_with_bytes_and_batches(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection)
+    total, per_table = adapter.profile_estimate(["dexdb.shop.customers"])
+    expected = 5_000_000_000 / _SCAN_BYTES_PER_SECOND  # one batch (4 columns)
+    assert per_table["dexdb.shop.customers"] == pytest.approx(expected)
+    assert total == pytest.approx(expected)
+    # Estimation is free: metadata only, no scan ran.
+    assert fake_pg_connection.data_statements == []
+
+
+def test_query_estimate_uses_the_free_planner(fake_pg_connection):
+    fake_pg_connection.plan_costs = lambda sql: 640_000.0  # planner cost units
+    adapter = make_adapter(fake_pg_connection)
+    estimate = adapter.query_estimate("SELECT count(*) FROM dexdb.shop.customers")
+    # 640k planner pages * 8192 bytes over the scan rate.
+    assert estimate == pytest.approx(640_000.0 * 8192 / _SCAN_BYTES_PER_SECOND)
+    explains = [
+        s.sql for s in fake_pg_connection.statements if s.sql.startswith("EXPLAIN")
+    ]
+    assert len(explains) == 1
+    assert explains[0].startswith("EXPLAIN (FORMAT JSON) ")
+    assert fake_pg_connection.data_statements == []
+
+
+def test_query_estimate_falls_back_to_table_bytes(fake_pg_connection):
+    def broken_plan(sql: str) -> float:
+        raise RuntimeError("no plan for you")
+
+    fake_pg_connection.plan_costs = broken_plan
+    adapter = make_adapter(fake_pg_connection)
+    estimate = adapter.query_estimate("SELECT count(*) FROM dexdb.shop.customers")
+    assert estimate == pytest.approx(5_000_000_000 / _SCAN_BYTES_PER_SECOND)
+
+
+def test_query_estimate_floors_small_statements(fake_pg_connection):
+    fake_pg_connection.plan_costs = lambda sql: 1.0
+    adapter = make_adapter(fake_pg_connection)
+    assert (
+        adapter.query_estimate("SELECT count(*) FROM dexdb.shop.customers")
+        == _MIN_STATEMENT_SECONDS
+    )
+
+
+def test_query_estimate_refuses_non_select(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection)
+    with pytest.raises(Exception, match="read-only"):
+        adapter.query_estimate("DELETE FROM dexdb.shop.customers")
+
+
+def test_describe_estimate_names_seconds_and_heuristic(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection)
+    payload = adapter.describe_estimate(12.5, {"dexdb.shop.customers": 12.5})
+    assert payload["estimated_seconds"] == 12.5
+    assert payload["estimate_quality"] == "heuristic"
+    assert "--confirm --budget" in payload["hint"]
+    assert "statement_timeout" in payload["hint"]
+    assert payload["per_table_seconds"] == {"dexdb.shop.customers": 12.5}
+    # No currency translation exists for db load.
+    assert "estimated_usd" not in payload
+    assert adapter.spend_display() == {}
+
+
+# --- the cost gate binds ------------------------------------------------------------
+
+
+def test_unconfirmed_scan_never_executes(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection, confirmed=False)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    with pytest.raises(ConfirmationRequiredError):
+        adapter.column_aggregates("dexdb.shop.customers", columns)
+    assert fake_pg_connection.data_statements == []
+
+
+def test_over_ceiling_refuses_client_side(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection, ceiling=1.0)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    with pytest.raises(OverCeilingError):
+        adapter.column_aggregates("dexdb.shop.customers", columns)
+    assert fake_pg_connection.data_statements == []
+
+
+def test_every_billed_statement_is_server_capped(fake_pg_connection):
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n_total": 100, "nn_0": 100, "nn_1": 90, "nn_2": 80, "nn_3": 70}],
+        seconds=1.0,
+    )
+    adapter = make_adapter(fake_pg_connection, ceiling=600.0)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    adapter.column_aggregates("dexdb.shop.customers", columns)
+    billed = fake_pg_connection.data_statements
+    assert billed, "the aggregate batch must have run"
+    for statement in billed:
+        assert statement.session_timeout_ms is not None
+        assert statement.session_timeout_ms <= 600_000
+
+
+def test_server_timeout_translates_to_over_ceiling(fake_pg_connection):
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(rows=[], seconds=999.0)
+    adapter = make_adapter(fake_pg_connection, ceiling=200.0)
+    with pytest.raises(OverCeilingError, match="statement_timeout"):
+        adapter.run_query(
+            "SELECT count(*) FROM dexdb.shop.customers",
+            max_rows=10,
+            timeout_seconds=500.0,
+        )
+    # The killed statement still billed what ran (the timeout's worth).
+    assert fake_pg_connection.clock.now == pytest.approx(200.0, abs=1.0)
+
+
+def test_wall_clock_timeout_translates_to_timeout_error(fake_pg_connection):
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(rows=[], seconds=999.0)
+    adapter = make_adapter(fake_pg_connection, ceiling=600.0)
+    with pytest.raises(TimeoutError, match="narrow it"):
+        adapter.run_query(
+            "SELECT count(*) FROM dexdb.shop.customers",
+            max_rows=10,
+            timeout_seconds=30.0,
+        )
+
+
+def test_exhausted_budget_refuses_before_the_server(fake_pg_connection):
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n_total": 1}], seconds=99.4
+    )
+    adapter = make_adapter(fake_pg_connection, ceiling=100.0)
+    adapter.run_query(
+        "SELECT count(*) FROM dexdb.shop.customers",
+        max_rows=10,
+        timeout_seconds=500.0,
+    )
+    # 99.4 of 100 seconds billed; under one second remains.
+    with pytest.raises(OverCeilingError, match="under one database-second"):
+        adapter.run_query("SELECT 1", max_rows=10, timeout_seconds=500.0)
+
+
+def test_actual_seconds_land_in_the_ledger(fake_pg_connection):
+    entries: list[dict] = []
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n": 1}], seconds=2.5
+    )
+    adapter = make_adapter(fake_pg_connection, record=entries.append)
+    adapter.run_query(
+        "SELECT count(*) AS n FROM dexdb.shop.customers",
+        max_rows=10,
+        timeout_seconds=30.0,
+    )
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["connector"] == "postgres"
+    assert entry["billed_seconds"] == pytest.approx(2.5)
+    assert "billed_bytes" not in entry
+    assert entry["statement_sha256"]
+    assert "SELECT" not in str(entry.values())
+
+
+def test_session_ceiling_binds_across_commands(fake_pg_connection):
+    adapter = make_adapter(
+        fake_pg_connection,
+        ceiling=None,
+        session_ceiling=100.0,
+        session_spent=99.5,
+    )
+    with pytest.raises(OverCeilingError):
+        adapter.run_query(
+            "SELECT count(*) FROM dexdb.shop.customers",
+            max_rows=10,
+            timeout_seconds=30.0,
+        )
+
+
+# --- profiling ----------------------------------------------------------------------
+
+
+def _aggregate_rows(sql: str) -> FakeResult:
+    # COUNT(*) plus one nn_<i> per column; values keyed by alias.
+    aliases = [part.split(" AS ")[-1] for part in sql.split(",")]
+    row = {}
+    for alias in aliases:
+        alias = alias.split(" FROM ")[0].strip()
+        row[alias] = 100 if alias == "n_total" else 90
+    return FakeResult(rows=[row], seconds=0.5)
+
+
+def test_aggregates_one_cheap_pass_no_count_distinct(fake_pg_connection):
+    fake_pg_connection.row_resolver = _aggregate_rows
+    adapter = make_adapter(fake_pg_connection)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    aggregates = adapter.column_aggregates(
+        "dexdb.shop.customers", columns, safe_min_max={"id"}
+    )
+    sql = fake_pg_connection.data_statements[0].sql
+    assert "COUNT(*)" in sql
+    assert "COUNT(DISTINCT" not in sql  # pg_stats carries distinct, not a scan
+    by_name = {a.name: a for a in aggregates}
+    # id: pg_stats n_distinct -1 scales by the exact row count from the batch.
+    assert by_name["id"].distinct_count == 100
+    assert by_name["id"].distinct_count_exact is False
+    assert by_name["id"].is_unique is None  # estimates are never a proof
+    # email: positive n_distinct used directly.
+    assert by_name["email"].distinct_count == 90
+    assert by_name["email"].null_fraction == pytest.approx(0.1)
+
+
+def test_degraded_types_get_non_null_counts_only(fake_pg_connection):
+    fake_pg_connection.row_resolver = _aggregate_rows
+    adapter = make_adapter(fake_pg_connection)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    aggregates = adapter.column_aggregates(
+        "dexdb.shop.customers", columns, safe_min_max={"payload", "tags"}
+    )
+    sql = fake_pg_connection.data_statements[0].sql
+    by_name = {a.name: a for a in aggregates}
+    for degraded in ("payload", "tags"):  # jsonb and text[]
+        assert by_name[degraded].distinct_count is None
+        assert by_name[degraded].min_value is None
+        assert f'MIN("{degraded}")' not in sql
+        assert by_name[degraded].null_fraction is not None
+
+
+def test_min_max_only_for_engine_cleared_columns(fake_pg_connection):
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(
+        rows=[
+            {
+                "n_total": 100,
+                "nn_0": 100,
+                "mn_0": 1,
+                "mx_0": 100,
+                "nn_1": 90,
+                "nn_2": 80,
+                "nn_3": 70,
+            }
+        ],
+        seconds=0.5,
+    )
+    adapter = make_adapter(fake_pg_connection)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    aggregates = adapter.column_aggregates(
+        "dexdb.shop.customers", columns, safe_min_max={"id"}
+    )
+    sql = fake_pg_connection.data_statements[0].sql
+    assert 'MIN("id")' in sql
+    assert 'MIN("email")' not in sql
+    by_name = {a.name: a for a in aggregates}
+    assert by_name["id"].min_value == 1
+    assert by_name["email"].min_value is None
+
+
+def test_stats_reads_never_select_value_columns(fake_pg_connection):
+    fake_pg_connection.row_resolver = _aggregate_rows
+    adapter = make_adapter(fake_pg_connection)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    adapter.column_aggregates("dexdb.shop.customers", columns)
+    stats_reads = [s.sql for s in fake_pg_connection.statements if "pg_stats" in s.sql]
+    assert stats_reads, "profiling must consult pg_stats"
+    for sql in stats_reads:
+        assert "most_common_vals" not in sql
+        assert "histogram_bounds" not in sql
+
+
+def test_missing_stats_notes_analyze(fake_pg_connection):
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n_total": 50, "nn_0": 50, "nn_1": 50}], seconds=0.5
+    )
+    adapter = make_adapter(fake_pg_connection, ceiling=2000.0)
+    _meta, columns = adapter.table_metadata("dexdb.shop.events")
+    aggregates = adapter.column_aggregates("dexdb.shop.events", columns)
+    assert all(a.distinct_count is None for a in aggregates)
+    assert any("ANALYZE" in note for note in adapter.table_notes("dexdb.shop.events"))
+
+
+def test_exact_count_from_scan_supersedes_reltuples(fake_pg_connection):
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n_total": 137, "nn_0": 137, "nn_1": 137, "nn_2": 1, "nn_3": 1}],
+        seconds=0.5,
+    )
+    adapter = make_adapter(fake_pg_connection)
+    meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    assert meta.row_count == 100  # the planner estimate
+    adapter.column_aggregates("dexdb.shop.customers", columns)
+    meta, _ = adapter.table_metadata("dexdb.shop.customers")
+    assert meta.row_count == 137  # the exact count the scan paid for
+
+
+def test_sampling_above_threshold_notes_and_voids_uniqueness(fake_pg_connection):
+    fake_pg_connection.row_resolver = _aggregate_rows
+    adapter = make_adapter(
+        fake_pg_connection,
+        target=PostgresTarget(max_full_profile_bytes=1_000_000),
+    )
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    adapter.column_aggregates("dexdb.shop.customers", columns)
+    sql = fake_pg_connection.data_statements[0].sql
+    assert "TABLESAMPLE SYSTEM" in sql
+    notes = adapter.table_notes("dexdb.shop.customers")
+    assert any("block sample" in note for note in notes)
+    # A sampled COUNT(*) must not be cached as the exact row count.
+    meta, _ = adapter.table_metadata("dexdb.shop.customers")
+    assert meta.row_count == 100
+
+
+def test_exact_distinct_counts_ride_with_count_star(fake_pg_connection):
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n_total": 120, "d_0": 120}], seconds=0.5
+    )
+    adapter = make_adapter(fake_pg_connection)
+    counts = adapter.exact_distinct_counts("dexdb.shop.customers", ["id"])
+    assert counts == {"id": 120}
+    sql = fake_pg_connection.data_statements[0].sql
+    assert 'COUNT(DISTINCT "id")' in sql
+    assert "COUNT(*)" in sql
+    meta, _ = adapter.table_metadata("dexdb.shop.customers")
+    assert meta.row_count == 120
+
+
+def test_escalation_skipped_when_budget_cannot_cover(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection, ceiling=1.0)
+    counts = adapter.exact_distinct_counts("dexdb.shop.customers", ["id"])
+    assert counts == {}
+    assert fake_pg_connection.data_statements == []
+    notes = adapter.table_notes("dexdb.shop.customers")
+    assert any("escalation skipped" in note for note in notes)
+
+
+# --- run_query ----------------------------------------------------------------------
+
+
+def test_run_query_truncates_and_reports(fake_pg_connection):
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n": i} for i in range(5)], seconds=0.1
+    )
+    adapter = make_adapter(fake_pg_connection)
+    result = adapter.run_query(
+        "SELECT id AS n FROM dexdb.shop.customers",
+        max_rows=3,
+        timeout_seconds=30.0,
+    )
+    assert result.columns == ["n"]
+    assert len(result.cells) == 3
+    assert result.truncated is True
+
+
+def test_run_query_rejects_writes(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection)
+    with pytest.raises(Exception, match="read-only"):
+        adapter.run_query(
+            "UPDATE dexdb.shop.customers SET email = 'x'",
+            max_rows=10,
+            timeout_seconds=30.0,
+        )
+    assert fake_pg_connection.data_statements == []
+
+
+# --- credential discovery -----------------------------------------------------------
+
+
+def test_discovery_prefers_config_service(tmp_path: Path):
+    service_file = tmp_path / "pg_service.conf"
+    service_file.write_text(
+        "[analytics]\nhost=db.example.com\nport=5432\ndbname=shop\nuser=dex\n",
+        encoding="utf-8",
+    )
+    params, method = resolve_postgres_connection(
+        PostgresTarget(service="analytics"),
+        {"PGSERVICEFILE": str(service_file), "DATABASE_URL": "postgres://x:y@h/d"},
+        tmp_path,
+    )
+    assert params == {"service": "analytics"}
+    assert method == "config_service:external"
+
+
+def test_discovery_missing_service_names_the_fix(tmp_path: Path):
+    with pytest.raises(CredentialDiscoveryError, match=r"pg_service\.conf"):
+        resolve_postgres_connection(
+            PostgresTarget(service="missing"),
+            {"PGSERVICEFILE": str(tmp_path / "none.conf")},
+            tmp_path,
+        )
+
+
+def test_discovery_database_url_classifies_password(tmp_path: Path):
+    params, method = resolve_postgres_connection(
+        PostgresTarget(),
+        {"DATABASE_URL": "postgresql://dex:secret@localhost:5433/shop"},
+        tmp_path,
+    )
+    assert params == {"conninfo": "postgresql://dex:secret@localhost:5433/shop"}
+    assert method == "database_url:password"
+
+
+def test_discovery_database_url_without_password_is_external(tmp_path: Path):
+    _params, method = resolve_postgres_connection(
+        PostgresTarget(),
+        {"DATABASE_URL": "postgresql://dex@localhost/shop"},
+        tmp_path,
+    )
+    assert method == "database_url:external"
+
+
+def test_discovery_pg_env_lets_libpq_resolve(tmp_path: Path):
+    params, method = resolve_postgres_connection(
+        PostgresTarget(),
+        {"PGHOST": "localhost", "PGDATABASE": "shop", "PGPASSWORD": "secret"},
+        tmp_path,
+    )
+    assert params == {}  # libpq reads PG* natively
+    assert method == "environment:password"
+
+
+def test_discovery_pgservice_env(tmp_path: Path):
+    _params, method = resolve_postgres_connection(
+        PostgresTarget(), {"PGSERVICE": "analytics"}, tmp_path
+    )
+    assert method == "environment:service_file"
+
+
+def test_discovery_config_target(tmp_path: Path):
+    params, method = resolve_postgres_connection(
+        PostgresTarget(host="db.internal", port=5433, dbname="shop", user="dex"),
+        {},
+        tmp_path,
+    )
+    assert params == {
+        "host": "db.internal",
+        "port": 5433,
+        "dbname": "shop",
+        "user": "dex",
+    }
+    assert method == "config_target:external"
+
+
+def test_discovery_dbt_profile_fallback(tmp_path: Path):
+    project = tmp_path / "analytics"
+    project.mkdir()
+    (project / "dbt_project.yml").write_text(
+        "name: analytics\nversion: '1.0.0'\nprofile: analytics\n", encoding="utf-8"
+    )
+    (project / "profiles.yml").write_text(
+        "analytics:\n"
+        "  target: dev\n"
+        "  outputs:\n"
+        "    dev:\n"
+        "      type: postgres\n"
+        "      host: db.example.com\n"
+        "      port: 5432\n"
+        "      user: dbt\n"
+        "      password: hunter2\n"
+        "      dbname: shop\n",
+        encoding="utf-8",
+    )
+    params, method = resolve_postgres_connection(PostgresTarget(), {}, tmp_path)
+    assert params["host"] == "db.example.com"
+    assert params["dbname"] == "shop"
+    assert method == "dbt_profile:password"
+
+
+def test_discovery_failure_names_every_fix(tmp_path: Path):
+    with pytest.raises(CredentialDiscoveryError) as excinfo:
+        resolve_postgres_connection(PostgresTarget(), {}, tmp_path)
+    message = str(excinfo.value)
+    for fix in ("DATABASE_URL", "pg_service.conf", "profiles.yml", "postgres.host"):
+        assert fix in message
+
+
+def test_discovery_never_surfaces_a_password(tmp_path: Path):
+    _params, method = resolve_postgres_connection(
+        PostgresTarget(),
+        {"DATABASE_URL": "postgresql://dex:supersecret@localhost/shop"},
+        tmp_path,
+    )
+    assert "supersecret" not in method

--- a/packages/dex-core/tests/conftest.py
+++ b/packages/dex-core/tests/conftest.py
@@ -135,6 +135,47 @@ def fake_sf_connection():
 
 
 @pytest.fixture
+def fake_pg_connection():
+    """The standard populated fake Postgres connection (see
+    tests/fakes/postgres.py).
+
+    Requires the real psycopg library (the [postgres] extra) for its error
+    types; skipped when absent, but CI and the release gate install the extra,
+    so the Postgres safety families run everywhere that matters. ``customers``
+    carries fresh planner statistics; ``events`` has never been analyzed
+    (reltuples -1, no pg_stats rows) so the missing-stats degradations are on
+    by default.
+    """
+
+    pytest.importorskip("psycopg")
+    from fakes.postgres import FakePostgresConnection, FakePostgresTable
+
+    tables = [
+        FakePostgresTable(
+            schema="shop",
+            name="customers",
+            columns=[
+                ("id", "bigint", False),
+                ("email", "text", True),
+                ("payload", "jsonb", True),
+                ("tags", "text[]", True),
+            ],
+            reltuples=100.0,
+            total_bytes=5_000_000_000,  # 5 GB -> a non-trivial seconds estimate
+            stats={"id": -1.0, "email": 90.0},
+        ),
+        FakePostgresTable(
+            schema="shop",
+            name="events",
+            columns=[("id", "bigint", True), ("payload", "jsonb", True)],
+            reltuples=-1.0,
+            total_bytes=50_000_000_000,  # 50 GB
+        ),
+    ]
+    return FakePostgresConnection(tables=tables, database="dexdb")
+
+
+@pytest.fixture
 def dbt_project_dir(tmp_path: Path) -> Path:
     """A minimal dbt project with a project-local profiles.yml.
 

--- a/packages/dex-core/tests/explore/test_profile.py
+++ b/packages/dex-core/tests/explore/test_profile.py
@@ -295,3 +295,64 @@ def test_adapter_without_exact_counts_degrades_gracefully():
     assert col.distinct_count_exact is False
     # In the noise band and unproven: no non-uniqueness verdict.
     assert not any("not unique" in n for n in datasets[0].data_quality)
+
+
+def test_row_count_refreshes_after_the_aggregate_scan():
+    """Adapters whose free row counts are planner estimates (Postgres
+    reltuples) upgrade to the exact COUNT(*) the aggregate scan paid for; the
+    profile engine must re-read the metadata so uniqueness proofs and the
+    dataset row count compare against real rows, not the estimate."""
+
+    from exmergo_dex_core.adapters.base import (
+        ColumnAggregate,
+        ColumnMeta,
+        ObjectMeta,
+    )
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    class EstimatingAdapter:
+        name = "stub"
+        dialect = "duckdb"
+
+        def __init__(self):
+            self.scanned = False
+
+        def table_metadata(self, identifier):
+            rows = 1000 if self.scanned else 1200  # estimate is stale-high
+            meta = ObjectMeta(
+                identifier=identifier,
+                object_type="table",
+                schema="s",
+                name="t",
+                row_count=rows,
+                byte_size=None,
+                column_count=1,
+            )
+            return meta, [
+                ColumnMeta(name="id", data_type="INTEGER", nullable=False, ordinal=0)
+            ]
+
+        def column_aggregates(self, identifier, columns, *, safe_min_max=None):
+            self.scanned = True
+            return [
+                ColumnAggregate(
+                    name="id",
+                    null_fraction=0.0,
+                    distinct_count=990,  # near-unique against the REAL count
+                    is_unique=None,
+                    min_value=None,
+                    max_value=None,
+                )
+            ]
+
+        def exact_distinct_counts(self, identifier, columns):
+            return dict.fromkeys(columns, 1000)
+
+    datasets = profile_mod.profile(EstimatingAdapter(), ["db.s.t"])
+    assert datasets[0].row_count == 1000  # the exact count, not the estimate
+    id_col = datasets[0].columns[0]
+    # 990 approx over 1000 real rows is in the escalation band; the exact scan
+    # returns 1000 == 1000, a proof that would be missed against 1200.
+    assert id_col.distinct_count == 1000
+    assert id_col.distinct_count_exact is True
+    assert id_col.is_unique is True

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -399,3 +399,31 @@ def test_empty_result_is_explained_not_silent(tmp_path: Path, capsys):
     data = payload["data"]
     assert data["relationships"] == []
     assert any("nothing to infer" in n for n in data["notes"])
+
+
+def test_overlap_probe_transpiles_to_postgres_and_stays_select_only():
+    """The probe is authored once in DuckDB SQL; on Postgres it must transpile
+    to a statement that re-parses in the postgres dialect and passes the
+    SELECT-only guard (the dialect risk a new connector carries)."""
+
+    import sqlglot
+
+    from exmergo_dex_core.cache import Relationship
+    from exmergo_dex_core.explore.relationships import probe_statements
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    rel = Relationship(
+        from_dataset="dexdb.app.order_items",
+        from_columns=["product_id"],
+        to_dataset="dexdb.app.products",
+        to_columns=["id"],
+    )
+    statements = probe_statements([rel], "postgres")
+    assert len(statements) == 1
+    sql = statements[0]
+    assert_select_only(sql, dialect="postgres")
+    parsed = sqlglot.parse_one(sql, read="postgres")
+    assert parsed is not None
+    # Portable shapes survive the rewrite; DuckDB-only FILTER syntax does not
+    # appear (BigQuery lacks it and Postgres parses it differently).
+    assert "order_items" in sql and "products" in sql

--- a/packages/dex-core/tests/fakes/postgres.py
+++ b/packages/dex-core/tests/fakes/postgres.py
@@ -1,0 +1,279 @@
+"""A stateful fake of the psycopg connection surface dex uses.
+
+Behavioral, not a mock: it records every statement in order, serves the
+``pg_catalog`` lookups (inventory, columns, ``pg_stats``, namespace scope, the
+capabilities probe) from a table registry, answers ``EXPLAIN (FORMAT JSON)``
+with a plan cost derived from the referenced tables' sizes (overridable per
+test), simulates per-statement duration by advancing an injectable clock (the
+adapter measures wall-clock elapsed through the same clock, so timing
+assertions are deterministic), tracks the session parameters the adapter sets,
+and enforces ``statement_timeout`` the way the server does: a real
+``psycopg.errors.QueryCanceled`` raised at execute, with the elapsed time
+capped at the timeout (a killed statement still bills what ran). Tests assert
+against observable behavior (statement ordering, session state, ledger
+effects), not call signatures.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from psycopg import errors as pg_errors
+
+# Statements with no registered duration run this long on the fake clock.
+DEFAULT_STATEMENT_SECONDS = 0.2
+
+_PLANNER_PAGE_BYTES = 8192
+
+
+class FakeClock:
+    """The adapter's injectable clock; the fake connection advances it by each
+    statement's simulated duration."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+@dataclass
+class FakeColumnDescription:
+    name: str
+    type_code: int = 25  # text
+
+
+@dataclass
+class FakePostgresTable:
+    schema: str
+    name: str
+    # (column_name, format_type output, nullable), e.g. ("id", "bigint", False)
+    columns: list[tuple[str, str, bool]]
+    reltuples: float = -1.0
+    total_bytes: int = 0
+    kind: str = "table"  # "table" | "view" | "materialized_view"
+    # attname -> pg_stats.n_distinct (positive = count, negative = ratio)
+    stats: dict[str, float] = field(default_factory=dict)
+
+    @property
+    def relkind(self) -> str:
+        return {"table": "r", "view": "v", "materialized_view": "m"}[self.kind]
+
+
+@dataclass
+class FakeStatement:
+    sql: str
+    session_timeout_ms: int | None
+
+
+@dataclass
+class FakeResult:
+    """What one executed SELECT returns: dict rows keyed by alias, plus how
+    long the statement 'runs' on the fake clock."""
+
+    rows: list[dict]
+    seconds: float = DEFAULT_STATEMENT_SECONDS
+
+
+class FakeCursor:
+    def __init__(self, conn: FakePostgresConnection):
+        self._conn = conn
+        self._rows: list[tuple] = []
+        self.description: list[FakeColumnDescription] = []
+
+    def execute(self, sql: str):
+        stripped = sql.strip()
+        upper = stripped.upper()
+        self._record(sql)
+
+        if upper.startswith("SET "):
+            self._apply_session_parameter(stripped)
+            return self
+        if upper.startswith("EXPLAIN"):
+            inner = stripped.split(")", 1)[1].strip()
+            cost = self._conn.plan_cost(inner)
+            self._emit([{"QUERY PLAN": [{"Plan": {"Total Cost": cost}}]}])
+            return self
+        if "pg_catalog." in sql or "current_database()" in sql:
+            self._serve_catalog(stripped)
+            return self
+
+        # A data statement: simulate duration, enforce the session timeout the
+        # way the server does (kill and bill what ran).
+        result = self._conn.resolve(sql)
+        timeout_ms = self._conn.session_parameters.get("statement_timeout")
+        if timeout_ms is not None and result.seconds * 1000 > float(timeout_ms):
+            self._conn.clock.now += float(timeout_ms) / 1000.0
+            raise pg_errors.QueryCanceled(
+                "canceling statement due to statement timeout"
+            )
+        self._conn.clock.now += result.seconds
+        self._emit(result.rows)
+        return self
+
+    def fetchall(self) -> list[tuple]:
+        return list(self._rows)
+
+    def fetchmany(self, size: int) -> list[tuple]:
+        return list(self._rows[:size])
+
+    # --- internals -------------------------------------------------------------
+
+    def _record(self, sql: str) -> None:
+        timeout = self._conn.session_parameters.get("statement_timeout")
+        self._conn.statements.append(
+            FakeStatement(
+                sql=sql,
+                session_timeout_ms=int(timeout) if timeout is not None else None,
+            )
+        )
+
+    def _apply_session_parameter(self, sql: str) -> None:
+        # SET <param> = <value>
+        try:
+            assignment = sql.split(" ", 1)[1]
+            key, value = assignment.split("=", 1)
+            key = key.strip().lower()
+            value = value.strip().strip("'")
+            self._conn.session_parameters[key] = (
+                int(value) if value.lstrip("-").isdigit() else value
+            )
+        except (IndexError, ValueError):
+            pass
+
+    def _serve_catalog(self, sql: str) -> None:
+        if "current_database()" in sql and "server_version" in sql:
+            read_only = self._conn.session_parameters.get(
+                "default_transaction_read_only", "off"
+            )
+            self._emit(
+                [
+                    {
+                        "db": self._conn.database,
+                        "server_version": self._conn.server_version,
+                        "read_only": str(read_only),
+                    }
+                ]
+            )
+        elif "current_database()" in sql:
+            self._emit([{"db": self._conn.database}])
+        elif "pg_catalog.pg_stats" in sql:
+            table = self._find_stats_table(sql)
+            rows = (
+                [
+                    {"attname": name, "n_distinct": value}
+                    for name, value in sorted(table.stats.items())
+                ]
+                if table is not None
+                else []
+            )
+            self._emit(rows, columns=["attname", "n_distinct"])
+        elif "pg_catalog.pg_attribute" in sql:
+            rows = []
+            for t in sorted(self._conn.tables, key=lambda t: (t.schema, t.name)):
+                for col, data_type, nullable in t.columns:
+                    rows.append(
+                        {
+                            "schema_name": t.schema,
+                            "object_name": t.name,
+                            "column_name": col,
+                            "data_type": data_type,
+                            "nullable": nullable,
+                        }
+                    )
+            self._emit(rows)
+        elif "pg_catalog.pg_class" in sql:
+            rows = [
+                {
+                    "schema_name": t.schema,
+                    "object_name": t.name,
+                    "kind": t.relkind,
+                    "reltuples": t.reltuples,
+                    "total_bytes": t.total_bytes,
+                }
+                for t in sorted(self._conn.tables, key=lambda t: (t.schema, t.name))
+            ]
+            self._emit(rows)
+        elif "pg_catalog.pg_namespace" in sql:
+            names = sorted({t.schema for t in self._conn.tables})
+            self._emit([{"nspname": name} for name in names])
+        else:
+            self._emit([])
+
+    def _find_stats_table(self, sql: str) -> FakePostgresTable | None:
+        for t in self._conn.tables:
+            if f"schemaname = '{t.schema}'" in sql and f"tablename = '{t.name}'" in sql:
+                return t
+        return None
+
+    def _emit(self, rows: list[dict], columns: list[str] | None = None) -> None:
+        keys = columns or (list(rows[0].keys()) if rows else ["name"])
+        self.description = [FakeColumnDescription(name=key) for key in keys]
+        self._rows = [tuple(row[key] for key in keys) for row in rows]
+
+
+class FakePostgresConnection:
+    """Simulates exactly the connection surface the adapter touches; anything
+    else raises AttributeError, which is the point (the adapter must not grow
+    calls the fake does not vouch for)."""
+
+    def __init__(
+        self,
+        *,
+        tables: list[FakePostgresTable] | None = None,
+        database: str = "dexdb",
+        server_version: str = "16.4",
+        clock: FakeClock | None = None,
+        row_resolver: Callable[[str], FakeResult | list[dict]] | None = None,
+        plan_costs: Callable[[str], float | None] | None = None,
+    ):
+        self.tables = tables or []
+        self.database = database
+        self.server_version = server_version
+        self.clock = clock or FakeClock()
+        self.row_resolver = row_resolver
+        self.plan_costs = plan_costs
+        self.statements: list[FakeStatement] = []
+        self.session_parameters: dict[str, object] = {}
+        self.closed = False
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
+
+    def resolve(self, sql: str) -> FakeResult:
+        if self.row_resolver is None:
+            return FakeResult(rows=[])
+        resolved = self.row_resolver(sql)
+        return resolved if isinstance(resolved, FakeResult) else FakeResult(resolved)
+
+    def plan_cost(self, sql: str) -> float:
+        """The Total Cost EXPLAIN reports for ``sql``: a per-test override, or
+        the referenced tables' page counts (the planner's own calibration)."""
+
+        if self.plan_costs is not None:
+            override = self.plan_costs(sql)
+            if override is not None:
+                return override
+        pages = sum(
+            t.total_bytes / _PLANNER_PAGE_BYTES for t in self.tables if t.name in sql
+        )
+        return pages if pages > 0 else 100.0
+
+    def close(self) -> None:
+        self.closed = True
+
+    # --- convenience for assertions ---------------------------------------------
+
+    @property
+    def data_statements(self) -> list[FakeStatement]:
+        """Statements that scan data: SELECTs that are not catalog lookups,
+        the capabilities probe, or EXPLAIN plan requests."""
+
+        return [
+            s
+            for s in self.statements
+            if s.sql.strip().upper().startswith("SELECT")
+            and "pg_catalog." not in s.sql
+            and "current_database()" not in s.sql
+        ]

--- a/packages/dex-core/tests/guards/test_cost_guard.py
+++ b/packages/dex-core/tests/guards/test_cost_guard.py
@@ -148,3 +148,22 @@ def test_gate_cost_prefers_the_command_estimate():
     gate.preflight_command(500.0)
     gate.charge(200.0)
     assert gate.cost().estimate == 500.0
+
+
+def test_db_load_ledger_records_seconds():
+    # DB_LOAD is a time paradigm: its ledger unit and spend key are seconds,
+    # never bytes, so a Postgres entry can never sum into a bytes budget.
+    entries: list[dict] = []
+    gate = _gate(
+        paradigm=Paradigm.DB_LOAD,
+        connector="postgres",
+        record=entries.append,
+    )
+    assert gate.ledger_field() == "billed_seconds"
+    gate.charge(10.0)
+    gate.record_billed(3.5, statement="SELECT 1")
+    assert entries[0]["billed_seconds"] == 3.5
+    assert "billed_bytes" not in entries[0]
+    summary = gate.spend_summary()
+    assert summary["seconds_billed"] == 3.5
+    assert "bytes_billed" not in summary

--- a/packages/dex-core/tests/integration/conftest.py
+++ b/packages/dex-core/tests/integration/conftest.py
@@ -21,6 +21,15 @@ both):
 
     DEX_TEST_SNOWFLAKE_CONNECTION=dex-ci DEX_TEST_SNOWFLAKE_DATABASE=DEX_CI \
         uv run pytest tests/integration -q
+
+Postgres (bills nothing: a local container; db-load gating is exercised for
+real, statement timeouts and all). The DSN should be the read-only role from
+scripts/postgres_seed.sql; transform additionally needs the dbt_dev role's
+password in DEX_TEST_PG_DEV_PASSWORD (scripts/setup_postgres_dev.sh stands
+the whole thing up):
+
+    DEX_TEST_PG_DSN=postgresql://dex_ro:dex_ro@localhost:5433/dex_dogfood \
+        DEX_TEST_PG_DEV_PASSWORD=dbt_dev uv run pytest tests/integration -q
 """
 
 from __future__ import annotations
@@ -58,6 +67,14 @@ def _require_cloud_env(request):
             )
         pytest.importorskip("snowflake.connector")
         return
+    if request.node.get_closest_marker("postgres"):
+        if not os.environ.get("DEX_TEST_PG_DSN"):
+            pytest.skip(
+                "Postgres integration disabled: set DEX_TEST_PG_DSN (run "
+                "scripts/setup_postgres_dev.sh for a seeded local container)"
+            )
+        pytest.importorskip("psycopg")
+        return
     missing = [name for name in REQUIRED_ENV if not os.environ.get(name)]
     if missing:
         pytest.skip(f"BigQuery integration disabled: set {', '.join(missing)}")
@@ -87,3 +104,13 @@ def sf_connection_name() -> str | None:
 @pytest.fixture
 def sf_warehouse() -> str:
     return os.environ.get("DEX_TEST_SNOWFLAKE_WAREHOUSE", "DEX_CI_WH")
+
+
+@pytest.fixture
+def pg_dsn() -> str:
+    return os.environ["DEX_TEST_PG_DSN"]
+
+
+@pytest.fixture
+def pg_dev_password() -> str | None:
+    return os.environ.get("DEX_TEST_PG_DEV_PASSWORD")

--- a/packages/dex-core/tests/integration/test_postgres_connect.py
+++ b/packages/dex-core/tests/integration/test_postgres_connect.py
@@ -1,0 +1,86 @@
+"""Live `connect test` against Postgres: connection discovery, capabilities
+envelope, and the sanitizer, end to end. Free: capabilities is one catalog
+round-trip, no table scan. The target is the seeded container from
+scripts/setup_postgres_dev.sh (or the CI service container), connected as the
+read-only dex_ro role."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from exmergo_dex_core.cli import main
+
+pytestmark = [pytest.mark.integration, pytest.mark.postgres]
+
+
+def seed_repo(
+    root: Path,
+    *,
+    schemas: list[str] | None = None,
+    budget: float | None = None,
+    max_full_profile_bytes: int | None = None,
+) -> None:
+    postgres: dict = {"dev_schema": "dbt_dev"}
+    if schemas is not None:
+        postgres["schemas"] = schemas
+    if max_full_profile_bytes is not None:
+        postgres["max_full_profile_bytes"] = max_full_profile_bytes
+    config: dict = {"connector": "postgres", "postgres": postgres}
+    if budget is not None:
+        config["budget"] = {"ceiling": budget}
+    (root / ".dex").mkdir(parents=True, exist_ok=True)
+    (root / ".dex" / "config.yml").write_text(yaml.safe_dump(config), encoding="utf-8")
+
+
+def run_cli(argv: list[str], capsys) -> tuple[int, dict]:
+    rc = main(argv)
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1, "exactly one envelope line on stdout"
+    return rc, json.loads(out)
+
+
+def test_connect_test_discovers_connection_and_reports_read_only(
+    tmp_path: Path, capsys, pg_dsn, monkeypatch
+):
+    monkeypatch.setenv("DATABASE_URL", pg_dsn)
+    seed_repo(tmp_path)
+    rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
+    assert rc == 0, envelope
+    data = envelope["data"]
+    assert data["connector"] == "postgres"
+    assert data["dialect"] == "postgres"
+    assert data["read_only"] is True
+    assert data["session_read_only"] is True
+    assert data["paradigm"] == "db_load"
+    assert data["schema_count"] >= 1
+    assert envelope["cost"]["paradigm"] == "db_load"
+    # The auth method is coarse; no identity, password, or DSN crosses.
+    assert data["auth_method"].split(":")[0] in {
+        "config_service",
+        "database_url",
+        "environment",
+        "config_target",
+        "dbt_profile",
+    }
+    payload = json.dumps(envelope)
+    assert "dex_ro:" not in payload  # no user:password fragment
+    assert not _identity_keys(data)
+
+
+def _identity_keys(value, path="data") -> list[str]:
+    """Every key in the payload that names an identity or credential."""
+
+    hits: list[str] = []
+    if isinstance(value, dict):
+        for key, sub in value.items():
+            if str(key).lower() in {"user", "username", "login", "login_name"}:
+                hits.append(f"{path}.{key}")
+            hits.extend(_identity_keys(sub, f"{path}.{key}"))
+    elif isinstance(value, list):
+        for i, sub in enumerate(value):
+            hits.extend(_identity_keys(sub, f"{path}[{i}]"))
+    return hits

--- a/packages/dex-core/tests/integration/test_postgres_explore.py
+++ b/packages/dex-core/tests/integration/test_postgres_explore.py
@@ -1,0 +1,137 @@
+"""Live explore against the seeded Postgres: free inventory, the strict
+db-load handshake, PII flag-not-surface, relationship inference on the
+deliberately undeclared foreign key, and the query firewall. Loads nothing
+beyond the confirmed budgets; every scanning statement is capped server-side
+by the budget-derived statement_timeout."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from .test_postgres_connect import run_cli, seed_repo
+
+pytestmark = [pytest.mark.integration, pytest.mark.postgres]
+
+
+@pytest.fixture(autouse=True)
+def _dsn_env(pg_dsn, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", pg_dsn)
+
+
+def test_inventory_is_free_and_scoped(tmp_path: Path, capsys):
+    seed_repo(tmp_path, schemas=["app"])
+    rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "inventory"], capsys
+    )
+    assert rc == 0, envelope
+    identifiers = {o["identifier"] for o in envelope["data"]["objects"]}
+    assert any(i.endswith("app.customers") for i in identifiers)
+    assert all(".app." in i for i in identifiers)
+    # Free: no confirmation was required and nothing was billed.
+    assert envelope["status"] == "ok"
+    assert "spend" not in envelope["data"]
+
+
+def test_unconfirmed_profile_returns_the_handshake(tmp_path: Path, capsys):
+    seed_repo(tmp_path, schemas=["app"])
+    _rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "profile", "app.customers"],
+        capsys,
+    )
+    assert envelope["status"] == "needs_confirmation"
+    assert envelope["data"]["estimated_seconds"] > 0
+    assert envelope["data"]["estimate_quality"] == "heuristic"
+    assert "--confirm --budget" in envelope["data"]["hint"]
+
+
+def test_over_ceiling_refusal_is_live_and_loads_nothing(tmp_path: Path, capsys):
+    seed_repo(tmp_path, schemas=["app"])
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "explore",
+            "profile",
+            "app.events",
+            "--confirm",
+            "--budget",
+            "0.01",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert "exceeds the ceiling" in envelope["errors"][0]
+
+
+def test_confirmed_map_profiles_flags_pii_and_infers_the_missing_fk(
+    tmp_path: Path, capsys
+):
+    seed_repo(tmp_path, schemas=["app"], budget=120)
+    rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "map", "--confirm"], capsys
+    )
+    assert rc == 0, envelope
+    data = envelope["data"]
+    assert data["profiled_count"] >= 6
+    assert data["pii_column_count"] >= 3  # email, names, phone, address
+    assert data["spend"]["seconds_billed"] > 0
+
+    cache = json.loads((tmp_path / ".dex" / "cache.json").read_text(encoding="utf-8"))
+    # The deliberately undeclared FK is inferred from names and profiles.
+    assert any(
+        r["from_dataset"].endswith("app.order_items")
+        and r["from_columns"] == ["product_id"]
+        and r["to_dataset"].endswith("app.products")
+        for r in cache["relationships"]
+    )
+    # PII is flagged with min/max suppressed: no example value in the cache.
+    customers = next(
+        d for d in cache["datasets"] if d["identifier"].endswith("app.customers")
+    )
+    email = next(c for c in customers["columns"] if c["name"] == "email")
+    assert email["pii"]["category"] == "email"
+    assert email["min_value"] is None and email["max_value"] is None
+    assert "@example.com" not in json.dumps(cache)
+
+
+def test_query_firewall_allows_measuring_and_refuses_pii_values(tmp_path: Path, capsys):
+    seed_repo(tmp_path, schemas=["app"], budget=120)
+    rc, _ = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "map", "--confirm"], capsys
+    )
+    assert rc == 0
+
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "explore",
+            "query",
+            "SELECT status, count(*) AS n FROM app.orders GROUP BY status",
+            "--confirm",
+            "--budget",
+            "30",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+    assert envelope["data"]["row_count"] >= 1
+
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "explore",
+            "query",
+            "SELECT email FROM app.customers LIMIT 5",
+            "--confirm",
+            "--budget",
+            "30",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert "PII" in envelope["errors"][0]

--- a/packages/dex-core/tests/integration/test_postgres_transform.py
+++ b/packages/dex-core/tests/integration/test_postgres_transform.py
@@ -1,0 +1,97 @@
+"""Live transform against the seeded Postgres: init renders a secret-free
+dbt-postgres profile from the discovered connection, and a confirmed build
+lands only in the dedicated dbt_dev schema as the dbt_dev role, with actual
+database-seconds recorded to the ledger and the ceiling injected as a
+statement_timeout via PGOPTIONS."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from .test_postgres_connect import run_cli, seed_repo
+
+pytestmark = [pytest.mark.integration, pytest.mark.postgres]
+
+
+@pytest.fixture
+def dev_dsn(pg_dsn, pg_dev_password, monkeypatch) -> str:
+    """The pg_dsn rewritten to the dbt_dev role (builds need write access to
+    the dev schema; dex_ro deliberately has none). Password travels via
+    PGPASSWORD, exactly as the rendered profile expects."""
+
+    if not pg_dev_password:
+        pytest.skip("set DEX_TEST_PG_DEV_PASSWORD (the dbt_dev role's password)")
+    from psycopg.conninfo import conninfo_to_dict, make_conninfo
+
+    fields = {
+        k: v for k, v in conninfo_to_dict(pg_dsn).items() if k not in ("password",)
+    }
+    fields["user"] = "dbt_dev"
+    dsn = make_conninfo(**fields)
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    monkeypatch.setenv("PGPASSWORD", pg_dev_password)
+    return dsn
+
+
+def test_init_and_build_write_only_the_dev_schema(
+    tmp_path: Path, capsys, dev_dsn, pg_dev_password
+):
+    seed_repo(tmp_path, schemas=["app"], budget=300)
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "init",
+            "analytics",
+            "--connector",
+            "postgres",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+
+    rendered = (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
+    profile = yaml.safe_load(rendered)["analytics"]["outputs"]["dev"]
+    assert profile["type"] == "postgres"
+    assert profile["schema"] == "dbt_dev"
+    assert profile["threads"] == 1
+    # Never a secret in the rendered profile: the password field is an
+    # env_var reference, not a value. (A substring check on the password
+    # would false-positive here: the seeded dev password equals the role and
+    # schema name, which legitimately appear in the profile.)
+    assert profile["password"] == "{{ env_var('PGPASSWORD', '') }}"  # noqa: S105
+
+    (tmp_path / "analytics" / "models" / "staging" / "stg_orders.sql").write_text(
+        "SELECT id AS order_id, customer_id, status, total\nFROM app.orders\n",
+        encoding="utf-8",
+    )
+
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "build",
+            "--confirm",
+            "--budget",
+            "300",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+    data = envelope["data"]
+    assert data["success"] is True
+    assert any(n["name"] == "stg_orders" for n in data["nodes"])
+    assert data["seconds_billed"] > 0
+    assert any("statement_timeout" in w for w in envelope["warnings"])
+
+    ledger = (tmp_path / ".dex" / "spend.jsonl").read_text(encoding="utf-8")
+    entry = json.loads(ledger.splitlines()[-1])
+    assert entry["connector"] == "postgres"
+    assert entry["command"] == "transform build"
+    assert entry["billed_seconds"] > 0

--- a/packages/dex-core/tests/maintain/test_grain.py
+++ b/packages/dex-core/tests/maintain/test_grain.py
@@ -96,3 +96,47 @@ def test_metadata_only_baseline_warns_grain_has_nothing(dex, tmp_path):
     assert rc == 0 and payload["status"] == "ok"
     assert payload["data"]["finding_count"] == 0
     assert any("metadata-only" in w for w in payload["warnings"])
+
+
+def test_estimated_row_counts_cannot_fabricate_duplicates():
+    """An adapter whose free row counts are planner estimates (Postgres
+    reltuples) must not produce key_lost_uniqueness findings from the estimate
+    alone: grain_drift re-reads the metadata after the distinct scan, and the
+    adapter serves the exact count that scan paid for."""
+
+    from exmergo_dex_core.adapters.base import ColumnMeta, ObjectMeta
+    from exmergo_dex_core.cache import Dataset
+    from exmergo_dex_core.maintain.drift import GrainPlan, grain_drift
+
+    class EstimatingAdapter:
+        name = "stub"
+        dialect = "duckdb"
+
+        def __init__(self):
+            self.scanned = False
+
+        def table_metadata(self, identifier):
+            # 1200 is the stale planner estimate; 1000 is the exact count the
+            # distinct scan carried (COUNT(*) rides along on Postgres).
+            rows = 1000 if self.scanned else 1200
+            meta = ObjectMeta(
+                identifier=identifier,
+                object_type="table",
+                schema="s",
+                name="t",
+                row_count=rows,
+                byte_size=None,
+                column_count=1,
+            )
+            return meta, [
+                ColumnMeta(name="id", data_type="INTEGER", nullable=False, ordinal=0)
+            ]
+
+        def exact_distinct_counts(self, identifier, columns):
+            self.scanned = True
+            return dict.fromkeys(columns, 1000)
+
+    dataset = Dataset(identifier="db.s.t", candidate_keys=[["id"]], grain=["id"])
+    plan = GrainPlan(key_checks=[(dataset, ["id"], 1200)], fanout_pairs=[])
+    findings = grain_drift(EstimatingAdapter(), plan)
+    assert findings == []

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -852,6 +852,13 @@ def test_ledgers_never_mix_paradigms(tmp_path: Path):
             "billed_seconds": 42.0,
         }
     )
+    store.append_spend_log(
+        {
+            "at": "2026-07-05T00:00:03+00:00",
+            "connector": "postgres",
+            "billed_seconds": 7.0,
+        }
+    )
     assert store.spend_since("2026-07-05T00:00:00+00:00", connector="bigquery") == 5000
     assert (
         store.spend_since(
@@ -859,6 +866,231 @@ def test_ledgers_never_mix_paradigms(tmp_path: Path):
         )
         == 42.0
     )
+    assert (
+        store.spend_since(
+            "2026-07-05T00:00:00+00:00", field="billed_seconds", connector="postgres"
+        )
+        == 7.0
+    )
+
+
+# --- Postgres: the db-load connector exercises every family ---------------------
+#
+# These run against the fake connection (tests/fakes/postgres.py):
+# deterministic, offline, free. They importorskip on the [postgres] extra,
+# which CI and the release gate install, so trimming that extra from a
+# workflow would silently skip release-blocking families; keep
+# `--extra postgres` in ci.yml and release.yml.
+
+
+def _pg_adapter(fake_pg_connection, *, ceiling=600.0, confirmed=True):
+    from exmergo_dex_core.adapters.postgres import PostgresAdapter
+    from exmergo_dex_core.config import PostgresTarget
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    gate = CostGate(
+        paradigm=env.Paradigm.DB_LOAD,
+        ceiling=ceiling,
+        session_ceiling=None,
+        session_spent=0.0,
+        confirmed=confirmed,
+        connector="postgres",
+    )
+    return PostgresAdapter(
+        connection=fake_pg_connection,
+        cost_gate=gate,
+        target=PostgresTarget(),
+        auth_method="database_url:password",
+        clock=fake_pg_connection.clock,
+    )
+
+
+def test_postgres_generated_sql_is_select_only(fake_pg_connection):
+    # Family 1: every data statement the adapter generates passes the
+    # SELECT-only guard in the postgres dialect (asserted at build time).
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    adapter = _pg_adapter(fake_pg_connection)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    sql, _plan = adapter._build_aggregate_sql("dexdb.shop.customers", columns, {"id"})
+    assert sql.lstrip().upper().startswith("SELECT")
+    assert assert_select_only(sql, dialect="postgres") == sql
+
+
+def test_postgres_session_is_read_only_by_construction(fake_pg_connection):
+    # Family 1: default_transaction_read_only is set before any statement, so
+    # even a statement that slipped every guard would be refused server-side.
+    adapter = _pg_adapter(fake_pg_connection)
+    adapter.capabilities()
+    first = fake_pg_connection.statements[0].sql.lower()
+    assert "set default_transaction_read_only = on" in first
+
+
+def test_select_only_guard_rejects_postgres_writes_ddl_and_copy():
+    # Family 1: Postgres DML/DDL, COPY, and multi-statement forms are all
+    # refused when parsed in the postgres dialect.
+    from exmergo_dex_core.guards.sql_guard import NotSelectOnlyError, assert_select_only
+
+    for bad in (
+        "CREATE TABLE t AS SELECT 1",
+        "TRUNCATE TABLE app.t",
+        "SELECT 1; SELECT 2",
+        "DELETE FROM app.t WHERE TRUE",
+        "UPDATE app.t SET x = 1",
+        "COPY app.t TO '/tmp/exfil.csv'",
+        "ALTER TABLE app.t ADD COLUMN y text",
+        "DROP TABLE app.t",
+    ):
+        with pytest.raises(NotSelectOnlyError):
+            assert_select_only(bad, dialect="postgres")
+
+
+def test_postgres_unconfirmed_scan_never_executes(fake_pg_connection):
+    # Family 2: the strict handshake. Without --confirm nothing scans (the
+    # estimate comes from the free planner, so there is nothing to load).
+    from exmergo_dex_core.guards.cost_guard import ConfirmationRequiredError
+
+    adapter = _pg_adapter(fake_pg_connection, confirmed=False)
+    with pytest.raises(ConfirmationRequiredError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "dexdb"."shop"."customers"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert fake_pg_connection.data_statements == []
+
+
+def test_postgres_confirmed_run_without_a_ceiling_is_refused(fake_pg_connection):
+    # Family 2: nothing executes unbudgeted; confirmation cannot stand in for
+    # a ceiling on a metered paradigm.
+    from exmergo_dex_core.guards.cost_guard import CostGuardError
+
+    adapter = _pg_adapter(fake_pg_connection, ceiling=None, confirmed=True)
+    with pytest.raises(CostGuardError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "dexdb"."shop"."customers"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert fake_pg_connection.data_statements == []
+
+
+def test_postgres_over_ceiling_cannot_be_confirmed_through(fake_pg_connection):
+    # Family 2: over-ceiling blocks first, even fully confirmed.
+    from exmergo_dex_core.guards.cost_guard import OverCeilingError
+
+    adapter = _pg_adapter(fake_pg_connection, ceiling=2.0, confirmed=True)
+    with pytest.raises(OverCeilingError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "dexdb"."shop"."events"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert fake_pg_connection.data_statements == []
+
+
+def test_postgres_every_executed_statement_is_server_capped(fake_pg_connection):
+    # Family 2: defense in depth past the client-side gate; a wrong heuristic
+    # cannot overrun the budget because statement_timeout kills the statement.
+    fake_pg_connection.row_resolver = lambda sql: [{"n": 1}]
+    adapter = _pg_adapter(fake_pg_connection)
+    adapter.run_query(
+        'SELECT COUNT(*) AS n FROM "dexdb"."shop"."customers"',
+        max_rows=10,
+        timeout_seconds=200,
+    )
+    executed = fake_pg_connection.data_statements
+    assert executed
+    assert all(s.session_timeout_ms is not None for s in executed)
+
+
+def test_query_firewall_blocks_postgres_value_carrying_shapes():
+    # Family 3: PII stays flagged-not-surfaced under the postgres dialect,
+    # including Postgres's own value-carrying aggregates and casts.
+    from exmergo_dex_core.config import QueryLimits
+    from exmergo_dex_core.guards.query_firewall import (
+        QueryRefusedError,
+        inspect_query,
+    )
+
+    cache = _firewall_cache()
+    for bad in (
+        "SELECT STRING_AGG(email, ',') FROM db.main.customers",
+        "SELECT ARRAY_AGG(email) FROM db.main.customers",
+        "SELECT JSONB_AGG(email) FROM db.main.customers",
+        "SELECT TO_JSON(email) FROM db.main.customers",
+    ):
+        with pytest.raises(QueryRefusedError):
+            inspect_query(bad, cache, QueryLimits(), dialect="postgres")
+    # Measuring stays allowed in the postgres dialect too.
+    inspect_query(
+        "SELECT COUNT(DISTINCT email) FROM db.main.customers",
+        cache,
+        QueryLimits(),
+        dialect="postgres",
+    )
+
+
+def test_postgres_stats_reads_never_select_value_columns(fake_pg_connection):
+    # Family 3: pg_stats is the planner's own statistics view and its
+    # most_common_vals / histogram_bounds columns hold raw row values; the
+    # adapter's stats reads must never touch them.
+    fake_pg_connection.row_resolver = lambda sql: [
+        {"n_total": 100, "nn_0": 100, "nn_1": 90, "nn_2": 80, "nn_3": 70}
+    ]
+    adapter = _pg_adapter(fake_pg_connection)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    adapter.column_aggregates("dexdb.shop.customers", columns)
+    stats_reads = [s.sql for s in fake_pg_connection.statements if "pg_stats" in s.sql]
+    assert stats_reads
+    for sql in stats_reads:
+        assert "most_common_vals" not in sql
+        assert "histogram_bounds" not in sql
+        assert "most_common_elems" not in sql
+
+
+def test_postgres_capabilities_pass_the_sanitizer(fake_pg_connection, capsys):
+    # Family 5: the capabilities payload carries a coarse auth method, never
+    # an identity, password, or DSN, and survives the sanitizer end to end.
+    adapter = _pg_adapter(fake_pg_connection)
+    caps = adapter.capabilities()
+    env.emit(env.ok(caps))
+    out = capsys.readouterr().out
+    assert out
+    assert "@" not in out  # no user identity or DSN
+    assert caps["auth_method"].split(":")[0] in {
+        "config_service",
+        "database_url",
+        "environment",
+        "config_target",
+        "dbt_profile",
+        "unknown",
+    }
+    assert caps["auth_method"].split(":")[1] in {"password", "external", "service_file"}
+
+
+def test_postgres_spend_ledger_holds_no_sql_or_values(
+    tmp_path: Path, fake_pg_connection
+):
+    # Family 5: the audit trail is second counts and statement hashes only.
+    import json
+
+    from exmergo_dex_core.cache import DexStore
+
+    store = DexStore(tmp_path)
+    fake_pg_connection.row_resolver = lambda sql: [{"n": 1}]
+    adapter = _pg_adapter(fake_pg_connection)
+    adapter.cost_gate._record = store.append_spend_log
+    adapter.run_query(
+        'SELECT COUNT(*) AS n FROM "dexdb"."shop"."customers"',
+        max_rows=10,
+        timeout_seconds=200,
+    )
+    lines = (tmp_path / ".dex" / "spend.jsonl").read_text().splitlines()
+    entry = json.loads(lines[-1])
+    assert "SELECT" not in json.dumps(entry)
+    assert entry["billed_seconds"] > 0
+    assert entry["statement_sha256"]
 
 
 # --- Maintain: drift detection and reconcile exercise every family -------------

--- a/packages/dex-core/tests/transform/test_build.py
+++ b/packages/dex-core/tests/transform/test_build.py
@@ -113,9 +113,9 @@ def _fake_runner_factory(
     build_module = importlib.import_module("exmergo_dex_core.transform.build")
     calls: list[dict] = []
 
-    def fake(timeout: float, cwd):
+    def fake(timeout: float, cwd, env=None):
         def run(argv: list[str]):
-            calls.append({"argv": argv, "cwd": cwd})
+            calls.append({"argv": argv, "cwd": cwd, "env": env})
             return subprocess.CompletedProcess(
                 args=argv, returncode=returncode, stdout=stdout, stderr=stderr
             )
@@ -525,3 +525,25 @@ def test_billed_build_failure_names_the_real_error_in_errors(
     assert rc == 1
     assert envelope["status"] == "error"
     assert envelope["errors"][0] == f"dbt build failed: {msg}"
+
+
+def test_build_env_caps_postgres_statements_via_pgoptions(monkeypatch):
+    """On db-load gating the ceiling becomes a server-side statement_timeout
+    injected through PGOPTIONS (the maximum_bytes_billed analogue: dbt has no
+    dry-run, so the per-statement cap is the binding cost control)."""
+
+    from exmergo_dex_core.envelope import Paradigm
+    from exmergo_dex_core.transform.build import _build_env
+
+    monkeypatch.delenv("PGOPTIONS", raising=False)
+    env = _build_env(Paradigm.DB_LOAD, 120.0)
+    assert env is not None
+    assert env["PGOPTIONS"] == "-c statement_timeout=120s"
+
+    monkeypatch.setenv("PGOPTIONS", "-c search_path=app")
+    env = _build_env(Paradigm.DB_LOAD, 120.0)
+    assert env["PGOPTIONS"] == "-c search_path=app -c statement_timeout=120s"
+
+    assert _build_env(Paradigm.DB_LOAD, None) is None
+    assert _build_env(Paradigm.FREE_LOCAL, 120.0) is None
+    assert _build_env(Paradigm.BYTES_SCANNED, 120.0) is None

--- a/packages/dex-core/tests/transform/test_deps.py
+++ b/packages/dex-core/tests/transform/test_deps.py
@@ -26,7 +26,7 @@ def _fake_runner(monkeypatch, *, returncode: int, stdout: str = ""):
     build_module = importlib.import_module("exmergo_dex_core.transform.build")
     calls: list[dict] = []
 
-    def fake(timeout: float, cwd):
+    def fake(timeout: float, cwd, env=None):
         def run(argv: list[str]):
             calls.append({"argv": argv, "cwd": cwd})
             return subprocess.CompletedProcess(

--- a/packages/dex-core/tests/transform/test_init.py
+++ b/packages/dex-core/tests/transform/test_init.py
@@ -155,7 +155,7 @@ def test_init_refuses_when_a_project_exists_in_a_child_dir(
     assert not (tmp_path / "fresh").exists()
 
 
-@pytest.mark.parametrize("connector", ["databricks", "postgres"])
+@pytest.mark.parametrize("connector", ["databricks"])
 def test_cloud_connectors_error_actionably(tmp_path: Path, capsys, connector: str):
     rc, envelope = _run(_init_argv(tmp_path, "--connector", connector), capsys)
     assert rc == 1
@@ -276,6 +276,79 @@ def test_init_snowflake_never_persists_a_password(tmp_path: Path, capsys, monkey
     rendered = (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
     assert "hunter2" not in rendered
     assert "env_var" in rendered and "SNOWFLAKE_PASSWORD" in rendered
+
+
+def _seed_postgres_config(repo: Path, **target) -> None:
+    (repo / ".dex").mkdir(parents=True, exist_ok=True)
+    (repo / ".dex" / "config.yml").write_text(
+        yaml.safe_dump({"postgres": target}), encoding="utf-8"
+    )
+
+
+def test_init_postgres_bootstraps_a_project(tmp_path: Path, capsys, monkeypatch):
+    # Postgres discovery is environment-based and pure, so the real chain runs
+    # under test: no patching, just a DATABASE_URL.
+    pytest.importorskip("psycopg")
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql://dbt:hunter2-never-rendered@db.example.com:5439/shop",
+    )
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "postgres"), capsys)
+    assert rc == 0, envelope
+    assert envelope["data"]["connector"] == "postgres"
+    rendered = (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
+    profile = yaml.safe_load(rendered)
+    output = profile["analytics"]["outputs"]["dev"]
+    assert output["type"] == "postgres"
+    assert output["host"] == "db.example.com"
+    assert output["port"] == 5439
+    assert output["user"] == "dbt"
+    assert output["dbname"] == "shop"
+    assert output["schema"] == "dbt_dev"
+    assert output["threads"] == 1
+    # Never a password value: an env_var reference with an empty default so
+    # ~/.pgpass and peer auth still work at dbt runtime.
+    assert "hunter2" not in rendered
+    assert "env_var" in output["password"] and "PGPASSWORD" in output["password"]
+    # The dev schema choice is persisted for cmd_map's replica folding.
+    config = yaml.safe_load(
+        (tmp_path / ".dex" / "config.yml").read_text(encoding="utf-8")
+    )
+    assert config["postgres"]["dev_schema"] == "dbt_dev"
+
+
+def test_init_postgres_refuses_dev_schema_source_collision(
+    tmp_path: Path, capsys, monkeypatch
+):
+    pytest.importorskip("psycopg")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://dbt:x@db.example.com/shop")
+    _seed_postgres_config(tmp_path, schemas=["app", "dbt_dev"], dev_schema="dbt_dev")
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "postgres"), capsys)
+    assert rc == 1
+    assert "source schema" in envelope["errors"][0]
+    assert not (tmp_path / "analytics").exists()
+
+
+def test_init_postgres_refuses_incomplete_connection(
+    tmp_path: Path, capsys, monkeypatch
+):
+    pytest.importorskip("psycopg")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://db.example.com/")
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "postgres"), capsys)
+    assert rc == 1
+    message = envelope["errors"][0]
+    assert "dbt-postgres requires" in message
+    assert not (tmp_path / "analytics").exists()
+
+
+def test_init_postgres_without_a_connection_names_the_fixes(
+    tmp_path: Path, capsys, monkeypatch
+):
+    for var in ("DATABASE_URL", "PGHOST", "PGDATABASE", "PGSERVICE", "PGSERVICEFILE"):
+        monkeypatch.delenv(var, raising=False)
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "postgres"), capsys)
+    assert rc == 1
+    assert "DATABASE_URL" in envelope["errors"][0]
 
 
 def _seed_bigquery_config(repo: Path, **target) -> None:

--- a/packages/dex-core/tests/transform/test_parse.py
+++ b/packages/dex-core/tests/transform/test_parse.py
@@ -124,7 +124,7 @@ def test_parse_failure_blocks_the_plan_and_stores_nothing(
         }
     )
 
-    def fake(timeout: float, cwd):
+    def fake(timeout: float, cwd, env=None):
         def run(argv: list[str]):
             return subprocess.CompletedProcess(
                 args=argv, returncode=1, stdout=line, stderr=""
@@ -149,7 +149,7 @@ def test_shadow_parse_never_touches_the_real_project(
     build_module = importlib.import_module("exmergo_dex_core.transform.build")
     calls: list[dict] = []
 
-    def fake(timeout: float, cwd):
+    def fake(timeout: float, cwd, env=None):
         def run(argv: list[str]):
             calls.append({"argv": argv, "cwd": Path(cwd)})
             return subprocess.CompletedProcess(

--- a/packages/dex-core/uv.lock
+++ b/packages/dex-core/uv.lock
@@ -561,6 +561,22 @@ wheels = [
 ]
 
 [[package]]
+name = "dbt-postgres"
+version = "1.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "agate" },
+    { name = "dbt-adapters" },
+    { name = "dbt-common" },
+    { name = "dbt-core" },
+    { name = "psycopg2-binary" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/61/4b609911d827b9cb8a4b9647579cc6de0e02684fb2d9dce18213c9733628/dbt_postgres-1.10.2.tar.gz", hash = "sha256:83b6b03572452d74bf3b60ef2578c7172d6e5ff4c285c876cd51aa9ed09be4c4", size = 157388, upload-time = "2026-06-24T06:48:13.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/3a/32a00d796492ffcaa022eda9decf1f7366bce210715087fd985415b2fd94/dbt_postgres-1.10.2-py3-none-any.whl", hash = "sha256:1367386caa99ca59f8228eae6d0e03f9537f9615f55a5ba5cc80a5b06aa6d32e", size = 35517, upload-time = "2026-06-24T06:48:12.538Z" },
+]
+
+[[package]]
 name = "dbt-protos"
 version = "1.0.514"
 source = { registry = "https://pypi.org/simple" }
@@ -698,6 +714,7 @@ all = [
     { name = "databricks-sql-connector" },
     { name = "dbt-bigquery" },
     { name = "dbt-duckdb" },
+    { name = "dbt-postgres" },
     { name = "dbt-snowflake" },
     { name = "duckdb" },
     { name = "google-cloud-bigquery" },
@@ -725,6 +742,7 @@ duckdb = [
     { name = "sqlglot" },
 ]
 postgres = [
+    { name = "dbt-postgres" },
     { name = "psycopg", extra = ["binary"] },
     { name = "sqlglot" },
 ]
@@ -744,6 +762,8 @@ requires-dist = [
     { name = "dbt-bigquery", marker = "extra == 'bigquery'", specifier = ">=1.9" },
     { name = "dbt-duckdb", marker = "extra == 'all'", specifier = ">=1.9" },
     { name = "dbt-duckdb", marker = "extra == 'duckdb'", specifier = ">=1.9" },
+    { name = "dbt-postgres", marker = "extra == 'all'", specifier = ">=1.9" },
+    { name = "dbt-postgres", marker = "extra == 'postgres'", specifier = ">=1.9" },
     { name = "dbt-snowflake", marker = "extra == 'all'", specifier = ">=1.9" },
     { name = "dbt-snowflake", marker = "extra == 'snowflake'", specifier = ">=1.9" },
     { name = "duckdb", marker = "extra == 'all'", specifier = ">=1" },
@@ -1986,6 +2006,58 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
     { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
     { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/19/d4ce60954f3bb9d8e3bc5e5c4d1f2487de2d3851bf2391d54954c9df12a6/psycopg2_binary-2.9.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5c8ce6c61bd1b1f6b9c24ee32211599f6166af2c55abb19456090a21fd16554b", size = 3712338, upload-time = "2026-04-20T23:34:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/53/71/c85409ee0d78890f0660eff262e815e7dd2bb741a17611d82e9e8cd9dc5e/psycopg2_binary-2.9.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4a9eaa6e7f4ff91bec10aa3fb296878e75187bced5cc4bafe17dc40915e1326", size = 3822407, upload-time = "2026-04-20T23:34:05.977Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ed/60486c2c7f0d4d1ede2bfb1ed27e2498477ce646bc7f6b2759906303117e/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c6528cefc8e50fcc6f4a107e27a672058b36cc5736d665476aeb413ba88dbb06", size = 4578425, upload-time = "2026-04-20T23:34:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b9/656cb03fad9f4f49f2145c334b1126ee75189929ca4e6187d485a2d59951/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4e184b1fb6072bf05388aa41c697e1b2d01b3473f107e7ec44f186a32cfd0b8", size = 4273709, upload-time = "2026-04-20T23:34:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/99/66/08cf0da0e25cc6fb142c89be45fc8418792858f0c4cbff5e24530ff02cd6/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4766ab678563054d3f1d064a4db19cc4b5f9e3a8d9018592a8285cf200c248f3", size = 5893779, upload-time = "2026-04-20T23:34:13.905Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d7/eecd9ce8e146d3721115d82d3836efdbb712187e4590325df549989d18f4/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5a0253224780c978746cb9be55a946bcdaf40fe3519c0f622924cdabdafe2c39", size = 4109308, upload-time = "2026-04-20T23:34:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2e/b1dc289b362cc8d45697b57eefbd673186f49a4ea0906928988e3affcc98/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0dc9228d47c46bda253d2ecd6bb93b56a9f2d7ad33b684a1fa3622bf74ffe30c", size = 3654405, upload-time = "2026-04-20T23:34:19.303Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/4c4aea6473214dbdbd0fbba11aa4691e76dc01722c55724c5951719865ff/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f921f3cd87035ef7df233383011d7a53ea1d346224752c1385f1edfd790ceb6a", size = 3299187, upload-time = "2026-04-20T23:34:21.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/5d/b03b99986446a4f57b170ed9a2579fb7ff9783ca0fa5226b19db99737fee/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d999bd982a723113c1a45b55a7a6a90d64d0ed2278020ed625c490ff7bef96c", size = 3047716, upload-time = "2026-04-20T23:34:23.077Z" },
+    { url = "https://files.pythonhosted.org/packages/14/86/382ee4afbd1d97500c9d2862b20c2fdeddf4b7335e984df3fb4309f64108/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29d4d134bd0ab46ffb04e94aa3c5fa3ef582e9026609165e2f758ff76fc3a3be", size = 3349237, upload-time = "2026-04-20T23:34:25.211Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/16/9a57c75ba1eda7165c017342f526810d5f5a12647dde749c99ae9a7141d7/psycopg2_binary-2.9.12-cp311-cp311-win_amd64.whl", hash = "sha256:cb4a1dacdd48077150dc762a9e5ddbf32c256d66cb46f80839391aa458774936", size = 2757036, upload-time = "2026-04-20T23:34:27.77Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
+    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
+    { url = "https://files.pythonhosted.org/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965", size = 3712419, upload-time = "2026-04-20T23:34:58.754Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
+    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0", size = 2757347, upload-time = "2026-04-20T23:35:21.283Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1b/708c0dca874acfad6d65314271859899a79007686f3a1f74e82a2ed4b645/psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2", size = 3712428, upload-time = "2026-04-20T23:35:23.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/39/ddbea9d4b4de6aca9431b6ed253f530f8a02d3b8f9bcfd0dbfe2b3de6fe4/psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2", size = 3823184, upload-time = "2026-04-20T23:35:25.92Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/bc2fef74b106fa345567122a0659e6d94512ed7dc0131ec44c9e5aba3725/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f", size = 4579157, upload-time = "2026-04-20T23:35:28.542Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/d4e3b2005d3de607ca4fbb0e8742e248056e52184a6b94ebda3c1c2c329b/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354", size = 4274970, upload-time = "2026-04-20T23:35:30.418Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/42/c9853f8db3967fe08bcde11f53d53b85d351750cae726ce001cb68afa9c1/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033", size = 5895175, upload-time = "2026-04-20T23:35:33.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/b82b5601a97630308bef079f545ffec481bbbc795c2ba5ec416a01d03f60/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e", size = 4110658, upload-time = "2026-04-20T23:35:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8c/32ca69b0389ef25dd22937bf9e8fbe2ce27aea20b05ded48c4ce4cb42475/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5", size = 3656251, upload-time = "2026-04-20T23:35:37.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/29/96992a2b59e3b9d730fcf9612d0a387305025dc867a9fc490a9e496e074e/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5", size = 3301810, upload-time = "2026-04-20T23:35:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d", size = 3048977, upload-time = "2026-04-20T23:35:41.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd", size = 3351466, upload-time = "2026-04-20T23:35:43.993Z" },
+    { url = "https://files.pythonhosted.org/packages/20/be/b732c8418ffa5bcfda002890f5dc4c869fc17db66ff11f53b17cfe44afc0/psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980", size = 2848762, upload-time = "2026-04-20T23:35:46.421Z" },
 ]
 
 [[package]]

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -101,10 +101,10 @@ deps step in `transform build`) installs them.
   names which source was used), and bare init is an error listing the valid
   connectors. On success init writes `connector`, `dbt_project_dir`, and
   `dbt_target: dev` back to `.dex/config.yml`, so the choice is made once and is
-  ambient for every later command. DuckDB and BigQuery are the supported
-  connectors today; the remaining cloud connectors are accepted by the contract
-  but return an actionable not-yet-supported error until their dbt adapters
-  ship.
+  ambient for every later command. DuckDB, BigQuery, Snowflake, and Postgres
+  are the supported connectors today; Databricks is accepted by the contract
+  but returns an actionable not-yet-supported error until its dbt adapter
+  ships.
 - `transform plan` also accepts `--scaffold <table>` (repeatable): a
   deterministic staging skeleton (`stg_<table>.sql` plus per-model YAML with key
   tests and PII flags in column `meta`) generated from the `.dex/` cache.

--- a/references/postgres.md
+++ b/references/postgres.md
@@ -1,6 +1,154 @@
-# Connector: PostgreSQL (stub)
+# Connector: PostgreSQL
 
-Not yet implemented. The operational database AEs pull from. Cost paradigm:
-database load (not dollars), guarded with `statement_timeout`, `LIMIT`, a
-read-only role, and `SET TRANSACTION READ ONLY`. Auth from `DATABASE_URL` / `PG*`
-/ `pg_service.conf` / dbt `profiles.yml`. Namespace: `database.schema.table`.
+The operational database AEs pull from. Namespace: `database.schema.table`
+(one connection, one database; the first component is always the connected
+database). Cost paradigm: **database load**, expressed as database-seconds.
+Read-only against data, enforced in depth.
+
+## Authentication: discover, don't ask
+
+The engine discovers a connection at runtime and never prompts for or
+persists a password. Discovery order:
+
+1. `postgres.service` in `.dex/config.yml`, naming a `pg_service.conf` entry
+   (`PGSERVICEFILE`, else `~/.pg_service.conf`)
+2. `DATABASE_URL` (the twelve-factor URL most app stacks already export)
+3. the `PG*` environment (`PGHOST`/`PGDATABASE`/`PGSERVICE` and friends),
+   resolved natively by libpq, including `~/.pgpass`
+4. the committed non-secret `postgres.host`/`port`/`dbname`/`user` config
+   target (password still supplied by `PGPASSWORD` or `~/.pgpass`)
+5. the `host` of a `type: postgres` target in a discovered dbt `profiles.yml`
+
+Only a coarse method (for example `database_url:password` or
+`environment:external`) is ever surfaced; the credential kind is `password`
+when one is inline and `external` for everything else (`.pgpass`, peer or
+trust auth, SSL client certificates), deliberately coarse. DSNs, identities,
+and passwords never cross the envelope (the sanitizer additionally strips
+`user:pass@host` URL fragments). Every discovery failure names all the fixes.
+
+## Config
+
+```yaml
+# .dex/config.yml
+connector: postgres
+postgres:
+  service: analytics             # a pg_service.conf entry; optional
+  schemas:                       # source allowlist; empty means all visible
+    - app
+  dev_schema: dbt_dev            # where dbt dev builds write (never a source)
+  max_full_profile_bytes: null   # opt-in TABLESAMPLE threshold for huge tables
+budget:
+  ceiling: 60                    # per-command database-seconds; --budget overrides
+  session_ceiling: 600           # cumulative seconds per UTC day
+```
+
+Point dex at a **read-only role** (or better, a read replica) rather than a
+superuser on the primary; the documented grant shape is USAGE on source
+schemas plus SELECT on their tables, with write access only on the dedicated
+dev schema for the dbt role. `scripts/postgres_seed.sql` shows the shape
+(`dex_ro` and `dbt_dev` roles).
+
+## Cost model: load, not dollars
+
+Postgres bills nothing, but dex is usually pointed at a production OLTP
+primary, and an unbounded scan there is a real cost: it evicts cache, holds
+back vacuum, and steals cycles from the application. So the guarded quantity
+is **database-seconds**, gated through the same strict handshake as every
+metered connector.
+
+- **Free:** `connect test`, `explore inventory`, all schema facts
+  (`pg_catalog` lookups, no table scans), `pg_stats` reads, `EXPLAIN`
+  estimation, and the free axes of `maintain check` (schema and volume read
+  catalog metadata only).
+- **Metered:** profiling aggregates, `explore query`, relationship
+  verification probes, distinct-count escalations, and `transform build`.
+
+Budgets (`budget.ceiling`, `--budget`, `budget.session_ceiling`) are
+database-seconds: the number you budget is the number the server enforces.
+
+**Estimates are a heuristic, honestly labeled.** Query estimates come from
+the genuinely free planner preflight (`EXPLAIN (FORMAT JSON)`), so an
+index-served lookup is not quoted as a full scan; plan cost translates to
+seconds through a deliberately conservative scan rate, and profile estimates
+come from relation sizes over the same rate. Every handshake payload carries
+`estimate_quality: "heuristic"`.
+
+**The budget is hard-enforced regardless of estimate quality.** Before every
+metered statement the session's `statement_timeout` is set to the remaining
+budget, so a wrong heuristic cannot overrun the ceiling: Postgres kills the
+statement and dex reports the over-ceiling refusal. Actual spend is
+wall-clock seconds per statement (a killed statement still bills what ran),
+recorded to `.dex/spend.jsonl` as `billed_seconds` and summed into the daily
+session ceiling. Every session connects as `application_name = 'dex'` for
+attribution in `pg_stat_activity`.
+
+The handshake is the same strict two-step as every metered connector: a
+scanning command without `--confirm` returns `needs_confirmation` carrying
+the seconds estimate (per table where relevant); re-issue with
+`--confirm --budget <seconds>`. Nothing executes unconfirmed or without a
+ceiling, and an estimate over the ceiling is refused outright.
+
+## Read-only, enforced in depth
+
+- The session sets `default_transaction_read_only = on` before any statement,
+  so the server itself refuses writes (SQLSTATE 25006) even if every other
+  guard were bypassed. Connections are autocommit, so no idle-in-transaction
+  session ever holds back vacuum on the primary.
+- Every data statement passes the SELECT-only guard parsed in the postgres
+  dialect through one execution door (DML, DDL, `COPY`, and multi-statement
+  forms all refuse).
+- The adapter issues no mutating statements: catalog SELECTs, `EXPLAIN`, and
+  session `SET`s only.
+- The documented grant shape is a least-privilege read-only role; dbt dev
+  builds write to `dev_schema` (default `dbt_dev`), which is refused as a
+  source, and the generated profile renders one thread and an `env_var`
+  password reference, never a value.
+
+## Profiling behavior
+
+Profiling is deliberately light on the primary. The metered batch is one
+cheap single-pass scan per 50 columns: `COUNT(*)`, per-column non-null
+counts, and min/max only for engine-cleared safe columns. **Distinct counts
+come free from the planner's own statistics** (`pg_stats.n_distinct`, scaled
+by the exact row count when negative); the value-carrying statistics columns
+(`most_common_vals`, `histogram_bounds`) are never read. A statistics
+estimate is never a uniqueness verdict: near-unique keys escalate to an exact
+`COUNT(DISTINCT)` inside the confirmed budget through the standard escalation
+flow, and that scan also upgrades the row count from the `reltuples` estimate
+to an exact figure, so uniqueness proofs and grain verdicts compare against
+real rows.
+
+Freshness caveats, surfaced as data-quality notes rather than silently
+thinner numbers: a never-analyzed table has no row estimate and no distinct
+estimates (the note names `ANALYZE` as the fix), and `maintain volume` on
+unprofiled tables compares planner estimates whose accuracy tracks
+autovacuum's ANALYZE cadence. `json`, `jsonb`, arrays, `bytea`, `xml`,
+`tsvector`, and the geometric and PostGIS types degrade to non-null counts.
+Tables above `postgres.max_full_profile_bytes` are profiled from a block
+sample (`TABLESAMPLE SYSTEM`), noted, with uniqueness not judged.
+
+## dbt builds
+
+`transform init` renders a `type: postgres` dev profile from the discovered
+connection: host, port, user, and dbname from whichever source won discovery,
+`schema` pinned to the dedicated dev schema, one thread, and
+`password: "{{ env_var('PGPASSWORD', '') }}"` (the empty default keeps
+`~/.pgpass` and peer auth working when no variable is set). dbt has no
+dry-run, so `transform build` cannot be estimated upfront; the ceiling and
+confirmation still bind, and the ceiling is injected into the dbt subprocess
+as `PGOPTIONS="-c statement_timeout=<ceiling>s"`, the per-statement
+server-side cap (the `maximum_bytes_billed` analogue). Actual per-node
+execution time is summed into `billed_seconds` and recorded to the ledger.
+
+## Testing
+
+Offline: a stateful fake connection (`tests/fakes/postgres.py`) that records
+statement ordering, serves catalog and `pg_stats` lookups from a table
+registry, answers `EXPLAIN` with size-derived plan costs, simulates timing on
+an injected clock, and enforces `statement_timeout` with psycopg's real
+`QueryCanceled`. Live: an env-gated integration suite (`DEX_TEST_PG_DSN`,
+plus `DEX_TEST_PG_DEV_PASSWORD` for builds) against the seeded database from
+`scripts/postgres_seed.sql`; `scripts/setup_postgres_dev.sh` stands up the
+same thing locally in Docker, and CI runs the suite against a free, keyless
+`postgres:16` service container (kept in the integration workflow for
+pattern parity, never a merge gate).

--- a/scripts/postgres_seed.sql
+++ b/scripts/postgres_seed.sql
@@ -1,0 +1,179 @@
+-- Seed for the dex PostgreSQL dogfood/integration database.
+--
+-- Applied by scripts/setup_postgres_dev.sh (local Docker dogfood) and by the
+-- postgres job in .github/workflows/integration.yml (service container). Run
+-- against the dex_dogfood database as a superuser; scripts/setup_postgres_dev.sh
+-- handles creating the database and re-running this file idempotently.
+--
+-- The shape is a small realistic operational schema that exercises every
+-- explore/transform/maintain surface:
+--   - customers: PII columns (email, phone, names, address) for flag-not-surface
+--   - products: enum, numeric, text[] and jsonb columns for type degradation
+--   - orders -> customers, order_items -> orders, payments -> orders: declared FKs
+--   - order_items.product_id: deliberately NO declared FK (inference target)
+--   - v_order_totals: a view (no stored rows)
+--   - events: ~100k rows via generate_series (sampling / statement_timeout target)
+--   - dbt_dev: the empty dev schema dbt builds into (never a source)
+-- Roles:
+--   - dex_ro: the read-only role dex connects as (USAGE + SELECT on app only)
+--   - dbt_dev: reads app, writes only schema dbt_dev, statement_timeout pinned
+
+BEGIN;
+
+DROP SCHEMA IF EXISTS app CASCADE;
+DROP SCHEMA IF EXISTS dbt_dev CASCADE;
+
+CREATE SCHEMA app;
+CREATE SCHEMA dbt_dev;
+
+CREATE TYPE app.product_category AS ENUM ('electronics', 'grocery', 'apparel', 'home');
+CREATE TYPE app.order_status AS ENUM ('pending', 'paid', 'shipped', 'cancelled');
+
+CREATE TABLE app.customers (
+    id          bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    email       text NOT NULL UNIQUE,
+    first_name  text NOT NULL,
+    last_name   text NOT NULL,
+    phone       text,
+    address     text,
+    city        text,
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE app.products (
+    id        bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name      text NOT NULL,
+    category  app.product_category NOT NULL,
+    price     numeric(10, 2) NOT NULL,
+    tags      text[] NOT NULL DEFAULT '{}',
+    attrs     jsonb NOT NULL DEFAULT '{}'
+);
+
+CREATE TABLE app.orders (
+    id           bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    customer_id  bigint NOT NULL REFERENCES app.customers (id),
+    status       app.order_status NOT NULL DEFAULT 'pending',
+    total        numeric(12, 2) NOT NULL DEFAULT 0,
+    ordered_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- product_id deliberately carries no foreign key: relationship inference must
+-- find the app.order_items.product_id -> app.products.id join on its own.
+CREATE TABLE app.order_items (
+    id          bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    order_id    bigint NOT NULL REFERENCES app.orders (id),
+    product_id  bigint NOT NULL,
+    quantity    integer NOT NULL,
+    unit_price  numeric(10, 2) NOT NULL
+);
+
+CREATE TABLE app.payments (
+    id       bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    order_id bigint NOT NULL REFERENCES app.orders (id),
+    method   text NOT NULL,
+    payload  bytea,
+    paid_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE VIEW app.v_order_totals AS
+SELECT o.id AS order_id,
+       o.customer_id,
+       o.status,
+       sum(i.quantity * i.unit_price) AS computed_total
+FROM app.orders o
+JOIN app.order_items i ON i.order_id = o.id
+GROUP BY o.id, o.customer_id, o.status;
+
+INSERT INTO app.customers (email, first_name, last_name, phone, address, city)
+SELECT format('user%s@example.com', g),
+       format('First%s', g),
+       format('Last%s', g),
+       CASE WHEN g % 7 = 0 THEN NULL ELSE format('+1-555-%s', 1000 + g) END,
+       format('%s Main Street', g),
+       (ARRAY['Amsterdam', 'Berlin', 'Lisbon', 'Milan', 'Porto'])[1 + g % 5]
+FROM generate_series(1, 500) AS g;
+
+INSERT INTO app.products (name, category, price, tags, attrs)
+SELECT format('Product %s', g),
+       (ARRAY['electronics', 'grocery', 'apparel', 'home'])[1 + g % 4]::app.product_category,
+       round((random() * 200 + 1)::numeric, 2),
+       ARRAY['tag' || (g % 10), 'tag' || (g % 3)],
+       jsonb_build_object('weight_g', g * 10, 'in_stock', g % 2 = 0)
+FROM generate_series(1, 80) AS g;
+
+INSERT INTO app.orders (customer_id, status, total, ordered_at)
+SELECT 1 + (g * 7) % 500,
+       (ARRAY['pending', 'paid', 'shipped', 'cancelled'])[1 + g % 4]::app.order_status,
+       0,
+       now() - (g % 365) * interval '1 day'
+FROM generate_series(1, 2000) AS g;
+
+INSERT INTO app.order_items (order_id, product_id, quantity, unit_price)
+SELECT 1 + (g * 3) % 2000,
+       1 + (g * 11) % 80,
+       1 + g % 5,
+       round((random() * 200 + 1)::numeric, 2)
+FROM generate_series(1, 5000) AS g;
+
+UPDATE app.orders o
+SET total = t.computed_total
+FROM (
+    SELECT order_id, sum(quantity * unit_price) AS computed_total
+    FROM app.order_items
+    GROUP BY order_id
+) AS t
+WHERE o.id = t.order_id;
+
+INSERT INTO app.payments (order_id, method, payload, paid_at)
+SELECT o.id,
+       (ARRAY['card', 'transfer', 'wallet'])[1 + o.id % 3],
+       decode(md5(o.id::text), 'hex'),
+       o.ordered_at + interval '1 hour'
+FROM app.orders o
+WHERE o.status IN ('paid', 'shipped');
+
+-- The big table: sampling threshold and statement_timeout exercises.
+CREATE TABLE app.events (
+    id          bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    customer_id bigint NOT NULL,
+    event_type  text NOT NULL,
+    payload     jsonb NOT NULL,
+    occurred_at timestamptz NOT NULL
+);
+
+INSERT INTO app.events (customer_id, event_type, payload, occurred_at)
+SELECT 1 + g % 500,
+       (ARRAY['page_view', 'add_to_cart', 'checkout', 'search', 'login'])[1 + g % 5],
+       jsonb_build_object('session', g % 10000, 'step', g % 7),
+       now() - (g % 90) * interval '1 hour'
+FROM generate_series(1, 100000) AS g;
+
+COMMIT;
+
+-- Roles (idempotent: created once per cluster, re-granted per seed run).
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'dex_ro') THEN
+        CREATE ROLE dex_ro LOGIN PASSWORD 'dex_ro';
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'dbt_dev') THEN
+        CREATE ROLE dbt_dev LOGIN PASSWORD 'dbt_dev';
+    END IF;
+END
+$$;
+
+GRANT CONNECT ON DATABASE dex_dogfood TO dex_ro, dbt_dev;
+
+-- dex_ro: read the app schema, nothing else. No access to dbt_dev.
+GRANT USAGE ON SCHEMA app TO dex_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA app TO dex_ro;
+ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT ON TABLES TO dex_ro;
+
+-- dbt_dev: read sources, write only the dev schema; server-side time cap.
+GRANT USAGE ON SCHEMA app TO dbt_dev;
+GRANT SELECT ON ALL TABLES IN SCHEMA app TO dbt_dev;
+ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT ON TABLES TO dbt_dev;
+GRANT USAGE, CREATE ON SCHEMA dbt_dev TO dbt_dev;
+ALTER ROLE dbt_dev SET statement_timeout = '600s';
+
+ANALYZE;

--- a/scripts/setup_postgres_dev.sh
+++ b/scripts/setup_postgres_dev.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Stand up (or re-seed) the local dogfood PostgreSQL for the postgres connector.
+#
+# Unlike the cloud connectors' setup scripts, nothing here provisions cloud
+# infrastructure: the operational-database connector is exercised against a
+# throwaway local container. The same scripts/postgres_seed.sql drives the CI
+# service container in .github/workflows/integration.yml.
+#
+# Usage:
+#   scripts/setup_postgres_dev.sh          # start container if needed, (re)seed
+#   scripts/setup_postgres_dev.sh --down   # remove the container
+#
+# Idempotent: re-running drops and recreates the dex_dogfood database.
+
+set -euo pipefail
+
+CONTAINER=dex-pg
+PORT="${DEX_PG_PORT:-5433}"
+IMAGE=postgres:16
+SUPERPASS=postgres
+SEED="$(cd "$(dirname "$0")" && pwd)/postgres_seed.sql"
+
+if [[ "${1:-}" == "--down" ]]; then
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    echo "removed container $CONTAINER"
+    exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "docker daemon is not running; start Docker Desktop first" >&2
+    exit 1
+fi
+
+if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
+    docker run -d --name "$CONTAINER" \
+        -e POSTGRES_PASSWORD="$SUPERPASS" \
+        -p "$PORT":5432 \
+        "$IMAGE" >/dev/null
+    echo "started $IMAGE as $CONTAINER on port $PORT"
+elif [[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER")" != "true" ]]; then
+    docker start "$CONTAINER" >/dev/null
+    echo "restarted existing container $CONTAINER"
+fi
+
+until docker exec "$CONTAINER" pg_isready -U postgres -q; do
+    sleep 0.5
+done
+
+docker exec "$CONTAINER" psql -U postgres -q \
+    -c "DROP DATABASE IF EXISTS dex_dogfood WITH (FORCE)" \
+    -c "CREATE DATABASE dex_dogfood"
+docker exec -i "$CONTAINER" psql -U postgres -q -d dex_dogfood -v ON_ERROR_STOP=1 \
+    <"$SEED"
+
+echo "seeded dex_dogfood from scripts/postgres_seed.sql"
+echo
+echo "connect dex as the read-only role:"
+echo "  export DATABASE_URL=postgresql://dex_ro:dex_ro@localhost:$PORT/dex_dogfood"
+echo "dbt dev builds (transform build) authenticate as dbt_dev:"
+echo "  export PGPASSWORD=dbt_dev   # profiles.yml reads it via env_var"

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -57,27 +57,33 @@ measuring (COUNT, APPROX_COUNT_DISTINCT, AVG(LENGTH(...))), never value-carrying
 (MIN, ANY_VALUE, STRING_AGG). Never fall back to raw Python or a database CLI to
 run SQL; the firewall path is the only sanctioned one.
 
-## Cloud targets (BigQuery)
+## Cloud and database targets (BigQuery, Snowflake, Postgres)
 
-A cloud warehouse replaces `--path` with connector config. Start with
-`connect test --connector bigquery` (or set `connector: bigquery` plus a
-`bigquery:` block with `project` and a `datasets` allowlist in
-`.dex/config.yml`). Credentials are discovered, never asked for: if the
-envelope reports missing or expired credentials, tell the user to run
-`gcloud auth application-default login` and never ask them to paste a key or
-token.
+A remote warehouse or database replaces `--path` with connector config. Start
+with `connect test --connector <name>` (or set `connector:` plus the matching
+block in `.dex/config.yml`: `bigquery:` with `project` and a `datasets`
+allowlist, `snowflake:` with the pinned `warehouse` and a `databases`
+allowlist, `postgres:` with a `schemas` allowlist). Credentials are
+discovered, never asked for: if the envelope reports missing or expired
+credentials, relay the fix it names (for BigQuery
+`gcloud auth application-default login`; for Snowflake a `connections.toml`
+entry or `SNOWFLAKE_*` env; for Postgres `DATABASE_URL`, `PG*` env, or a
+`pg_service.conf` entry) and never ask the user to paste a key, token, or
+password.
 
-On a billed connector, scanning commands (`profile`, `map`, `relationships`,
+On a metered connector, scanning commands (`profile`, `map`, `relationships`,
 `query`) run a two-step handshake. The first call returns
-`needs_confirmation` with a dry-run byte estimate in `cost.estimate` (and a
-per-table breakdown where relevant). Surface the estimate to the user in
-human units (for example "about 6 MB, well under a cent"), get an explicit
-budget from them, and re-issue the same command with `--confirm` and
-`--budget <bytes>`. Never invent a budget the user did not agree to, and never
-retry
-with a raised budget on an over-ceiling refusal without asking. Metadata is
-free (`connect test`, `inventory` run immediately), and OK envelopes report
-actual spend under `data.spend`.
+`needs_confirmation` with an estimate in `cost.estimate` (and a per-table
+breakdown where relevant): an exact dry-run byte figure on BigQuery, a
+heuristic labeled `estimate_quality: "heuristic"` in warehouse-seconds on
+Snowflake (credits alongside) and database-seconds on Postgres (no dollars;
+the guarded quantity is load on the operational database). Surface the
+estimate to the user in human units, get an explicit budget from them, and
+re-issue the same command with `--confirm` and `--budget <magnitude>` in the
+paradigm's unit. Never invent a budget the user did not agree to, and never
+retry with a raised budget on an over-ceiling refusal without asking.
+Metadata is free (`connect test`, `inventory` run immediately), and OK
+envelopes report actual spend under `data.spend`.
 
 ## Guardrails (enforced in the engine, not here)
 

--- a/skills/maintain/SKILL.md
+++ b/skills/maintain/SKILL.md
@@ -61,19 +61,21 @@ depth, then `reconcile` to get the proposed fix.
 
 ## Per-axis cost: what is free and what scans
 
-Detection is read-only, but read-only is not the same as free on a billed
-connector (BigQuery). The axes split:
+Detection is read-only, but read-only is not the same as free on a metered
+connector (BigQuery, Snowflake, Postgres). The axes split:
 
 - **Schema, volume, and the reference/definition half of semantic are free**
   everywhere: they read metadata and the snapshot, and run immediately.
 - **Grain and the dimension-cardinality half of semantic scan the warehouse**, so
-  on a billed connector they run the two-step handshake. The first call returns
-  `needs_confirmation` with a dry-run estimate in `cost.estimate` (and a per-table
+  on a metered connector they run the two-step handshake. The first call returns
+  `needs_confirmation` with an estimate in `cost.estimate` (and a per-table
   breakdown). Surface it to the user in human units, get an explicit budget, and
-  re-issue the same command with `--confirm --budget <bytes>`. Never invent a
-  budget the user did not agree to, and never retry with a raised budget on an
-  over-ceiling refusal without asking.
-- **`check` is two-phase on a billed connector**: the free axes complete
+  re-issue the same command with `--confirm --budget <magnitude>` in the
+  paradigm's unit (bytes on BigQuery, warehouse-seconds on Snowflake,
+  database-seconds on Postgres). Never invent a budget the user did not agree
+  to, and never retry with a raised budget on an over-ceiling refusal without
+  asking.
+- **`check` is two-phase on a metered connector**: the free axes complete
   immediately and their findings ride along in the `needs_confirmation` envelope,
   with one combined estimate for the scanning axes. Confirm to complete the sweep.
 

--- a/skills/transform/SKILL.md
+++ b/skills/transform/SKILL.md
@@ -50,14 +50,19 @@ records `connector`, `dbt_project_dir`, and `dbt_target: dev` in
 `.dex/config.yml`; do not hand-write these files yourself. Init never assumes a
 connector: it errors rather than defaulting, so always pass the user's confirmed
 choice (a `connector:` already committed in `.dex/config.yml` also counts).
-DuckDB and BigQuery are the supported connectors today; the remaining cloud
-connectors return an actionable not-yet-supported error. DuckDB needs a
+DuckDB, BigQuery, Snowflake, and Postgres are the supported connectors today;
+Databricks returns an actionable not-yet-supported error. DuckDB needs a
 warehouse path (`--path`, or the `duckdb.path` config). BigQuery needs a GCP
 project (usually `bigquery.project` in `.dex/config.yml`; confirm it with the
 user) and writes builds to a dedicated dev dataset (`bigquery.dev_dataset`,
 default `dbt_dev`); auth is Application Default Credentials, so if credentials
 are missing tell the user to run `gcloud auth application-default login`,
-never ask for a key. Init refuses if any dbt project already exists.
+never ask for a key. Snowflake writes builds to a dedicated
+`snowflake.dev_database`/`dev_schema` on the pinned warehouse; Postgres writes
+builds to a dedicated `postgres.dev_schema` (default `dbt_dev`), with the
+password reaching dbt only through the `PGPASSWORD` environment variable.
+Both discover their connections and refuse with the fix named when none
+resolves. Init refuses if any dbt project already exists.
 
 ### dbt SQL models
 


### PR DESCRIPTION
## SCRUM-816: PostgreSQL Connector

Adds the operational-database connector (Phase 4b), the first on the **db-load paradigm**: nothing is billed in dollars, so the guarded quantity is load on the database, denominated in **database-seconds** through the same strict confirm handshake as the billed connectors.

### Engine
- `adapters/postgres.py`: free metadata via `pg_catalog` (no scans), query estimates from the free `EXPLAIN (FORMAT JSON)` planner preflight (index-aware; size-heuristic fallback), profile estimates from relation sizes, all labeled `estimate_quality: "heuristic"`. The budget is hard-enforced regardless: every metered statement runs under a server-side `statement_timeout` wound down to the remaining budget, and actual wall-clock seconds land in `.dex/spend.jsonl` as `billed_seconds`.
- Read-only in depth: `default_transaction_read_only = on` on every session (autocommit, `application_name = 'dex'`), SELECT-only guard in the postgres dialect through one execution door, catalog-SELECTs/EXPLAIN/SETs only, documented least-privilege role shape.
- Profiling stays light on a production primary: one cheap single-pass aggregate batch; distinct counts come free from `pg_stats.n_distinct` (never the value-carrying stats columns), with the existing exact escalation inside the confirmed budget.
- Credential discovery, never prompting: `postgres.service` (pg_service.conf) > `DATABASE_URL` > `PG*` env (libpq-native, incl. `.pgpass`) > config target > dbt profile. Only coarse methods surfaced.
- Two shared-engine fixes for approximate `reltuples`: profile and grain-drift re-read metadata after an exact scan, so uniqueness proofs and `key_lost_uniqueness` verdicts compare against real rows (no-ops on other adapters). Also: `explore map` replica folding now recognizes the Snowflake and Postgres dev schemas (was BigQuery-only).

### Transform
- `transform init --connector postgres`: secret-free dbt-postgres dev profile (`env_var('PGPASSWORD')` reference), dedicated `dev_schema` refused as a source, one thread.
- `transform build`: ceiling injected as `PGOPTIONS="-c statement_timeout=<ceiling>s"` (the `maximum_bytes_billed` analogue; dbt has no dry-run), per-node seconds recorded to the ledger. `[postgres]` extra now carries `dbt-postgres`.

### How to test

**Offline (no Docker needed)** — everything runs against the stateful fake:

    cd packages/dex-core
    uv sync --extra duckdb --extra postgres --extra dev
    uv run pytest -q                                  # full suite, 467 tests
    uv run pytest -q tests/test_safety_spine.py -k postgres   # the 11 safety families

**Live, against the seeded container** (requires Docker running):

    scripts/setup_postgres_dev.sh    # starts postgres:16 on :5433 and seeds dex_dogfood
    cd packages/dex-core
    DEX_TEST_PG_DSN=postgresql://dex_ro:dex_ro@localhost:5433/dex_dogfood \
      DEX_TEST_PG_DEV_PASSWORD=dbt_dev uv run pytest tests/integration -q -m postgres

**Hands-on ETM loop** (from any empty directory, engine installed as above):

    export DATABASE_URL=postgresql://dex_ro:dex_ro@localhost:5433/dex_dogfood
    dex connect test --connector postgres        # free; session_read_only: true
    dex explore inventory --connector postgres   # free; 7 objects in app
    dex explore map --connector postgres         # returns needs_confirmation + seconds estimate
    dex explore map --connector postgres --confirm --budget 60
    dex explore query "SELECT status, count(*) FROM dex_dogfood.app.orders GROUP BY status" --confirm --budget 10
    dex explore query "SELECT email FROM dex_dogfood.app.customers LIMIT 5" --confirm --budget 10   # PII: refused

    # builds authenticate as the dbt_dev role
    export DATABASE_URL=postgresql://dbt_dev:dbt_dev@localhost:5433/dex_dogfood PGPASSWORD=dbt_dev
    dex transform init analytics --connector postgres   # secret-free profiles.yml
    dex transform build --confirm --budget 120          # lands in schema dbt_dev only

Things worth poking at: an over-ceiling estimate cannot be confirmed through
(`--budget 0.01` on `app.events`); a slow query is killed server-side at the
budget (`SELECT count(*) FROM dex_dogfood.app.orders WHERE pg_sleep(0.01) IS NULL`
with `--budget 2` dies at ~2s and still bills what ran to `.dex/spend.jsonl`);
`dex maintain snapshot` then `ALTER`/`UPDATE` something in the container and
`dex maintain check --confirm --budget 60` reports the drift with no false
duplicates from reltuples. Re-running `scripts/setup_postgres_dev.sh` re-seeds
from scratch; `--down` removes the container.

In CI the same integration suite runs as the new `postgres` job in
`integration.yml` (keyless service container, seeded from the same SQL); the
offline safety families run in every ci.yml/release.yml gate via
`--extra postgres`.
