### PR TITLE
Scrum-883-fix-issue-45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- `explore relationships` only recognized `_id`-style foreign key columns, so
+  warehouses using a `_key` convention (dimensional surrogate keys, and
+  TPC-H's own FK structure: `O_CUSTKEY`, `L_ORDERKEY`, `N_REGIONKEY`, ...)
+  inferred zero joins. `_fk_stem` now recognizes `key` alongside `id`, and a
+  new alias-stripping match handles TPC-H's convention of naming a foreign
+  key after the child table's own alias rather than the parent's entity name
+  (`L_ORDERKEY` on `LINEITEM` referring to `O_ORDERKEY` on `ORDERS`). (#45)
+
 ## [1.0.1] - 2026-07-06
 
 ### Fixed

--- a/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
@@ -28,21 +28,51 @@ from .profile import NEAR_UNIQUE_RATIO
 # RAW_HOSTS, stg_races, and dim_customers all match FKs named after the bare entity.
 _LAYER_PREFIX = re.compile(r"^(raw|stg|src|dim|fct|fact|mart|int)_", re.IGNORECASE)
 
+# Suffixes that make a column id-shaped. `id` is the common convention; `key` is
+# just as common in dimensional models (`customer_key` surrogate keys) and is the
+# *only* FK convention in some warehouses (TPC-H: `o_custkey`, `l_orderkey`, ...).
+# A new convention (e.g. a shop that suffixes `_pk`/`_fk`) is a one-line addition
+# here, not a rewrite of the three shapes below.
+_ID_SUFFIXES = ("id", "key")
+
+# A short table-alias prefix on a key column, stripped before comparing FK and
+# parent-key names so an alias convention (TPC-H: `o_custkey` vs `c_custkey`)
+# doesn't hide a shared suffix. Bounded to 3 chars so a genuine entity name
+# (`customer_id`) is never mistaken for an alias.
+_COLUMN_ALIAS_PREFIX = re.compile(r"^[a-z]{1,3}_", re.IGNORECASE)
+
 
 def _fk_stem(column_name: str) -> str | None:
     """The entity stem of an id-shaped column, or None if not id-shaped.
 
-    Recognizes the three naming shapes seen in real warehouses: `customer_id` /
-    `HOST_ID` (underscore, any case), camelCase `raceId`, and a trailing upper `ID`
-    only when a separator precedes it (`HOSTID` stays ambiguous and is skipped).
-    A bare `id` is a key, not a foreign key, so it has no stem.
+    Recognizes each suffix in :data:`_ID_SUFFIXES` in the three naming shapes
+    seen in real warehouses: underscore-separated, any case (`customer_id`,
+    `HOST_ID`, `nation_key`), camelCase (`raceId`, `customerKey`), and a
+    trailing suffix with no separator at all. The no-separator shape is only
+    accepted for `key`: TPC-H's own FK convention is exactly that (`CUSTKEY`,
+    `NATIONKEY`), and unlike `id` it isn't the tail of ordinary English words
+    (`PAID`, `VALID`, `GRID`), so `HOSTID` stays ambiguous and skipped while
+    `CUSTKEY` doesn't. A bare `id` or `key` is a key, not a foreign key, so it
+    has no stem.
     """
 
-    if re.search(r"(?<=.)_id$", column_name, re.IGNORECASE):
+    if column_name.lower() in _ID_SUFFIXES:
+        return None
+    for suffix in _ID_SUFFIXES:
+        if re.search(rf"(?<=.)_{suffix}$", column_name, re.IGNORECASE):
+            return column_name[: -(len(suffix) + 1)]
+        camel_suffix = suffix[0].upper() + suffix[1:]
+        if re.search(rf"(?<=[a-z0-9]){camel_suffix}$", column_name):
+            return column_name[: -len(suffix)]
+    if re.search(r"(?<=[A-Za-z0-9])KEY$", column_name, re.IGNORECASE):
         return column_name[:-3]
-    if re.search(r"(?<=[a-z0-9])Id$", column_name):
-        return column_name[:-2]
     return None
+
+
+def _dealias(column_name: str) -> str:
+    """Lowercased column name with a short table-alias prefix stripped."""
+
+    return _COLUMN_ALIAS_PREFIX.sub("", column_name.lower())
 
 
 def _entity(table_name: str) -> str:
@@ -52,7 +82,7 @@ def _entity(table_name: str) -> str:
 
 
 def _is_id_shaped(column_name: str) -> bool:
-    return column_name.lower() == "id" or _fk_stem(column_name) is not None
+    return column_name.lower() in _ID_SUFFIXES or _fk_stem(column_name) is not None
 
 
 def candidate_keys(dataset: Dataset) -> list[list[str]]:
@@ -414,10 +444,15 @@ def _match_parent(
     fk = col.name.lower()
     stem_l = stem.lower()
 
-    # Strongest: <entity>_id / <entity>Id pointing at the parent named <entity>,
-    # joining to the parent's id-shaped key (`id`, `<entity>_id`, or `<entity>Id`).
+    # Strongest: <entity>_id / <entity>Id (or the _key equivalents) pointing at
+    # the parent named <entity>, joining to the parent's id-shaped key (bare
+    # `id`/`key`, `<entity>_id`, or `<entity>id`, for each suffix in
+    # `_ID_SUFFIXES`).
     if stem_l in parent_entities or _singularize(stem).lower() in parent_entities:
-        for target in ("id", f"{stem_l}_id", f"{stem_l}id"):
+        targets = list(_ID_SUFFIXES)
+        targets += [f"{stem_l}_{suffix}" for suffix in _ID_SUFFIXES]
+        targets += [f"{stem_l}{suffix}" for suffix in _ID_SUFFIXES]
+        for target in targets:
             pcol = parent_cols.get(target)
             if pcol is not None and _type_compatible(col.data_type, pcol.data_type):
                 base = 0.85 if target in parent_key_names else 0.5
@@ -429,6 +464,22 @@ def _match_parent(
         pcol = parent_cols[fk]
         if _type_compatible(col.data_type, pcol.data_type):
             return [pcol.name], _score(0.6, col, pcol)
+
+    # Same key suffix once each side's table-alias prefix is stripped: TPC-H
+    # names a foreign key after the *child's* alias, not the parent's entity
+    # (LINEITEM.l_orderkey -> ORDERS.o_orderkey), which the entity-name branch
+    # above can't see since "l" and "o" aren't ORDERS's entity name. Skipped
+    # when stripping collapses the name to a bare suffix (e.g. "x_key" -> "key"),
+    # which is too generic to trust as a match.
+    fk_bare = _dealias(fk)
+    if fk_bare != fk and fk_bare not in _ID_SUFFIXES:
+        for pname, pcol in parent_cols.items():
+            if (
+                pname in parent_key_names
+                and _dealias(pname) == fk_bare
+                and _type_compatible(col.data_type, pcol.data_type)
+            ):
+                return [pcol.name], _score(0.55, col, pcol)
 
     return None
 

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -146,6 +146,111 @@ def test_ambiguous_all_caps_id_suffix_is_not_a_fk():
     assert fk_candidate_count([ds]) == 2
 
 
+def test_underscore_key_suffix_matches_like_id():
+    """Dimensional models commonly use `<entity>_key` surrogate keys instead of
+    `<entity>_id`; the same matching rules must apply (issue #45)."""
+
+    customers = _ds(
+        "db.main.customers", [_col("customer_key", distinct=2, unique=True)], rows=2
+    )
+    orders = _ds("db.main.orders", [_col("customer_key", distinct=2)], rows=5)
+    rels = infer_relationships([customers, orders])
+    assert len(rels) == 1
+    assert rels[0].from_columns == ["customer_key"]
+    assert rels[0].to_dataset == "db.main.customers"
+    assert rels[0].confidence >= 0.85
+
+
+def test_camelcase_key_suffix_matches():
+    parts = _ds("db.main.parts", [_col("partKey", distinct=3, unique=True)], rows=3)
+    lines = _ds("db.main.lines", [_col("partKey", distinct=2)], rows=6)
+    rels = infer_relationships([parts, lines])
+    assert len(rels) == 1
+    assert rels[0].to_dataset == "db.main.parts"
+
+
+def test_bare_key_is_a_key_not_a_foreign_key():
+    """A column literally named `key` (like bare `id`) has no entity stem."""
+
+    ds = _ds("db.main.t", [_col("key", unique=True), _col("id")], rows=1)
+    assert fk_candidate_count([ds]) == 0
+
+
+def test_tpch_alias_prefixed_keys_are_inferred():
+    """TPC-H names every FK after the child table's own alias, not the parent's
+    entity name (`L_ORDERKEY` on LINEITEM, not `ORDERS_KEY`), and concatenates the
+    suffix with no separator at all (`CUSTKEY`, not `CUST_KEY`). Neither the
+    entity-name branch nor a bare `_id`-only stem detector can see these joins;
+    covers the exact chain reported in issue #45."""
+
+    region = _ds(
+        "db.tpch.region", [_col("R_REGIONKEY", distinct=5, unique=True)], rows=5
+    )
+    nation = _ds(
+        "db.tpch.nation",
+        [
+            _col("N_NATIONKEY", distinct=25, unique=True),
+            _col("N_REGIONKEY", distinct=5),
+        ],
+        rows=25,
+    )
+    supplier = _ds(
+        "db.tpch.supplier",
+        [
+            _col("S_SUPPKEY", distinct=100, unique=True),
+            _col("S_NATIONKEY", distinct=25),
+        ],
+        rows=100,
+    )
+    customer = _ds(
+        "db.tpch.customer",
+        [
+            _col("C_CUSTKEY", distinct=150, unique=True),
+            _col("C_NATIONKEY", distinct=25),
+        ],
+        rows=150,
+    )
+    part = _ds("db.tpch.part", [_col("P_PARTKEY", distinct=200, unique=True)], rows=200)
+    orders = _ds(
+        "db.tpch.orders",
+        [
+            _col("O_ORDERKEY", distinct=1500, unique=True),
+            _col("O_CUSTKEY", distinct=150),
+        ],
+        rows=1500,
+    )
+    lineitem = _ds(
+        "db.tpch.lineitem",
+        [
+            _col("L_ORDERKEY", distinct=1500),
+            _col("L_PARTKEY", distinct=200),
+            _col("L_SUPPKEY", distinct=100),
+        ],
+        rows=6000,
+    )
+    datasets = [region, nation, supplier, customer, part, orders, lineitem]
+    rels = infer_relationships(datasets)
+
+    found = {(r.from_dataset, r.from_columns[0], r.to_dataset) for r in rels}
+    assert ("db.tpch.orders", "O_CUSTKEY", "db.tpch.customer") in found
+    assert ("db.tpch.lineitem", "L_ORDERKEY", "db.tpch.orders") in found
+    assert ("db.tpch.lineitem", "L_PARTKEY", "db.tpch.part") in found
+    assert ("db.tpch.lineitem", "L_SUPPKEY", "db.tpch.supplier") in found
+    assert ("db.tpch.supplier", "S_NATIONKEY", "db.tpch.nation") in found
+    assert ("db.tpch.customer", "C_NATIONKEY", "db.tpch.nation") in found
+    assert ("db.tpch.nation", "N_REGIONKEY", "db.tpch.region") in found
+
+
+def test_dealiased_match_skips_when_stripped_to_a_bare_suffix():
+    """`x_key` / `y_key` collapse to the bare suffix `key` once dealiased; that's
+    too generic to trust, so two unrelated single-letter-prefixed keys must not
+    be matched to each other."""
+
+    a = _ds("db.main.alpha", [_col("a_key", distinct=2, unique=True)], rows=2)
+    b = _ds("db.main.beta", [_col("b_key", distinct=2)], rows=2)
+    assert infer_relationships([a, b]) == []
+
+
 # --- same-lineage / replica folding --------------------------------------------
 
 


### PR DESCRIPTION
_fk_stem` only recognized `_id`-style column names, so warehouses that use `_key` conventions produced zero inferred relationships. This includes dimensional models (`customer_key` surrogate keys) and, as reported in #45, TPC-H's real FK structure (`O_CUSTKEY`, `L_ORDERKEY`, `N_REGIONKEY`, ...), which uses no separator at all before `KEY`.
- Generalized the suffix list to `("id", "key")` so a future convention is a one-line addition, not a rewrite of the matching logic.
- Added a new match branch for TPC-H's alias-prefixed FK names (`L_ORDERKEY` on LINEITEM referring to `O_ORDERKEY` on ORDERS) , the existing entity-name match can't see this since the FK is named after the *child's* table alias, not the parent's entity name. Guarded so it doesn't degrade to matching on a bare `id`/`key` suffix alone.

## Why bare `KEY` (but not bare `ID`) is accepted without a separator `ID` is deliberately skipped without a separator (`HOSTID`) because it's the tail of ordinary English words (`PAID`, `VALID`, `GRID`). `KEY` isn't a realistic false positive in warehouse column names, and TPC-H's own PK/FK convention concatenates it directly (`CUSTKEY`, not `CUST_KEY`).


<img width="1527" height="160" alt="image" src="https://github.com/user-attachments/assets/a98dbbd3-3b94-4d54-9a54-25bc8c8b3b47" />
after fix: 
<img width="1530" height="161" alt="image" src="https://github.com/user-attachments/assets/4e0161b3-6153-4f37-bad6-208f768810c9" />



