### PR TITLE
SCRUM-895-Fix transform build surfacing dbt deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- `transform build` surfaced a dbt deprecation warning (`[WARNING]
+  PropertyMovedToConfigDeprecation`) as the failure cause instead of the real
+  error. dbt 1.11 logs these notices before the actual failure on every
+  normally-authored project, so the notice reliably won the `errors[0]` slot.
+  `_collect_messages` now promotes dbt's own `MainEncounteredError` event (the
+  structured summary of what actually failed) to the front and sinks
+  `[WARNING]`-tagged lines to `warnings` instead. (#50)
+
 ## [1.1.0] - 2026-07-09
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/transform/build.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/build.py
@@ -408,17 +408,30 @@ def _default_runner(
     return run
 
 
+# dbt 1.11 emits deprecation notices (e.g. PropertyMovedToConfigDeprecation) on
+# every run of a normally-authored project, tagged `[WARNING]` in their own
+# message text regardless of `info.level`. Left undistinguished from a real
+# failure, one of these reliably wins the errors[0] slot merely by logging
+# before the actual cause does. `MainEncounteredError` is dbt's own summary of
+# what actually killed the run and always leads when present.
+_DEPRECATION_MARKER = "[WARNING]"
+_MAIN_ENCOUNTERED_ERROR = "MainEncounteredError"
+
+
 def _collect_messages(
     completed: subprocess.CompletedProcess, log_hint: Path | None = None
 ) -> list[str]:
     """Reduce dbt's output to actionable one-liners for the envelope.
 
     Keeps the first line of each error/warn message (redacted, length-capped,
-    deduplicated); when anything was cut, the last entry points at the full log
-    instead of letting a raw traceback cross the envelope boundary.
+    deduplicated); deprecation notices sink below real errors so they cannot
+    poison the errors[0] slot, and dbt's own MainEncounteredError event (the
+    structured summary of the actual failure) always leads when present. When
+    anything was cut, the last entry points at the full log instead of letting
+    a raw traceback cross the envelope boundary.
     """
 
-    messages: list[str] = []
+    entries: list[tuple[str, str]] = []
     seen: set[str] = set()
     trimmed = False
     for line in (completed.stdout or "").splitlines():
@@ -440,7 +453,17 @@ def _collect_messages(
             trimmed = True
             continue
         seen.add(first_line)
-        messages.append(first_line)
+        entries.append((str(info.get("name") or ""), first_line))
+
+    primary = [m for _, m in entries if _DEPRECATION_MARKER not in m]
+    deprecations = [m for _, m in entries if _DEPRECATION_MARKER in m]
+    main_error = next(
+        (m for name, m in entries if name == _MAIN_ENCOUNTERED_ERROR), None
+    )
+    if main_error is not None:
+        primary = [main_error] + [m for m in primary if m != main_error]
+    messages = primary + deprecations
+
     if not messages and completed.stderr:
         messages.append(redact(completed.stderr.strip().splitlines()[-1]))
     if len(messages) > _MESSAGE_CAP:

--- a/packages/dex-core/tests/transform/test_build.py
+++ b/packages/dex-core/tests/transform/test_build.py
@@ -182,6 +182,60 @@ def test_build_failure_error_names_the_first_dbt_message(
     assert any("logs" in w and "dbt.log" in w for w in envelope["warnings"])
 
 
+def test_build_failure_error_skips_deprecation_warnings_for_the_real_cause(
+    dbt_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """Regression for #50: a dbt 1.11 deprecation notice logs before the real
+    failure on every normally-authored project, and must not win errors[0]."""
+
+    real_error = (
+        'Database error while listing schemas in database "NOPE_MISSING_DB"\n'
+        "  Database Error\n"
+        "    002043 (02000): SQL compilation error:\n"
+        "    Object does not exist, or operation cannot be performed."
+    )
+    lines = [
+        json.dumps(
+            {
+                "info": {
+                    "level": "warn",
+                    "name": "PropertyMovedToConfigDeprecation",
+                    "msg": "[WARNING][PropertyMovedToConfigDeprecation]: "
+                    "Deprecated functionality",
+                }
+            }
+        ),
+        json.dumps(
+            {
+                "info": {
+                    "level": "error",
+                    "name": "MainEncounteredError",
+                    "msg": real_error,
+                }
+            }
+        ),
+    ]
+    _fake_runner_factory(monkeypatch, returncode=2, stdout="\n".join(lines))
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert envelope["errors"][0] == (
+        "dbt build failed: Database error while listing schemas in database "
+        '"NOPE_MISSING_DB"'
+    )
+    assert any("PropertyMovedToConfigDeprecation" in w for w in envelope["warnings"])
+
+
 def test_missing_dev_db_with_sources_is_an_actionable_error(
     dbt_project_dir: Path, tmp_path: Path, capsys, forbid_dbt
 ):


### PR DESCRIPTION
Fixes #50: _collect_messages picked messages[0] in raw dbt log order, so a [WARNING] deprecation notice (logged during parsing) beat the actual failure (logged during execution) into errors[0] on every build failure.

Now deprecation-tagged lines sink to the end, and dbt's MainEncounteredError event (the real failure summary) is promoted to the front when present. Deprecations still surface in warnings, just no longer mistaken for the cause.


Before : 
<img width="1582" height="652" alt="Screenshot 2026-07-10 153457" src="https://github.com/user-attachments/assets/2ecfbf6e-4ba9-4fdf-bb15-a6997310dc75" />
After : 
<img width="1583" height="342" alt="Screenshot 2026-07-10 153526" src="https://github.com/user-attachments/assets/75908b69-3b25-411c-8355-6a8500552115" />
