### PR TITLE
SCRUM-897-surface dbt deprecation warnings at plan time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- `semantic define`/`update`/`plan` reported `warnings: []` for a plan that
+  parsed cleanly but whose YAML would go on to log dbt deprecation notices
+  (e.g. `PropertyMovedToConfigDeprecation`) at `transform build`. `shadow_parse`
+  only collected messages on a failed parse; it now collects them on a clean
+  parse too, and the caller surfaces them as plan-time warnings instead of
+  letting the author discover them for the first time at build (where they
+  also poisoned the failure-error channel, #50). (#55)
+
 ## [1.1.0] - 2026-07-09
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/transform/build.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/build.py
@@ -224,10 +224,14 @@ def shadow_parse(
     logs/, any stray database a relative profile path would create) lives and
     dies with the copy.
 
-    Returns ``{"available", "reason", "messages"}``: unavailable means the
-    caller degrades to a warning (dbt or profiles missing, mirroring the
-    schema-validation fallback); available with empty messages means the parse
-    passed; non-empty messages are the parse errors.
+    Returns ``{"available", "reason", "success", "messages"}``: unavailable
+    means the caller degrades to a warning (dbt or profiles missing, mirroring
+    the schema-validation fallback). When available, ``success`` says whether
+    the parse itself passed; ``messages`` is populated either way, since dbt
+    logs deprecation notices on a project that parses cleanly, and a plan that
+    validates today should not go on to warn about them for the first time at
+    `transform build` (#55). On failure, ``messages`` are the parse errors
+    (dbt's own summary event leads if present; see :func:`_collect_messages`).
     """
 
     # Absolute so --profiles-dir (pointing at the real project) does not
@@ -239,6 +243,7 @@ def shadow_parse(
         return {
             "available": False,
             "reason": "dbt is not installed; plan validated by schema checks only",
+            "success": None,
             "messages": [],
         }
     try:
@@ -247,6 +252,7 @@ def shadow_parse(
         return {
             "available": False,
             "reason": "no profiles.yml found; dbt parse skipped",
+            "success": None,
             "messages": [],
         }
 
@@ -282,10 +288,15 @@ def shadow_parse(
             argv += ["--target", target]
         run = runner or _default_runner(timeout, shadow)
         completed = run(argv)
-        messages: list[str] = []
-        if completed.returncode != 0:
-            messages = _collect_messages(completed) or ["dbt parse failed"]
-    return {"available": True, "reason": None, "messages": messages}
+        success = completed.returncode == 0
+        # Collected unconditionally: a passing parse can still have logged
+        # deprecation notices, which the caller surfaces as plan-time warnings
+        # rather than letting the author discover them for the first time at
+        # `transform build`.
+        messages = _collect_messages(completed)
+        if not success and not messages:
+            messages = ["dbt parse failed"]
+    return {"available": True, "reason": None, "success": success, "messages": messages}
 
 
 def has_package_spec(project_dir: Path | str) -> bool:

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -383,6 +383,7 @@ def _semantic_plan(args: argparse.Namespace, mode: str) -> env.Envelope:
     # that already-surfaced reason, and authoring the spine comes next), or
     # with --no-parse.
     parse_warning: str | None = None
+    parse_deprecations: list[str] = []
     if getattr(args, "no_parse", False):
         pass
     elif spine_warning:
@@ -395,11 +396,17 @@ def _semantic_plan(args: argparse.Namespace, mode: str) -> env.Envelope:
         parse_result = shadow_parse(project, edits, target=config.dbt_target)
         if not parse_result["available"]:
             parse_warning = parse_result["reason"]
-        elif parse_result["messages"]:
+        elif not parse_result["success"]:
             return env.error(
                 _failure_message("dbt parse failed", parse_result["messages"]),
                 warnings=parse_result["messages"][1:],
             )
+        elif parse_result["messages"]:
+            # The parse passed, but dbt logged deprecation notices against this
+            # exact YAML (#55): surface them now, at plan time, rather than
+            # let the author discover them for the first time at `transform
+            # build` (where they also poison the failure-error channel, #50).
+            parse_deprecations = [f"dbt: {m}" for m in parse_result["messages"]]
 
     envelope = _make_plan(args, intent, edits)
     if envelope.status is env.Status.OK:
@@ -411,6 +418,7 @@ def _semantic_plan(args: argparse.Namespace, mode: str) -> env.Envelope:
             envelope.warnings.append(spine_warning)
         if parse_warning:
             envelope.warnings.append(parse_warning)
+        envelope.warnings.extend(parse_deprecations)
     return envelope
 
 

--- a/packages/dex-core/tests/transform/test_parse.py
+++ b/packages/dex-core/tests/transform/test_parse.py
@@ -227,6 +227,42 @@ def test_parse_skipped_while_the_project_lacks_a_time_spine(
     assert any("dbt parse skipped" in w for w in envelope["warnings"])
 
 
+def test_parse_success_still_surfaces_deprecation_warnings(
+    dbt_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """Regression for #55: a clean parse (returncode 0) with a deprecation
+    notice on stdout must not report warnings: [] just because nothing failed
+    -- the same YAML would go on to warn at `transform build` (#50)."""
+
+    _add_time_spine(dbt_project_dir)
+    build_module = importlib.import_module("exmergo_dex_core.transform.build")
+    line = json.dumps(
+        {
+            "info": {
+                "level": "warn",
+                "name": "PropertyMovedToConfigDeprecation",
+                "msg": "[WARNING][PropertyMovedToConfigDeprecation]: Deprecated "
+                "functionality",
+            }
+        }
+    )
+
+    def fake(timeout: float, cwd, env=None):
+        def run(argv: list[str]):
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout=line, stderr=""
+            )
+
+        return run
+
+    monkeypatch.setattr(build_module, "_default_runner", fake)
+    rc, envelope = _define(tmp_path, _payload_file(tmp_path, _SEMANTIC_YAML), capsys)
+    assert rc == 0, envelope
+    assert envelope["status"] == "ok"
+    assert len(_plans_on_disk(tmp_path)) == 1
+    assert any("PropertyMovedToConfigDeprecation" in w for w in envelope["warnings"])
+
+
 def test_real_dbt_parse_catches_a_dangling_model_ref(
     dbt_project_dir: Path, tmp_path: Path, capsys
 ):


### PR DESCRIPTION
Fixes #55: `semantic define`/`update`/`plan` reported `warnings: []` for a plan that parsed cleanly but whose YAML would go on to log dbt deprecation notices (e.g. `PropertyMovedToConfigDeprecation`) at `transform build`.

`shadow_parse` only collected dbt's log messages when the parse failed. It now collects them on a clean parse too, and the caller surfaces them as plan-time warnings instead of letting the author discover them for the first time at build.

Scoped to `semantic define/update/plan`, the only command that runs dbt's real parser today; `transform plan` (model_sql/schem21a_yml) has no such gate and is out of scope here.

<img width="1575" height="335" alt="Screenshot 2026-07-10 161324" src="https://github.com/user-attachments/assets/c82595d9-c5fa-4c57-93d2-21f57694abe7" />

 after fix: 

<img width="1583" height="287" alt="Screenshot 2026-07-10 161049" src="https://github.com/user-attachments/assets/cb395f0b-67fb-4bc0-bd78-81329e739c24" />
