### PR TITLE
Snowflake Issues Dogfood

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ release is connector-neutral.
 
 | Subcommand | Returns |
 |---|---|
-| `connect test` | capabilities, dialect, `read_only: true`; DuckDB takes `--path`, BigQuery takes `--project`/`--dataset` convenience overrides (never written to config); Snowflake and Databricks report the pinned warehouse and its credit or DBU rate |
+| `connect test` | capabilities, dialect, `read_only: true`; DuckDB takes `--path`, every warehouse connector takes repeatable `--scope` (BigQuery also accepts its older `--project`/`--dataset`), never written to config; Snowflake and Databricks report the pinned warehouse and its credit or DBU rate |
 | `explore inventory [--rank]` | ranked object summary (counts, sizes; no rows) |
 | `explore profile <objects>` | column profiles + PII flags (column, category, confidence) + candidate keys, grain, data-quality warnings |
 | `explore relationships [--verify]` | inferred + declared joins with confidences, plus notes on what inference examined; `--verify` measures each join with an aggregate overlap probe |
@@ -50,7 +50,7 @@ release is connector-neutral.
 | `transform plan "<intent>" --edits-file <f>` | proposed dbt edits as diffs (nothing applied); `--scaffold <table>` adds a staging skeleton from the cache |
 | `transform apply [plan-id]` | writes diffs into the dbt project (a reviewable git diff); a human edit since planning returns `needs_confirmation`, never an overwrite; no id applies the latest unapplied plan of any kind |
 | `transform plans` | list stored plans, pending and applied, newest first |
-| `transform build --target dev` | cost preflight first; runs only with `--confirm` and a budget; prod-looking targets refused outright; cwd pinned to the project dir; auto-runs `dbt deps` when packages are declared but not installed |
+| `transform build --target dev` | prod-looking targets refused outright; then a free dev-target preflight (refuses when `.dex/config.yml` and the rendered `profiles.yml` disagree, or when the dev database does not exist, naming the fix); then the cost preflight; runs only with `--confirm` and a budget; cwd pinned to the project dir; auto-runs `dbt deps` when packages are declared but not installed |
 | `transform deps` | install/refresh dbt packages (repo-confined; no warehouse spend) |
 | `semantic define\|update\|plan ... --edits-file <f>` | dbt semantic model edits as diffs; validated up to and including dbt's own parser (a throwaway project copy) before the plan is stored; `plan` accepts a mix and classifies per name; degrades to a warning when dbt is absent, `--no-parse` skips; applied with `transform apply` like any other plan |
 | `maintain snapshot` | capture/refresh the known-good baseline in `.dex/snapshot.json` (pins the `.dex/` map + per-layer definition fingerprints) |
@@ -118,7 +118,10 @@ firewall has cleared them.
 3. Read-only against data; writes confined to the repo. DuckDB opens read-only;
    generated SQL is SELECT-only; agent-authored SQL runs only through the query
    firewall; builds run against a dev target only, never prod.
-4. Cost-aware by connector. Nothing runs without a ceiling.
+4. Cost-aware by connector. Nothing runs without a ceiling. The source allowlist
+   in `.dex/config.yml` is a committed cost boundary: `--scope` narrows it for one
+   command and can never widen it, and a scope that names nothing is refused
+   rather than dropped.
 5. Nothing reaches agent context except through the sanitized envelope.
    Credentials never; data values only from profiled, PII-cleared columns,
    bounded and capped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **`--scope`**, a portable, repeatable source-scope override that every
+  warehouse connector reads in its own namespace vocabulary: a `dataset` on
+  BigQuery, a `schema`, `database`, or `database.schema` on Snowflake, a
+  `catalog`/`catalog.schema` on Databricks, a `schema` on Postgres. Nothing is
+  written back to `.dex/config.yml`. A committed source allowlist is a cost
+  boundary, so `--scope` may only narrow it, never widen it, and a scope that
+  reaches outside is refused.
+- **Snowflake scope resolution and validation.** Scopes now resolve against the
+  account through free SHOW metadata before anything is estimated. A bare schema
+  is qualified against the databases in scope; an ambiguous one asks for
+  `database.schema`; one that names nothing is refused with the schemas that do
+  exist listed. `connect test --scope <bad>` therefore fails for free.
+- **A dev-target preflight before `transform build`.** It runs after the prod
+  refusal and before the cost gate, and it is free, so a build that cannot
+  succeed is refused before anyone is asked to weigh a budget. On Snowflake it
+  refuses a missing `dev_database` and names the `CREATE DATABASE` statement that
+  fixes it; dbt creates schemas but never databases, so the first build otherwise
+  failed inside dbt's `list_schemas` macro with an opaque
+  `002043: Object does not exist`. DuckDB's existing missing-file refusal moved
+  into the same preflight unchanged.
+
+### Fixed
+
+- **`explore map --dataset <schema>` was accepted and silently ignored on
+  Snowflake** (and, identically, on Databricks and Postgres). Scoping was
+  governed solely by the config allowlist, so a nonexistent schema was accepted
+  without error and the estimate spanned every table the allowlist permitted. A
+  user could confirm a budget believing it bounded an eight-table schema while it
+  in fact covered billion-row tables elsewhere. Scoping flags are now honored or
+  named in an error, never dropped.
+- **A `.dex/config.yml` edit to the dev target was inert after `transform
+  init`.** `profiles.yml` was the sole source of truth thereafter, so retargeting
+  `snowflake.dev_database` produced a green build against the old database.
+  `transform build` now refuses when the two disagree, naming both values and
+  both files. It never rewrites `profiles.yml`, which may legitimately be
+  hand-edited.
+
+### Changed
+
+- **`--project` and `--dataset` now error on every connector except BigQuery**,
+  where they remain as aliases of `--scope`. They were previously accepted and
+  discarded, which is strictly worse than a refusal. `--scope` on DuckDB errors
+  too: a DuckDB target is one file, selected with `--path`.
+- **`--dataset` on BigQuery now narrows a committed `bigquery.datasets`
+  allowlist rather than replacing it.** With no allowlist committed it still sets
+  one, so the `connect test --project X --dataset Y` smoke test is unchanged.
+
 ## [1.1.0] - 2026-07-09
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/adapters/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/base.py
@@ -94,6 +94,27 @@ class QueryResult:
     truncated: bool
 
 
+def scope_within(scope: str, committed: list[str]) -> bool:
+    """Whether one scope entry lies inside a committed source allowlist.
+
+    Every connector's scope entries are dotted namespace paths that grow coarse to
+    fine (``project.dataset``, ``database.schema``, ``catalog.schema``), so
+    containment is prefix containment on path segments: ``RAW.EVENTS`` is inside
+    ``RAW``, and ``RAW`` is not inside ``RAW.EVENTS``. Comparison is
+    case-insensitive because the connectors disagree about identifier case and a
+    case mismatch must never read as an escape attempt.
+
+    This is what makes ``--scope`` narrow-only. A committed allowlist is a cost
+    boundary, so a per-command flag has to stay inside it.
+    """
+
+    entry = scope.strip().lower()
+    return any(
+        entry == c.strip().lower() or entry.startswith(c.strip().lower() + ".")
+        for c in committed
+    )
+
+
 def json_safe(value: object | None) -> object | None:
     """Coerce a connector scalar to a JSON-serializable primitive for the envelope."""
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
@@ -28,16 +28,39 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import Callable
+from contextlib import contextmanager
 from typing import Any
 
 from ..config import SnowflakeTarget
 from ..envelope import Paradigm
 from ..guards.cost_guard import CostGate, OverCeilingError
 from ..guards.sql_guard import assert_select_only
-from .base import ColumnAggregate, ColumnMeta, ObjectMeta, QueryResult, json_safe
+from .base import (
+    ColumnAggregate,
+    ColumnMeta,
+    ObjectMeta,
+    QueryResult,
+    json_safe,
+    scope_within,
+)
 
 PARADIGM = "compute_time"
 DIALECT = "snowflake"
+
+# Snowflake keeps a read-only INFORMATION_SCHEMA in every database and an
+# account-internal SNOWFLAKE database. Neither is ever a source, and neither may
+# be reached by a scope entry.
+_RESERVED_SCHEMA = "INFORMATION_SCHEMA"
+_RESERVED_DATABASE = "SNOWFLAKE"
+
+# How many sibling names an error message lists before it stops. Long enough to
+# spot a typo, short enough not to paste a thousand-schema account into stdout.
+_SUGGESTION_CAP = 12
+
+# How many databases a bare schema name may be searched across before dex asks
+# for a qualified <database>.<schema> instead. Each candidate costs one free SHOW
+# SCHEMAS round-trip, and an unscoped enterprise account has hundreds.
+_BARE_SCOPE_SEARCH_LIMIT = 20
 
 # Columns are profiled in batches so one statement against a very wide table
 # does not balloon (up to 4 expressions per column).
@@ -121,6 +144,7 @@ class SnowflakeAdapter:
         target: SnowflakeTarget | None = None,
         account: str | None = None,
         auth_method: str = "unknown",
+        scope_override: list[str] | None = None,
         clock: Callable[[], float] = time.monotonic,
     ):
         self._conn = connection
@@ -128,6 +152,10 @@ class SnowflakeAdapter:
         self.target = target or SnowflakeTarget()
         self.account = account
         self.auth_method = auth_method
+        # A per-command `--scope`, kept apart from the committed allowlist in the
+        # target: it may only narrow that allowlist, and deciding whether it does
+        # requires resolving bare schema names against the account first.
+        self._scope_override = list(scope_override or [])
         self._clock = clock
         # Imported lazily (the caller constructed the connection, so the
         # library is present); the error types drive refusal translation.
@@ -140,6 +168,9 @@ class SnowflakeAdapter:
         self._objects: dict[str, dict] = {}
         self._columns: dict[str, list[ColumnMeta]] = {}
         self._inventory_loaded = False
+        self._resolved_scopes: list[str] | None = None
+        self._visible_databases: set[str] | None = None
+        self._schemas_by_database: dict[str, set[str]] = {}
         self._warehouse_info: dict | None = None
         self._notes: dict[str, list[str]] = {}
         # The 60s resume minimum is charged once per command, by whichever
@@ -317,26 +348,163 @@ class SnowflakeAdapter:
             return True
 
     def _scopes(self) -> list[str]:
-        """The allowlist entries in scope (``db`` or ``db.schema``), or every
-        database the role can see when no allowlist is configured. The
-        account-internal SNOWFLAKE database is never a source."""
+        """Every source scope this command reads, resolved and proven to exist.
 
-        if self.target.databases:
-            return sorted({entry.upper() for entry in self.target.databases})
-        return sorted(
-            str(row["name"]).upper()
-            for row in self._show("SHOW DATABASES")
-            if str(row["name"]).upper() != "SNOWFLAKE"
+        Resolution is free (SHOW only, no warehouse) and cached for the command.
+        It runs before anything is estimated, because an unresolvable scope that
+        silently falls back to the whole allowlist is a cost-safety bug: the
+        estimate the user confirms would cover tables they never named.
+        """
+
+        if self._resolved_scopes is None:
+            self._resolved_scopes = self._resolve_scopes()
+        return self._resolved_scopes
+
+    def _resolve_scopes(self) -> list[str]:
+        committed = self.target.databases
+        if committed:
+            with _blame("snowflake.databases in .dex/config.yml"):
+                configured = sorted(
+                    {
+                        self._resolve_scope(entry, sorted(self._databases()))
+                        for entry in committed
+                    }
+                )
+        else:
+            configured = sorted(self._databases())
+        if not self._scope_override:
+            return configured
+
+        # A --scope searches only the databases the config already allows, so a
+        # bare schema name can never resolve into a database outside the committed
+        # boundary; a qualified one that tries is refused below.
+        searchable = sorted({scope.split(".")[0] for scope in configured})
+        with _blame("--scope"):
+            requested = sorted(
+                {
+                    self._resolve_scope(entry, searchable)
+                    for entry in self._scope_override
+                }
+            )
+        outside = [scope for scope in requested if not scope_within(scope, configured)]
+        if outside:
+            raise SnowflakeConnectionError(
+                f"scope {_name_list(outside)} is outside the committed allowlist "
+                f"(snowflake.databases: {_name_list(configured)}); --scope narrows "
+                "the configured scope, it never widens it"
+            )
+        return requested
+
+    def _resolve_scope(self, entry: str, searchable: list[str]) -> str:
+        """One scope entry, resolved to ``DATABASE`` or ``DATABASE.SCHEMA`` and
+        proven to exist. ``searchable`` bounds where a bare schema may be found.
+
+        Every failure path here names the entry and lists the near misses, because
+        Snowflake's own answer to a bad scope is ``002043: Object does not exist``,
+        which names neither the object nor the fix.
+        """
+
+        token = entry.strip().upper()
+        if not token:
+            raise SnowflakeConnectionError("empty scope entry")
+
+        if "." in token:
+            database, _, schema = token.partition(".")
+            if "." in schema:
+                raise SnowflakeConnectionError(
+                    f"scope '{entry}' has too many parts; a source scope is "
+                    "<database> or <database>.<schema>, never a table"
+                )
+            if database not in self._databases():
+                reserved = (
+                    f" (the account-internal {_RESERVED_DATABASE} database is never "
+                    "a source)"
+                    if database == _RESERVED_DATABASE
+                    else ""
+                )
+                raise SnowflakeConnectionError(
+                    f"scope '{entry}' names no database this role can see{reserved}; "
+                    f"{self._visible_hint()}"
+                )
+            schemas = self._schemas(database)
+            if schema not in schemas:
+                raise SnowflakeConnectionError(
+                    f"scope '{entry}' does not exist: database {database} has no "
+                    f"schema {schema}; schemas there: {_name_list(sorted(schemas))}"
+                )
+            return f"{database}.{schema}"
+
+        if token in self._databases():
+            return token
+
+        # Qualifying a bare schema costs one SHOW SCHEMAS per candidate database.
+        # That is free but not instant, so a wide-open account is asked to qualify
+        # rather than made to wait through hundreds of round-trips.
+        if len(searchable) > _BARE_SCOPE_SEARCH_LIMIT:
+            raise SnowflakeConnectionError(
+                f"scope '{entry}' is a bare schema name and this role can see "
+                f"{len(searchable)} databases; qualify it as <database>.{token}, or "
+                "narrow snowflake.databases in .dex/config.yml first"
+            )
+
+        matches = sorted(db for db in searchable if token in self._schemas(db))
+        if len(matches) == 1:
+            return f"{matches[0]}.{token}"
+        if not matches:
+            schemas = sorted({s for db in searchable for s in self._schemas(db)})
+            raise SnowflakeConnectionError(
+                f"scope '{entry}' names no database and no schema in "
+                f"{_name_list(searchable)}; schemas there: {_name_list(schemas)}; "
+                f"{self._visible_hint()}"
+            )
+        raise SnowflakeConnectionError(
+            f"scope '{entry}' is ambiguous: it names a schema in "
+            f"{_name_list(matches)}; qualify it as <database>.{token}"
         )
 
-    def _database_scope(self) -> list[str]:
-        """Distinct databases in scope; also the live credential probe (SHOW
-        DATABASES round-trips even when an allowlist is configured)."""
+    def _visible_hint(self) -> str:
+        return f"visible databases: {_name_list(sorted(self._databases()))}"
 
-        visible = {str(row["name"]).upper() for row in self._show("SHOW DATABASES")}
-        if not self.target.databases:
-            return sorted(visible - {"SNOWFLAKE"})
-        return sorted({entry.split(".")[0].upper() for entry in self.target.databases})
+    def _databases(self) -> set[str]:
+        """Every database the role can see. Free, and doubles as the live
+        credential probe: SHOW DATABASES fails on a stale or underprivileged
+        credential."""
+
+        if self._visible_databases is None:
+            self._visible_databases = {
+                str(row["name"]).upper() for row in self._show("SHOW DATABASES")
+            } - {_RESERVED_DATABASE}
+        return self._visible_databases
+
+    def _schemas(self, database: str) -> set[str]:
+        """Every source schema of one database. Free, and cached: a bare scope
+        entry searches several databases and must not re-ask for each."""
+
+        if database not in self._schemas_by_database:
+            rows = self._show(f"SHOW SCHEMAS IN DATABASE {_quote_ident(database)}")
+            self._schemas_by_database[database] = {
+                str(row["name"]).upper() for row in rows
+            } - {_RESERVED_SCHEMA}
+        return self._schemas_by_database[database]
+
+    def _database_scope(self) -> list[str]:
+        """Distinct databases across the resolved scopes."""
+
+        return sorted({scope.split(".")[0] for scope in self._scopes()})
+
+    def missing_dev_namespaces(self, database: str) -> list[str]:
+        """Which parts of a dbt dev target do not exist yet. Free: SHOW only.
+
+        dbt creates schemas but never databases, so ``dev_schema`` is deliberately
+        not checked: its absence is normal on a first build. A missing database is
+        fatal, and left to dbt it surfaces from the ``list_schemas`` macro as
+        ``002043: Object does not exist``, naming neither the database nor the fix.
+        The list shape (rather than a bool) is what the catalog-plus-schema
+        connectors will want when they grow the same preflight.
+        """
+
+        rows = self._show(f"SHOW DATABASES LIKE '{_escape_literal(database.upper())}'")
+        return [] if rows else [f'dev_database "{database}"']
 
     def _scope_clause(self, scope: str) -> str:
         if "." in scope:
@@ -831,6 +999,31 @@ class SnowflakeAdapter:
         close = getattr(self._conn, "close", None)
         if close is not None:
             close()
+
+
+def _name_list(names: list[str]) -> str:
+    """Names for an error message, capped so a thousand-schema account cannot
+    turn a one-line refusal into a page of stdout."""
+
+    shown = list(names)[:_SUGGESTION_CAP]
+    suffix = (
+        f", and {len(names) - _SUGGESTION_CAP} more"
+        if len(names) > _SUGGESTION_CAP
+        else ""
+    )
+    return (", ".join(shown) + suffix) if shown else "(none)"
+
+
+@contextmanager
+def _blame(origin: str):
+    """Attribute a scope failure to the thing the user has to go edit. The
+    resolver does not know whether an entry came from the committed allowlist or
+    from a flag, and the fix differs entirely."""
+
+    try:
+        yield
+    except SnowflakeConnectionError as exc:
+        raise SnowflakeConnectionError(f"{exc} [from {origin}]") from exc
 
 
 def _quote_ident(name: str) -> str:

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -57,9 +57,13 @@ def _sub_connection_options() -> argparse.ArgumentParser:
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--connector", default=argparse.SUPPRESS)
     common.add_argument("--path", default=argparse.SUPPRESS)
-    # BigQuery's equivalent of --path: a convenience smoke-test override for the
-    # project and dataset allowlist, so `connect test` works before a
-    # .dex/config.yml bigquery block exists. Nothing is written to config.
+    # The portable source-scope override, repeatable: each connector reads it in
+    # its own namespace vocabulary. Nothing is written to config, and a scope may
+    # only narrow a committed allowlist, never widen it.
+    common.add_argument("--scope", action="append", default=argparse.SUPPRESS)
+    # BigQuery's older spelling of --scope, kept because `connect test --project X
+    # --dataset Y` is how a BigQuery connection is smoke-tested before a
+    # .dex/config.yml bigquery block exists. Both error on other connectors.
     common.add_argument("--project", default=argparse.SUPPRESS)
     common.add_argument("--dataset", action="append", default=argparse.SUPPRESS)
     common.add_argument("--repo-root", default=argparse.SUPPRESS)
@@ -76,6 +80,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # Real defaults live on the top-level parser so every namespace has them.
     parser.add_argument("--connector", default=None)
     parser.add_argument("--path", default=None)
+    parser.add_argument("--scope", action="append", default=None)
     parser.add_argument("--project", default=None)
     parser.add_argument("--dataset", action="append", default=None)
     parser.add_argument("--repo-root", default=".")

--- a/packages/dex-core/src/exmergo_dex_core/command_args.py
+++ b/packages/dex-core/src/exmergo_dex_core/command_args.py
@@ -32,6 +32,7 @@ def open_from_args(args: argparse.Namespace) -> Adapter:
         path=getattr(args, "path", None),
         project=getattr(args, "project", None),
         datasets=getattr(args, "dataset", None),
+        scopes=getattr(args, "scope", None),
         repo_root=repo_root(args),
         budget=getattr(args, "budget", None),
         confirmed=getattr(args, "confirm", False),

--- a/packages/dex-core/src/exmergo_dex_core/connect.py
+++ b/packages/dex-core/src/exmergo_dex_core/connect.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import yaml
 
 from .adapters import get_adapter
+from .adapters.base import scope_within
 from .cache import DexStore
 from .config import (
     BigQueryTarget,
@@ -45,12 +46,36 @@ class CredentialDiscoveryError(Exception):
     names the command or config that fixes it, never a credential value."""
 
 
+class ScopeError(Exception):
+    """Raised when a source scope is not one this connector can honor: a flag it
+    does not speak, or an entry outside the committed allowlist. The message
+    always names the offending entry and the vocabulary that would work."""
+
+
+# Where each connector keeps its committed source allowlist, and how a `--scope`
+# entry reads in that connector's namespace vocabulary. DuckDB is absent because
+# it has no namespace to scope: the target is one file.
+_SCOPE_FIELDS = {
+    "bigquery": "datasets",
+    "snowflake": "databases",
+    "databricks": "catalogs",
+    "postgres": "schemas",
+}
+_SCOPE_GRAMMAR = {
+    "bigquery": "--scope <dataset> (or <project>.<dataset>)",
+    "snowflake": "--scope <schema>, <database>, or <database>.<schema>",
+    "databricks": "--scope <catalog> (or <catalog>.<schema>)",
+    "postgres": "--scope <schema>",
+}
+
+
 def open_adapter(
     *,
     connector: str | None = None,
     path: str | None = None,
     project: str | None = None,
     datasets: list[str] | None = None,
+    scopes: list[str] | None = None,
     repo_root: str | Path = ".",
     budget: float | None = None,
     confirmed: bool = False,
@@ -59,14 +84,19 @@ def open_adapter(
     """Resolve the connection target and return an open, read-only adapter.
 
     Resolution order: explicit arguments win, then ``.dex/config.yml``. For
-    DuckDB the only input is a file path; for BigQuery ``project``/``datasets``
-    are convenience overrides of the config target (never written back).
+    DuckDB the only input is a file path. ``scopes`` narrows the source
+    allowlist for this one command in every warehouse connector's own
+    vocabulary; ``project``/``datasets`` are BigQuery's older spelling of the
+    same idea. None of them are written back to config.
     ``budget``/``confirmed`` feed the cost gate on billed connectors and are
     ignored by free ones; ``command`` labels ledger entries.
     """
 
     config = load_config(repo_root) or DexConfig()
     connector = connector or config.connector
+    assert_scope_vocabulary(
+        connector, project=project, datasets=datasets, scopes=scopes
+    )
 
     if connector == "duckdb":
         resolved = path or (config.duckdb.path if config.duckdb else None)
@@ -84,25 +114,114 @@ def open_adapter(
             confirmed=confirmed,
             command=command,
             project_override=project,
-            dataset_override=datasets,
+            dataset_override=datasets or scopes,
         )
 
     if connector == "snowflake":
         return _open_snowflake(
-            config, repo_root, budget=budget, confirmed=confirmed, command=command
+            config,
+            repo_root,
+            budget=budget,
+            confirmed=confirmed,
+            command=command,
+            scope_override=scopes,
         )
 
     if connector == "databricks":
         return _open_databricks(
-            config, repo_root, budget=budget, confirmed=confirmed, command=command
+            config,
+            repo_root,
+            budget=budget,
+            confirmed=confirmed,
+            command=command,
+            scope_override=scopes,
         )
 
     if connector == "postgres":
         return _open_postgres(
-            config, repo_root, budget=budget, confirmed=confirmed, command=command
+            config,
+            repo_root,
+            budget=budget,
+            confirmed=confirmed,
+            command=command,
+            scope_override=scopes,
         )
 
     return get_adapter(connector)
+
+
+def assert_scope_vocabulary(
+    connector: str,
+    *,
+    project: str | None,
+    datasets: list[str] | None,
+    scopes: list[str] | None,
+) -> None:
+    """Refuse a scoping flag the connector cannot honor.
+
+    Accepted-and-ignored is strictly worse than rejected. A ``--dataset`` silently
+    dropped on Snowflake let a user confirm a budget believing it bounded an
+    eight-table schema, when the estimate in fact spanned billion-row tables
+    elsewhere in the allowlist. So the only two outcomes a scoping flag may have
+    are "honored" and "named in an error".
+    """
+
+    if connector == "duckdb":
+        for flag, value in (
+            ("--project", project),
+            ("--dataset", datasets),
+            ("--scope", scopes),
+        ):
+            if value:
+                raise ScopeError(
+                    f"{flag} does not apply to the duckdb connector: a DuckDB "
+                    "target is a single file, selected with --path"
+                )
+        return
+    if connector not in _SCOPE_FIELDS:
+        return
+    if connector != "bigquery":
+        for flag, value in (("--project", project), ("--dataset", datasets)):
+            if value:
+                raise ScopeError(
+                    f"{flag} is BigQuery vocabulary and has no meaning for the "
+                    f"{connector} connector; scope this command with "
+                    f"{_SCOPE_GRAMMAR[connector]}"
+                )
+        return
+    if datasets and scopes:
+        raise ScopeError(
+            "--dataset and --scope both scope a BigQuery command; pass one "
+            "(--scope is the spelling every connector understands)"
+        )
+
+
+def narrow_target(target, connector: str, scope_override: list[str] | None):
+    """Apply a ``--scope`` override to a connector target, in memory only.
+
+    A per-command scope must never rewrite the committed ``.dex/config.yml``, and
+    it may only narrow: a committed allowlist is a cost boundary, so a flag cannot
+    reach outside it. When nothing is committed, the override sets the allowlist,
+    which is what makes ``connect test --scope X`` work before a config block
+    exists.
+
+    Entries are matched textually here. Snowflake resolves bare schema names
+    against the account before it can test containment, so it narrows inside the
+    adapter and never reaches this function.
+    """
+
+    if not scope_override:
+        return target
+    field = _SCOPE_FIELDS[connector]
+    committed = [str(entry) for entry in getattr(target, field)]
+    outside = [s for s in scope_override if not scope_within(s, committed)]
+    if committed and outside:
+        raise ScopeError(
+            f"scope {', '.join(repr(s) for s in outside)} is outside the committed "
+            f"allowlist ({connector}.{field}: {', '.join(committed)}); --scope "
+            "narrows the configured scope, it never widens it"
+        )
+    return target.model_copy(update={field: list(scope_override)})
 
 
 def _open_bigquery(
@@ -116,15 +235,11 @@ def _open_bigquery(
     dataset_override: list[str] | None = None,
 ):
     target = config.bigquery or BigQueryTarget()
-    if project_override or dataset_override:
+    target = narrow_target(target, "bigquery", dataset_override)
+    if project_override:
         # A command-line override of the committed target, applied in memory
         # only: a smoke test should not silently rewrite .dex/config.yml.
-        updates: dict = {}
-        if project_override:
-            updates["project"] = project_override
-        if dataset_override:
-            updates["datasets"] = dataset_override
-        target = target.model_copy(update=updates)
+        target = target.model_copy(update={"project": project_override})
     credentials, adc_project, principal_type = _default_credentials()
     project = resolve_bigquery_project(
         target, os.environ, adc_project, repo_root=repo_root
@@ -167,6 +282,7 @@ def _open_snowflake(
     budget: float | None,
     confirmed: bool,
     command: str | None,
+    scope_override: list[str] | None = None,
 ):
     target = config.snowflake or SnowflakeTarget()
     params, method = resolve_snowflake_connection(target, os.environ, repo_root)
@@ -209,6 +325,10 @@ def _open_snowflake(
         target=target,
         account=str(params.get("account") or "") or None,
         auth_method=method,
+        # Not folded into the target: a bare `--scope TPCH_SF1` is a schema name
+        # that only the account can resolve to a database, so the adapter has to
+        # see the override and the committed allowlist as two separate things.
+        scope_override=scope_override,
     )
 
 
@@ -418,8 +538,10 @@ def _open_databricks(
     budget: float | None,
     confirmed: bool,
     command: str | None,
+    scope_override: list[str] | None = None,
 ):
     target = config.databricks or DatabricksTarget()
+    target = narrow_target(target, "databricks", scope_override)
 
     try:
         from databricks.sdk import WorkspaceClient
@@ -645,8 +767,10 @@ def _open_postgres(
     budget: float | None,
     confirmed: bool,
     command: str | None,
+    scope_override: list[str] | None = None,
 ):
     target = config.postgres or PostgresTarget()
+    target = narrow_target(target, "postgres", scope_override)
     params, method = resolve_postgres_connection(target, os.environ, repo_root)
 
     try:

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -228,6 +228,48 @@ def resolve_target(project_dir: Path | str, target: str | None = None) -> Target
     )
 
 
+# The only keys of a profile output that may leave this module. Every one is a
+# namespace identifier, not a credential: no user, account, host, password, token,
+# or key path is ever surfaced, so what comes back is always safe to put in an
+# envelope and show to the agent.
+_TARGET_IDENTIFIER_KEYS = frozenset(
+    {"type", "database", "schema", "warehouse", "dataset", "project", "catalog", "path"}
+)
+
+
+def target_identifiers(
+    project_dir: Path | str, target: str | None = None
+) -> dict[str, str]:
+    """The namespace a profiles.yml target writes to, and nothing else.
+
+    Where ``resolve_target`` answers "which adapter", this answers "which
+    database, schema, warehouse". It exists so the engine can compare the
+    rendered profile against ``.dex/config.yml`` and refuse a build whose config
+    has silently drifted out of the profile that actually governs it. Missing
+    profile or target yields ``{}``: the caller degrades to no check rather than
+    erroring on a project it cannot read.
+    """
+
+    project = Path(project_dir)
+    try:
+        view_profile = load(project).profile_name
+        profiles = _load_profiles(project)
+    except (DbtProjectError, yaml.YAMLError):
+        return {}
+    profile = profiles.get(view_profile)
+    if not isinstance(profile, dict):
+        return {}
+    outputs = profile.get("outputs") or {}
+    output = outputs.get(target or profile.get("target"))
+    if not isinstance(output, dict):
+        return {}
+    return {
+        key: str(value)
+        for key, value in output.items()
+        if key in _TARGET_IDENTIFIER_KEYS and value is not None
+    }
+
+
 def duckdb_target_path(
     project_dir: Path | str, target: str | None = None
 ) -> Path | None:

--- a/packages/dex-core/src/exmergo_dex_core/transform/build.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/build.py
@@ -26,13 +26,7 @@ from typing import Any
 
 import yaml
 
-from ..dbt_project import (
-    DbtProjectError,
-    Edit,
-    contained_path,
-    duckdb_target_path,
-    profiles_dir,
-)
+from ..dbt_project import DbtProjectError, Edit, contained_path, profiles_dir
 from ..dbt_project import load as load_project
 from ..envelope import Cost, Paradigm, redact
 from ..guards.cost_guard import preflight
@@ -93,15 +87,19 @@ def build(
     ceiling: float | None = None,
     confirmed: bool = False,
     paradigm: Paradigm = Paradigm.FREE_LOCAL,
+    dev_target_check: Callable[[], list[str]] | None = None,
     runner: Runner | None = None,
     timeout: float = _DBT_TIMEOUT_SECONDS,
 ) -> tuple[dict[str, Any], Cost]:
     """Run ``dbt build`` against a dev target, gated. Returns (summary, cost).
 
-    Refusal order is deliberate: the target check runs before the cost gate, so a
-    prod target is refused outright rather than merely unconfirmed. DuckDB spend
-    is zero (``FREE_LOCAL``) but the preflight still runs, so the confirmation
-    path is exercised on the free connector exactly as it will be on billed ones.
+    Refusal order is deliberate. The target check runs first, so a prod target is
+    refused outright rather than merely unconfirmed. ``dev_target_check`` runs
+    next, before the cost gate: it is free, and a dev target that has drifted or
+    does not exist makes the build impossible, so the user should learn that
+    instead of being asked to weigh a budget for a run that cannot succeed. It
+    returns warnings and raises to refuse; the callable is injected so the engine
+    stays independent of connection handling and testable without a warehouse.
 
     On a billed paradigm the estimate is honestly ``None``: dbt has no dry-run,
     so the engine cannot preflight the bytes a build will scan. The ceiling and
@@ -110,8 +108,6 @@ def build(
     """
 
     assert_dev_target(target, configured_target)
-    estimate = 0.0 if paradigm is Paradigm.FREE_LOCAL else None
-    cost = preflight(estimate, ceiling, paradigm=paradigm, confirmed=confirmed)
 
     if project_dir is None:
         raise DbtRunError("no dbt project directory resolved for the build")
@@ -120,7 +116,10 @@ def build(
     # double (dbt would look for project/project and fail).
     project = Path(project_dir).resolve()
 
-    seeding_warning = _check_dev_database(project, target)
+    target_warnings = dev_target_check() if dev_target_check is not None else []
+
+    estimate = 0.0 if paradigm is Paradigm.FREE_LOCAL else None
+    cost = preflight(estimate, ceiling, paradigm=paradigm, confirmed=confirmed)
 
     # Most real projects carry a packages.yml, and dbt refuses to compile until
     # its packages are installed; running deps here (post-gate) means the first
@@ -164,48 +163,11 @@ def build(
     summary = _summarize(project, target, completed)
     if deps_ran:
         summary["deps"] = {"ran": True, "success": True}
-    if seeding_warning:
-        # A note, not a failure cause: kept out of `messages`, whose first entry
+    if target_warnings:
+        # Notes, not failure causes: kept out of `messages`, whose first entry
         # is promoted to the envelope's error line on failure.
-        summary["notes"] = [seeding_warning]
+        summary["notes"] = list(target_warnings)
     return summary, cost
-
-
-def _check_dev_database(project: Path, target: str) -> str | None:
-    """Catch the missing-dev-database failure mode before dbt does.
-
-    A duckdb target whose file does not exist yet is legitimate when the project
-    builds everything from models, but a project reading from ``sources:`` would
-    get a fresh empty database and then fail every source relation with a
-    confusing catalog error. That case is refused with the seeding step spelled
-    out; the source-less case only warns.
-    """
-
-    db_path = duckdb_target_path(project, target)
-    if db_path is None or db_path.exists():
-        return None
-    if _declares_sources(project):
-        raise DbtRunError(
-            f"the dev target database {db_path} does not exist and the project "
-            "reads from sources; seed it before building (for example copy the "
-            f"source warehouse: cp <source>.duckdb {db_path}), or point the dev "
-            "target at an existing database file"
-        )
-    return f"dev target database {db_path} does not exist; dbt will create an empty one"
-
-
-def _declares_sources(project: Path) -> bool:
-    view = load_project(project)
-    for source in view.files.values():
-        if not source.path.endswith((".yml", ".yaml")):
-            continue
-        try:
-            parsed = yaml.safe_load(source.content)
-        except yaml.YAMLError:
-            continue
-        if isinstance(parsed, dict) and parsed.get("sources"):
-            return True
-    return False
 
 
 def shadow_parse(

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -137,6 +137,7 @@ def cmd_build(args: argparse.Namespace) -> env.Envelope:
     # `from .build import ...` rather than `from . import build`: the package
     # re-exports the build *function* under the same name as the module, and the
     # submodule-path form resolves the module unambiguously.
+    from . import dev_target
     from .build import build as run_build
 
     repo_root = command_args.repo_root(args)
@@ -152,15 +153,23 @@ def cmd_build(args: argparse.Namespace) -> env.Envelope:
         "postgres": Paradigm.DB_LOAD,
     }.get(connector, Paradigm.FREE_LOCAL)
 
+    project = command_args.project_dir(args)
+    # A --connector flag governs this build, so the drift check must compare the
+    # profile against that connector's config block, not the committed default.
+    effective = config.model_copy(update={"connector": connector})
+
     try:
         summary, cost = run_build(
-            command_args.project_dir(args),
+            project,
             target=target,
             configured_target=config.dbt_target,
             select=getattr(args, "select", None),
             ceiling=ceiling,
             confirmed=bool(getattr(args, "confirm", False)),
             paradigm=paradigm,
+            dev_target_check=lambda: dev_target.check(
+                project, target, effective, repo_root
+            ),
         )
     except ConfirmationRequiredError as exc:
         return env.needs_confirmation(

--- a/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
@@ -1,0 +1,231 @@
+"""Whether the dev target a build is about to use is coherent and reachable.
+
+Two failures put a build on the wrong footing before dbt ever runs, and dbt
+reports neither of them well.
+
+The first is drift. ``transform init`` renders ``.dex/config.yml`` into
+``profiles.yml``, and from then on the profile is what dbt reads. Editing the
+config afterwards changes nothing, so a user who retargets their dev database
+gets a green build against the old one. dex asks you to author that config file,
+so it has to be live or say plainly that it is not.
+
+The second is absence. dbt creates schemas but never databases, so a dev database
+that does not exist yet fails somewhere inside dbt's ``list_schemas`` macro with
+``002043: Object does not exist``, a message that names neither the database nor
+the fix.
+
+Both are refusals, not warnings, and both are free: the drift check reads two
+files, and the existence check rides the connector's free metadata path. They run
+before the cost gate, so a build that cannot possibly succeed is refused before
+anyone is asked to weigh a budget. Neither ever rewrites ``profiles.yml``: a
+hand-edited profile is a legitimate thing to have, and dex proposes rather than
+imposes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from ..cache import DEX_DIR
+from ..config import CONFIG_FILE, DexConfig
+from ..dbt_project import PROFILES_FILE, duckdb_target_path, target_identifiers
+from ..dbt_project import load as load_project
+
+
+class DevTargetError(Exception):
+    """Raised when the dev target cannot be built against. The message always
+    names both of the values that disagree, or the statement that fixes it."""
+
+
+# Per connector, the config fields that must agree with the profile keys they were
+# rendered into, and whether the connector folds identifier case. Only fields the
+# user actually set are compared, so an unset config field never reads as drift.
+_DRIFT_FIELDS: dict[str, tuple[tuple[str, str, str], ...]] = {
+    # (config attribute, config key path for the message, profiles.yml key)
+    "snowflake": (
+        ("dev_database", "snowflake.dev_database", "database"),
+        ("dev_schema", "snowflake.dev_schema", "schema"),
+        ("warehouse", "snowflake.warehouse", "warehouse"),
+    ),
+    "bigquery": (
+        ("dev_dataset", "bigquery.dev_dataset", "dataset"),
+        ("project", "bigquery.project", "project"),
+    ),
+    "databricks": (
+        ("dev_catalog", "databricks.dev_catalog", "catalog"),
+        ("dev_schema", "databricks.dev_schema", "schema"),
+    ),
+    "postgres": (("dev_schema", "postgres.dev_schema", "schema"),),
+    "duckdb": (("path", "duckdb.path", "path"),),
+}
+
+# Connectors whose identifiers are case-insensitive, so DBT_DEV and dbt_dev are
+# the same namespace and must not be reported as drift.
+_CASE_FOLDING = {"snowflake"}
+
+
+def check(
+    project_dir: Path | str,
+    target: str,
+    config: DexConfig,
+    repo_root: Path | str = ".",
+) -> list[str]:
+    """Refuse a dev target that has drifted or does not exist. Returns warnings.
+
+    Raises :class:`DevTargetError` on a refusal. Anything it cannot check (an
+    unreadable profile, a connector with no preflight yet) is not a refusal:
+    absence of evidence stays absence of evidence, and dbt's own error remains
+    the backstop.
+    """
+
+    project = Path(project_dir)
+    profile = target_identifiers(project, target)
+    _assert_no_drift(project, target, config, profile, repo_root)
+    return _assert_namespace_exists(project, target, config, repo_root)
+
+
+def _assert_no_drift(
+    project: Path,
+    target: str,
+    config: DexConfig,
+    profile: dict[str, str],
+    repo_root: Path | str,
+) -> None:
+    if not profile:
+        return
+    config_rel = f"{DEX_DIR}/{CONFIG_FILE}"
+    profile_rel = _relative(project / PROFILES_FILE, repo_root)
+
+    profile_type = profile.get("type")
+    if profile_type and profile_type != config.connector:
+        raise DevTargetError(
+            f"{config_rel} and {profile_rel} disagree about the connector: "
+            f"config.yml says connector: {config.connector}, {PROFILES_FILE} "
+            f"target '{target}' says type: {profile_type}; edit one to match the "
+            "other (dex never rewrites a profile you may have hand-edited)"
+        )
+
+    target_config = getattr(config, config.connector, None)
+    if target_config is None:
+        return
+    fold = config.connector in _CASE_FOLDING
+    divergent = []
+    for attribute, config_key, profile_key in _DRIFT_FIELDS.get(config.connector, ()):
+        # An unset config field was never a claim about the dev target, so it
+        # cannot have drifted away from one.
+        if attribute not in target_config.model_fields_set:
+            continue
+        want = getattr(target_config, attribute, None)
+        got = profile.get(profile_key)
+        if want is None or got is None:
+            continue
+        if (str(want).upper() == got.upper()) if fold else (str(want) == got):
+            continue
+        divergent.append(
+            f"  {config_key}: {want}\n  {PROFILES_FILE} {target}.{profile_key}: {got}"
+        )
+    if divergent:
+        raise DevTargetError(
+            f"{config_rel} and {profile_rel} disagree about the dev target:\n"
+            + "\n".join(divergent)
+            + "\nedit one to match the other, then re-run (dex never rewrites a "
+            "profile you may have hand-edited)"
+        )
+
+
+def _assert_namespace_exists(
+    project: Path, target: str, config: DexConfig, repo_root: Path | str
+) -> list[str]:
+    if config.connector == "duckdb":
+        return _duckdb_namespace(project, target)
+    if config.connector == "snowflake":
+        return _snowflake_namespace(config, repo_root)
+    # BigQuery, Databricks, and Postgres have the same gap: nothing checks that
+    # the dev dataset/catalog/schema exists, or that the principal may write it.
+    # Each needs its own free probe; until then dbt's error is the only signal.
+    return []
+
+
+def _duckdb_namespace(project: Path, target: str) -> list[str]:
+    """A duckdb target whose file does not exist yet is legitimate when the
+    project builds everything from models, but a project reading from ``sources:``
+    would get a fresh empty database and then fail every source relation with a
+    confusing catalog error. That case is refused with the seeding step spelled
+    out; the source-less case only warns."""
+
+    db_path = duckdb_target_path(project, target)
+    if db_path is None or db_path.exists():
+        return []
+    if _declares_sources(project):
+        raise DevTargetError(
+            f"the dev target database {db_path} does not exist and the project "
+            "reads from sources; seed it before building (for example copy the "
+            f"source warehouse: cp <source>.duckdb {db_path}), or point the dev "
+            "target at an existing database file"
+        )
+    return [
+        f"dev target database {db_path} does not exist; dbt will create an empty one"
+    ]
+
+
+def _snowflake_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
+    """Free: SHOW only, no warehouse, so this costs nothing on a billed connector.
+
+    dex discovers its own connection (connections.toml, the environment) while dbt
+    reads ``profiles.yml``, and the two can legitimately differ, so a connection
+    dex cannot open is reported as a warning rather than raised: the preflight
+    must never be the thing that breaks a build dbt could have run.
+    """
+
+    target = config.snowflake
+    if target is None or not target.dev_database:
+        return []
+
+    from ..connect import open_adapter
+
+    try:
+        adapter = open_adapter(connector="snowflake", repo_root=repo_root)
+    except Exception as exc:  # degrade to a note; never block a build dbt could run
+        # The exception class rides along: silently degrading is how a real defect
+        # in the preflight would go unnoticed for a long time.
+        return [
+            "could not preflight the dev database "
+            f"({type(exc).__name__}: {exc}); dbt will report any problem with it"
+        ]
+    try:
+        missing = adapter.missing_dev_namespaces(target.dev_database)
+    finally:
+        adapter.close()
+
+    if not missing:
+        return []
+    raise DevTargetError(
+        f"snowflake {missing[0]} does not exist; create it with:\n"
+        f"  CREATE DATABASE IF NOT EXISTS {target.dev_database};\n"
+        "(dbt creates schemas but never databases, so the first build cannot "
+        "create it), or point snowflake.dev_database at a database the role "
+        "can write"
+    )
+
+
+def _declares_sources(project: Path) -> bool:
+    view = load_project(project)
+    for source in view.files.values():
+        if not source.path.endswith((".yml", ".yaml")):
+            continue
+        try:
+            parsed = yaml.safe_load(source.content)
+        except yaml.YAMLError:
+            continue
+        if isinstance(parsed, dict) and parsed.get("sources"):
+            return True
+    return False
+
+
+def _relative(path: Path, repo_root: Path | str) -> str:
+    try:
+        return str(path.resolve().relative_to(Path(repo_root).resolve()))
+    except ValueError:
+        return str(path)

--- a/packages/dex-core/tests/adapters/test_connect_snowflake.py
+++ b/packages/dex-core/tests/adapters/test_connect_snowflake.py
@@ -37,6 +37,7 @@ def make_adapter(
     session_spent: float = 0.0,
     record=None,
     target: SnowflakeTarget | None = None,
+    scope_override: list[str] | None = None,
 ) -> SnowflakeAdapter:
     gate = CostGate(
         paradigm=Paradigm.COMPUTE_TIME,
@@ -54,6 +55,7 @@ def make_adapter(
         target=target or SnowflakeTarget(warehouse="DEX_WH"),
         account="TESTORG-TESTACCT",
         auth_method="named_connection:key_pair",
+        scope_override=scope_override,
         clock=connection.clock,
     )
 
@@ -588,3 +590,247 @@ def test_connections_toml_parsing(tmp_path: Path):
     assert connections["dex-ci"]["user"] == "DEX_DEV"
     assert connections["admin"]["user"] == "ADMIN"
     assert connections["__default__"] == "dex-ci"
+
+
+# --- scope resolution: honored or named in an error, never dropped -----------------
+
+
+@pytest.fixture
+def multi_db_connection():
+    """Two source databases that share a PUBLIC schema, plus an empty scratch
+    database. Enough to exercise qualification, ambiguity, and the dev-target
+    preflight, and modeled on the shape that made `--dataset` dangerous: one
+    database holding schemas of wildly different size."""
+
+    from fakes.snowflake import (
+        FakeSnowflakeConnection,
+        FakeSnowflakeTable,
+        FakeWarehouse,
+    )
+
+    def table(database, schema, name, size):
+        return FakeSnowflakeTable(
+            database=database,
+            schema=schema,
+            name=name,
+            columns=[("ID", "FIXED", False)],
+            rows=10,
+            bytes=size,
+        )
+
+    return FakeSnowflakeConnection(
+        tables=[
+            table("SAMPLE", "TPCH_SF1", "ORDERS", 1_000_000),
+            table("SAMPLE", "TPCH_SF1", "CUSTOMER", 1_000_000),
+            table("SAMPLE", "TPCDS_SF100TCL", "STORE_SALES", 900_000_000_000),
+            table("SAMPLE", "PUBLIC", "SHARED", 1_000),
+            table("RAW", "PUBLIC", "EVENTS", 1_000),
+            table("RAW", "STAGING", "SEEDS", 1_000),
+        ],
+        warehouses=[FakeWarehouse(name="DEX_WH", size="X-Small", state="SUSPENDED")],
+        empty_databases=["DBT_DEV"],
+    )
+
+
+def _scoped_identifiers(adapter) -> list[str]:
+    return [o.identifier for o in adapter.list_objects()]
+
+
+def test_qualified_scope_bounds_the_inventory(multi_db_connection):
+    adapter = make_adapter(
+        multi_db_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=["SAMPLE"]),
+        scope_override=["SAMPLE.TPCH_SF1"],
+    )
+    assert _scoped_identifiers(adapter) == [
+        "SAMPLE.TPCH_SF1.CUSTOMER",
+        "SAMPLE.TPCH_SF1.ORDERS",
+    ]
+
+
+def test_bare_schema_scope_qualifies_against_the_allowlist(multi_db_connection):
+    """The exact spelling the field report used: `--scope TPCH_SF1`, no database.
+
+    It must resolve to SAMPLE.TPCH_SF1 and bound the estimate to those two
+    tables, never silently span the 900 GB TPCDS schema next door.
+    """
+
+    adapter = make_adapter(
+        multi_db_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=["SAMPLE"]),
+        scope_override=["TPCH_SF1"],
+    )
+    assert _scoped_identifiers(adapter) == [
+        "SAMPLE.TPCH_SF1.CUSTOMER",
+        "SAMPLE.TPCH_SF1.ORDERS",
+    ]
+
+
+def test_bare_database_scope_is_a_database_scope(multi_db_connection):
+    adapter = make_adapter(
+        multi_db_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=["SAMPLE", "RAW"]),
+        scope_override=["RAW"],
+    )
+    assert _scoped_identifiers(adapter) == [
+        "RAW.PUBLIC.EVENTS",
+        "RAW.STAGING.SEEDS",
+    ]
+
+
+def test_nonexistent_schema_scope_is_refused_and_names_what_exists(multi_db_connection):
+    """The bug from the field report: this used to be accepted and dropped, and
+    the estimate silently covered the whole allowlist."""
+
+    adapter = make_adapter(
+        multi_db_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=["SAMPLE"]),
+        scope_override=["__NONEXISTENT_SCHEMA__"],
+    )
+    with pytest.raises(SnowflakeConnectionError) as exc:
+        adapter.list_objects()
+    message = str(exc.value)
+    assert "__NONEXISTENT_SCHEMA__" in message
+    assert "TPCH_SF1" in message and "TPCDS_SF100TCL" in message
+    assert "[from --scope]" in message
+    # Free: refusal never reaches a warehouse.
+    assert data_statements(multi_db_connection) == []
+
+
+def test_nonexistent_qualified_schema_names_the_database_and_its_schemas(
+    multi_db_connection,
+):
+    adapter = make_adapter(
+        multi_db_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=["SAMPLE"]),
+        scope_override=["SAMPLE.__NOPE__"],
+    )
+    with pytest.raises(SnowflakeConnectionError) as exc:
+        adapter.list_objects()
+    assert "database SAMPLE has no schema __NOPE__" in str(exc.value)
+
+
+def test_nonexistent_database_scope_is_refused(multi_db_connection):
+    adapter = make_adapter(
+        multi_db_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH"),
+        scope_override=["__NO_DB__.PUBLIC"],
+    )
+    with pytest.raises(SnowflakeConnectionError) as exc:
+        adapter.list_objects()
+    assert "names no database this role can see" in str(exc.value)
+    assert "SAMPLE" in str(exc.value)
+
+
+def test_ambiguous_bare_schema_demands_qualification(multi_db_connection):
+    adapter = make_adapter(
+        multi_db_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=["SAMPLE", "RAW"]),
+        scope_override=["PUBLIC"],
+    )
+    with pytest.raises(SnowflakeConnectionError) as exc:
+        adapter.list_objects()
+    message = str(exc.value)
+    assert "ambiguous" in message
+    assert "qualify it as <database>.PUBLIC" in message
+
+
+def test_scope_cannot_widen_the_committed_allowlist(multi_db_connection):
+    """The cost boundary: `snowflake.databases` is committed to the repo, so a
+    per-command flag must not reach the 900 GB schema it deliberately excludes."""
+
+    adapter = make_adapter(
+        multi_db_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=["SAMPLE.TPCH_SF1"]),
+        scope_override=["SAMPLE.TPCDS_SF100TCL"],
+    )
+    with pytest.raises(SnowflakeConnectionError) as exc:
+        adapter.list_objects()
+    message = str(exc.value)
+    assert "outside the committed allowlist" in message
+    assert "never widens" in message
+    assert data_statements(multi_db_connection) == []
+
+
+def test_committed_allowlist_entry_that_does_not_exist_is_blamed_on_config(
+    multi_db_connection,
+):
+    adapter = make_adapter(
+        multi_db_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=["SAMPLE.__GONE__"]),
+    )
+    with pytest.raises(SnowflakeConnectionError) as exc:
+        adapter.list_objects()
+    assert "[from snowflake.databases in .dex/config.yml]" in str(exc.value)
+
+
+def test_connect_test_validates_the_scope_for_free(multi_db_connection):
+    """capabilities() resolves scopes, so `connect test --scope <bad>` fails
+    before any command that would spend."""
+
+    adapter = make_adapter(
+        multi_db_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=["SAMPLE"]),
+        scope_override=["__NOPE__"],
+    )
+    with pytest.raises(SnowflakeConnectionError):
+        adapter.capabilities()
+    assert data_statements(multi_db_connection) == []
+
+
+def test_information_schema_is_never_a_scope(multi_db_connection):
+    adapter = make_adapter(
+        multi_db_connection,
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=["SAMPLE"]),
+        scope_override=["INFORMATION_SCHEMA"],
+    )
+    with pytest.raises(SnowflakeConnectionError):
+        adapter.list_objects()
+
+
+# --- the dev-target preflight (free) ----------------------------------------------
+
+
+def test_missing_dev_database_is_reported(multi_db_connection):
+    adapter = make_adapter(multi_db_connection)
+    assert adapter.missing_dev_namespaces("NOT_THERE") == ['dev_database "NOT_THERE"']
+    assert data_statements(multi_db_connection) == []
+
+
+def test_existing_but_empty_dev_database_is_fine(multi_db_connection):
+    """dbt creates the schema; only the database has to pre-exist. An empty
+    scratch database is exactly the state before a first build."""
+
+    adapter = make_adapter(multi_db_connection)
+    assert adapter.missing_dev_namespaces("DBT_DEV") == []
+    assert data_statements(multi_db_connection) == []
+
+
+def test_bare_schema_on_a_wide_open_account_asks_for_qualification(monkeypatch):
+    """Qualifying a bare schema costs one free SHOW SCHEMAS per candidate
+    database. On an account with hundreds, dex asks rather than round-trips."""
+
+    from fakes.snowflake import (
+        FakeSnowflakeConnection,
+        FakeSnowflakeTable,
+        FakeWarehouse,
+    )
+
+    connection = FakeSnowflakeConnection(
+        tables=[
+            FakeSnowflakeTable(
+                database=f"DB{i:03d}",
+                schema="RAW",
+                name="T",
+                columns=[("ID", "FIXED", True)],
+            )
+            for i in range(30)
+        ],
+        warehouses=[FakeWarehouse(name="DEX_WH")],
+    )
+    adapter = make_adapter(connection, scope_override=["RAW"])
+    with pytest.raises(SnowflakeConnectionError) as exc:
+        adapter.list_objects()
+    message = str(exc.value)
+    assert "30 databases" in message
+    assert "qualify it as <database>.RAW" in message

--- a/packages/dex-core/tests/adapters/test_scope_flags.py
+++ b/packages/dex-core/tests/adapters/test_scope_flags.py
@@ -1,0 +1,120 @@
+"""The scoping flags: honored, or named in an error. Never accepted and dropped.
+
+A `--dataset` silently discarded on Snowflake let a confirm handshake quote an
+estimate spanning tables the user never asked for, so the rule is that every
+scoping flag either scopes the command or refuses it. These tests pin the
+vocabulary each connector speaks and the narrow-only rule that keeps a committed
+allowlist a real cost boundary. Nothing here opens a connection.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from exmergo_dex_core.config import (
+    BigQueryTarget,
+    DatabricksTarget,
+    PostgresTarget,
+)
+from exmergo_dex_core.connect import ScopeError, assert_scope_vocabulary, narrow_target
+
+
+def _assert(connector, *, project=None, datasets=None, scopes=None):
+    assert_scope_vocabulary(
+        connector, project=project, datasets=datasets, scopes=scopes
+    )
+
+
+# --- vocabulary --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("connector", ["snowflake", "databricks", "postgres"])
+@pytest.mark.parametrize(
+    ("flag", "kwargs"),
+    [("--project", {"project": "p"}), ("--dataset", {"datasets": ["d"]})],
+)
+def test_bigquery_flags_are_refused_on_other_connectors(connector, flag, kwargs):
+    with pytest.raises(ScopeError) as exc:
+        _assert(connector, **kwargs)
+    message = str(exc.value)
+    assert flag in message
+    assert connector in message
+    # The error has to name the flag that would have worked.
+    assert "--scope" in message
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"project": "p"}, {"datasets": ["d"]}, {"scopes": ["s"]}],
+)
+def test_duckdb_refuses_every_scope_flag(kwargs):
+    with pytest.raises(ScopeError) as exc:
+        _assert("duckdb", **kwargs)
+    assert "--path" in str(exc.value)
+
+
+def test_bigquery_accepts_its_own_flags():
+    _assert("bigquery", project="p", datasets=["analytics"])
+
+
+@pytest.mark.parametrize(
+    "connector", ["bigquery", "snowflake", "databricks", "postgres"]
+)
+def test_scope_is_accepted_on_every_warehouse_connector(connector):
+    _assert(connector, scopes=["analytics"])
+
+
+def test_bigquery_refuses_dataset_and_scope_together():
+    with pytest.raises(ScopeError) as exc:
+        _assert("bigquery", datasets=["a"], scopes=["b"])
+    assert "pass one" in str(exc.value)
+
+
+def test_no_flags_is_always_fine():
+    for connector in ("duckdb", "bigquery", "snowflake", "databricks", "postgres"):
+        _assert(connector)
+
+
+# --- narrow, never widen -------------------------------------------------------------
+
+
+def test_scope_sets_the_allowlist_when_none_is_committed():
+    """This is what makes `connect test --scope X` work before a config block
+    exists, which is the reason the BigQuery flags were introduced."""
+
+    target = narrow_target(BigQueryTarget(), "bigquery", ["analytics"])
+    assert target.datasets == ["analytics"]
+
+
+def test_scope_narrows_a_committed_allowlist():
+    target = narrow_target(
+        DatabricksTarget(catalogs=["prod", "raw"]), "databricks", ["raw.events"]
+    )
+    assert target.catalogs == ["raw.events"]
+
+
+def test_scope_outside_the_committed_allowlist_is_refused():
+    with pytest.raises(ScopeError) as exc:
+        narrow_target(BigQueryTarget(datasets=["analytics"]), "bigquery", ["billing"])
+    message = str(exc.value)
+    assert "billing" in message
+    assert "bigquery.datasets: analytics" in message
+    assert "never widens" in message
+
+
+def test_containment_is_case_insensitive():
+    """A case mismatch is not an escape attempt: the connectors disagree about
+    identifier case, and Postgres folds to lower while Snowflake folds to upper."""
+
+    target = narrow_target(PostgresTarget(schemas=["Public"]), "postgres", ["public"])
+    assert target.schemas == ["public"]
+
+
+def test_a_coarser_scope_cannot_escape_a_finer_allowlist():
+    with pytest.raises(ScopeError):
+        narrow_target(DatabricksTarget(catalogs=["raw.events"]), "databricks", ["raw"])
+
+
+def test_no_override_leaves_the_target_untouched():
+    committed = BigQueryTarget(datasets=["analytics"])
+    assert narrow_target(committed, "bigquery", None) is committed

--- a/packages/dex-core/tests/fakes/snowflake.py
+++ b/packages/dex-core/tests/fakes/snowflake.py
@@ -13,6 +13,7 @@ ordering, session state, ledger effects), not call signatures.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -21,6 +22,21 @@ from snowflake.connector import errors as sf_errors
 
 # Statements with no registered duration run this long on the fake clock.
 DEFAULT_STATEMENT_SECONDS = 0.5
+
+
+def _object_does_not_exist() -> sf_errors.ProgrammingError:
+    """What the service actually says when a SHOW names a database or schema that
+    is not there. Verbatim, because the whole point of dex's scope resolver is
+    that this message names neither the object nor the fix, and a fake that
+    quietly returned no rows here would hide the bug being guarded against."""
+
+    return sf_errors.ProgrammingError(
+        msg=(
+            "002043 (02000): SQL compilation error: Object does not exist, or "
+            "operation cannot be performed."
+        ),
+        errno=2043,
+    )
 
 
 class FakeClock:
@@ -171,8 +187,25 @@ class FakeCursor:
     def _serve_show(self, sql: str) -> None:
         upper = sql.strip().upper()
         if upper.startswith("SHOW DATABASES"):
-            names = sorted({t.database for t in self._conn.tables})
+            like = self._like_pattern(sql)
+            names = sorted(
+                name
+                for name in self._conn.databases
+                if like is None or name.upper() == like.upper()
+            )
             self._emit([{"name": name} for name in names])
+        elif upper.startswith("SHOW SCHEMAS"):
+            like = self._like_pattern(sql)
+            names = sorted(
+                {t.schema for t in self._scoped(sql)} | {"INFORMATION_SCHEMA"}
+            )
+            self._emit(
+                [
+                    {"name": name}
+                    for name in names
+                    if like is None or name.upper() == like.upper()
+                ]
+            )
         elif upper.startswith("SHOW WAREHOUSES"):
             like = self._like_pattern(sql)
             rows = [
@@ -226,6 +259,12 @@ class FakeCursor:
         if " IN SCHEMA " in upper:
             scope = sql[upper.index(" IN SCHEMA ") + len(" IN SCHEMA ") :].strip()
             db, schema = (part.strip('"') for part in scope.split(".", 1))
+            if db.upper() not in {d.upper() for d in self._conn.databases}:
+                raise _object_does_not_exist()
+            if schema.upper() not in {
+                t.schema.upper() for t in tables if t.database.upper() == db.upper()
+            }:
+                raise _object_does_not_exist()
             return [
                 t
                 for t in tables
@@ -235,6 +274,8 @@ class FakeCursor:
         if " IN DATABASE " in upper:
             scope = sql[upper.index(" IN DATABASE ") + len(" IN DATABASE ") :].strip()
             db = scope.strip('"')
+            if db.upper() not in {d.upper() for d in self._conn.databases}:
+                raise _object_does_not_exist()
             return [t for t in tables if t.database.upper() == db.upper()]
         if " IN TABLE " in upper:
             scope = sql[upper.index(" IN TABLE ") + len(" IN TABLE ") :].strip()
@@ -244,10 +285,10 @@ class FakeCursor:
 
     @staticmethod
     def _like_pattern(sql: str) -> str | None:
-        upper = sql.upper()
-        if "LIKE" not in upper:
-            return None
-        return sql[upper.index("LIKE") + 4 :].strip().strip("'")
+        # Only the quoted literal, so a trailing `IN DATABASE x` never leaks into
+        # the pattern the way a naive split on LIKE would let it.
+        match = re.search(r"\bLIKE\s+'([^']*)'", sql, re.IGNORECASE)
+        return match.group(1) if match else None
 
     def _emit(self, rows: list[dict]) -> None:
         keys = list(rows[0].keys()) if rows else ["name"]
@@ -268,8 +309,15 @@ class FakeSnowflakeConnection:
         clock: FakeClock | None = None,
         row_resolver: Callable[[str], FakeResult | list[dict]] | None = None,
         resume_seconds: float = 60.0,
+        empty_databases: list[str] | None = None,
     ):
         self.tables = tables or []
+        # Databases exist independently of their contents. `empty_databases` is
+        # how a scratch database that holds nothing yet gets modeled, which is
+        # exactly the state a dbt dev target is in before its first build.
+        self.databases = sorted(
+            {t.database for t in self.tables} | set(empty_databases or [])
+        )
         self.warehouses = warehouses or [FakeWarehouse(name="DEX_WH")]
         self.clock = clock or FakeClock()
         self.row_resolver = row_resolver

--- a/packages/dex-core/tests/integration/test_snowflake_explore.py
+++ b/packages/dex-core/tests/integration/test_snowflake_explore.py
@@ -152,3 +152,94 @@ def test_firewalled_query_round_trip(
     assert rc == 0, envelope
     assert envelope["data"]["cells"] == [[5]]
     assert envelope["data"]["spend"]["seconds_billed"] >= 0
+
+
+def test_scope_bounds_the_estimate_to_the_named_schema(
+    tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
+):
+    """A scope that is honored bounds the spend. The committed allowlist here is
+    the whole sample database, which spans four orders of magnitude in table size;
+    `--scope TPCH_SF1` must quote an estimate for those eight tables alone.
+    """
+
+    seed_repo(
+        tmp_path,
+        sf_scratch_database,
+        sf_warehouse,
+        sf_connection_name,
+        databases=["SNOWFLAKE_SAMPLE_DATA"],
+    )
+    root = str(tmp_path)
+    rc, scoped = run_cli(
+        ["--repo-root", root, "explore", "map", "--scope", "TPCH_SF1"], capsys
+    )
+    assert rc == 0, scoped
+    assert scoped["status"] == "needs_confirmation"
+    per_table = scoped["data"]["per_table_seconds"]
+    assert {ident.split(".")[1] for ident in per_table} == {"TPCH_SF1"}
+    assert len(per_table) == 8
+
+    rc, unscoped = run_cli(["--repo-root", root, "explore", "map"], capsys)
+    assert rc == 0, unscoped
+    # The whole point: scoping is worth orders of magnitude, and before this was
+    # honored both calls returned the same estimate.
+    assert scoped["cost"]["estimate"] < unscoped["cost"]["estimate"] / 1000
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
+
+
+def test_bogus_scope_is_refused_for_free(
+    tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
+):
+    seed_repo(
+        tmp_path,
+        sf_scratch_database,
+        sf_warehouse,
+        sf_connection_name,
+        databases=["SNOWFLAKE_SAMPLE_DATA"],
+    )
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "explore",
+            "map",
+            "--scope",
+            "__NONEXISTENT_SCHEMA__",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert envelope["status"] == "error"
+    error = envelope["errors"][0]
+    assert "__NONEXISTENT_SCHEMA__" in error
+    # The refusal names what does exist, which the raw 002043 never did.
+    assert "TPCH_SF1" in error
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
+
+
+def test_scope_cannot_widen_the_committed_allowlist_live(
+    tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
+):
+    """The committed allowlist keeps the ~170 GB SF1000 schema out of reach; a
+    flag must not be able to pull it back in."""
+
+    seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
+    rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "map", "--scope", HUGE_SCOPE], capsys
+    )
+    assert rc == 1
+    assert "never widens" in envelope["errors"][0]
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
+
+
+def test_bigquery_flags_are_refused_on_snowflake(
+    tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
+):
+    seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
+    rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "map", "--dataset", "TPCH_SF1"],
+        capsys,
+    )
+    assert rc == 1
+    assert "--dataset" in envelope["errors"][0]
+    assert "--scope" in envelope["errors"][0]

--- a/packages/dex-core/tests/integration/test_snowflake_transform.py
+++ b/packages/dex-core/tests/integration/test_snowflake_transform.py
@@ -125,3 +125,74 @@ def test_init_plan_apply_build_into_the_scratch_database(
         cursor.execute(f"DROP VIEW IF EXISTS {relation}")
     finally:
         conn.close()
+
+
+def test_missing_dev_database_is_refused_before_the_cost_gate(
+    tmp_path: Path, capsys, sf_warehouse, sf_connection_name
+):
+    """dbt creates schemas but never databases, so a `dev_database` that does not
+    exist used to die inside dbt's `list_schemas` macro with an opaque
+    `002043: Object does not exist`. The preflight is free and runs before the
+    confirm handshake, so this refuses without `--confirm` and without spend."""
+
+    pytest.importorskip("dbt.adapters.snowflake")
+    root = str(tmp_path)
+    seed_repo(tmp_path, "DEX_NO_SUCH_DEV_DATABASE", sf_warehouse, sf_connection_name)
+
+    rc, envelope = run_cli(
+        ["--repo-root", root, "transform", "init", "analytics"], capsys
+    )
+    assert rc == 0, envelope
+
+    rc, envelope = run_cli(
+        ["--repo-root", root, "transform", "build", "--target", "dev"], capsys
+    )
+    assert rc == 1
+    assert envelope["status"] == "error"
+    error = envelope["errors"][0]
+    assert "DEX_NO_SUCH_DEV_DATABASE" in error
+    assert "CREATE DATABASE IF NOT EXISTS DEX_NO_SUCH_DEV_DATABASE" in error
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
+
+
+def test_config_drift_from_the_rendered_profile_is_refused(
+    tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
+):
+    """`transform init` renders config into profiles.yml, which dbt then reads.
+    A later config edit that never reached the profile must not build silently
+    against the old target."""
+
+    pytest.importorskip("dbt.adapters.snowflake")
+    root = str(tmp_path)
+    seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
+
+    rc, envelope = run_cli(
+        ["--repo-root", root, "transform", "init", "analytics"], capsys
+    )
+    assert rc == 0, envelope
+
+    config_path = tmp_path / ".dex" / "config.yml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["snowflake"]["dev_database"] = "DEX_RETARGETED_ELSEWHERE"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            root,
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+            "--budget",
+            str(SF_MAX_SECONDS),
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert envelope["status"] == "error"
+    error = envelope["errors"][0]
+    assert "DEX_RETARGETED_ELSEWHERE" in error
+    assert sf_scratch_database in error
+    assert "disagree about the dev target" in error

--- a/packages/dex-core/tests/test_cli_contract.py
+++ b/packages/dex-core/tests/test_cli_contract.py
@@ -90,3 +90,43 @@ def test_connect_test_without_path_is_clean_error(capsys, tmp_path):
     assert rc == 1
     assert payload["status"] == "error"
     assert payload["errors"]
+
+
+@pytest.mark.parametrize(
+    "argv_builder",
+    [
+        lambda: ["--scope", "raw", "explore", "inventory"],
+        lambda: ["explore", "inventory", "--scope", "raw"],
+        lambda: ["--scope", "raw", "--scope", "staging", "explore", "inventory"],
+    ],
+    ids=["before-subcommand", "after-subcommand", "repeatable"],
+)
+def test_scope_parses_in_either_position_and_repeats(argv_builder, tmp_path, capsys):
+    """`--scope` is a connection option like `--path`, so it has to work on both
+    sides of the subcommand and accumulate."""
+
+    rc = main(["--repo-root", str(tmp_path), *argv_builder()])
+    payload = json.loads(capsys.readouterr().out)
+    # DuckDB is the default connector and has no scope, so this is a clean refusal
+    # rather than a parse error: the point is that argparse accepted the flag.
+    assert rc == 1
+    assert payload["status"] == "error"
+    assert "--scope" in payload["errors"][0]
+
+
+def test_scope_is_accepted_on_every_subcommand():
+    """A scoping flag missing from one subcommand is how `--dataset` came to be
+    silently dropped in the first place."""
+
+    from exmergo_dex_core.cli import _build_parser
+
+    parser = _build_parser()
+    for group, subcommands in COMMAND_SURFACE.items():
+        for sub in subcommands:
+            argv = [group, sub, "--scope", "raw"]
+            if group == "explore" and sub == "profile":
+                argv.append("t")
+            elif group == "explore" and sub == "query":
+                argv.append("select 1")
+            args = parser.parse_args(argv)
+            assert args.scope == ["raw"], f"{group} {sub} dropped --scope"

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -136,6 +136,25 @@ def test_cost_guard_blocks_over_ceiling():
         cost_guard.preflight(estimate=10_000, ceiling=10)
 
 
+def test_a_scope_flag_cannot_widen_the_committed_allowlist():
+    """The source allowlist in .dex/config.yml is a committed cost boundary. A
+    per-command flag scopes work inside it and can never reach outside it, on any
+    connector."""
+
+    from exmergo_dex_core import config as config_mod
+    from exmergo_dex_core.connect import ScopeError, narrow_target
+
+    for connector, field, target in (
+        ("bigquery", "datasets", config_mod.BigQueryTarget(datasets=["analytics"])),
+        ("databricks", "catalogs", config_mod.DatabricksTarget(catalogs=["raw"])),
+        ("postgres", "schemas", config_mod.PostgresTarget(schemas=["public"])),
+    ):
+        narrowed = narrow_target(target, connector, [getattr(target, field)[0]])
+        assert getattr(narrowed, field) == getattr(target, field)
+        with pytest.raises(ScopeError):
+            narrow_target(target, connector, ["somewhere_else"])
+
+
 # --- Family 3: PII flagged, never surfaced -----------------------------------
 
 
@@ -650,7 +669,14 @@ def test_bigquery_spend_ledger_holds_no_sql_or_values(tmp_path: Path, fake_bq_cl
 # `--extra snowflake` in ci.yml and release.yml.
 
 
-def _sf_adapter(fake_sf_connection, *, ceiling=600.0, confirmed=True):
+def _sf_adapter(
+    fake_sf_connection,
+    *,
+    ceiling=600.0,
+    confirmed=True,
+    databases=None,
+    scope_override=None,
+):
     from exmergo_dex_core.adapters.snowflake import SnowflakeAdapter
     from exmergo_dex_core.config import SnowflakeTarget
     from exmergo_dex_core.guards.cost_guard import CostGate
@@ -666,11 +692,41 @@ def _sf_adapter(fake_sf_connection, *, ceiling=600.0, confirmed=True):
     return SnowflakeAdapter(
         connection=fake_sf_connection,
         cost_gate=gate,
-        target=SnowflakeTarget(warehouse="DEX_WH"),
+        target=SnowflakeTarget(warehouse="DEX_WH", databases=databases or []),
         account="TESTORG-TESTACCT",
         auth_method="named_connection:key_pair",
+        scope_override=scope_override,
         clock=fake_sf_connection.clock,
     )
+
+
+def test_snowflake_scope_flag_cannot_widen_the_committed_allowlist(fake_sf_connection):
+    # Family 2: Snowflake resolves bare schema names against the account, so it
+    # enforces the committed cost boundary inside the adapter, after resolution
+    # and before anything is estimated or spent.
+    from exmergo_dex_core.adapters.snowflake import SnowflakeConnectionError
+
+    adapter = _sf_adapter(
+        fake_sf_connection, databases=["SHOP.PUBLIC"], scope_override=["SHOP"]
+    )
+    with pytest.raises(SnowflakeConnectionError, match="never widens"):
+        adapter.list_objects()
+    assert fake_sf_connection.data_statements == []
+
+
+def test_snowflake_unresolvable_scope_never_falls_back_to_the_whole_allowlist(
+    fake_sf_connection,
+):
+    # Family 2: the cost-safety bug this guards. A scope that names nothing must
+    # refuse, never silently widen to every table the allowlist permits.
+    from exmergo_dex_core.adapters.snowflake import SnowflakeConnectionError
+
+    adapter = _sf_adapter(
+        fake_sf_connection, databases=["SHOP"], scope_override=["__NOT_A_SCHEMA__"]
+    )
+    with pytest.raises(SnowflakeConnectionError):
+        adapter.profile_estimate(["SHOP.PUBLIC.EVENTS"])
+    assert fake_sf_connection.data_statements == []
 
 
 def test_snowflake_generated_sql_is_select_only(fake_sf_connection):

--- a/packages/dex-core/tests/transform/test_build.py
+++ b/packages/dex-core/tests/transform/test_build.py
@@ -19,6 +19,35 @@ def _run(argv: list[str], capsys) -> tuple[int, dict]:
 
 
 @pytest.fixture
+def bigquery_project_dir(dbt_project_dir: Path) -> Path:
+    """The shared dbt project, retyped to a BigQuery dev target.
+
+    The billed-paradigm tests drive `--connector bigquery` for its cost gate, and
+    the dev-target preflight now (correctly) refuses a build whose profile names a
+    different adapter than the connector governing it. So the profile has to say
+    what the test claims it is.
+    """
+
+    (dbt_project_dir / "profiles.yml").write_text(
+        "dex_test:\n"
+        "  target: dev\n"
+        "  outputs:\n"
+        "    dev:\n"
+        "      type: bigquery\n"
+        "      method: oauth\n"
+        "      project: dex-test\n"
+        "      dataset: dbt_dev\n"
+        "    prod:\n"
+        "      type: bigquery\n"
+        "      method: oauth\n"
+        "      project: dex-test\n"
+        "      dataset: prod\n",
+        encoding="utf-8",
+    )
+    return dbt_project_dir
+
+
+@pytest.fixture
 def forbid_dbt(monkeypatch: pytest.MonkeyPatch):
     """Fail the test if the gate lets a dbt subprocess launch."""
 
@@ -392,7 +421,7 @@ def test_relative_project_dir_builds_without_path_doubling(
 
 
 def test_billed_build_unconfirmed_needs_confirmation_with_unknown_estimate(
-    dbt_project_dir: Path, tmp_path: Path, capsys, forbid_dbt
+    bigquery_project_dir: Path, tmp_path: Path, capsys, forbid_dbt
 ):
     rc, envelope = _run(
         [
@@ -418,7 +447,7 @@ def test_billed_build_unconfirmed_needs_confirmation_with_unknown_estimate(
 
 
 def test_billed_build_without_a_budget_is_refused(
-    dbt_project_dir: Path, tmp_path: Path, capsys, forbid_dbt
+    bigquery_project_dir: Path, tmp_path: Path, capsys, forbid_dbt
 ):
     rc, envelope = _run(
         [
@@ -440,12 +469,12 @@ def test_billed_build_without_a_budget_is_refused(
 
 
 def test_billed_build_sums_bytes_billed_into_the_ledger(
-    dbt_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+    bigquery_project_dir: Path, tmp_path: Path, capsys, monkeypatch
 ):
     import json as json_mod
 
     _fake_runner_factory(monkeypatch, returncode=0)
-    target_dir = dbt_project_dir / "target"
+    target_dir = bigquery_project_dir / "target"
     target_dir.mkdir(exist_ok=True)
     (target_dir / "run_results.json").write_text(
         json_mod.dumps(
@@ -494,7 +523,7 @@ def test_billed_build_sums_bytes_billed_into_the_ledger(
 
 
 def test_billed_build_failure_names_the_real_error_in_errors(
-    dbt_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+    bigquery_project_dir: Path, tmp_path: Path, capsys, monkeypatch
 ):
     """The failure-path envelope on the billed connector: the real dbt message
     rides in errors, not buried in warnings (guards the sanitized-failure fix on
@@ -547,3 +576,42 @@ def test_build_env_caps_postgres_statements_via_pgoptions(monkeypatch):
     assert _build_env(Paradigm.DB_LOAD, None) is None
     assert _build_env(Paradigm.FREE_LOCAL, 120.0) is None
     assert _build_env(Paradigm.BYTES_SCANNED, 120.0) is None
+
+
+def test_dev_target_check_runs_before_the_cost_gate(
+    dbt_project_dir: Path, tmp_path: Path, capsys, forbid_dbt
+):
+    """A dev target that cannot work is refused before anyone is asked to weigh a
+    budget. The preflight is free, so surfacing `needs_confirmation` for a build
+    that is already doomed would be the wrong order.
+    """
+
+    (dbt_project_dir / "models" / "staging" / "sources.yml").write_text(
+        "version: 2\nsources:\n  - name: raw\n    tables:\n      - name: customers\n",
+        encoding="utf-8",
+    )
+    # No --confirm: the old ordering would have returned needs_confirmation here.
+    rc, envelope = _run(
+        ["--repo-root", str(tmp_path), "transform", "build", "--target", "dev"], capsys
+    )
+    assert rc == 1
+    assert envelope["status"] == "error"
+    assert "seed" in envelope["errors"][0]
+
+
+def test_prod_refusal_still_beats_the_dev_target_check(
+    dbt_project_dir: Path, tmp_path: Path, capsys, forbid_dbt
+):
+    """Ordering, continued: a prod target is refused outright, before dex goes
+    looking at whether that target happens to exist."""
+
+    (dbt_project_dir / "models" / "staging" / "sources.yml").write_text(
+        "version: 2\nsources:\n  - name: raw\n    tables:\n      - name: customers\n",
+        encoding="utf-8",
+    )
+    rc, envelope = _run(
+        ["--repo-root", str(tmp_path), "transform", "build", "--target", "prod"], capsys
+    )
+    assert rc == 1
+    assert "prod" in envelope["errors"][0].lower()
+    assert "seed" not in envelope["errors"][0]

--- a/packages/dex-core/tests/transform/test_dev_target.py
+++ b/packages/dex-core/tests/transform/test_dev_target.py
@@ -1,0 +1,251 @@
+"""The dev-target preflight: config that looks live is live, or says so.
+
+Drift (`.dex/config.yml` edited after `transform init` rendered `profiles.yml`)
+and absence (a dev database dbt cannot create for itself) are both refusals, both
+free, and both happen before the cost gate. The drift half needs no connection at
+all, which is why most of this file is pure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.config import (
+    DexConfig,
+    DuckDBTarget,
+    SnowflakeTarget,
+)
+from exmergo_dex_core.transform import dev_target
+
+
+def _write_profile(project: Path, output: str, target: str = "dev") -> None:
+    (project / "profiles.yml").write_text(
+        f"dex_test:\n  target: {target}\n  outputs:\n    {target}:\n{output}",
+        encoding="utf-8",
+    )
+
+
+def _snowflake_profile(project: Path, **overrides: str) -> None:
+    fields = {
+        "type": "snowflake",
+        "account": "ORG-ACCT",
+        "user": "DEX",
+        "warehouse": "DEX_WH",
+        "database": "DBT_DEV",
+        "schema": "DBT_DEV",
+        # Quoted exactly as `transform init` renders it: unquoted Jinja is not
+        # valid YAML, for dex or for dbt.
+        "password": "'{{ env_var(''SNOWFLAKE_PASSWORD'') }}'",
+        **overrides,
+    }
+    _write_profile(project, "".join(f"      {k}: {v}\n" for k, v in fields.items()))
+
+
+def _snowflake_config(**overrides) -> DexConfig:
+    fields = {"warehouse": "DEX_WH", "dev_database": "DBT_DEV", "dev_schema": "DBT_DEV"}
+    fields.update(overrides)
+    return DexConfig(connector="snowflake", snowflake=SnowflakeTarget(**fields))
+
+
+@pytest.fixture(autouse=True)
+def no_warehouse(monkeypatch):
+    """No connection reachable by default, so the drift half is exercised alone
+    and no unit test can wander onto a real account. Tests that need a warehouse
+    replace this with a fake adapter."""
+
+    def unreachable(**_kwargs):
+        raise RuntimeError("no connection discovered")
+
+    monkeypatch.setattr("exmergo_dex_core.connect.open_adapter", unreachable)
+
+
+# --- drift: config and profile must agree ------------------------------------------
+
+
+def test_retargeted_dev_database_is_refused_naming_both_values(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    """The field report: edit `snowflake.dev_database`, get a green build against
+    the old database. Now it refuses, and the message names both sides."""
+
+    _snowflake_profile(dbt_project_dir)
+    config = _snowflake_config(dev_database="DBT_DEV_DOES_NOT_EXIST")
+
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    message = str(exc.value)
+    assert "snowflake.dev_database: DBT_DEV_DOES_NOT_EXIST" in message
+    assert "profiles.yml dev.database: DBT_DEV" in message
+    assert ".dex/config.yml" in message and "analytics/profiles.yml" in message
+
+
+def test_matching_config_and_profile_pass(dbt_project_dir: Path, tmp_path: Path):
+    _snowflake_profile(dbt_project_dir)
+    # No connection is configured, so the existence half degrades to a note.
+    warnings = dev_target.check(dbt_project_dir, "dev", _snowflake_config(), tmp_path)
+    assert all("disagree" not in w for w in warnings)
+
+
+def test_snowflake_identifier_case_is_not_drift(dbt_project_dir: Path, tmp_path: Path):
+    _snowflake_profile(dbt_project_dir, database="DBT_DEV")
+    config = _snowflake_config(dev_database="dbt_dev")
+    dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+
+
+def test_a_drifted_warehouse_is_refused(dbt_project_dir: Path, tmp_path: Path):
+    _snowflake_profile(dbt_project_dir, warehouse="DEX_WH")
+    config = _snowflake_config(warehouse="BIG_WH")
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    assert "snowflake.warehouse: BIG_WH" in str(exc.value)
+
+
+def test_an_unset_config_field_is_not_drift(dbt_project_dir: Path, tmp_path: Path):
+    """A field the user never set was never a claim about the dev target, so a
+    profile that names something there cannot have drifted away from it."""
+
+    _snowflake_profile(dbt_project_dir, schema="ANALYTICS_DEV")
+    config = DexConfig(
+        connector="snowflake",
+        snowflake=SnowflakeTarget(warehouse="DEX_WH", dev_database="DBT_DEV"),
+    )
+    dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+
+
+def test_a_switched_connector_is_refused(dbt_project_dir: Path, tmp_path: Path):
+    """The shared fixture renders a duckdb profile; config says snowflake."""
+
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", _snowflake_config(), tmp_path)
+    message = str(exc.value)
+    assert "disagree about the connector" in message
+    assert "connector: snowflake" in message
+    assert "type: duckdb" in message
+
+
+def test_an_unreadable_profile_is_not_a_refusal(tmp_path: Path):
+    """Absence of evidence stays absence of evidence: a project dex cannot read
+    is dbt's problem to report, not a preflight refusal."""
+
+    warnings = dev_target.check(tmp_path, "dev", _snowflake_config(), tmp_path)
+    assert all("disagree" not in w for w in warnings)
+
+
+def test_a_malformed_profile_is_not_a_refusal(dbt_project_dir: Path, tmp_path: Path):
+    """Unquoted Jinja is invalid YAML. dbt will say so; the preflight must not
+    crash with a parser traceback on the way there."""
+
+    _write_profile(dbt_project_dir, "      password: {{ env_var('X') }}\n")
+    warnings = dev_target.check(dbt_project_dir, "dev", _snowflake_config(), tmp_path)
+    assert all("disagree" not in w for w in warnings)
+
+
+def test_drift_message_never_carries_a_credential(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    """The profile holds a password reference, a user, and an account. Only
+    namespace identifiers may reach the message that goes into the envelope."""
+
+    _snowflake_profile(dbt_project_dir)
+    config = _snowflake_config(dev_database="OTHER_DB")
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    message = str(exc.value)
+    for secret in ("password", "SNOWFLAKE_PASSWORD", "ORG-ACCT", "user"):
+        assert secret not in message
+
+
+# --- existence: duckdb keeps the behavior it always had -----------------------------
+
+
+def test_duckdb_missing_file_with_sources_refuses(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    (dbt_project_dir / "models" / "staging" / "sources.yml").write_text(
+        "version: 2\nsources:\n  - name: raw\n    tables:\n      - name: customers\n",
+        encoding="utf-8",
+    )
+    config = DexConfig(connector="duckdb")
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    assert "seed" in str(exc.value)
+
+
+def test_duckdb_missing_file_without_sources_only_warns(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    warnings = dev_target.check(
+        dbt_project_dir, "dev", DexConfig(connector="duckdb"), tmp_path
+    )
+    assert len(warnings) == 1
+    assert "dbt will create an empty one" in warnings[0]
+
+
+def test_duckdb_path_drift_is_refused(dbt_project_dir: Path, tmp_path: Path):
+    config = DexConfig(
+        connector="duckdb", duckdb=DuckDBTarget(path="/elsewhere.duckdb")
+    )
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    assert "duckdb.path: /elsewhere.duckdb" in str(exc.value)
+
+
+# --- existence: snowflake, through the fake ------------------------------------------
+
+
+def test_missing_snowflake_dev_database_refuses_with_the_create_statement(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    pytest.importorskip("snowflake.connector")
+    from fakes.snowflake import FakeSnowflakeConnection, FakeWarehouse
+
+    from exmergo_dex_core.adapters.snowflake import SnowflakeAdapter
+    from exmergo_dex_core.envelope import Paradigm
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    connection = FakeSnowflakeConnection(
+        warehouses=[FakeWarehouse(name="DEX_WH")], empty_databases=["SOMETHING_ELSE"]
+    )
+
+    def fake_open_adapter(**_kwargs):
+        return SnowflakeAdapter(
+            connection=connection,
+            cost_gate=CostGate(
+                paradigm=Paradigm.COMPUTE_TIME,
+                ceiling=None,
+                session_ceiling=None,
+                session_spent=0.0,
+                confirmed=False,
+                connector="snowflake",
+            ),
+            target=SnowflakeTarget(warehouse="DEX_WH"),
+            clock=connection.clock,
+        )
+
+    monkeypatch.setattr("exmergo_dex_core.connect.open_adapter", fake_open_adapter)
+    _snowflake_profile(dbt_project_dir)
+
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", _snowflake_config(), tmp_path)
+    message = str(exc.value)
+    assert 'dev_database "DBT_DEV" does not exist' in message
+    assert "CREATE DATABASE IF NOT EXISTS DBT_DEV;" in message
+    assert "dbt creates schemas but never databases" in message
+    # The preflight is free: it never reaches a warehouse.
+    assert connection.data_statements == []
+
+
+def test_an_unopenable_connection_degrades_to_a_note(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    """dex discovers its own connection while dbt reads profiles.yml; the two can
+    legitimately differ, so the preflight must never break a build dbt could run.
+    The note names the failure class, so a defect here cannot hide as a shrug."""
+
+    _snowflake_profile(dbt_project_dir)
+    warnings = dev_target.check(dbt_project_dir, "dev", _snowflake_config(), tmp_path)
+    assert len(warnings) == 1
+    assert "could not preflight the dev database" in warnings[0]
+    assert "RuntimeError" in warnings[0]

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -162,9 +162,24 @@ re-map carry their prior profiles forward (`carried_forward_count`), each
 stamped with its own `profiled_at`.
 
 Global flags (shared resolution path): `--connector`, `--path` (DuckDB),
-`--project` and `--dataset` (BigQuery convenience overrides of the config
-target, repeatable `--dataset`; never written back to config, so `connect test`
-works before a `bigquery:` block exists), `--repo-root`, `--confirm`, `--budget`.
+`--scope`, `--project` and `--dataset` (BigQuery only), `--repo-root`,
+`--confirm`, `--budget`.
+
+`--scope` is repeatable and narrows the source allowlist for one command. Each
+connector reads it in its own namespace vocabulary: a `dataset` on BigQuery, a
+`schema`, `database`, or `database.schema` on Snowflake, a `catalog` or
+`catalog.schema` on Databricks, a `schema` on Postgres. It is never written back
+to config, so `connect test --scope X` works before a connector block exists.
+
+Two rules make it a cost control rather than a hint:
+
+- **Scope narrows, never widens.** When `.dex/config.yml` commits a source
+  allowlist, that allowlist is a cost boundary and every `--scope` entry must
+  resolve inside it. A scope that reaches outside is refused.
+- **A scope is honored or named in an error, never dropped.** An entry that
+  names nothing refuses and lists what exists. `--project` and `--dataset` are
+  BigQuery vocabulary and error on any other connector; DuckDB has no namespace
+  to scope and refuses all three (its target is `--path`).
 
 ## The query firewall
 

--- a/references/snowflake.md
+++ b/references/snowflake.md
@@ -57,6 +57,47 @@ smallest warehouse that works (X-Small with 60s auto-suspend is the intended
 shape; `scripts/setup_snowflake_ci.sh` provisions exactly that plus a resource
 monitor as the hard monthly backstop).
 
+## Scoping a command
+
+`snowflake.databases` is the committed source allowlist, and a single database
+can span four orders of magnitude in table size, so prefer `db.schema` entries
+over bare `db` when the difference matters for cost.
+
+`--scope` narrows that allowlist for one command, and is repeatable. It accepts
+a bare schema (`--scope TPCH_SF1`, qualified against the databases already in
+scope), a database, or a qualified `database.schema`. Resolution is free (SHOW
+metadata, no warehouse) and happens before anything is estimated:
+
+- A scope that names no database and no schema is **refused**, and the error
+  lists the schemas that do exist. It is never quietly dropped, because an
+  estimate that silently spans the whole allowlist is one a user could confirm
+  believing it bounded a handful of tables.
+- A bare schema that exists in more than one in-scope database is refused as
+  ambiguous, asking for `database.schema`.
+- A scope outside the committed allowlist is refused. `--scope` narrows; it
+  never widens.
+
+`--project` and `--dataset` are BigQuery vocabulary and error here.
+
+## Preflight before a dbt build
+
+`transform build` refuses, for free, before the cost gate:
+
+- when `.dex/config.yml` and the rendered `profiles.yml` disagree about the dev
+  database, schema, or warehouse (the profile is what dbt reads, so a config
+  edit that never reached it would otherwise build against the old target), and
+- when `snowflake.dev_database` does not exist. dbt creates schemas but never
+  databases, so the first build would fail inside dbt's `list_schemas` macro
+  with `002043: Object does not exist`. dex names the database and the
+  statement that fixes it:
+
+```sql
+CREATE DATABASE IF NOT EXISTS DBT_DEV;
+```
+
+dex never creates it for you, and never rewrites your `profiles.yml`: its only
+writes are reviewable diffs inside the repo.
+
 ## Cost model: the inversion from BigQuery
 
 On BigQuery, metadata is free and scans bill by bytes. On Snowflake the rule

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -89,6 +89,15 @@ retry with a raised budget on an over-ceiling refusal without asking.
 Metadata is free (`connect test`, `inventory` run immediately), and OK
 envelopes report actual spend under `data.spend`.
 
+When an estimate is larger than the work deserves, narrow the scope rather than
+raise the budget. `--scope` (repeatable) bounds a command to part of the
+configured source allowlist, in the connector's own vocabulary: a dataset on
+BigQuery, a `schema` or `database.schema` on Snowflake, a `catalog.schema` on
+Databricks, a schema on Postgres. It is free to resolve, it can only narrow what
+`.dex/config.yml` already allows, and a scope that names nothing is refused with
+the schemas that do exist listed. So `explore map --scope <schema>` is the first
+thing to reach for on a warehouse whose full map would be expensive.
+
 ## Guardrails (enforced in the engine, not here)
 
 - Read-only against data. The connection is opened read-only and generated SQL is

--- a/skills/transform/SKILL.md
+++ b/skills/transform/SKILL.md
@@ -98,15 +98,29 @@ already exists.
   `dbt_packages/` exists but is stale). No confirmation needed: deps writes only
   inside the project and never touches the warehouse.
 
-### Seeding the dev warehouse
+### Preparing the dev target
 
-A DuckDB dev target points at a database file, and dbt happily creates an empty
-one if it does not exist, which then fails every `source()` relation with a
-confusing catalog error. The engine refuses that build up front and names the
-fix. The convention: copy the shared source warehouse to the dev target path
-(for example `cp shared/f1.duckdb <project>/dev.duckdb`), or point the dev
-target at an existing database file. Projects without sources just get a
-warning and an empty database, which is fine for model-only builds.
+Before the cost gate, and for free, `transform build` refuses two things and
+names the fix for each. Neither costs anything to check, so both surface on the
+unconfirmed call rather than after a budget has been agreed.
+
+**Config that has drifted from the profile.** `transform init` renders
+`.dex/config.yml` into the project's `profiles.yml`, and dbt reads only the
+profile from then on. If a later config edit never reached it (a retargeted
+`dev_database`, a different warehouse), the build refuses and names both values
+and both files. Edit one to match the other. The engine never rewrites
+`profiles.yml`, which you may legitimately have hand-edited.
+
+**A dev target that does not exist.** On Snowflake, dbt creates schemas but never
+databases, so a missing `dev_database` is refused with the `CREATE DATABASE`
+statement to run; dex will not create it for you, because its only writes are
+reviewable diffs inside the repo. On DuckDB the dev target is a database file,
+and dbt would happily create an empty one, then fail every `source()` relation
+with a confusing catalog error. The convention there: copy the shared source
+warehouse to the dev target path (for example
+`cp shared/f1.duckdb <project>/dev.duckdb`), or point the dev target at an
+existing file. Projects without sources just get a warning and an empty
+database, which is fine for model-only builds.
 
 ### The semantic layer
 


### PR DESCRIPTION
## What this changes

Heavy dogfood on Snowflake emerged some issues that needed fixing

Adapters
- Better scope resolution for entity names 
  - each adapter calls "database" and "schema" differently. For example in BigQuery their called "dataset" and "schema"

dbt
- preflight check for dev database existence
- dev database no longer inert in .dex/config.yml post Snowflake `transform init` command

## Related issues

Closes: 
- #48 
- #51
- #52

(Internally: SCRUM-894, SCRUM-896, SCRUM-899)