### PR TITLE
Hotfix - Scope resolution for all connectors and dev target preflight check for all connectors

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.1.0",
+  "version": "v1.1.1",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -130,8 +130,43 @@ jobs:
           enable-cache: true
       - name: Sync (snowflake + duckdb + dev extras)
         run: uv sync --extra snowflake --extra duckdb --extra dev
+      # Keyless: connect, explore, and the transform tests' own skip guard all
+      # run on the workload identity above. The transform tests skip themselves
+      # here (dbt cannot authenticate that way) and run in the next step.
       - name: Live Snowflake integration suite
         run: uv run pytest tests/integration -q -m snowflake
+      # The one step that cannot be keyless. dbt-snowflake's profile has no
+      # workload-identity provider field, so `transform init` refuses to render
+      # a WIF profile and these tests need a durable credential: a key pair on
+      # a separate service user holding the same least-privilege role, so the
+      # blast radius is unchanged (read the samples, write the transient
+      # scratch database) and DEX_CI itself stays keyless. The secret is
+      # readable only by this environment, whose deployments are pinned to
+      # main, so a pull request cannot reach it. Emptying SNOWFLAKE_TOKEN and
+      # the WIF provider is what makes discovery pick the key pair rather than
+      # the token the job already minted.
+      - name: Live Snowflake transform suite (dbt, key pair)
+        env:
+          SNOWFLAKE_USER: ${{ vars.DEX_TEST_SNOWFLAKE_DBT_USER }}
+          SNOWFLAKE_AUTHENTICATOR: SNOWFLAKE_JWT
+          SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER: ""
+          SNOWFLAKE_TOKEN: ""
+          SNOWFLAKE_PRIVATE_KEY: ${{ secrets.DEX_TEST_SNOWFLAKE_PRIVATE_KEY }}
+        run: |
+          # Without these the suite reads Snowflake as "not configured" and
+          # skips itself green, which is the one failure mode this step exists
+          # to prevent. Refuse instead: the credential comes from the setup
+          # script, so a missing one means it has not been re-run.
+          if [ -z "$SNOWFLAKE_USER" ] || [ -z "$SNOWFLAKE_PRIVATE_KEY" ]; then
+            echo "::error::DEX_TEST_SNOWFLAKE_DBT_USER or DEX_TEST_SNOWFLAKE_PRIVATE_KEY is missing from the snowflake-integration environment; re-run scripts/setup_snowflake_ci.sh"
+            exit 1
+          fi
+          key="${RUNNER_TEMP}/snowflake_ci_dbt_key.p8"
+          install -m 600 /dev/null "$key"
+          printf '%s' "$SNOWFLAKE_PRIVATE_KEY" > "$key"
+          trap 'rm -f "$key"' EXIT
+          SNOWFLAKE_PRIVATE_KEY_FILE="$key" \
+            uv run pytest tests/integration/test_snowflake_transform.py -q -m snowflake
 
   databricks:
     if: github.repository == 'exmergo/dex'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **The live Snowflake transform tests failed in CI rather than skipping.** Every
+  test in that suite starts from `transform init`, which refuses a
+  workload-identity connection because dbt-snowflake's profile carries no
+  workload-identity provider field and so cannot authenticate that way. CI
+  authenticates keylessly through GitHub OIDC, so two of the three tests asserted
+  a successful init against a connection the engine refuses by design. The guard
+  now covers the suite instead of a single test, and CI runs the dbt tests on a
+  dedicated key-pair service user holding the same least-privilege role, so the
+  coverage is restored rather than skipped. The refusal itself was correct and is
+  unchanged.
 - **`explore map --dataset <schema>` was accepted and silently ignored on
   Snowflake** (and, identically, on Databricks and Postgres). Scoping was
   governed solely by the config allowlist, so a nonexistent schema was accepted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-07-12
+
 ### Added
 
 - **`--scope`**, a portable, repeatable source-scope override that every
@@ -18,6 +20,24 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   written back to `.dex/config.yml`. A committed source allowlist is a cost
   boundary, so `--scope` may only narrow it, never widen it, and a scope that
   reaches outside is refused.
+- **Source-scope validation on every warehouse connector.** BigQuery, Databricks,
+  and Postgres now resolve each scope entry through their own free metadata path
+  before anything is estimated, matching what Snowflake already did: a dataset,
+  catalog, `catalog.schema`, or schema that names nothing is refused, and the
+  message lists what does exist and names where the entry came from (the `--scope`
+  or `--dataset` flag, or the allowlist in `.dex/config.yml`). `connect test`
+  therefore fails for free on a bad scope.
+- **A dev-target preflight on every warehouse connector.** The free check that
+  runs before the cost gate now covers BigQuery, Databricks, and Postgres. What
+  dbt cannot create for itself is refused; what it can create is not, and that
+  lands differently per connector: dbt never creates a Databricks catalog, so a
+  missing `dev_catalog` is refused with the `CREATE CATALOG` statement that fixes
+  it; dbt *does* create its BigQuery dev dataset, so an absent one warns (naming
+  the `bigquery.datasets.create` permission the build needs) while an unreachable
+  dev project is refused; and dbt creates its Postgres dev schema only if the role
+  may, so the privilege is what gets checked, asked of the role in the rendered
+  profile rather than the one dex reads with, and refused with the `GRANT` that
+  fixes it.
 - **Snowflake scope resolution and validation.** Scopes now resolve against the
   account through free SHOW metadata before anything is estimated. A bare schema
   is qualified against the databases in scope; an ambiguous one asks for

--- a/packages/dex-core/src/exmergo_dex_core/adapters/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/base.py
@@ -18,6 +18,8 @@ caps and truncates them before the envelope.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -113,6 +115,39 @@ def scope_within(scope: str, committed: list[str]) -> bool:
         entry == c.strip().lower() or entry.startswith(c.strip().lower() + ".")
         for c in committed
     )
+
+
+SUGGESTION_CAP = 12
+
+
+def name_list(names: Iterable[str]) -> str:
+    """Names for an error message, capped so a thousand-schema account cannot
+    turn a one-line refusal into a page of stdout."""
+
+    names = list(names)
+    shown = names[:SUGGESTION_CAP]
+    suffix = (
+        f", and {len(names) - SUGGESTION_CAP} more"
+        if len(names) > SUGGESTION_CAP
+        else ""
+    )
+    return (", ".join(shown) + suffix) if shown else "(none)"
+
+
+@contextmanager
+def blame(origin: str, error: type[Exception]):
+    """Attribute a scope failure to the thing the user has to go edit. A resolver
+    does not know whether an entry came from the committed allowlist or from a
+    flag, and the fix differs entirely.
+
+    ``error`` is the connector's own exception class, so the re-raise stays the
+    type that connector's callers already catch.
+    """
+
+    try:
+        yield
+    except error as exc:
+        raise error(f"{exc} [from {origin}]") from exc
 
 
 def json_safe(value: object | None) -> object | None:

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -22,7 +22,15 @@ from ..config import BigQueryTarget
 from ..envelope import Paradigm
 from ..guards.cost_guard import CostGate, OverCeilingError
 from ..guards.sql_guard import assert_select_only
-from .base import ColumnAggregate, ColumnMeta, ObjectMeta, QueryResult, json_safe
+from .base import (
+    ColumnAggregate,
+    ColumnMeta,
+    ObjectMeta,
+    QueryResult,
+    blame,
+    json_safe,
+    name_list,
+)
 
 PARADIGM = "bytes_scanned"
 DIALECT = "bigquery"
@@ -40,6 +48,11 @@ _MIN_BILLED_BYTES = 10 * 1024 * 1024
 # min/max, and non-null counting via COUNTIF (COUNT DISTINCT is invalid on
 # them and plain COUNT is not supported for every one of these types).
 _NESTED_FIELD_TYPES = {"RECORD", "STRUCT", "JSON", "GEOGRAPHY", "RANGE", "INTERVAL"}
+
+
+class BigQueryConnectionError(Exception):
+    """Raised when a source scope (or the dev project) cannot be resolved. The
+    message always names the fix, never a credential."""
 
 
 class BigQueryAdapter:
@@ -63,12 +76,18 @@ class BigQueryAdapter:
         target: BigQueryTarget | None = None,
         credentials: Any | None = None,
         principal_type: str | None = None,
+        scope_origin: str | None = None,
         client: Any | None = None,
     ):
         self.project = project
         self.cost_gate = cost_gate
         self.target = target or BigQueryTarget()
         self.principal_type = principal_type or "unknown"
+        # What the scope entries in the target came from, so a refusal names the
+        # thing the user has to go edit: a per-command flag or the committed
+        # allowlist. `narrow_target` has already collapsed the two by the time
+        # the adapter sees them, and the fix differs entirely.
+        self._scope_origin = scope_origin or "bigquery.datasets in .dex/config.yml"
         # Imported lazily so the base package import does not require the
         # [bigquery] extra; only this adapter pulls it in.
         try:
@@ -88,18 +107,16 @@ class BigQueryAdapter:
         # confirmed profiling pass do not re-fetch (each fetch is a free API
         # call, but table facts also back the notes and sampling decisions).
         self._tables: dict[str, Any] = {}
+        self._resolved_datasets: list[str] | None = None
         self._notes: dict[str, list[str]] = {}
 
     # --- capabilities ---------------------------------------------------------
 
     def capabilities(self) -> dict[str, object]:
+        # Resolving the scopes is also the live probe `connect test` needs: every
+        # entry is proven with a metadata GET, so a stale ADC token cannot report
+        # a healthy connection, and neither can an allowlist that names nothing.
         datasets = self._dataset_ids()
-        # `connect test` must prove a live round-trip, not just credential
-        # discovery: with a dataset allowlist, _dataset_ids makes no API call,
-        # and a stale ADC token would otherwise report a healthy connection.
-        # One free metadata GET exercises the credential for real.
-        if self.target.datasets:
-            self._client.get_dataset(datasets[0])
         cost = self.cost_gate.cost()
         return {
             "connector": self.name,
@@ -179,26 +196,116 @@ class BigQueryAdapter:
         return str(base)
 
     def _dataset_ids(self) -> list[str]:
-        """The datasets in scope, fully qualified as ``project.dataset``.
+        """The datasets in scope, fully qualified as ``project.dataset``, resolved
+        and proven to exist.
 
         Allowlist entries may name another project (``project.dataset``), which
         is how public datasets (``bigquery-public-data.samples``) are explored:
         reads go there, jobs still run in and bill to ``self.project``. Bare
         entries qualify against ``self.project``; no allowlist means every
         dataset of the configured project.
+
+        Resolution is free (metadata GET, no query) and cached for the command.
+        It runs before anything is estimated, because a scope that resolves to
+        nothing and silently falls back to the whole allowlist is a cost-safety
+        bug: the estimate the user confirms would cover tables they never named.
         """
 
-        if self.target.datasets:
+        if self._resolved_datasets is None:
+            self._resolved_datasets = self._resolve_datasets()
+        return self._resolved_datasets
+
+    def _resolve_datasets(self) -> list[str]:
+        if not self.target.datasets:
             return sorted(
-                {
-                    entry if "." in entry else f"{self.project}.{entry}"
-                    for entry in self.target.datasets
-                }
+                f"{self.project}.{item.dataset_id}"
+                for item in self._client.list_datasets(self.project)
             )
-        return sorted(
-            f"{self.project}.{item.dataset_id}"
-            for item in self._client.list_datasets(self.project)
-        )
+        with blame(self._scope_origin, BigQueryConnectionError):
+            return sorted(
+                {self._resolve_dataset(entry) for entry in self.target.datasets}
+            )
+
+    def _resolve_dataset(self, entry: str) -> str:
+        """One scope entry, qualified and proven to exist.
+
+        The GET is the proof, rather than listing the project and testing
+        membership: a principal may legitimately be granted one dataset without
+        the project-wide ``bigquery.datasets.list``, and public projects are far
+        too large to enumerate for a containment check. The listing is only used
+        to name the near misses once something has already failed.
+        """
+
+        token = entry.strip()
+        if not token:
+            raise BigQueryConnectionError("empty scope entry")
+        if token.count(".") > 1:
+            raise BigQueryConnectionError(
+                f"scope '{entry}' has too many parts; a source scope is "
+                "<dataset> or <project>.<dataset>, never a table"
+            )
+        qualified = token if "." in token else f"{self.project}.{token}"
+        project, _, dataset = qualified.partition(".")
+        try:
+            self._client.get_dataset(qualified)
+        except self._api_exceptions.NotFound as exc:
+            raise BigQueryConnectionError(
+                f"scope '{entry}' does not exist: project {project} has no "
+                f"dataset {dataset}; {self._visible_hint(project)}"
+            ) from exc
+        except self._api_exceptions.Forbidden as exc:
+            raise BigQueryConnectionError(
+                f"scope '{entry}' is not readable by this principal; grant "
+                "roles/bigquery.dataViewer on it, or point bigquery.datasets at "
+                "a dataset the principal can read"
+            ) from exc
+        return qualified
+
+    def _visible_hint(self, project: str) -> str:
+        """The datasets that do exist, for a refusal message. Best effort: a
+        principal that may GET a dataset without listing the project still gets
+        the refusal, just without the near misses."""
+
+        try:
+            visible = sorted(
+                item.dataset_id for item in self._client.list_datasets(project)
+            )
+        except Exception:  # a hint is never worth failing the refusal for
+            return "and its datasets cannot be listed by this principal"
+        return f"datasets there: {name_list(visible)}"
+
+    def missing_dev_namespaces(self, dataset: str) -> list[str]:
+        """Which parts of a dbt dev target do not exist yet. Free: metadata GET,
+        no query, so this costs nothing on a bytes-billed connector.
+
+        Unlike Snowflake and Databricks, dbt-bigquery *does* create its dev
+        dataset (its ``create_schema`` issues ``CREATE SCHEMA IF NOT EXISTS``),
+        so an absent dataset is normal on a first build and is reported for the
+        caller to warn about, not to refuse. What dbt cannot create is the
+        project, so an unreachable one is raised here.
+        """
+
+        qualified = dataset if "." in dataset else f"{self.project}.{dataset}"
+        project = qualified.partition(".")[0]
+        try:
+            self._client.get_dataset(qualified)
+        except self._api_exceptions.NotFound:
+            # Distinguish "no such dataset" (dbt will create it) from "no such
+            # project" (dbt cannot), because BigQuery answers both with NotFound.
+            # list_datasets returns a lazy iterator, so it has to be drained for
+            # the request to actually go out; without that, an unreachable project
+            # reads as a reachable one.
+            try:
+                list(self._client.list_datasets(project, max_results=1))
+            except Exception as exc:  # any failure to reach the project is fatal
+                raise BigQueryConnectionError(
+                    f"the dev project {project} is not reachable by this "
+                    f"principal ({type(exc).__name__}); dbt creates datasets but "
+                    "never projects, so point bigquery.dev_dataset at a dataset "
+                    "in a project the principal can write"
+                ) from exc
+            return [f'dev_dataset "{qualified}"']
+        return []
 
     def _get_table(self, identifier: str) -> Any:
         cached = self._tables.get(identifier)

--- a/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
@@ -36,7 +36,15 @@ from ..config import DatabricksTarget
 from ..envelope import Paradigm
 from ..guards.cost_guard import CostGate, OverCeilingError
 from ..guards.sql_guard import assert_select_only
-from .base import ColumnAggregate, ColumnMeta, ObjectMeta, QueryResult, json_safe
+from .base import (
+    ColumnAggregate,
+    ColumnMeta,
+    ObjectMeta,
+    QueryResult,
+    blame,
+    json_safe,
+    name_list,
+)
 
 PARADIGM = "compute_time"
 DIALECT = "databricks"
@@ -149,6 +157,7 @@ class DatabricksAdapter:
         target: DatabricksTarget | None = None,
         host: str | None = None,
         auth_method: str = "unknown",
+        scope_origin: str | None = None,
         clock: Callable[[], float] = time.monotonic,
     ):
         self._workspace = workspace
@@ -157,11 +166,19 @@ class DatabricksAdapter:
         self.target = target or DatabricksTarget()
         self.host = host
         self.auth_method = auth_method
+        # What the scope entries in the target came from, so a refusal names the
+        # thing the user has to go edit: a per-command flag or the committed
+        # allowlist. `narrow_target` has already collapsed the two by the time
+        # the adapter sees them, and the fix differs entirely.
+        self._scope_origin = scope_origin or "databricks.catalogs in .dex/config.yml"
         self._clock = clock
         self._conn: Any = None
         self._objects: dict[str, dict] = {}
         self._columns: dict[str, list[ColumnMeta]] = {}
         self._inventory_loaded = False
+        self._resolved_scopes: list[tuple[str, str | None]] | None = None
+        self._visible_catalogs: set[str] | None = None
+        self._schemas_by_catalog: dict[str, set[str]] = {}
         self._warehouse_info: dict | None = None
         self._notes: dict[str, list[str]] = {}
         # The startup floor is charged once per command, by whichever billed
@@ -268,11 +285,7 @@ class DatabricksAdapter:
     def _schema_names(self, catalog: str, schema_filter: str | None) -> list[str]:
         if schema_filter is not None:
             return [schema_filter]
-        return [
-            str(schema.name)
-            for schema in self._workspace.schemas.list(catalog_name=catalog)
-            if str(schema.name) != "information_schema"
-        ]
+        return sorted(self._schemas(catalog))
 
     def _register(self, table: Any) -> None:
         identifier = str(table.full_name)
@@ -346,30 +359,182 @@ class DatabricksAdapter:
         )
 
     def _scopes(self) -> list[tuple[str, str | None]]:
-        """The allowlist entries in scope as ``(catalog, schema-or-None)``
-        pairs, or every catalog the principal can see when no allowlist is
-        configured. The ``system`` catalog is never a source."""
+        """Every source scope this command reads, as ``(catalog, schema-or-None)``
+        pairs, resolved and proven to exist.
 
-        if self.target.catalogs:
-            scopes = []
-            for entry in sorted({e.lower() for e in self.target.catalogs}):
-                catalog, _, schema = entry.partition(".")
-                scopes.append((catalog, schema or None))
-            return scopes
-        return [
-            (str(catalog.name), None)
-            for catalog in self._workspace.catalogs.list()
-            if str(catalog.name) != "system"
-        ]
+        Resolution is free (Unity Catalog REST, no warehouse) and cached for the
+        command. It runs before anything is estimated, because a scope that
+        resolves to nothing and silently falls back to the whole allowlist is a
+        cost-safety bug: the estimate the user confirms would cover tables they
+        never named.
+        """
+
+        if self._resolved_scopes is None:
+            self._resolved_scopes = self._resolve_scopes()
+        return self._resolved_scopes
+
+    def _resolve_scopes(self) -> list[tuple[str, str | None]]:
+        if not self.target.catalogs:
+            # Nothing committed: every catalog the principal can see is the
+            # allowlist by definition, so there is nothing to prove.
+            return [
+                (catalog, None)
+                for catalog in sorted(self._catalogs())
+                if catalog != "system"
+            ]
+        with blame(self._scope_origin, DatabricksConnectionError):
+            return [
+                self._resolve_scope(entry)
+                for entry in sorted({e.lower() for e in self.target.catalogs})
+            ]
+
+    def _resolve_scope(self, entry: str) -> tuple[str, str | None]:
+        """One scope entry, proven to exist. Unity Catalog names are always
+        rooted in a catalog, so unlike Snowflake there is no bare schema to
+        qualify and no ambiguity to resolve: an entry either names something or
+        it does not."""
+
+        token = entry.strip().lower()
+        if not token:
+            raise DatabricksConnectionError("empty scope entry")
+        catalog, _, schema = token.partition(".")
+        if "." in schema:
+            raise DatabricksConnectionError(
+                f"scope '{entry}' has too many parts; a source scope is "
+                "<catalog> or <catalog>.<schema>, never a table"
+            )
+        visible = self._catalogs()
+        if catalog not in {name.lower() for name in visible}:
+            raise DatabricksConnectionError(
+                f"scope '{entry}' names no catalog this principal can see; "
+                f"visible catalogs: {name_list(sorted(visible))}"
+            )
+        if not schema:
+            return (catalog, None)
+        schemas = self._schemas(catalog)
+        if schema not in {name.lower() for name in schemas}:
+            raise DatabricksConnectionError(
+                f"scope '{entry}' does not exist: catalog {catalog} has no "
+                f"schema {schema}; schemas there: {name_list(sorted(schemas))}"
+            )
+        return (catalog, schema)
+
+    def _catalogs(self) -> set[str]:
+        """Every catalog the principal can see, as Unity Catalog spells them. Free
+        (REST, no warehouse), cached, and the live credential probe: the listing
+        fails on a stale or underprivileged credential."""
+
+        if self._visible_catalogs is None:
+            self._visible_catalogs = {
+                str(catalog.name) for catalog in self._workspace.catalogs.list()
+            }
+        return self._visible_catalogs
+
+    def _schemas(self, catalog: str) -> set[str]:
+        """Every schema in one catalog, as Unity Catalog spells them. Free (REST),
+        cached per catalog. ``information_schema`` is never a source."""
+
+        if catalog not in self._schemas_by_catalog:
+            self._schemas_by_catalog[catalog] = {
+                str(schema.name)
+                for schema in self._workspace.schemas.list(catalog_name=catalog)
+                if str(schema.name) != "information_schema"
+            }
+        return self._schemas_by_catalog[catalog]
 
     def _catalog_scope(self) -> list[str]:
-        """Distinct catalogs in scope; also the live credential probe (the
-        catalogs list round-trips even when an allowlist is configured)."""
+        """Distinct catalogs across the resolved scopes."""
 
-        visible = {str(c.name) for c in self._workspace.catalogs.list()}
-        if not self.target.catalogs:
-            return sorted(visible - {"system"})
-        return sorted({entry.split(".")[0].lower() for entry in self.target.catalogs})
+        return sorted({catalog for catalog, _schema in self._scopes()})
+
+    def missing_dev_namespaces(self, catalog: str) -> list[str]:
+        """Which parts of a dbt dev target do not exist yet. Free: REST only, so
+        the billed SQL session is never opened.
+
+        dbt creates schemas but never catalogs, so ``dev_schema`` is deliberately
+        not checked: its absence is normal on a first build. A missing catalog is
+        fatal, and left to dbt it surfaces from deep inside the first build as a
+        ``CREATE SCHEMA`` failure naming neither the catalog nor the fix.
+        """
+
+        visible = {name.lower() for name in self._catalogs()}
+        return [] if catalog.lower() in visible else [f'dev_catalog "{catalog}"']
+
+    def dev_write_grants(self, catalog: str, schema: str) -> list[str]:
+        """The privileges the principal is missing to build into the dev namespace,
+        as far as Unity Catalog can prove. Free: REST only.
+
+        A dev catalog that exists but cannot be written is the other half of the
+        preflight, and the one dbt reports worst: the first model dies with
+        ``PERMISSION_DENIED: User does not have CREATE TABLE and USE SCHEMA``,
+        after the warehouse has already woken and the budget has already been
+        spent.
+
+        Reported, never raised, because Unity Catalog cannot prove the negative.
+        Ownership does not appear in the effective-privilege API (a catalog owner
+        reads back as holding nothing at all), and a metastore admin bypasses
+        grants entirely, so an empty answer is not evidence of no access. Refusing
+        on it would break builds dbt could run, which this preflight must never do.
+        Ownership is therefore checked first, and what is left is a warning.
+        """
+
+        principal = str(self._workspace.current_user.me().user_name)
+        owns_catalog = self._owns(self._workspace.catalogs.get(catalog), principal)
+        catalog_privileges = (
+            set()
+            if owns_catalog
+            else self._effective_privileges("CATALOG", catalog, principal)
+        )
+
+        qualified = f"{catalog}.{schema}"
+        if schema.lower() not in {name.lower() for name in self._schemas(catalog)}:
+            # The schema is not there yet, and dbt creates it: what that needs is
+            # the right to create inside the catalog, which its owner always has.
+            if owns_catalog:
+                return []
+            return [
+                f"{privilege} ON CATALOG {catalog}"
+                for privilege in ("USE CATALOG", "CREATE SCHEMA")
+                if privilege not in catalog_privileges
+            ]
+
+        # The schema exists, and owning the catalog is not enough to write inside a
+        # schema someone else owns: Unity Catalog answers that with the very
+        # PERMISSION_DENIED this check exists to predict.
+        if self._owns(self._workspace.schemas.get(qualified), principal):
+            return []
+        held = self._effective_privileges("SCHEMA", qualified, principal)
+        missing = [
+            f"{privilege} ON SCHEMA {qualified}"
+            for privilege in ("USE SCHEMA", "CREATE TABLE")
+            if privilege not in held
+        ]
+        if missing and not owns_catalog and "USE CATALOG" not in catalog_privileges:
+            missing.insert(0, f"USE CATALOG ON CATALOG {catalog}")
+        return missing
+
+    @staticmethod
+    def _owns(securable: Any, principal: str) -> bool:
+        return str(getattr(securable, "owner", "") or "").lower() == principal.lower()
+
+    def _effective_privileges(
+        self, securable_type: str, full_name: str, principal: str
+    ) -> set[str]:
+        """Everything ``principal`` effectively holds on one securable, including
+        what it inherits through its groups. Free (REST). An error here is not a
+        refusal: it degrades to "nothing proven", and the caller only warns."""
+
+        try:
+            effective = self._workspace.grants.get_effective(
+                securable_type=securable_type, full_name=full_name, principal=principal
+            )
+        except Exception:  # a grant we cannot read is not a grant we can deny on
+            return set()
+        return {
+            str(privilege.privilege)
+            for assignment in (effective.privilege_assignments or [])
+            for privilege in (assignment.privileges or [])
+        }
 
     # --- the warehouse and the DBU translation ----------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
@@ -42,7 +42,15 @@ from ..config import PostgresTarget
 from ..envelope import Paradigm
 from ..guards.cost_guard import CostGate, OverCeilingError
 from ..guards.sql_guard import assert_select_only
-from .base import ColumnAggregate, ColumnMeta, ObjectMeta, QueryResult, json_safe
+from .base import (
+    ColumnAggregate,
+    ColumnMeta,
+    ObjectMeta,
+    QueryResult,
+    blame,
+    json_safe,
+    name_list,
+)
 
 PARADIGM = "db_load"
 DIALECT = "postgres"
@@ -120,12 +128,18 @@ class PostgresAdapter:
         cost_gate: CostGate,
         target: PostgresTarget | None = None,
         auth_method: str = "unknown",
+        scope_origin: str | None = None,
         clock: Callable[[], float] = time.monotonic,
     ):
         self._conn = connection
         self.cost_gate = cost_gate
         self.target = target or PostgresTarget()
         self.auth_method = auth_method
+        # What the scope entries in the target came from, so a refusal names the
+        # thing the user has to go edit: a per-command flag or the committed
+        # allowlist. `narrow_target` has already collapsed the two by the time
+        # the adapter sees them, and the fix differs entirely.
+        self._scope_origin = scope_origin or "postgres.schemas in .dex/config.yml"
         self._clock = clock
         # Imported lazily (the caller constructed the connection, so the
         # library is present); the error types drive refusal translation.
@@ -140,6 +154,8 @@ class PostgresAdapter:
         self._stats: dict[str, dict[str, float]] = {}
         self._exact_rows: dict[str, int] = {}
         self._inventory_loaded = False
+        self._resolved_schemas: list[str] | None = None
+        self._visible_schemas: set[str] | None = None
         self._database: str | None = None
         self._notes: dict[str, list[str]] = {}
         self._session_prepared = False
@@ -211,7 +227,10 @@ class PostgresAdapter:
         if self._inventory_loaded:
             return
         database = self._current_database()
-        allowed = set(self.target.schemas)
+        # The resolved scopes, not the raw config: an entry that names nothing is
+        # refused before this filter drops it, which is the silent-empty-inventory
+        # bug this connector was most exposed to.
+        allowed = set(self._schema_scope()) if self.target.schemas else set()
         # relkind: r table, p partitioned table, f foreign table, m
         # materialized view, v view. reltuples is the planner's estimate (-1
         # means never analyzed); pg_total_relation_size is a catalog lookup,
@@ -296,17 +315,115 @@ class PostgresAdapter:
         return self._database
 
     def _schema_scope(self) -> list[str]:
-        """The allowlisted schemas, or every visible non-system schema when no
-        allowlist is configured."""
+        """Every source schema this command reads, proven to exist.
 
-        if self.target.schemas:
-            return sorted(set(self.target.schemas))
+        Resolution is free (one pg_catalog SELECT, no scan) and cached for the
+        command. It runs before anything is estimated, because a scope that
+        resolves to nothing and silently falls back to the whole allowlist is a
+        cost-safety bug: the estimate the user confirms would cover tables they
+        never named. Postgres was the worst of the connectors here, because an
+        allowlist entry was echoed back without ever asking the server, and the
+        inventory filter then dropped it silently: a typo simply returned nothing.
+        """
+
+        if self._resolved_schemas is None:
+            self._resolved_schemas = self._resolve_schemas()
+        return self._resolved_schemas
+
+    def _resolve_schemas(self) -> list[str]:
+        visible = self._schemas()
+        if not self.target.schemas:
+            return sorted(visible)
+        with blame(self._scope_origin, PostgresConnectionError):
+            return sorted(
+                {self._resolve_schema(entry, visible) for entry in self.target.schemas}
+            )
+
+    def _resolve_schema(self, entry: str, visible: set[str]) -> str:
+        """One scope entry, proven to exist. A Postgres scope is always a bare
+        schema in the connected database (dbt refuses cross-database references
+        outright), so there is nothing to qualify and nothing to disambiguate."""
+
+        token = entry.strip()
+        if not token:
+            raise PostgresConnectionError("empty scope entry")
+        if "." in token:
+            raise PostgresConnectionError(
+                f"scope '{entry}' has too many parts; a Postgres source scope is "
+                "a bare <schema> in the connected database "
+                f"({self._current_database()}), never a database or a table"
+            )
+        if token not in visible:
+            raise PostgresConnectionError(
+                f"scope '{entry}' names no schema in database "
+                f"{self._current_database()}; schemas there: "
+                f"{name_list(sorted(visible))}"
+            )
+        return token
+
+    def _schemas(self) -> set[str]:
+        """Every non-system schema in the connected database. Free (one catalog
+        SELECT, no scan), cached, and the live credential probe."""
+
+        if self._visible_schemas is None:
+            rows = self._catalog(
+                "SELECT nspname FROM pg_catalog.pg_namespace "
+                "WHERE nspname <> 'information_schema' "
+                "AND nspname NOT LIKE 'pg\\_%'"
+            )
+            self._visible_schemas = {str(row["nspname"]) for row in rows}
+        return self._visible_schemas
+
+    def missing_dev_namespaces(self, schema: str, *, role: str) -> list[str]:
+        """What stops ``role`` from building into the dev schema. Free: catalog
+        lookups and privilege predicates, no scan.
+
+        dbt creates the schema itself, so its absence is not fatal on its own:
+        what is fatal is the privilege to create it. Postgres therefore differs
+        from Snowflake and Databricks, where the missing *object* is the whole
+        problem. ``role`` is the one in the rendered profile rather than the
+        connected user, because dex may legitimately read as a read-only role
+        while dbt writes as another, and Postgres will answer a privilege
+        question about any role.
+        """
+
+        if not self._role_exists(role):
+            raise PostgresConnectionError(
+                f"the dbt role {role} does not exist in database "
+                f"{self._current_database()}; create it, or point the profile at "
+                "a role that exists"
+            )
+        who = f"'{_escape_literal(role)}'"
+        if schema not in self._schemas():
+            # dbt will issue CREATE SCHEMA IF NOT EXISTS on the first build, which
+            # needs CREATE on the database. Absent that, the build dies with a
+            # bare permission error naming neither the schema nor the grant.
+            row = self._catalog(
+                f"SELECT has_database_privilege({who}, current_database(), "
+                "'CREATE') AS may_create"
+            )[0]
+            return [] if bool(row["may_create"]) else [f'dev_schema "{schema}"']
+        where = f"{who}, '{_escape_literal(schema)}'"
+        row = self._catalog(
+            f"SELECT has_schema_privilege({where}, 'CREATE') AS may_create, "
+            f"has_schema_privilege({where}, 'USAGE') AS may_use"
+        )[0]
+        missing = [
+            privilege
+            for privilege, granted in (
+                ("USAGE", row["may_use"]),
+                ("CREATE", row["may_create"]),
+            )
+            if not bool(granted)
+        ]
+        return [f'{", ".join(missing)} on dev_schema "{schema}"'] if missing else []
+
+    def _role_exists(self, role: str) -> bool:
         rows = self._catalog(
-            "SELECT nspname FROM pg_catalog.pg_namespace "
-            "WHERE nspname <> 'information_schema' "
-            "AND nspname NOT LIKE 'pg\\_%'"
+            "SELECT 1 AS present FROM pg_catalog.pg_roles "  # noqa: S608
+            f"WHERE rolname = '{_escape_literal(role)}'"
         )
-        return sorted(str(row["nspname"]) for row in rows)
+        return bool(rows)
 
     def _table_stats(self, identifier: str) -> dict[str, float]:
         """Free per-table distinct estimates from the planner's statistics.

--- a/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import Callable
-from contextlib import contextmanager
 from typing import Any
 
 from ..config import SnowflakeTarget
@@ -40,7 +39,9 @@ from .base import (
     ColumnMeta,
     ObjectMeta,
     QueryResult,
+    blame,
     json_safe,
+    name_list,
     scope_within,
 )
 
@@ -52,10 +53,6 @@ DIALECT = "snowflake"
 # be reached by a scope entry.
 _RESERVED_SCHEMA = "INFORMATION_SCHEMA"
 _RESERVED_DATABASE = "SNOWFLAKE"
-
-# How many sibling names an error message lists before it stops. Long enough to
-# spot a typo, short enough not to paste a thousand-schema account into stdout.
-_SUGGESTION_CAP = 12
 
 # How many databases a bare schema name may be searched across before dex asks
 # for a qualified <database>.<schema> instead. Each candidate costs one free SHOW
@@ -363,7 +360,8 @@ class SnowflakeAdapter:
     def _resolve_scopes(self) -> list[str]:
         committed = self.target.databases
         if committed:
-            with _blame("snowflake.databases in .dex/config.yml"):
+            origin = "snowflake.databases in .dex/config.yml"
+            with blame(origin, SnowflakeConnectionError):
                 configured = sorted(
                     {
                         self._resolve_scope(entry, sorted(self._databases()))
@@ -379,7 +377,7 @@ class SnowflakeAdapter:
         # bare schema name can never resolve into a database outside the committed
         # boundary; a qualified one that tries is refused below.
         searchable = sorted({scope.split(".")[0] for scope in configured})
-        with _blame("--scope"):
+        with blame("--scope", SnowflakeConnectionError):
             requested = sorted(
                 {
                     self._resolve_scope(entry, searchable)
@@ -389,8 +387,8 @@ class SnowflakeAdapter:
         outside = [scope for scope in requested if not scope_within(scope, configured)]
         if outside:
             raise SnowflakeConnectionError(
-                f"scope {_name_list(outside)} is outside the committed allowlist "
-                f"(snowflake.databases: {_name_list(configured)}); --scope narrows "
+                f"scope {name_list(outside)} is outside the committed allowlist "
+                f"(snowflake.databases: {name_list(configured)}); --scope narrows "
                 "the configured scope, it never widens it"
             )
         return requested
@@ -430,7 +428,7 @@ class SnowflakeAdapter:
             if schema not in schemas:
                 raise SnowflakeConnectionError(
                     f"scope '{entry}' does not exist: database {database} has no "
-                    f"schema {schema}; schemas there: {_name_list(sorted(schemas))}"
+                    f"schema {schema}; schemas there: {name_list(sorted(schemas))}"
                 )
             return f"{database}.{schema}"
 
@@ -454,16 +452,16 @@ class SnowflakeAdapter:
             schemas = sorted({s for db in searchable for s in self._schemas(db)})
             raise SnowflakeConnectionError(
                 f"scope '{entry}' names no database and no schema in "
-                f"{_name_list(searchable)}; schemas there: {_name_list(schemas)}; "
+                f"{name_list(searchable)}; schemas there: {name_list(schemas)}; "
                 f"{self._visible_hint()}"
             )
         raise SnowflakeConnectionError(
             f"scope '{entry}' is ambiguous: it names a schema in "
-            f"{_name_list(matches)}; qualify it as <database>.{token}"
+            f"{name_list(matches)}; qualify it as <database>.{token}"
         )
 
     def _visible_hint(self) -> str:
-        return f"visible databases: {_name_list(sorted(self._databases()))}"
+        return f"visible databases: {name_list(sorted(self._databases()))}"
 
     def _databases(self) -> set[str]:
         """Every database the role can see. Free, and doubles as the live
@@ -999,31 +997,6 @@ class SnowflakeAdapter:
         close = getattr(self._conn, "close", None)
         if close is not None:
             close()
-
-
-def _name_list(names: list[str]) -> str:
-    """Names for an error message, capped so a thousand-schema account cannot
-    turn a one-line refusal into a page of stdout."""
-
-    shown = list(names)[:_SUGGESTION_CAP]
-    suffix = (
-        f", and {len(names) - _SUGGESTION_CAP} more"
-        if len(names) > _SUGGESTION_CAP
-        else ""
-    )
-    return (", ".join(shown) + suffix) if shown else "(none)"
-
-
-@contextmanager
-def _blame(origin: str):
-    """Attribute a scope failure to the thing the user has to go edit. The
-    resolver does not know whether an entry came from the committed allowlist or
-    from a flag, and the fix differs entirely."""
-
-    try:
-        yield
-    except SnowflakeConnectionError as exc:
-        raise SnowflakeConnectionError(f"{exc} [from {origin}]") from exc
 
 
 def _quote_ident(name: str) -> str:

--- a/packages/dex-core/src/exmergo_dex_core/connect.py
+++ b/packages/dex-core/src/exmergo_dex_core/connect.py
@@ -115,6 +115,9 @@ def open_adapter(
             command=command,
             project_override=project,
             dataset_override=datasets or scopes,
+            # Both flags scope BigQuery, and the refusal has to name the one the
+            # user actually typed.
+            scope_flag=("--dataset" if datasets else "--scope" if scopes else None),
         )
 
     if connector == "snowflake":
@@ -224,6 +227,18 @@ def narrow_target(target, connector: str, scope_override: list[str] | None):
     return target.model_copy(update={field: list(scope_override)})
 
 
+def scope_origin(connector: str, flag: str | None) -> str:
+    """What a scope refusal should tell the user to go edit.
+
+    ``narrow_target`` copies a per-command scope over the committed allowlist, so
+    by the time an adapter proves the entries exist it can no longer tell which
+    of the two it is holding, and the fix differs entirely: edit the flag, or
+    edit the file. The caller knows, so it says.
+    """
+
+    return flag or f"{connector}.{_SCOPE_FIELDS[connector]} in .dex/config.yml"
+
+
 def _open_bigquery(
     config: DexConfig,
     repo_root: str | Path,
@@ -233,6 +248,7 @@ def _open_bigquery(
     command: str | None,
     project_override: str | None = None,
     dataset_override: list[str] | None = None,
+    scope_flag: str | None = None,
 ):
     target = config.bigquery or BigQueryTarget()
     target = narrow_target(target, "bigquery", dataset_override)
@@ -272,6 +288,7 @@ def _open_bigquery(
         cost_gate=gate,
         credentials=credentials,
         principal_type=principal_type,
+        scope_origin=scope_origin("bigquery", scope_flag),
     )
 
 
@@ -593,6 +610,7 @@ def _open_databricks(
         target=target,
         host=_databricks_hostname(sdk_config.host),
         auth_method=method,
+        scope_origin=scope_origin("databricks", "--scope" if scope_override else None),
     )
 
 
@@ -809,6 +827,7 @@ def _open_postgres(
         cost_gate=gate,
         target=target,
         auth_method=method,
+        scope_origin=scope_origin("postgres", "--scope" if scope_override else None),
     )
 
 

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -270,6 +270,38 @@ def target_identifiers(
     }
 
 
+def target_role(project_dir: Path | str, target: str | None = None) -> str | None:
+    """The role a profiles.yml target authenticates as, for a privilege preflight.
+
+    Deliberately not part of :func:`target_identifiers`, whose result is
+    envelope-safe by contract and therefore carries namespace identifiers only.
+    A role name is an identity, so it gets its own door and one narrow caller:
+    asking the warehouse whether *that* role may write the dev namespace.
+
+    It has to be the profile's role rather than the one dex connects as, because
+    reading a warehouse with a read-only role while dbt builds with a writing one
+    is an ordinary split, and asking the wrong role would refuse a build dbt could
+    have run. Callers may name it in the refusal (the GRANT that fixes the problem
+    is useless without it) and nowhere else.
+    """
+
+    project = Path(project_dir)
+    try:
+        view_profile = load(project).profile_name
+        profiles = _load_profiles(project)
+    except (DbtProjectError, yaml.YAMLError):
+        return None
+    profile = profiles.get(view_profile)
+    if not isinstance(profile, dict):
+        return None
+    outputs = profile.get("outputs") or {}
+    output = outputs.get(target or profile.get("target"))
+    if not isinstance(output, dict):
+        return None
+    role = output.get("user")
+    return str(role) if role else None
+
+
 def duckdb_target_path(
     project_dir: Path | str, target: str | None = None
 ) -> Path | None:

--- a/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
@@ -9,17 +9,23 @@ config afterwards changes nothing, so a user who retargets their dev database
 gets a green build against the old one. dex asks you to author that config file,
 so it has to be live or say plainly that it is not.
 
-The second is absence. dbt creates schemas but never databases, so a dev database
-that does not exist yet fails somewhere inside dbt's ``list_schemas`` macro with
-``002043: Object does not exist``, a message that names neither the database nor
-the fix.
+The second is that the dev target cannot be built into. dbt creates schemas, and
+nothing above them, so the namespace the schema lives in has to be there already:
+a missing Snowflake database dies inside dbt's ``list_schemas`` macro with
+``002043: Object does not exist``, and a missing Databricks catalog dies inside
+the ``create schema`` it issues. Neither message names the object or the fix. The
+rule is therefore: what dbt cannot create for itself is refused here, and what it
+can create is not. That lands differently per connector, so each has its own free
+probe. BigQuery does create its dev dataset, so an absent one is a warning and
+only an unreachable project is fatal. Postgres creates its dev schema too, but
+only if the role may, so what gets checked there is the privilege, asked of the
+role in the rendered profile rather than the one dex reads with.
 
-Both are refusals, not warnings, and both are free: the drift check reads two
-files, and the existence check rides the connector's free metadata path. They run
-before the cost gate, so a build that cannot possibly succeed is refused before
-anyone is asked to weigh a budget. Neither ever rewrites ``profiles.yml``: a
-hand-edited profile is a legitimate thing to have, and dex proposes rather than
-imposes.
+The refusals are free: the drift check reads two files, and every existence check
+rides the connector's free metadata path. They run before the cost gate, so a
+build that cannot possibly succeed is refused before anyone is asked to weigh a
+budget. Neither ever rewrites ``profiles.yml``: a hand-edited profile is a
+legitimate thing to have, and dex proposes rather than imposes.
 """
 
 from __future__ import annotations
@@ -30,7 +36,12 @@ import yaml
 
 from ..cache import DEX_DIR
 from ..config import CONFIG_FILE, DexConfig
-from ..dbt_project import PROFILES_FILE, duckdb_target_path, target_identifiers
+from ..dbt_project import (
+    PROFILES_FILE,
+    duckdb_target_path,
+    target_identifiers,
+    target_role,
+)
 from ..dbt_project import load as load_project
 
 
@@ -138,14 +149,52 @@ def _assert_no_drift(
 def _assert_namespace_exists(
     project: Path, target: str, config: DexConfig, repo_root: Path | str
 ) -> list[str]:
+    """What dbt cannot create for itself is fatal; what it can create is not.
+
+    That rule is the whole shape of this dispatch, and it lands differently per
+    connector because their ``create_schema`` implementations differ. dbt creates
+    schemas everywhere, so no connector's dev *schema* is checked. Above the
+    schema it stops: it never creates a Snowflake database or a Databricks
+    catalog, so a missing one is refused. BigQuery is the exception, because
+    dbt-bigquery does create its dev dataset; only the project it cannot create,
+    so an absent dataset is a warning and an unreachable project a refusal.
+    Postgres inverts it again: dbt creates the schema, but only if the role may,
+    so the privilege is what gets checked.
+    """
+
     if config.connector == "duckdb":
         return _duckdb_namespace(project, target)
     if config.connector == "snowflake":
         return _snowflake_namespace(config, repo_root)
-    # BigQuery, Databricks, and Postgres have the same gap: nothing checks that
-    # the dev dataset/catalog/schema exists, or that the principal may write it.
-    # Each needs its own free probe; until then dbt's error is the only signal.
+    if config.connector == "databricks":
+        return _databricks_namespace(config, repo_root)
+    if config.connector == "bigquery":
+        return _bigquery_namespace(config, repo_root)
+    if config.connector == "postgres":
+        return _postgres_namespace(project, target, config, repo_root)
     return []
+
+
+def _open_for_preflight(connector: str, repo_root: Path | str):
+    """The adapter, or the note to degrade to.
+
+    dex discovers its own connection (a connections file, the environment) while
+    dbt reads ``profiles.yml``, and the two can legitimately differ, so a
+    connection dex cannot open is reported rather than raised: the preflight must
+    never be the thing that breaks a build dbt could have run. The exception class
+    rides along, because silently degrading is how a real defect in the preflight
+    would go unnoticed for a long time.
+    """
+
+    from ..connect import open_adapter
+
+    try:
+        return open_adapter(connector=connector, repo_root=repo_root), None
+    except Exception as exc:
+        return None, (
+            "could not preflight the dev database "
+            f"({type(exc).__name__}: {exc}); dbt will report any problem with it"
+        )
 
 
 def _duckdb_namespace(project: Path, target: str) -> list[str]:
@@ -171,29 +220,15 @@ def _duckdb_namespace(project: Path, target: str) -> list[str]:
 
 
 def _snowflake_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
-    """Free: SHOW only, no warehouse, so this costs nothing on a billed connector.
-
-    dex discovers its own connection (connections.toml, the environment) while dbt
-    reads ``profiles.yml``, and the two can legitimately differ, so a connection
-    dex cannot open is reported as a warning rather than raised: the preflight
-    must never be the thing that breaks a build dbt could have run.
-    """
+    """Free: SHOW only, no warehouse, so this costs nothing on a billed connector."""
 
     target = config.snowflake
     if target is None or not target.dev_database:
         return []
 
-    from ..connect import open_adapter
-
-    try:
-        adapter = open_adapter(connector="snowflake", repo_root=repo_root)
-    except Exception as exc:  # degrade to a note; never block a build dbt could run
-        # The exception class rides along: silently degrading is how a real defect
-        # in the preflight would go unnoticed for a long time.
-        return [
-            "could not preflight the dev database "
-            f"({type(exc).__name__}: {exc}); dbt will report any problem with it"
-        ]
+    adapter, note = _open_for_preflight("snowflake", repo_root)
+    if adapter is None:
+        return [note]
     try:
         missing = adapter.missing_dev_namespaces(target.dev_database)
     finally:
@@ -207,6 +242,146 @@ def _snowflake_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
         "(dbt creates schemas but never databases, so the first build cannot "
         "create it), or point snowflake.dev_database at a database the role "
         "can write"
+    )
+
+
+def _databricks_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
+    """Free: Unity Catalog REST only, so the billed SQL warehouse is never woken.
+
+    The closest analogue of the Snowflake case: dbt-databricks creates the dev
+    schema (``create schema if not exists <catalog>.<schema>``) but never the
+    catalog it lives in, so a missing catalog fails the first build from inside
+    that statement, naming neither the catalog nor the fix.
+    """
+
+    target = config.databricks
+    if target is None or not target.dev_catalog:
+        return []
+
+    from .init import _DEFAULT_DBX_DEV_SCHEMA
+
+    schema = target.dev_schema or _DEFAULT_DBX_DEV_SCHEMA
+    adapter, note = _open_for_preflight("databricks", repo_root)
+    if adapter is None:
+        return [note]
+    try:
+        missing = adapter.missing_dev_namespaces(target.dev_catalog)
+        ungranted = (
+            adapter.dev_write_grants(target.dev_catalog, schema) if not missing else []
+        )
+    finally:
+        adapter.close()
+
+    if missing:
+        raise DevTargetError(
+            f"databricks {missing[0]} does not exist; create it with:\n"
+            f"  CREATE CATALOG IF NOT EXISTS {target.dev_catalog};\n"
+            "(dbt creates schemas but never catalogs, so the first build cannot "
+            "create it), or point databricks.dev_catalog at a catalog the principal "
+            "can write"
+        )
+    if not ungranted:
+        return []
+    grants = "\n".join(f"  GRANT {grant} TO `<principal>`;" for grant in ungranted)
+    return [
+        f"the dev target {target.dev_catalog}.{schema} exists but Unity Catalog "
+        "reports no privilege on it for this principal, so the build may fail with "
+        "PERMISSION_DENIED after the warehouse has already woken. Grant it:\n"
+        f"{grants}\n"
+        "(ownership and metastore-admin rights are invisible to the grants API, so "
+        "this is a warning, not a refusal: the build may still succeed)"
+    ]
+
+
+def _bigquery_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
+    """Free: a metadata GET, no query, so nothing is billed on a bytes-billed
+    connector.
+
+    BigQuery is the connector where the missing dev namespace is *not* fatal:
+    dbt-bigquery's ``create_schema`` issues ``CREATE SCHEMA IF NOT EXISTS``, which
+    creates the dataset, so an absent one is the normal state before a first build
+    and gets a warning rather than a refusal. Refusing it would block a build that
+    would have succeeded. What dbt cannot create is the project, and an unreachable
+    one is raised by the adapter.
+    """
+
+    target = config.bigquery
+    if target is None or not target.dev_dataset:
+        return []
+
+    dataset = target.dev_dataset
+    adapter, note = _open_for_preflight("bigquery", repo_root)
+    if adapter is None:
+        return [note]
+    try:
+        missing = adapter.missing_dev_namespaces(dataset)
+        qualified = dataset if "." in dataset else f"{adapter.project}.{dataset}"
+    except Exception as exc:  # an unreachable dev project: dbt cannot create one
+        raise DevTargetError(str(exc)) from exc
+    finally:
+        adapter.close()
+
+    if not missing:
+        return []
+    location = target.location or "<location>"
+    return [
+        f"dev_dataset {qualified} does not exist; dbt will create it on the first "
+        "build, which needs bigquery.datasets.create on the project. Without that "
+        "permission the build fails there instead, so create it first: "
+        f"bq mk --dataset --location={location} {qualified}"
+    ]
+
+
+def _postgres_namespace(
+    project: Path, target: str, config: DexConfig, repo_root: Path | str
+) -> list[str]:
+    """Free: catalog lookups and privilege predicates, no scan.
+
+    Postgres inverts the question. dbt creates the dev schema, so its absence is
+    not the failure; the privilege to create it is. And the role that needs the
+    privilege is the one in the rendered profile, not the one dex connects as:
+    reading the warehouse read-only and building as a role that can write is a
+    perfectly ordinary split, and this preflight exists precisely to catch the
+    case where the writing role cannot, in fact, write.
+    """
+
+    pg = config.postgres
+    if pg is None or not pg.dev_schema:
+        return []
+    role = target_role(project, target)
+    if not role:
+        # No rendered profile to read a role from (or it names none): there is no
+        # role to ask a privilege question about, so there is nothing to check.
+        return []
+
+    adapter, note = _open_for_preflight("postgres", repo_root)
+    if adapter is None:
+        return [note]
+    try:
+        missing = adapter.missing_dev_namespaces(pg.dev_schema, role=role)
+    except Exception as exc:  # the profile's role does not exist in the database
+        raise DevTargetError(str(exc)) from exc
+    finally:
+        adapter.close()
+
+    if not missing:
+        return []
+    problem = missing[0]
+    if problem.startswith("dev_schema"):
+        raise DevTargetError(
+            f"postgres {problem} does not exist and role {role} may not create "
+            "it; create it with:\n"
+            f"  CREATE SCHEMA IF NOT EXISTS {pg.dev_schema} AUTHORIZATION "
+            f"{role};\n"
+            "(dbt creates its dev schema, but only if the role may, so the first "
+            "build otherwise dies on a bare permission error), or point "
+            "postgres.dev_schema at a schema the role can write"
+        )
+    raise DevTargetError(
+        f"postgres role {role} is missing {problem}; grant it with:\n"
+        f"  GRANT USAGE, CREATE ON SCHEMA {pg.dev_schema} TO {role};\n"
+        "(dbt builds every model in that schema), or point postgres.dev_schema "
+        "at a schema the role can write"
     )
 
 

--- a/packages/dex-core/tests/adapters/test_connect_bigquery.py
+++ b/packages/dex-core/tests/adapters/test_connect_bigquery.py
@@ -13,7 +13,7 @@ pytest.importorskip("google.cloud.bigquery")
 from google.cloud import bigquery
 
 from exmergo_dex_core.adapters import get_adapter, get_dialect
-from exmergo_dex_core.adapters.bigquery import BigQueryAdapter
+from exmergo_dex_core.adapters.bigquery import BigQueryAdapter, BigQueryConnectionError
 from exmergo_dex_core.config import BigQueryTarget
 from exmergo_dex_core.envelope import Paradigm
 from exmergo_dex_core.guards.cost_guard import (
@@ -34,6 +34,7 @@ def make_adapter(
     session_spent: float = 0.0,
     record=None,
     target: BigQueryTarget | None = None,
+    scope_origin: str | None = None,
 ) -> BigQueryAdapter:
     gate = CostGate(
         paradigm=Paradigm.BYTES_SCANNED,
@@ -51,6 +52,7 @@ def make_adapter(
         target=target or BigQueryTarget(),
         client=client,
         principal_type="user",
+        scope_origin=scope_origin,
     )
 
 
@@ -547,3 +549,91 @@ def test_project_and_dataset_flags_override_the_config_target(tmp_path, monkeypa
     assert captured["project"] == "cli-proj"
     assert captured["target"].project == "cli-proj"
     assert captured["target"].datasets == ["ds_a", "ds_b"]
+
+
+# --- scope resolution: an entry that names nothing is refused, not dropped ------------
+
+
+def test_nonexistent_dataset_scope_is_refused_and_names_what_exists(fake_bq_client):
+    """The cost-safety bug: a scope that resolves to nothing used to reach
+    list_tables and die on a raw google NotFound, naming neither the fix nor the
+    datasets that do exist."""
+
+    adapter = make_adapter(
+        fake_bq_client,
+        target=BigQueryTarget(datasets=["no_such_dataset"]),
+    )
+    with pytest.raises(BigQueryConnectionError) as exc:
+        adapter.list_objects()
+    message = str(exc.value)
+    assert "no_such_dataset" in message
+    assert "shop" in message and "logs" in message  # the datasets that do exist
+    assert "[from bigquery.datasets in .dex/config.yml]" in message
+    assert fake_bq_client.query_calls == []
+
+
+def test_scope_refusal_blames_the_flag_it_came_from(fake_bq_client):
+    """`--dataset` and `--scope` both scope BigQuery, and narrow_target copies
+    either one over the committed allowlist, so the adapter is told which."""
+
+    adapter = make_adapter(
+        fake_bq_client,
+        target=BigQueryTarget(datasets=["nope"]),
+        scope_origin="--dataset",
+    )
+    with pytest.raises(BigQueryConnectionError, match=r"\[from --dataset\]"):
+        adapter.list_objects()
+
+
+def test_a_table_shaped_scope_is_refused(fake_bq_client):
+    adapter = make_adapter(
+        fake_bq_client,
+        target=BigQueryTarget(datasets=["test-proj.shop.customers"]),
+    )
+    with pytest.raises(BigQueryConnectionError, match="never a table"):
+        adapter.list_objects()
+
+
+def test_a_valid_scope_still_bounds_the_inventory(fake_bq_client):
+    adapter = make_adapter(fake_bq_client, target=BigQueryTarget(datasets=["shop"]))
+    assert [o.identifier for o in adapter.list_objects()] == [
+        "test-proj.shop.customers",
+        "test-proj.shop.events",
+    ]
+    assert fake_bq_client.query_calls == []
+
+
+# --- the dev-target preflight (free) --------------------------------------------------
+
+
+def test_a_missing_dev_dataset_is_reported_not_raised(fake_bq_client):
+    """dbt-bigquery creates its dev dataset (CREATE SCHEMA IF NOT EXISTS), so an
+    absent one is the normal state before a first build: the caller warns rather
+    than refusing, unlike Snowflake and Databricks."""
+
+    adapter = make_adapter(fake_bq_client)
+    assert adapter.missing_dev_namespaces("dbt_dev") == [
+        'dev_dataset "test-proj.dbt_dev"'
+    ]
+    assert fake_bq_client.query_calls == []
+
+
+def test_an_existing_dev_dataset_is_fine(fake_bq_client):
+    fake_bq_client.empty_datasets.add("test-proj.dbt_dev")
+    adapter = make_adapter(fake_bq_client)
+    assert adapter.missing_dev_namespaces("dbt_dev") == []
+    assert fake_bq_client.query_calls == []
+
+
+def test_an_unreachable_dev_project_is_raised(fake_bq_client):
+    """What dbt cannot create for itself: it makes datasets, never projects. The
+    listing that distinguishes the two is lazy in the real client, so a project
+    that is merely never iterated would read as a healthy one."""
+
+    adapter = make_adapter(fake_bq_client)
+    with pytest.raises(BigQueryConnectionError) as exc:
+        adapter.missing_dev_namespaces("no-such-project.dbt_dev")
+    message = str(exc.value)
+    assert "no-such-project" in message
+    assert "dbt creates datasets but never projects" in message
+    assert fake_bq_client.query_calls == []

--- a/packages/dex-core/tests/adapters/test_connect_databricks.py
+++ b/packages/dex-core/tests/adapters/test_connect_databricks.py
@@ -42,6 +42,7 @@ def make_adapter(
     session_spent: float = 0.0,
     record=None,
     target: DatabricksTarget | None = None,
+    scope_origin: str | None = None,
 ) -> DatabricksAdapter:
     gate = CostGate(
         paradigm=Paradigm.COMPUTE_TIME,
@@ -60,6 +61,7 @@ def make_adapter(
         target=target or DatabricksTarget(warehouse="fake-wh"),
         host="test.cloud.databricks.com",
         auth_method="default_profile:oauth_user",
+        scope_origin=scope_origin,
         clock=fake.clock,
     )
 
@@ -698,3 +700,86 @@ def test_discovery_falls_back_to_dbt_profiles(
     )
     assert "from-dbt.cloud.databricks.com" in cfg.host
     assert method == "dbt_profile:token"
+
+
+# --- scope resolution: an entry that names nothing is refused, not dropped ------------
+
+
+def test_nonexistent_catalog_scope_is_refused_and_names_what_exists(fake_databricks):
+    """The cost-safety bug: a scope that resolves to nothing used to yield an
+    empty inventory, so the user scoped to nothing and was never told."""
+
+    adapter = make_adapter(
+        fake_databricks,
+        target=DatabricksTarget(warehouse="fake-wh", catalogs=["no_such_catalog"]),
+    )
+    with pytest.raises(DatabricksConnectionError) as exc:
+        adapter.list_objects()
+    message = str(exc.value)
+    assert "no_such_catalog" in message
+    assert "shop" in message  # the catalogs that do exist
+    assert "[from databricks.catalogs in .dex/config.yml]" in message
+    assert data_statements(fake_databricks) == []
+    assert fake_databricks.connect_count == 0  # never woke the warehouse
+
+
+def test_nonexistent_schema_scope_is_refused_and_names_what_exists(fake_databricks):
+    adapter = make_adapter(
+        fake_databricks,
+        target=DatabricksTarget(warehouse="fake-wh", catalogs=["shop.nope"]),
+        scope_origin="--scope",
+    )
+    with pytest.raises(DatabricksConnectionError) as exc:
+        adapter.list_objects()
+    message = str(exc.value)
+    assert "shop.nope" in message
+    assert "catalog shop has no schema nope" in message
+    assert "core" in message  # the schemas that do exist there
+    # The blame names the flag the entry actually came from, not the config file
+    # it was copied over: the two have entirely different fixes.
+    assert "[from --scope]" in message
+    assert data_statements(fake_databricks) == []
+
+
+def test_a_table_shaped_scope_is_refused(fake_databricks):
+    adapter = make_adapter(
+        fake_databricks,
+        target=DatabricksTarget(warehouse="fake-wh", catalogs=["shop.core.customers"]),
+    )
+    with pytest.raises(DatabricksConnectionError, match="never a table"):
+        adapter.list_objects()
+
+
+def test_scope_resolution_is_free_and_cached(fake_databricks):
+    """Free (REST only) and one round-trip per command: the estimate pass and the
+    confirmed run share the resolution."""
+
+    adapter = make_adapter(
+        fake_databricks,
+        target=DatabricksTarget(warehouse="fake-wh", catalogs=["shop.core"]),
+    )
+    adapter.list_objects()
+    adapter.list_objects()
+    calls = fake_databricks.workspace.metadata_calls
+    assert calls.count("catalogs.list") == 1
+    assert data_statements(fake_databricks) == []
+
+
+# --- the dev-target preflight (free) --------------------------------------------------
+
+
+def test_missing_dev_catalog_is_reported(fake_databricks):
+    adapter = make_adapter(fake_databricks)
+    assert adapter.missing_dev_namespaces("not_there") == ['dev_catalog "not_there"']
+    assert data_statements(fake_databricks) == []
+    assert fake_databricks.connect_count == 0
+
+
+def test_existing_but_empty_dev_catalog_is_fine(fake_databricks):
+    """dbt creates the schema; only the catalog has to pre-exist. An empty scratch
+    catalog is exactly the state before a first build."""
+
+    fake_databricks.workspace._empty_catalogs.append("dex_dev")
+    adapter = make_adapter(fake_databricks)
+    assert adapter.missing_dev_namespaces("dex_dev") == []
+    assert data_statements(fake_databricks) == []

--- a/packages/dex-core/tests/adapters/test_connect_postgres.py
+++ b/packages/dex-core/tests/adapters/test_connect_postgres.py
@@ -42,6 +42,7 @@ def make_adapter(
     session_spent: float = 0.0,
     record=None,
     target: PostgresTarget | None = None,
+    scope_origin: str | None = None,
 ) -> PostgresAdapter:
     gate = CostGate(
         paradigm=Paradigm.DB_LOAD,
@@ -58,6 +59,7 @@ def make_adapter(
         cost_gate=gate,
         target=target or PostgresTarget(),
         auth_method="database_url:password",
+        scope_origin=scope_origin,
         clock=connection.clock,
     )
 
@@ -632,3 +634,140 @@ def test_discovery_never_surfaces_a_password(tmp_path: Path):
         tmp_path,
     )
     assert "supersecret" not in method
+
+
+# --- scope resolution: an entry that names nothing is refused, not dropped ------------
+
+
+def test_nonexistent_schema_scope_is_refused_and_names_what_exists(fake_pg_connection):
+    """Postgres was the worst of the connectors here: the allowlist was echoed
+    back without ever asking the server, and the inventory filter then dropped
+    the unmatched entry, so a typo simply returned nothing."""
+
+    adapter = make_adapter(
+        fake_pg_connection, target=PostgresTarget(schemas=["no_such_schema"])
+    )
+    with pytest.raises(PostgresConnectionError) as exc:
+        adapter.list_objects()
+    message = str(exc.value)
+    assert "no_such_schema" in message
+    assert "shop" in message  # the schemas that do exist
+    assert "[from postgres.schemas in .dex/config.yml]" in message
+    assert fake_pg_connection.data_statements == []
+
+
+def test_scope_refusal_blames_the_flag_it_came_from(fake_pg_connection):
+    adapter = make_adapter(
+        fake_pg_connection,
+        target=PostgresTarget(schemas=["nope"]),
+        scope_origin="--scope",
+    )
+    with pytest.raises(PostgresConnectionError, match=r"\[from --scope\]"):
+        adapter.list_objects()
+
+
+def test_a_qualified_scope_is_refused_as_postgres_vocabulary(fake_pg_connection):
+    """dbt refuses cross-database references outright, so a Postgres scope is
+    always a bare schema in the connected database."""
+
+    adapter = make_adapter(
+        fake_pg_connection, target=PostgresTarget(schemas=["dexdb.shop"])
+    )
+    with pytest.raises(PostgresConnectionError, match="never a database or a table"):
+        adapter.list_objects()
+
+
+def test_a_valid_scope_still_bounds_the_inventory(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection, target=PostgresTarget(schemas=["shop"]))
+    assert {o.schema for o in adapter.list_objects()} == {"shop"}
+    assert fake_pg_connection.data_statements == []
+
+
+# --- the dev-target preflight (free): the privilege, not the object -------------------
+
+
+def _with_role(role):
+    from fakes.postgres import FakePostgresConnection, FakePostgresTable
+
+    return FakePostgresConnection(
+        tables=[
+            FakePostgresTable(
+                schema="shop", name="customers", columns=[("id", "bigint", False)]
+            )
+        ],
+        roles=[role],
+        empty_schemas=["dbt_dev"],
+    )
+
+
+def test_a_writable_dev_schema_is_fine(fake_pg_connection):
+    from fakes.postgres import FakeRole
+
+    connection = _with_role(
+        FakeRole(name="dbt_dev", schema_privileges={"dbt_dev": {"USAGE", "CREATE"}})
+    )
+    adapter = make_adapter(connection)
+    assert adapter.missing_dev_namespaces("dbt_dev", role="dbt_dev") == []
+    assert connection.data_statements == []
+
+
+def test_a_dev_schema_the_role_cannot_write_is_reported(fake_pg_connection):
+    from fakes.postgres import FakeRole
+
+    connection = _with_role(
+        FakeRole(name="dbt_dev", schema_privileges={"dbt_dev": {"USAGE"}})
+    )
+    adapter = make_adapter(connection)
+    assert adapter.missing_dev_namespaces("dbt_dev", role="dbt_dev") == [
+        'CREATE on dev_schema "dbt_dev"'
+    ]
+
+
+def test_an_absent_dev_schema_is_fine_when_the_role_may_create_it(fake_pg_connection):
+    """dbt creates the schema itself, so absence alone is not the failure."""
+
+    from fakes.postgres import FakeRole
+
+    connection = _with_role(FakeRole(name="dbt_dev", may_create_in_database=True))
+    adapter = make_adapter(connection)
+    assert adapter.missing_dev_namespaces("not_there", role="dbt_dev") == []
+
+
+def test_an_absent_dev_schema_the_role_cannot_create_is_reported(fake_pg_connection):
+    from fakes.postgres import FakeRole
+
+    connection = _with_role(FakeRole(name="dbt_dev", may_create_in_database=False))
+    adapter = make_adapter(connection)
+    assert adapter.missing_dev_namespaces("not_there", role="dbt_dev") == [
+        'dev_schema "not_there"'
+    ]
+
+
+def test_the_privilege_is_asked_of_the_profile_role_not_the_connected_user(
+    fake_pg_connection,
+):
+    """The whole reason the role is passed in: dex may read the warehouse as a
+    read-only role while dbt builds as another, so asking about the connected
+    user would refuse a build dbt could have run."""
+
+    from fakes.postgres import FakeRole
+
+    connection = _with_role(
+        FakeRole(name="dbt_dev", schema_privileges={"dbt_dev": {"USAGE", "CREATE"}})
+    )
+    adapter = make_adapter(connection)
+    # The writing role may build; the read-only role dex connects as may not, and
+    # that is not a reason to refuse.
+    assert adapter.missing_dev_namespaces("dbt_dev", role="dbt_dev") == []
+    with pytest.raises(PostgresConnectionError, match="dex_ro"):
+        adapter.missing_dev_namespaces("dbt_dev", role="dex_ro")
+
+
+def test_a_profile_role_the_database_does_not_know_is_refused(fake_pg_connection):
+    from fakes.postgres import FakeRole
+
+    connection = _with_role(FakeRole(name="dbt_dev"))
+    adapter = make_adapter(connection)
+    with pytest.raises(PostgresConnectionError) as exc:
+        adapter.missing_dev_namespaces("dbt_dev", role="ghost")
+    assert "ghost" in str(exc.value)

--- a/packages/dex-core/tests/fakes/bigquery.py
+++ b/packages/dex-core/tests/fakes/bigquery.py
@@ -128,9 +128,17 @@ class FakeBigQueryClient:
         tables: list[FakeTable] | None = None,
         row_resolver: Callable[[str], FakeResult | list[dict]] | None = None,
         default_query_bytes: int = DEFAULT_QUERY_BYTES,
+        empty_datasets: list[str] | None = None,
     ):
         self.project = project
         self.tables: dict[str, FakeTable] = {t.identifier: t for t in (tables or [])}
+        # Datasets that exist but hold no table: the state a scratch dev dataset
+        # is in before a first build, which a table-derived registry cannot
+        # otherwise express. Bare names qualify against `project`.
+        self.empty_datasets = {
+            name if "." in name else f"{project}.{name}"
+            for name in (empty_datasets or [])
+        }
         self.row_resolver = row_resolver
         self.default_query_bytes = default_query_bytes
         self.query_calls: list[FakeQueryCall] = []
@@ -146,18 +154,46 @@ class FakeBigQueryClient:
 
     # --- metadata surface (free API calls) ------------------------------------
 
-    def list_datasets(self, project: str | None = None):
-        dataset_ids = sorted({t.dataset_id for t in self.tables.values()})
-        return [SimpleNamespace(dataset_id=d) for d in dataset_ids]
+    def list_datasets(self, project: str | None = None, max_results: int | None = None):
+        """Lazy, like the real client's HTTPIterator: the request goes out (and an
+        unreachable project raises NotFound) only when the result is iterated. A
+        caller that never drains it learns nothing, which is exactly how a
+        not-really-checked project once read as a healthy one."""
+
+        target = project or self.project
+
+        def _pages():
+            if target not in self._projects():
+                raise api_exceptions.NotFound(f"project not found: {target}")
+            dataset_ids = sorted(
+                {t.dataset_id for t in self.tables.values() if t.project == target}
+                | {
+                    name.split(".", 1)[1]
+                    for name in self.empty_datasets
+                    if name.startswith(f"{target}.")
+                }
+            )
+            for dataset_id in dataset_ids[:max_results] if max_results else dataset_ids:
+                yield SimpleNamespace(dataset_id=dataset_id)
+
+        return _pages()
 
     def get_dataset(self, dataset_ref: str):
         project, dataset_id = str(dataset_ref).rsplit(".", 1)
-        if not any(
+        known = any(
             t.project == project and t.dataset_id == dataset_id
             for t in self.tables.values()
-        ):
+        )
+        if not known and str(dataset_ref) not in self.empty_datasets:
             raise api_exceptions.NotFound(f"dataset not found: {dataset_ref}")
         return SimpleNamespace(dataset_id=dataset_id, project=project)
+
+    def _projects(self) -> set[str]:
+        return (
+            {self.project}
+            | {t.project for t in self.tables.values()}
+            | {name.split(".", 1)[0] for name in self.empty_datasets}
+        )
 
     def list_tables(self, dataset_ref: str):
         _project, dataset_id = str(dataset_ref).rsplit(".", 1)

--- a/packages/dex-core/tests/fakes/databricks.py
+++ b/packages/dex-core/tests/fakes/databricks.py
@@ -95,19 +95,67 @@ class FakeWorkspaceClient:
         tables: list[FakeDatabricksTable] | None = None,
         warehouse: FakeWarehouse | None = None,
         omit_list_columns: bool = False,
+        empty_catalogs: list[str] | None = None,
+        principal: str = "dex@example.com",
+        owners: dict[str, str] | None = None,
+        grants: dict[str, set[str]] | None = None,
     ):
         self._tables = tables or []
+        # Catalogs that exist but hold no table: the state a scratch dev catalog
+        # is in before a first build, which a table-derived registry cannot
+        # otherwise express.
+        self._empty_catalogs = list(empty_catalogs or [])
+        # Who this client authenticates as, who owns each securable (by full name),
+        # and what the principal is granted on each. Ownership and grants are
+        # separate on purpose: Unity Catalog does not report ownership through the
+        # effective-privilege API, so an owner reads back as holding nothing, and
+        # the dev-target preflight has to consult both.
+        self.principal = principal
+        self._owners = dict(owners or {})
+        self._grants = {name: set(held) for name, held in (grants or {}).items()}
         self.warehouse = warehouse or FakeWarehouse()
         self.omit_list_columns = omit_list_columns
         self.metadata_calls: list[str] = []
-        self.catalogs = SimpleNamespace(list=self._list_catalogs)
-        self.schemas = SimpleNamespace(list=self._list_schemas)
+        self.catalogs = SimpleNamespace(list=self._list_catalogs, get=self._get_catalog)
+        self.schemas = SimpleNamespace(list=self._list_schemas, get=self._get_schema)
         self.tables = SimpleNamespace(list=self._list_tables, get=self._get_table)
         self.warehouses = SimpleNamespace(get=self._get_warehouse)
+        self.current_user = SimpleNamespace(me=self._me)
+        self.grants = SimpleNamespace(get_effective=self._get_effective)
+
+    def _me(self):
+        self.metadata_calls.append("current_user.me")
+        return SimpleNamespace(user_name=self.principal)
+
+    def _get_catalog(self, name: str):
+        self.metadata_calls.append(f"catalogs.get:{name}")
+        return SimpleNamespace(name=name, owner=self._owners.get(name))
+
+    def _get_schema(self, full_name: str):
+        self.metadata_calls.append(f"schemas.get:{full_name}")
+        return SimpleNamespace(full_name=full_name, owner=self._owners.get(full_name))
+
+    def _get_effective(self, securable_type: str, full_name: str, *, principal: str):
+        """Effective privileges, which in Unity Catalog do NOT include the ones an
+        owner holds implicitly: an owner reads back as holding nothing."""
+
+        self.metadata_calls.append(f"grants.get_effective:{full_name}")
+        held = (
+            self._grants.get(full_name, set()) if principal == self.principal else set()
+        )
+        return SimpleNamespace(
+            privilege_assignments=[
+                SimpleNamespace(
+                    privileges=[SimpleNamespace(privilege=p) for p in sorted(held)]
+                )
+            ]
+            if held
+            else []
+        )
 
     def _list_catalogs(self):
         self.metadata_calls.append("catalogs.list")
-        names = sorted({t.catalog for t in self._tables})
+        names = sorted({t.catalog for t in self._tables} | set(self._empty_catalogs))
         return [SimpleNamespace(name=name) for name in names]
 
     def _list_schemas(self, catalog_name: str):

--- a/packages/dex-core/tests/fakes/postgres.py
+++ b/packages/dex-core/tests/fakes/postgres.py
@@ -16,6 +16,7 @@ effects), not call signatures.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -62,6 +63,23 @@ class FakePostgresTable:
 
 
 @dataclass
+class FakeRole:
+    """A role and what it may do, for the dev-target privilege preflight.
+
+    The preflight asks about the role in the rendered profile, which need not be
+    the role the connection authenticated as, so the fake answers privilege
+    questions per role rather than for one implicit current user.
+    """
+
+    name: str
+    # CREATE on the database: what dbt needs to create a dev schema that is not
+    # there yet.
+    may_create_in_database: bool = False
+    # schema name -> the privileges this role holds on it ({"USAGE", "CREATE"}).
+    schema_privileges: dict[str, set[str]] = field(default_factory=dict)
+
+
+@dataclass
 class FakeStatement:
     sql: str
     session_timeout_ms: int | None
@@ -95,7 +113,11 @@ class FakeCursor:
             cost = self._conn.plan_cost(inner)
             self._emit([{"QUERY PLAN": [{"Plan": {"Total Cost": cost}}]}])
             return self
-        if "pg_catalog." in sql or "current_database()" in sql:
+        if (
+            "pg_catalog." in sql
+            or "current_database()" in sql
+            or "has_schema_privilege" in sql
+        ):
             self._serve_catalog(stripped)
             return self
 
@@ -143,7 +165,20 @@ class FakeCursor:
             pass
 
     def _serve_catalog(self, sql: str) -> None:
-        if "current_database()" in sql and "server_version" in sql:
+        # The privilege predicates come first: has_database_privilege names
+        # current_database() too, and would otherwise be answered as the
+        # capabilities probe.
+        if "has_database_privilege" in sql:
+            role = self._conn.roles.get(_first_literal(sql))
+            self._emit([{"may_create": bool(role and role.may_create_in_database)}])
+        elif "has_schema_privilege" in sql:
+            # The adapter asks about both privileges in one round-trip, so the
+            # answer carries both: SELECT ... AS may_create, ... AS may_use.
+            literals = _literals(sql)
+            role = self._conn.roles.get(literals[0] if literals else "")
+            held = role.schema_privileges.get(literals[1], set()) if role else set()
+            self._emit([{"may_create": "CREATE" in held, "may_use": "USAGE" in held}])
+        elif "current_database()" in sql and "server_version" in sql:
             read_only = self._conn.session_parameters.get(
                 "default_transaction_read_only", "off"
             )
@@ -195,8 +230,13 @@ class FakeCursor:
                 for t in sorted(self._conn.tables, key=lambda t: (t.schema, t.name))
             ]
             self._emit(rows)
+        elif "pg_catalog.pg_roles" in sql:
+            known = [name for name in self._conn.roles if f"'{name}'" in sql]
+            self._emit([{"present": 1} for _ in known])
         elif "pg_catalog.pg_namespace" in sql:
-            names = sorted({t.schema for t in self._conn.tables})
+            names = sorted(
+                {t.schema for t in self._conn.tables} | self._conn.empty_schemas
+            )
             self._emit([{"nspname": name} for name in names])
         else:
             self._emit([])
@@ -213,6 +253,17 @@ class FakeCursor:
         self._rows = [tuple(row[key] for key in keys) for row in rows]
 
 
+def _literals(sql: str) -> list[str]:
+    """The single-quoted literals of an engine-built catalog query, in order."""
+
+    return re.findall(r"'([^']*)'", sql)
+
+
+def _first_literal(sql: str) -> str:
+    found = _literals(sql)
+    return found[0] if found else ""
+
+
 class FakePostgresConnection:
     """Simulates exactly the connection surface the adapter touches; anything
     else raises AttributeError, which is the point (the adapter must not grow
@@ -227,8 +278,16 @@ class FakePostgresConnection:
         clock: FakeClock | None = None,
         row_resolver: Callable[[str], FakeResult | list[dict]] | None = None,
         plan_costs: Callable[[str], float | None] | None = None,
+        roles: list[FakeRole] | None = None,
+        empty_schemas: list[str] | None = None,
     ):
         self.tables = tables or []
+        # Roles the database knows, and their privileges: what the dev-target
+        # preflight interrogates. Schemas holding no table (a scratch dev schema
+        # before a first build) cannot come from the table registry, so they are
+        # declared here.
+        self.roles = {role.name: role for role in (roles or [])}
+        self.empty_schemas = set(empty_schemas or [])
         self.database = database
         self.server_version = server_version
         self.clock = clock or FakeClock()
@@ -267,8 +326,10 @@ class FakePostgresConnection:
 
     @property
     def data_statements(self) -> list[FakeStatement]:
-        """Statements that scan data: SELECTs that are not catalog lookups,
-        the capabilities probe, or EXPLAIN plan requests."""
+        """Statements that scan data: SELECTs that are not catalog lookups, the
+        capabilities probe, the dev-target privilege predicates, or EXPLAIN plan
+        requests. The privilege predicates are catalog reads like the rest: they
+        answer from pg_authid, scanning nothing."""
 
         return [
             s
@@ -276,4 +337,5 @@ class FakePostgresConnection:
             if s.sql.strip().upper().startswith("SELECT")
             and "pg_catalog." not in s.sql
             and "current_database()" not in s.sql
+            and "has_schema_privilege" not in s.sql
         ]

--- a/packages/dex-core/tests/integration/test_bigquery_explore.py
+++ b/packages/dex-core/tests/integration/test_bigquery_explore.py
@@ -152,3 +152,41 @@ def test_firewalled_query_round_trip(tmp_path: Path, capsys, bq_project: str):
         for line in (tmp_path / ".dex" / "queries.jsonl").read_text().splitlines()
     ]
     assert decisions == ["needs_confirmation", "allowed"]
+
+
+# --- scope resolution against the live project (free: metadata GET, no query) ---------
+
+
+def test_a_bogus_scope_is_refused_for_free(tmp_path: Path, capsys, bq_project):
+    """The cost-safety bug: a scope that resolves to nothing used to reach
+    list_tables and die on a raw google NotFound, naming neither the fix nor the
+    datasets that do exist."""
+
+    seed_repo(tmp_path, bq_project, datasets=["__no_such_dataset__"])
+    rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
+    assert rc == 1
+    assert envelope["status"] == "error"
+    error = envelope["errors"][0]
+    assert "__no_such_dataset__" in error
+    assert "[from bigquery.datasets in .dex/config.yml]" in error
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
+
+
+def test_scope_cannot_widen_the_committed_allowlist_live(
+    tmp_path: Path, capsys, bq_project
+):
+    seed_repo(tmp_path, bq_project, datasets=["bigquery-public-data.samples"])
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "explore",
+            "map",
+            "--scope",
+            "bigquery-public-data.austin_bikeshare",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert "never widens" in envelope["errors"][0]
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()

--- a/packages/dex-core/tests/integration/test_bigquery_transform.py
+++ b/packages/dex-core/tests/integration/test_bigquery_transform.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 
 from .conftest import MAX_BYTES
-from .test_bigquery_connect import run_cli
+from .test_bigquery_connect import run_cli, seed_repo
 
 pytestmark = [pytest.mark.integration, pytest.mark.bigquery]
 
@@ -118,3 +118,40 @@ def test_init_plan_apply_build_into_the_scratch_dataset(
         client.delete_table(table, not_found_ok=True)
     finally:
         client.close()
+
+
+def test_a_missing_dev_dataset_warns_rather_than_refusing(
+    tmp_path: Path, capsys, bq_project
+):
+    """BigQuery is the connector where the missing dev namespace is not fatal:
+    dbt-bigquery's create_schema issues CREATE SCHEMA IF NOT EXISTS, which creates
+    the dataset. Refusing would block a first build that would have succeeded, so
+    the preflight warns and names the permission that build needs."""
+
+    pytest.importorskip("dbt.adapters.bigquery")
+    root = str(tmp_path)
+    seed_repo(tmp_path, bq_project)
+    config_path = tmp_path / ".dex" / "config.yml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["bigquery"]["dev_dataset"] = "dex_absent_dev_dataset"
+    config["bigquery"]["location"] = "US"
+    config["budget"] = {"ceiling": 100 * 1024 * 1024}
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    rc, envelope = run_cli(
+        ["--repo-root", root, "transform", "init", "analytics"], capsys
+    )
+    assert rc == 0, envelope
+
+    # No model is authored, so the build creates nothing: the preflight's warning
+    # is what is under test, not dbt's dataset creation.
+    rc, built = run_cli(
+        ["--repo-root", root, "transform", "build", "--target", "dev", "--confirm"],
+        capsys,
+    )
+    assert rc == 0, built
+    warnings = [w for w in built["warnings"] if "dev_dataset" in w]
+    assert len(warnings) == 1
+    assert "dex_absent_dev_dataset does not exist" in warnings[0]
+    assert "bigquery.datasets.create" in warnings[0]
+    assert "bq mk --dataset --location=US" in warnings[0]

--- a/packages/dex-core/tests/integration/test_databricks_explore.py
+++ b/packages/dex-core/tests/integration/test_databricks_explore.py
@@ -147,3 +147,54 @@ def test_firewalled_query_round_trip(
     assert rc == 0, envelope
     assert envelope["data"]["cells"] == [[5]]
     assert envelope["data"]["spend"]["seconds_billed"] >= 0
+
+
+# --- scope resolution against the live workspace (free: Unity Catalog REST) -----------
+
+
+def test_a_bogus_scope_is_refused_for_free(tmp_path: Path, capsys, dbx_warehouse):
+    """The cost-safety bug: a scope that resolves to nothing used to yield an
+    empty inventory, so the user scoped to nothing and was never told."""
+
+    seed_repo(tmp_path, dbx_warehouse, None, catalogs=["samples"])
+    rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "map", "--scope", "samples.__nope__"],
+        capsys,
+    )
+    assert rc == 1
+    assert envelope["status"] == "error"
+    error = envelope["errors"][0]
+    assert "__nope__" in error
+    # The refusal names what does exist, and the flag it came from.
+    assert "nyctaxi" in error
+    assert "[from --scope]" in error
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
+
+
+def test_a_bogus_committed_catalog_is_refused_for_free(
+    tmp_path: Path, capsys, dbx_warehouse
+):
+    seed_repo(tmp_path, dbx_warehouse, None, catalogs=["__no_such_catalog__"])
+    rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
+    assert rc == 1
+    error = envelope["errors"][0]
+    assert "__no_such_catalog__" in error
+    assert "[from databricks.catalogs in .dex/config.yml]" in error
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
+
+
+def test_scope_cannot_widen_the_committed_allowlist_live(
+    tmp_path: Path, capsys, dbx_warehouse
+):
+    """The committed allowlist is a cost boundary: it holds this run to one
+    sample schema, and a flag must not be able to reach a different one (nyctaxi
+    exists, which is the point: the refusal is the boundary, not the typo)."""
+
+    seed_repo(tmp_path, dbx_warehouse, None, catalogs=[SAMPLE_SCOPE])
+    rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "map", "--scope", "samples.nyctaxi"],
+        capsys,
+    )
+    assert rc == 1
+    assert "never widens" in envelope["errors"][0]
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()

--- a/packages/dex-core/tests/integration/test_databricks_transform.py
+++ b/packages/dex-core/tests/integration/test_databricks_transform.py
@@ -21,6 +21,40 @@ pytestmark = [pytest.mark.integration, pytest.mark.databricks]
 MODEL_NAME = "dex_probe"
 
 
+@pytest.fixture(autouse=True)
+def non_interactive_credential():
+    """A dbt build here must never depend on a human at a browser.
+
+    `transform init` renders a user-OAuth connection as `auth_type: oauth`, and
+    dbt-databricks then runs its own browser flow. In CI that never happens (the
+    workflow exchanges the GitHub OIDC token and exports DATABRICKS_TOKEN, which
+    dbt reads through the same env_var reference a PAT would), but a local run
+    discovering a user-OAuth profile would sit for ten minutes waiting for a
+    browser that no test harness will ever open, and then fail on a timeout that
+    names none of this.
+
+    So the requirement is stated rather than stumbled into: skip unless the
+    discovered credential is one dbt can use unattended.
+    """
+
+    pytest.importorskip("databricks.sql")
+    from exmergo_dex_core.config import DatabricksTarget
+    from exmergo_dex_core.connect import resolve_databricks_connection
+
+    try:
+        _config, method = resolve_databricks_connection(
+            DatabricksTarget(), os.environ, "."
+        )
+    except Exception as exc:  # no connection at all: the suite's own gate reports it
+        pytest.skip(f"no Databricks connection discovered ({type(exc).__name__})")
+    if method.rsplit(":", 1)[-1] == "oauth_user":
+        pytest.skip(
+            "dbt needs a credential it can use unattended; the discovered "
+            "connection is user OAuth, which sends dbt to a browser. Export "
+            "DATABRICKS_TOKEN (for example: databricks auth token -p <profile>)"
+        )
+
+
 def test_init_plan_apply_build_into_the_scratch_catalog(
     tmp_path: Path, capsys, dbx_warehouse, dbx_scratch_catalog
 ):
@@ -130,3 +164,32 @@ def test_init_plan_apply_build_into_the_scratch_catalog(
         cursor.execute(f"DROP VIEW IF EXISTS {relation}")
     finally:
         conn.close()
+
+
+def test_missing_dev_catalog_is_refused_before_the_cost_gate(
+    tmp_path: Path, capsys, dbx_warehouse
+):
+    """dbt creates schemas but never catalogs, so a `dev_catalog` that does not
+    exist dies inside the `create schema` dbt issues, naming neither the catalog
+    nor the fix. The preflight is free (Unity Catalog REST, no SQL session) and
+    runs before the confirm handshake, so this refuses without `--confirm` and
+    without spend."""
+
+    pytest.importorskip("dbt.adapters.databricks")
+    root = str(tmp_path)
+    seed_repo(tmp_path, dbx_warehouse, "dex_no_such_dev_catalog")
+
+    rc, envelope = run_cli(
+        ["--repo-root", root, "transform", "init", "analytics"], capsys
+    )
+    assert rc == 0, envelope
+
+    rc, envelope = run_cli(
+        ["--repo-root", root, "transform", "build", "--target", "dev"], capsys
+    )
+    assert rc == 1
+    assert envelope["status"] == "error"
+    error = envelope["errors"][0]
+    assert "dex_no_such_dev_catalog" in error
+    assert "CREATE CATALOG IF NOT EXISTS dex_no_such_dev_catalog" in error
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()

--- a/packages/dex-core/tests/integration/test_postgres_explore.py
+++ b/packages/dex-core/tests/integration/test_postgres_explore.py
@@ -135,3 +135,35 @@ def test_query_firewall_allows_measuring_and_refuses_pii_values(tmp_path: Path, 
     )
     assert rc == 1
     assert "PII" in envelope["errors"][0]
+
+
+# --- scope resolution against the live database (free: one pg_catalog SELECT) ---------
+
+
+def test_a_bogus_scope_is_refused_for_free(tmp_path: Path, capsys, pg_dsn):
+    """Postgres was the worst of the connectors here: the allowlist was echoed
+    back without ever asking the server, and the inventory filter then dropped the
+    unmatched entry, so a typo simply returned nothing at all."""
+
+    seed_repo(tmp_path, schemas=["__no_such_schema__"])
+    rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
+    assert rc == 1
+    assert envelope["status"] == "error"
+    error = envelope["errors"][0]
+    assert "__no_such_schema__" in error
+    # The refusal names what does exist, which the silent empty inventory never did.
+    assert "app" in error
+    assert "[from postgres.schemas in .dex/config.yml]" in error
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
+
+
+def test_scope_cannot_widen_the_committed_allowlist_live(
+    tmp_path: Path, capsys, pg_dsn
+):
+    seed_repo(tmp_path, schemas=["app"])
+    rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "map", "--scope", "public"], capsys
+    )
+    assert rc == 1
+    assert "never widens" in envelope["errors"][0]
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()

--- a/packages/dex-core/tests/integration/test_postgres_transform.py
+++ b/packages/dex-core/tests/integration/test_postgres_transform.py
@@ -95,3 +95,47 @@ def test_init_and_build_write_only_the_dev_schema(
     assert entry["connector"] == "postgres"
     assert entry["command"] == "transform build"
     assert entry["billed_seconds"] > 0
+
+
+def test_an_unwritable_dev_schema_is_refused_before_the_cost_gate(
+    tmp_path: Path, capsys, dev_dsn
+):
+    """dbt creates its dev schema, but only if the role may. The seeded dbt_dev
+    role holds CREATE on the dbt_dev schema and nothing else, so a dev schema that
+    does not exist yet cannot be created: the first build would die on a bare
+    permission error naming neither the schema nor the grant. The preflight is
+    free (catalog lookups and privilege predicates) and runs before the confirm
+    handshake, so this refuses without `--confirm` and without load."""
+
+    pytest.importorskip("dbt.adapters.postgres")
+    root = str(tmp_path)
+    seed_repo(tmp_path, schemas=["app"], budget=300)
+    config_path = tmp_path / ".dex" / "config.yml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["postgres"]["dev_schema"] = "dex_absent_dev_schema"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            root,
+            "transform",
+            "init",
+            "analytics",
+            "--connector",
+            "postgres",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+
+    rc, envelope = run_cli(
+        ["--repo-root", root, "transform", "build", "--target", "dev"], capsys
+    )
+    assert rc == 1
+    assert envelope["status"] == "error"
+    error = envelope["errors"][0]
+    assert "dex_absent_dev_schema" in error
+    assert "may not create it" in error
+    assert "CREATE SCHEMA IF NOT EXISTS dex_absent_dev_schema AUTHORIZATION" in error
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()

--- a/packages/dex-core/tests/integration/test_snowflake_transform.py
+++ b/packages/dex-core/tests/integration/test_snowflake_transform.py
@@ -21,16 +21,29 @@ pytestmark = [pytest.mark.integration, pytest.mark.snowflake]
 MODEL_NAME = "dex_probe"
 
 
+@pytest.fixture(autouse=True)
+def dbt_capable_connection():
+    """Every test here starts from `transform init`, which refuses a
+    workload-identity connection outright: dbt-snowflake authenticates by
+    password, key pair, SSO, or OAuth token only (its profile carries no
+    workload-identity provider field at all), so a rendered profile would fail
+    every build with an opaque auth error.
+
+    So this suite needs a durable credential and skips without one. CI runs it
+    on a dedicated key-pair service user rather than the workload identity the
+    rest of the Snowflake job uses; a local run discovers a key-pair or SSO
+    connection. Drop this once dbt-snowflake grows workload-identity support
+    and init renders it.
+    """
+
+    pytest.importorskip("dbt.adapters.snowflake")
+    if os.environ.get("SNOWFLAKE_AUTHENTICATOR", "").upper() == "WORKLOAD_IDENTITY":
+        pytest.skip("dbt needs a durable credential; workload identity not yet in dbt")
+
+
 def test_init_plan_apply_build_into_the_scratch_database(
     tmp_path: Path, capsys, sf_scratch_database, sf_warehouse, sf_connection_name
 ):
-    pytest.importorskip("dbt.adapters.snowflake")
-    if os.environ.get("SNOWFLAKE_AUTHENTICATOR", "").upper() == "WORKLOAD_IDENTITY":
-        # Stable dbt-snowflake cannot authenticate via workload identity, so
-        # `transform init` deliberately refuses such a connection. The build
-        # path is exercised by the local key-pair run; unskip once
-        # dbt-snowflake ships workload-identity support and init renders it.
-        pytest.skip("dbt builds need a durable credential; WIF not yet in dbt")
     root = str(tmp_path)
     seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
 
@@ -47,8 +60,16 @@ def test_init_plan_apply_build_into_the_scratch_database(
     assert dev["database"] == sf_scratch_database
     assert dev["schema"] == "DBT_DEV"
     assert dev["threads"] == 1
-    # Discovery renders auth without persisting a secret value.
-    assert "password" not in dev or "env_var" in str(dev.get("password"))
+    # Discovery renders auth without ever persisting a credential value: a key
+    # pair renders as a path to the key, a password as an env_var reference the
+    # profile resolves at dbt runtime. Asserted against the rendered text, not
+    # just the parsed keys, so any future auth branch that inlines a secret
+    # trips this rather than quietly shipping one in a file dbt writes to disk.
+    profile_text = (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
+    assert "PRIVATE KEY" not in profile_text, "key material inlined into the profile"
+    for secret_key in ("password", "token", "private_key"):
+        rendered = str(dev.get(secret_key, ""))
+        assert not rendered or "env_var" in rendered, f"{secret_key} inlined"
 
     edits_file = tmp_path / "edits.json"
     edits_file.write_text(
@@ -135,7 +156,6 @@ def test_missing_dev_database_is_refused_before_the_cost_gate(
     `002043: Object does not exist`. The preflight is free and runs before the
     confirm handshake, so this refuses without `--confirm` and without spend."""
 
-    pytest.importorskip("dbt.adapters.snowflake")
     root = str(tmp_path)
     seed_repo(tmp_path, "DEX_NO_SUCH_DEV_DATABASE", sf_warehouse, sf_connection_name)
 
@@ -162,7 +182,6 @@ def test_config_drift_from_the_rendered_profile_is_refused(
     A later config edit that never reached the profile must not build silently
     against the old target."""
 
-    pytest.importorskip("dbt.adapters.snowflake")
     root = str(tmp_path)
     seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
 

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -729,6 +729,73 @@ def test_snowflake_unresolvable_scope_never_falls_back_to_the_whole_allowlist(
     assert fake_sf_connection.data_statements == []
 
 
+def test_an_unresolvable_scope_never_falls_back_on_any_connector(
+    fake_bq_client, fake_databricks, fake_pg_connection
+):
+    # Family 2: the same cost-safety bug, on every warehouse connector. A source
+    # scope that names nothing must refuse, and must do so on the free metadata
+    # path: never an empty inventory the user was not told about, and never a
+    # fallback to every table the allowlist permits. The estimate a user confirms
+    # has to cover what they actually named.
+    from exmergo_dex_core.adapters.bigquery import (
+        BigQueryAdapter,
+        BigQueryConnectionError,
+    )
+    from exmergo_dex_core.adapters.databricks import (
+        DatabricksAdapter,
+        DatabricksConnectionError,
+    )
+    from exmergo_dex_core.adapters.postgres import (
+        PostgresAdapter,
+        PostgresConnectionError,
+    )
+    from exmergo_dex_core.config import BigQueryTarget, DatabricksTarget, PostgresTarget
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    def gate(paradigm, connector):
+        return CostGate(
+            paradigm=paradigm,
+            ceiling=None,
+            session_ceiling=None,
+            session_spent=0.0,
+            confirmed=True,
+            connector=connector,
+        )
+
+    bigquery = BigQueryAdapter(
+        project="test-proj",
+        cost_gate=gate(env.Paradigm.BYTES_SCANNED, "bigquery"),
+        target=BigQueryTarget(datasets=["__not_a_dataset__"]),
+        client=fake_bq_client,
+    )
+    databricks = DatabricksAdapter(
+        workspace=fake_databricks.workspace,
+        sql_connect=fake_databricks.sql_connect,
+        cost_gate=gate(env.Paradigm.COMPUTE_TIME, "databricks"),
+        target=DatabricksTarget(warehouse="fake-wh", catalogs=["__not_a_catalog__"]),
+        clock=fake_databricks.clock,
+    )
+    postgres = PostgresAdapter(
+        connection=fake_pg_connection,
+        cost_gate=gate(env.Paradigm.DB_LOAD, "postgres"),
+        target=PostgresTarget(schemas=["__not_a_schema__"]),
+        clock=fake_pg_connection.clock,
+    )
+
+    with pytest.raises(BigQueryConnectionError):
+        bigquery.list_objects()
+    with pytest.raises(DatabricksConnectionError):
+        databricks.list_objects()
+    with pytest.raises(PostgresConnectionError):
+        postgres.list_objects()
+
+    # Refused on the free path: nothing was queried, and no SQL session opened.
+    assert fake_bq_client.query_calls == []
+    assert fake_databricks.connection.data_statements == []
+    assert fake_databricks.connect_count == 0
+    assert fake_pg_connection.data_statements == []
+
+
 def test_snowflake_generated_sql_is_select_only(fake_sf_connection):
     # Family 1: every data statement the adapter generates passes the
     # SELECT-only guard in the snowflake dialect (asserted at build time).

--- a/packages/dex-core/tests/transform/test_dev_target.py
+++ b/packages/dex-core/tests/transform/test_dev_target.py
@@ -249,3 +249,381 @@ def test_an_unopenable_connection_degrades_to_a_note(
     assert len(warnings) == 1
     assert "could not preflight the dev database" in warnings[0]
     assert "RuntimeError" in warnings[0]
+
+
+# --- existence, through the fakes: what dbt cannot create for itself ------------------
+
+
+def _fake_open(monkeypatch, adapter):
+    monkeypatch.setattr(
+        "exmergo_dex_core.connect.open_adapter", lambda **_kwargs: adapter
+    )
+
+
+def _databricks(
+    dbt_project_dir: Path,
+    *,
+    empty_catalogs: list[str],
+    owners: dict[str, str] | None = None,
+    grants: dict[str, set[str]] | None = None,
+):
+    pytest.importorskip("databricks.sql")
+    from fakes.databricks import (
+        FakeDatabricks,
+        FakeDatabricksConnection,
+        FakeWorkspaceClient,
+    )
+
+    from exmergo_dex_core.adapters.databricks import DatabricksAdapter
+    from exmergo_dex_core.config import DatabricksTarget
+    from exmergo_dex_core.envelope import Paradigm
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    workspace = FakeWorkspaceClient(
+        empty_catalogs=empty_catalogs,
+        # The healthy default: the principal owns the dev catalog, so it may
+        # create the dev schema inside it, which is the state a first build wants.
+        owners=owners if owners is not None else {"dex_dev": "dex@example.com"},
+        grants=grants,
+    )
+    fake = FakeDatabricks(workspace=workspace, connection=FakeDatabricksConnection())
+    adapter = DatabricksAdapter(
+        workspace=fake.workspace,
+        sql_connect=fake.sql_connect,
+        cost_gate=CostGate(
+            paradigm=Paradigm.COMPUTE_TIME,
+            ceiling=None,
+            session_ceiling=None,
+            session_spent=0.0,
+            confirmed=False,
+            connector="databricks",
+        ),
+        target=DatabricksTarget(warehouse="fake-wh"),
+        clock=fake.clock,
+    )
+    _write_profile(
+        dbt_project_dir,
+        "      type: databricks\n"
+        "      catalog: dex_dev\n"
+        "      schema: dbt_dev\n"
+        "      http_path: /sql/1.0/warehouses/fake-wh\n",
+    )
+    config = DexConfig(
+        connector="databricks",
+        databricks=DatabricksTarget(
+            warehouse="fake-wh", dev_catalog="dex_dev", dev_schema="dbt_dev"
+        ),
+    )
+    return fake, adapter, config
+
+
+def test_missing_databricks_dev_catalog_refuses_with_the_create_statement(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    fake, adapter, config = _databricks(
+        dbt_project_dir, empty_catalogs=["something_else"]
+    )
+    _fake_open(monkeypatch, adapter)
+
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    message = str(exc.value)
+    assert 'dev_catalog "dex_dev" does not exist' in message
+    assert "CREATE CATALOG IF NOT EXISTS dex_dev;" in message
+    assert "dbt creates schemas but never catalogs" in message
+    # Free: Unity Catalog REST only, so the billed SQL warehouse never woke.
+    assert fake.connect_count == 0
+
+
+def test_an_existing_databricks_dev_catalog_the_principal_owns_passes(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    fake, adapter, config = _databricks(dbt_project_dir, empty_catalogs=["dex_dev"])
+    _fake_open(monkeypatch, adapter)
+    assert dev_target.check(dbt_project_dir, "dev", config, tmp_path) == []
+    assert fake.connect_count == 0
+
+
+def test_a_databricks_dev_schema_the_principal_cannot_write_is_warned_about(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """The failure this caught in the field: the dev catalog exists, so existence
+    alone said yes, but the dev schema inside it belonged to another principal.
+    dbt reported it as PERMISSION_DENIED on the first model, after the warehouse
+    had woken and the budget had been spent.
+
+    Owning the catalog is not enough to write inside a schema someone else owns,
+    which is exactly what Unity Catalog answered live.
+    """
+
+    from fakes.databricks import FakeDatabricksTable
+
+    fake, adapter, config = _databricks(
+        dbt_project_dir,
+        empty_catalogs=[],
+        owners={"dex_dev": "dex@example.com", "dex_dev.dbt_dev": "someone-else"},
+        grants={},
+    )
+    # A table puts the dbt_dev schema on the map, so the schema exists but is not
+    # owned by us and carries no grant.
+    fake.workspace._tables.append(
+        FakeDatabricksTable(
+            catalog="dex_dev",
+            schema="dbt_dev",
+            name="prior",
+            columns=[("id", "bigint", True)],
+        )
+    )
+    _fake_open(monkeypatch, adapter)
+
+    warnings = dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    assert len(warnings) == 1
+    assert "PERMISSION_DENIED" in warnings[0]
+    assert "GRANT USE SCHEMA ON SCHEMA dex_dev.dbt_dev" in warnings[0]
+    assert "GRANT CREATE TABLE ON SCHEMA dex_dev.dbt_dev" in warnings[0]
+    # A warning, not a refusal: ownership and metastore-admin rights are invisible
+    # to the grants API, so an empty answer cannot prove the build would fail.
+    assert fake.connect_count == 0
+
+
+def test_a_granted_databricks_dev_schema_passes(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """Grants, not just ownership: a principal explicitly granted what dbt needs
+    must not be warned at."""
+
+    from fakes.databricks import FakeDatabricksTable
+
+    fake, adapter, config = _databricks(
+        dbt_project_dir,
+        empty_catalogs=[],
+        owners={"dex_dev": "someone-else", "dex_dev.dbt_dev": "someone-else"},
+        grants={
+            "dex_dev": {"USE CATALOG"},
+            "dex_dev.dbt_dev": {"USE SCHEMA", "CREATE TABLE"},
+        },
+    )
+    fake.workspace._tables.append(
+        FakeDatabricksTable(
+            catalog="dex_dev",
+            schema="dbt_dev",
+            name="prior",
+            columns=[("id", "bigint", True)],
+        )
+    )
+    _fake_open(monkeypatch, adapter)
+    assert dev_target.check(dbt_project_dir, "dev", config, tmp_path) == []
+
+
+def _bigquery(
+    dbt_project_dir: Path, *, project: str = "test-proj", dev: str = "dbt_dev"
+):
+    pytest.importorskip("google.cloud.bigquery")
+    from fakes.bigquery import FakeBigQueryClient
+
+    from exmergo_dex_core.adapters.bigquery import BigQueryAdapter
+    from exmergo_dex_core.config import BigQueryTarget
+    from exmergo_dex_core.envelope import Paradigm
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    client = FakeBigQueryClient(project="test-proj", empty_datasets=["shop"])
+    adapter = BigQueryAdapter(
+        project="test-proj",
+        cost_gate=CostGate(
+            paradigm=Paradigm.BYTES_SCANNED,
+            ceiling=None,
+            session_ceiling=None,
+            session_spent=0.0,
+            confirmed=False,
+            connector="bigquery",
+        ),
+        target=BigQueryTarget(),
+        client=client,
+    )
+    _write_profile(
+        dbt_project_dir,
+        f"      type: bigquery\n      project: {project}\n      dataset: {dev}\n",
+    )
+    config = DexConfig(
+        connector="bigquery",
+        bigquery=BigQueryTarget(project=project, dev_dataset=dev, location="US"),
+    )
+    return client, adapter, config
+
+
+def test_a_missing_bigquery_dev_dataset_warns_rather_than_refusing(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """The connector where the missing namespace is not fatal: dbt-bigquery's
+    create_schema issues CREATE SCHEMA IF NOT EXISTS, which creates the dataset.
+    Refusing would block a first build that would have succeeded."""
+
+    client, adapter, config = _bigquery(dbt_project_dir, dev="dbt_dev")
+    _fake_open(monkeypatch, adapter)
+
+    warnings = dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    assert len(warnings) == 1
+    assert "test-proj.dbt_dev does not exist" in warnings[0]
+    assert "bigquery.datasets.create" in warnings[0]
+    assert "bq mk --dataset --location=US test-proj.dbt_dev" in warnings[0]
+    assert client.query_calls == []
+
+
+def test_an_existing_bigquery_dev_dataset_passes(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    _client, adapter, config = _bigquery(dbt_project_dir, dev="shop")
+    _fake_open(monkeypatch, adapter)
+    assert dev_target.check(dbt_project_dir, "dev", config, tmp_path) == []
+
+
+def test_an_unreachable_bigquery_dev_project_refuses(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """What dbt cannot create for itself: it makes datasets, never projects."""
+
+    _client, adapter, config = _bigquery(dbt_project_dir, project="test-proj")
+    config.bigquery.dev_dataset = "no-such-project.dbt_dev"
+    _write_profile(
+        dbt_project_dir,
+        "      type: bigquery\n"
+        "      project: test-proj\n"
+        "      dataset: no-such-project.dbt_dev\n",
+    )
+    _fake_open(monkeypatch, adapter)
+
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    assert "dbt creates datasets but never projects" in str(exc.value)
+
+
+def _postgres(dbt_project_dir: Path, role, *, dev: str = "dbt_dev", profile_user=None):
+    pytest.importorskip("psycopg")
+    from fakes.postgres import FakePostgresConnection, FakePostgresTable
+
+    from exmergo_dex_core.adapters.postgres import PostgresAdapter
+    from exmergo_dex_core.config import PostgresTarget
+    from exmergo_dex_core.envelope import Paradigm
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    connection = FakePostgresConnection(
+        tables=[
+            FakePostgresTable(
+                schema="app", name="orders", columns=[("id", "bigint", False)]
+            )
+        ],
+        roles=[role],
+        empty_schemas=["dbt_dev"],
+    )
+    adapter = PostgresAdapter(
+        connection=connection,
+        cost_gate=CostGate(
+            paradigm=Paradigm.DB_LOAD,
+            ceiling=None,
+            session_ceiling=None,
+            session_spent=0.0,
+            confirmed=False,
+            connector="postgres",
+        ),
+        target=PostgresTarget(),
+        clock=connection.clock,
+    )
+    _write_profile(
+        dbt_project_dir,
+        "      type: postgres\n"
+        f"      user: {profile_user or role.name}\n"
+        "      dbname: dexdb\n"
+        f"      schema: {dev}\n",
+    )
+    config = DexConfig(connector="postgres", postgres=PostgresTarget(dev_schema=dev))
+    return connection, adapter, config
+
+
+def test_a_writable_postgres_dev_schema_passes(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    from fakes.postgres import FakeRole
+
+    role = FakeRole(name="dbt_dev", schema_privileges={"dbt_dev": {"USAGE", "CREATE"}})
+    connection, adapter, config = _postgres(dbt_project_dir, role)
+    _fake_open(monkeypatch, adapter)
+    assert dev_target.check(dbt_project_dir, "dev", config, tmp_path) == []
+    assert connection.data_statements == []
+
+
+def test_an_unwritable_postgres_dev_schema_refuses_with_the_grant(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    from fakes.postgres import FakeRole
+
+    role = FakeRole(name="dbt_dev", schema_privileges={"dbt_dev": {"USAGE"}})
+    connection, adapter, config = _postgres(dbt_project_dir, role)
+    _fake_open(monkeypatch, adapter)
+
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    message = str(exc.value)
+    assert 'missing CREATE on dev_schema "dbt_dev"' in message
+    assert "GRANT USAGE, CREATE ON SCHEMA dbt_dev TO dbt_dev;" in message
+    assert connection.data_statements == []
+
+
+def test_an_absent_postgres_dev_schema_the_role_cannot_create_refuses(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """dbt creates the schema, but only if the role may, so the privilege is what
+    is checked. The first build otherwise dies on a bare permission error."""
+
+    from fakes.postgres import FakeRole
+
+    role = FakeRole(name="dbt_dev", may_create_in_database=False)
+    _connection, adapter, config = _postgres(dbt_project_dir, role, dev="not_there")
+    _fake_open(monkeypatch, adapter)
+
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    message = str(exc.value)
+    assert 'dev_schema "not_there" does not exist and role dbt_dev may not create it'
+    assert "CREATE SCHEMA IF NOT EXISTS not_there AUTHORIZATION dbt_dev;" in message
+
+
+def test_the_postgres_privilege_is_asked_of_the_profile_role(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """dex may read the warehouse as a read-only role while dbt builds as another,
+    so the question has to be asked of the role the profile names. The refusal
+    naming that role, and not the one dex connects as, is the proof it was."""
+
+    from fakes.postgres import FakeRole
+
+    builder = FakeRole(name="ci_builder", schema_privileges={"dbt_dev": {"USAGE"}})
+    _connection, adapter, config = _postgres(
+        dbt_project_dir, builder, profile_user="ci_builder"
+    )
+    _fake_open(monkeypatch, adapter)
+
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    message = str(exc.value)
+    assert "role ci_builder is missing" in message
+    assert "TO ci_builder;" in message
+
+
+def test_an_unopenable_connection_degrades_to_a_note_on_every_connector(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    """The autouse no_warehouse fixture makes open_adapter raise. A preflight that
+    cannot reach the warehouse must never be the thing that breaks a build dbt
+    could have run."""
+
+    from exmergo_dex_core.config import DatabricksTarget
+
+    _write_profile(dbt_project_dir, "      type: databricks\n      catalog: dex_dev\n")
+    config = DexConfig(
+        connector="databricks",
+        databricks=DatabricksTarget(warehouse="wh", dev_catalog="dex_dev"),
+    )
+    warnings = dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    assert len(warnings) == 1
+    assert "could not preflight the dev database" in warnings[0]
+    assert "RuntimeError" in warnings[0]

--- a/scripts/setup_snowflake_ci.sh
+++ b/scripts/setup_snowflake_ci.sh
@@ -19,15 +19,26 @@
 #     Federation (GitHub OIDC), pinned to this repository and to the
 #     snowflake-integration environment; no key or password is ever created
 #     or stored for CI
+#   - DEX_CI_DBT user: a SERVICE user with an RSA key pair, used by the one
+#     part of CI that cannot be keyless. dbt-snowflake authenticates by
+#     password, key pair, SSO, or OAuth token only: its profile carries no
+#     workload-identity provider field, so `transform init` refuses to render
+#     a WIF profile and the dbt tests need a durable credential. The private
+#     key goes straight into the GitHub environment as a secret and is never
+#     written to this machine; each run of this script rotates it, so the two
+#     halves cannot drift apart. Keeping this identity separate leaves DEX_CI
+#     itself keyless.
 #   - DEX_DEV user: a SERVICE user with a locally generated RSA key pair plus
 #     a `dex-ci` entry in ~/.snowflake/connections.toml, for running the live
 #     integration suite while developing
 #   - the GitHub environment (deployments restricted to main) carrying the
-#     two variables the workflow reads
+#     variables the workflow reads and the dbt key-pair secret
 #
 # Everything account-specific is a parameter, so nothing private lives in this
 # script. Idempotent: safe to re-run; existing resources are left in place and
-# the WIF pinning is refreshed.
+# the WIF pinning is refreshed. The one exception is the DEX_CI_DBT key pair,
+# which is rotated on every run (see below): both halves are replaced together,
+# so a re-run mid-CI can fail an in-flight dbt job. Re-run when CI is idle.
 #
 # Usage:
 #   scripts/setup_snowflake_ci.sh <account-identifier> [snow-connection-name]
@@ -58,6 +69,7 @@ MONITOR="DEX_CI_MONITOR"
 DATABASE="DEX_CI"
 ROLE="DEX_CI_ROLE"
 CI_USER="DEX_CI"
+CI_DBT_USER="DEX_CI_DBT"
 DEV_USER="DEX_DEV"
 GH_ENV="snowflake-integration"
 DEV_CONN_NAME="dex-ci"
@@ -78,6 +90,7 @@ echo "   monitor:     ${MONITOR} (${CREDIT_QUOTA} credits/month, suspends)"
 echo "   database:    ${DATABASE} (transient, retention 0)"
 echo "   role:        ${ROLE}"
 echo "   ci user:     ${CI_USER} (WIF: GitHub OIDC, env ${GH_ENV})"
+echo "   ci dbt user: ${CI_DBT_USER} (key pair, rotated into ${GH_ENV} on every run)"
 echo "   dev user:    ${DEV_USER} (key pair, connection '${DEV_CONN_NAME}')"
 echo
 
@@ -136,6 +149,18 @@ sql "CREATE USER IF NOT EXISTS ${CI_USER}
      );
      GRANT ROLE ${ROLE} TO USER ${CI_USER};"
 
+echo "-- CI dbt service user (key pair; dbt-snowflake cannot use workload identity)"
+# Same role, so the same blast radius as the WIF user: read the samples, write
+# the transient scratch database, nothing else. The key itself is minted below,
+# once the GitHub environment that carries it exists.
+sql "CREATE USER IF NOT EXISTS ${CI_DBT_USER}
+       TYPE = SERVICE
+       DEFAULT_ROLE = ${ROLE}
+       DEFAULT_WAREHOUSE = ${WAREHOUSE}
+       DEFAULT_NAMESPACE = ${DATABASE}
+       COMMENT = 'dex integration CI, dbt only (key pair; dbt cannot do WIF)';
+     GRANT ROLE ${ROLE} TO USER ${CI_DBT_USER};"
+
 echo "-- Local dev service user (key pair; the key never leaves this machine)"
 sql "CREATE USER IF NOT EXISTS ${DEV_USER}
        TYPE = SERVICE
@@ -158,7 +183,12 @@ PUBLIC_KEY=$(openssl rsa -in "$KEY_FILE" -pubout 2>/dev/null | grep -v '^-----' 
 sql "ALTER USER ${DEV_USER} SET RSA_PUBLIC_KEY = '${PUBLIC_KEY}';"
 
 echo "-- Local snow connection '${DEV_CONN_NAME}' (used by the integration suite)"
-if snow connection list 2>/dev/null | grep -q "$DEV_CONN_NAME"; then
+# Read the list into a variable and match in-shell rather than piping into
+# `grep -q`: grep exits at the first match, `snow` dies of SIGPIPE writing the
+# rest, and under `pipefail` that failure becomes the pipeline's, so an
+# existing connection reads as missing and the add below aborts the whole run.
+EXISTING_CONNECTIONS=$(snow connection list --format json 2>/dev/null || true)
+if [[ "$EXISTING_CONNECTIONS" == *"\"connection_name\": \"${DEV_CONN_NAME}\""* ]]; then
   echo "   connection ${DEV_CONN_NAME} already exists"
 else
   snow connection add --connection-name "$DEV_CONN_NAME" \
@@ -178,6 +208,26 @@ gh api -X POST "repos/${REPO}/environments/${GH_ENV}/deployment-branch-policies"
 echo "-- GitHub environment variables (identifiers, not secrets: WIF stores no credential)"
 gh variable set DEX_TEST_SNOWFLAKE_ACCOUNT --repo "$REPO" --env "$GH_ENV" --body "$ACCOUNT"
 gh variable set DEX_TEST_SNOWFLAKE_USER --repo "$REPO" --env "$GH_ENV" --body "$CI_USER"
+gh variable set DEX_TEST_SNOWFLAKE_DBT_USER --repo "$REPO" --env "$GH_ENV" --body "$CI_DBT_USER"
+
+echo "-- CI dbt key pair (minted here, pushed to ${GH_ENV}, never kept on disk)"
+# The one credential CI stores, because dbt-snowflake has no keyless option.
+# It is minted into a temp dir the trap wipes, so the private half exists only
+# in this process and in the GitHub environment: nothing to leak from this
+# machine, and no third copy to go stale. Re-running rotates both halves
+# together, which is why this is not guarded by an "if exists" like the dev
+# key: a key we deliberately do not keep cannot be reused.
+CI_KEY_DIR=$(mktemp -d)
+trap 'rm -rf "$CI_KEY_DIR"' EXIT
+CI_KEY_FILE="${CI_KEY_DIR}/dex_ci_dbt_rsa_key.p8"
+(umask 077 && openssl genrsa 2048 2>/dev/null \
+  | openssl pkcs8 -topk8 -inform PEM -nocrypt -out "$CI_KEY_FILE")
+CI_PUBLIC_KEY=$(openssl rsa -in "$CI_KEY_FILE" -pubout 2>/dev/null \
+  | grep -v '^-----' | tr -d '\n')
+sql "ALTER USER ${CI_DBT_USER} SET RSA_PUBLIC_KEY = '${CI_PUBLIC_KEY}';"
+gh secret set DEX_TEST_SNOWFLAKE_PRIVATE_KEY \
+  --repo "$REPO" --env "$GH_ENV" < "$CI_KEY_FILE"
+echo "   rotated ${CI_DBT_USER}'s key pair and DEX_TEST_SNOWFLAKE_PRIVATE_KEY"
 
 echo
 echo "== Done. Verify with:"

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -39,7 +39,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.1.0"
+DEX_CORE_VERSION = "1.1.1"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -39,7 +39,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.1.0"
+DEX_CORE_VERSION = "1.1.1"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -39,7 +39,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.1.0"
+DEX_CORE_VERSION = "1.1.1"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
## What this changes

Extend #62 to all connectors

In short
- dev_database preflight checks now available for all connectors (not just Snowflake)
- scope resolution now available for all connectors (not just Snowflake)


## Related issues

Closes: #60 
Closes: #61 
