### PR TITLE
Explore commands are now dbt project aware with optional "--use-project" flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,9 @@ release is connector-neutral.
 |---|---|
 | `connect test` | capabilities, dialect, `read_only: true`; DuckDB takes `--path`, every warehouse connector takes repeatable `--scope` (BigQuery also accepts its older `--project`/`--dataset`), never written to config; Snowflake and Databricks report the pinned warehouse and its credit or DBU rate |
 | `explore inventory [--rank]` | ranked object summary (counts, sizes; no rows) |
-| `explore profile <objects>` | column profiles + PII flags (column, category, confidence) + candidate keys, grain, data-quality warnings |
-| `explore relationships [--verify]` | inferred + declared joins with confidences, plus notes on what inference examined; `--verify` measures each join with an aggregate overlap probe |
-| `explore map [--verify]` | writes/updates the `.dex/` map; prints a summary |
+| `explore profile <objects>` | column profiles + PII flags (column, category, confidence) + candidate keys, grain, data-quality warnings; `--use-project` lets a semantic model's declared primary entity override the heuristic grain (disagreements noted) |
+| `explore relationships [--verify] [--use-project]` | inferred joins with confidences, plus notes on what inference examined; `--verify` measures each join with an aggregate overlap probe; `--use-project` folds in the dbt project's declared foreign keys at confidence 1.0 (a declared join wins over the same inferred edge) |
+| `explore map [--verify] [--use-project]` | writes/updates the `.dex/` map; prints a summary; `--use-project` additionally applies declared grain and ranks metric-backing models higher |
 | `explore query "<SELECT ...>"` | runs one agent-authored SELECT through the query firewall: columnar, capped result; values only from profiled, PII-cleared columns; requires the `.dex/` cache (`explore map` first) |
 | `transform init "<name>" --connector <c>` | bootstrap a dbt project skeleton (`dbt_project.yml`, `models/staging/` + `models/marts/`, a dev-only `profiles.yml`), reported as create diffs; refuses if any dbt project exists; the connector never defaults, so bare init errors (an explicit flag or a committed `connector:` in `.dex/config.yml` is required) |
 | `transform plan "<intent>" --edits-file <f>` | proposed dbt edits as diffs (nothing applied); `--scaffold <table>` adds a staging skeleton from the cache |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **`--use-project`: explore can read the dbt project, on request.**
+  Exploration still starts bare (default behavior is unchanged; a dbt project
+  in the repo earns only a discovery note). With the flag, `explore
+  relationships` and `explore map` report joins the project itself declares:
+  every resolvable `relationships` test becomes a declared join at confidence
+  1.0, resolved against the connection's inventory (manifest-first for exact
+  physical names, with a name-based fallback when the project is not
+  compiled). A declared join that matches nothing, or more than one object,
+  is surfaced as a note instead of guessed. An inferred join that duplicates
+  a declared one is folded into it and noted as independently confirmed.
+- **Declared grain and declared-unique checks (under `--use-project`).**
+  A semantic model's primary entity overrides the heuristic grain on the
+  matching profiled dataset (disagreements are noted), and a profiled column
+  that contradicts its declared `unique` test gets a data-quality note.
+  Candidate keys stay measurement-only. `explore profile` takes the flag too.
+- **Metric-aware ranking (under `--use-project`).** Models reachable from
+  metric definitions feed the ranking hints alongside (never displacing) the
+  configured `ranking_hints`, so metric-backing tables surface first.
+  Declared joins also sharpen the existing connectivity signal.
+- A stale compiled manifest (older than the model sources) is noted rather
+  than trusted silently; a repo with no dbt project, several projects, or an
+  unreadable one degrades to heuristics exactly as before.
+
+### Changed
+
+- One shared read view in the engine's dbt project reader now feeds explore's
+  declared joins, the semantic definitions, and `maintain snapshot`'s
+  fingerprints (previously a separate parser); snapshot output is unchanged.
+
 ## [1.1.1] - 2026-07-12
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -111,6 +111,16 @@ def _build_parser() -> argparse.ArgumentParser:
                     sp.add_argument(
                         "--verify", action="store_true", default=argparse.SUPPRESS
                     )
+                # Exploration starts bare: warehouse truth, independent of
+                # whatever repo dex runs from. --use-project opts in to folding
+                # the project's declared definitions (joins, grain, metric
+                # lineage) into the result.
+                if group == "explore" and name in {"profile", "relationships", "map"}:
+                    sp.add_argument(
+                        "--use-project",
+                        action="store_true",
+                        default=argparse.SUPPRESS,
+                    )
                 # transform init takes the project name; plan the intent; apply
                 # the plan id.
                 if group == "transform" and name in {"init", "plan", "apply"}:

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +36,14 @@ from .diffs import file_diff
 PROJECT_FILE = "dbt_project.yml"
 PROFILES_FILE = "profiles.yml"
 MANIFEST_PATH = Path("target") / "manifest.json"
+SEMANTIC_MANIFEST_PATH = Path("target") / "semantic_manifest.json"
+
+# The ref()/source() call shapes as they appear in model SQL, schema YAML test
+# arguments, and semantic-model `model:` fields. Shared by every reader that
+# traces a dbt-level name, so they can never disagree on what counts as a ref.
+REF_PATTERN = re.compile(r"ref\(\s*['\"]([^'\"]+)['\"]")
+SOURCE_PATTERN = re.compile(r"source\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]")
+BARE_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 # dbt project-root manifests dex may author outside the model paths. They declare
 # package dependencies (not model content), so the editing surface widens by
@@ -437,3 +447,583 @@ def contained_path(root: Path, rel_path: str, model_paths: list[str]) -> Path:
         f"edit path '{rel_path}' is outside the project's model paths "
         f"({', '.join(model_paths)}); dex edits only the dbt project surface"
     )
+
+
+# --- Read view: what the project declares -------------------------------------
+#
+# Everything below is read-only projection over the loaded project: declared
+# foreign keys and column tests, semantic definitions, and the physical
+# relations they resolve to. Consumers that must work without a dbt project
+# (explore on a raw warehouse) go through `definitions()`, which degrades to an
+# empty view instead of raising.
+
+
+def yaml_documents(view: DbtProjectView) -> list[tuple[dict[str, Any], str]]:
+    """Every parseable YAML document under the model paths, with its path.
+
+    A broken hand-written file is skipped, not an error: readers of declared
+    definitions must not fail on files they don't own.
+    """
+
+    documents: list[tuple[dict[str, Any], str]] = []
+    for source in view.files.values():
+        if not source.path.endswith((".yml", ".yaml")):
+            continue
+        try:
+            parsed = yaml.safe_load(source.content)
+        except yaml.YAMLError:
+            continue
+        if isinstance(parsed, dict):
+            documents.append((parsed, source.path))
+    return documents
+
+
+def semantic_yaml_entries(
+    view: DbtProjectView,
+) -> list[tuple[str, dict[str, Any], str]]:
+    """Raw ``semantic_models`` / ``metrics`` YAML entries as ``(kind, entry,
+    path)`` triples, kind being ``"semantic_model"`` or ``"metric"``.
+
+    Sourced from the YAML files only, never a compiled artifact, so consumers
+    that fingerprint definitions hash exactly what the author wrote.
+    """
+
+    entries: list[tuple[str, dict[str, Any], str]] = []
+    for parsed, path in yaml_documents(view):
+        entries.extend(
+            ("semantic_model", entry, path)
+            for entry in parsed.get("semantic_models") or []
+            if isinstance(entry, dict) and entry.get("name")
+        )
+        entries.extend(
+            ("metric", entry, path)
+            for entry in parsed.get("metrics") or []
+            if isinstance(entry, dict) and entry.get("name")
+        )
+    return entries
+
+
+def physical_column(entry: Any) -> str | None:
+    """The single physical column a dimension/entity/measure references, if any.
+
+    A bare-identifier ``expr`` is the column; a name with no ``expr`` is treated
+    by dbt as the column itself; a computed expression maps to None. Guessing
+    columns out of expressions would make every reader over-claim.
+    """
+
+    if not isinstance(entry, dict):
+        return None
+    expr = entry.get("expr")
+    if expr is None:
+        name = entry.get("name")
+        return name if isinstance(name, str) else None
+    if isinstance(expr, str) and BARE_IDENTIFIER.fullmatch(expr.strip()):
+        return expr.strip()
+    return None
+
+
+def metric_inputs(entry: dict[str, Any]) -> tuple[list[str], list[str]]:
+    """The measures and metrics one metric definition draws from, by type.
+
+    Simple/cumulative metrics ground in one measure; ratio and derived metrics
+    reference other metrics; conversion metrics ground in two measures. Unknown
+    types yield nothing rather than guessing.
+    """
+
+    metric_type = str(entry.get("type", "")).lower()
+    params = entry.get("type_params")
+    params = params if isinstance(params, dict) else {}
+    measures: list[str] = []
+    metrics: list[str] = []
+
+    def add(bucket: list[str], value: Any) -> None:
+        if isinstance(value, str):
+            bucket.append(value)
+        elif isinstance(value, dict) and isinstance(value.get("name"), str):
+            bucket.append(value["name"])
+
+    if metric_type in {"simple", "cumulative"}:
+        add(measures, params.get("measure"))
+    elif metric_type == "ratio":
+        add(metrics, params.get("numerator"))
+        add(metrics, params.get("denominator"))
+    elif metric_type == "derived":
+        for input_metric in params.get("metrics") or []:
+            add(metrics, input_metric)
+    elif metric_type == "conversion":
+        conversion = params.get("conversion_type_params")
+        if isinstance(conversion, dict):
+            add(measures, conversion.get("base_measure"))
+            add(measures, conversion.get("conversion_measure"))
+    return measures, metrics
+
+
+class DeclaredForeignKey(BaseModel):
+    """One ``relationships`` test: child column to parent column.
+
+    ``relation`` / ``to_relation`` carry quote-stripped physical names when the
+    manifest resolves them; the YAML fallback leaves them None, and downstream
+    resolution is name-based.
+    """
+
+    model: str
+    relation: str | None = None
+    column: str
+    to_model: str
+    to_relation: str | None = None
+    to_column: str
+    source: str
+
+
+class DeclaredKey(BaseModel):
+    """A column carrying ``unique`` and/or ``not_null`` tests on one model."""
+
+    model: str
+    relation: str | None = None
+    column: str
+    unique: bool = False
+    not_null: bool = False
+    source: str
+
+
+class ProjectDefinitions(BaseModel):
+    """What the dbt project declares, loaded once for consumers that must keep
+    working without one.
+
+    ``present`` False means no readable project: every collection is empty and
+    consumers degrade instead of erroring. ``relationship_source`` and
+    ``semantic_source`` record where each half came from (``"manifest"`` is
+    exact, ``"yaml"`` resolves by name). ``model_relations`` maps referable
+    names (model names and ``source.table``) to quote-stripped physical
+    relations. ``primary_entities`` maps model names to their declared grain
+    column; ``metric_models`` lists models reachable from any metric. ``notes``
+    are analyst-readable caveats for the caller's envelope.
+    """
+
+    present: bool = False
+    project_dir: str | None = None
+    manifest_loaded: bool = False
+    manifest_stale: bool = False
+    relationship_source: str | None = None
+    semantic_source: str | None = None
+    foreign_keys: list[DeclaredForeignKey] = Field(default_factory=list)
+    declared_keys: list[DeclaredKey] = Field(default_factory=list)
+    model_relations: dict[str, str] = Field(default_factory=dict)
+    primary_entities: dict[str, str] = Field(default_factory=dict)
+    metric_models: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+def definitions(
+    repo_root: Path | str = ".", project_dir: Path | str | None = None
+) -> ProjectDefinitions:
+    """Load the project's declared and semantic definitions, degrading quietly.
+
+    ``project_dir`` pins the project (callers pass ``dbt_project_dir`` from
+    ``.dex/config.yml``); otherwise the repo root and its immediate children
+    are searched. No project, an ambiguous choice, or an unreadable project
+    yields the empty view (with a note where there is something actionable to
+    say), never an exception: explore runs on raw warehouses where absence is
+    the normal case.
+    """
+
+    root = Path(repo_root)
+    if project_dir is not None:
+        project = Path(project_dir)
+    else:
+        candidates = discover_projects(root)
+        if not candidates:
+            return ProjectDefinitions()
+        if len(candidates) > 1:
+            listed = ", ".join(str(c) for c in candidates)
+            return ProjectDefinitions(
+                notes=[
+                    f"multiple dbt projects found ({listed}); set "
+                    "dbt_project_dir in .dex/config.yml to use their declared "
+                    "definitions"
+                ]
+            )
+        project = candidates[0]
+
+    try:
+        view = load(project)
+    except DbtProjectError as exc:
+        return ProjectDefinitions(
+            notes=[
+                f"dbt project at '{project}' could not be read ({exc}); "
+                "declared definitions unavailable"
+            ]
+        )
+
+    defs = ProjectDefinitions(present=True, project_dir=str(project))
+
+    nodes = (view.manifest or {}).get("nodes")
+    if isinstance(nodes, dict) and nodes:
+        _declared_from_manifest(view.manifest or {}, defs)
+    else:
+        _declared_from_yaml(view, defs)
+
+    semantic_manifest = _read_semantic_manifest(Path(view.root))
+    if semantic_manifest is not None:
+        _semantic_from_manifest(semantic_manifest, defs)
+    else:
+        _semantic_from_yaml(semantic_yaml_entries(view), defs)
+
+    if defs.manifest_loaded:
+        _flag_stale_manifest(view, defs)
+    return defs
+
+
+def _strip_relation_quoting(relation: str) -> str:
+    """``"db"."schema"."table"`` / `` `project.dataset.table` `` / bracketed
+    forms down to plain dotted parts, matching adapter-normalized identifiers."""
+
+    text = relation.strip()
+    # BigQuery wraps the whole dotted name in one backtick pair; strip before
+    # splitting so the dots become visible.
+    if text.startswith("`") and text.endswith("`"):
+        text = text.strip("`")
+    parts = [
+        part.strip().strip('"').strip("`").lstrip("[").rstrip("]")
+        for part in text.split(".")
+    ]
+    return ".".join(part for part in parts if part)
+
+
+def _parse_relation_ref(value: Any) -> str | None:
+    """A ``ref('x')`` / ``source('a', 'b')`` argument as a referable name."""
+
+    if not isinstance(value, str):
+        return None
+    ref = REF_PATTERN.search(value)
+    if ref:
+        return ref.group(1)
+    src = SOURCE_PATTERN.search(value)
+    if src:
+        return f"{src.group(1)}.{src.group(2)}"
+    return None
+
+
+def _declared_from_manifest(manifest: dict[str, Any], defs: ProjectDefinitions) -> None:
+    """Declared FKs and column tests from compiled test nodes, physically
+    resolved through each node's ``relation_name``. Every access is guarded:
+    hand-rolled or truncated manifests must fall through quietly, not raise."""
+
+    nodes = manifest.get("nodes") or {}
+    sources = manifest.get("sources") or {}
+
+    # unique_id -> referable name, and referable name -> physical relation.
+    names: dict[str, str] = {}
+    relations: dict[str, str] = {}
+    for uid, node in nodes.items():
+        if not isinstance(node, dict) or node.get("resource_type") != "model":
+            continue
+        config = node.get("config")
+        if isinstance(config, dict) and config.get("enabled") is False:
+            continue
+        name = node.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        names[uid] = name
+        relation = node.get("relation_name")
+        # Ephemeral models compile with a null relation_name: referable in the
+        # project but not physically resolvable, so they stay out of relations.
+        if isinstance(relation, str) and relation:
+            relations[name] = _strip_relation_quoting(relation)
+    for uid, node in sources.items():
+        if not isinstance(node, dict):
+            continue
+        source_name, table = node.get("source_name"), node.get("name")
+        if not (isinstance(source_name, str) and isinstance(table, str)):
+            continue
+        key = f"{source_name}.{table}"
+        names[uid] = key
+        relation = node.get("relation_name")
+        if isinstance(relation, str) and relation:
+            relations[key] = _strip_relation_quoting(relation)
+
+    def attached_name(node: dict[str, Any], exclude: str | None = None) -> str | None:
+        attached = node.get("attached_node")
+        if isinstance(attached, str) and attached in names:
+            return names[attached]
+        # Older manifests lack attached_node; a relationships test then depends
+        # on exactly the child and the parent, so the non-parent entry is the child.
+        depends = node.get("depends_on")
+        dep_nodes = depends.get("nodes") if isinstance(depends, dict) else None
+        for dep in dep_nodes or []:
+            name = names.get(dep)
+            if name is not None and name != exclude:
+                return name
+        return None
+
+    keys: dict[tuple[str, str], DeclaredKey] = {}
+    for node in nodes.values():
+        if not isinstance(node, dict) or node.get("resource_type") != "test":
+            continue
+        meta = node.get("test_metadata")
+        if not isinstance(meta, dict):
+            continue
+        kwargs = meta.get("kwargs")
+        kwargs = kwargs if isinstance(kwargs, dict) else {}
+        column = kwargs.get("column_name")
+        if not isinstance(column, str) or not column:
+            continue
+        test_name = meta.get("name")
+        if test_name == "relationships":
+            to_model = _parse_relation_ref(kwargs.get("to"))
+            field = kwargs.get("field")
+            if not to_model or not isinstance(field, str) or not field:
+                continue
+            child = attached_name(node, exclude=to_model)
+            if child is None:
+                continue
+            defs.foreign_keys.append(
+                DeclaredForeignKey(
+                    model=child,
+                    relation=relations.get(child),
+                    column=column,
+                    to_model=to_model,
+                    to_relation=relations.get(to_model),
+                    to_column=field,
+                    source="manifest",
+                )
+            )
+        elif test_name in ("unique", "not_null"):
+            child = attached_name(node)
+            if child is None:
+                continue
+            key = keys.setdefault(
+                (child, column),
+                DeclaredKey(
+                    model=child,
+                    relation=relations.get(child),
+                    column=column,
+                    source="manifest",
+                ),
+            )
+            if test_name == "unique":
+                key.unique = True
+            else:
+                key.not_null = True
+
+    defs.declared_keys = list(keys.values())
+    defs.model_relations.update(relations)
+    defs.manifest_loaded = True
+    defs.relationship_source = "manifest"
+
+
+def _declared_from_yaml(view: DbtProjectView, defs: ProjectDefinitions) -> None:
+    """Column-level tests straight from schema YAML: model-level names only,
+    no physical resolution. Model-level relationships tests (declared under the
+    model's ``tests:`` with a ``column_name`` kwarg) are a manifest-only shape."""
+
+    keys: dict[tuple[str, str], DeclaredKey] = {}
+    for parsed, _path in yaml_documents(view):
+        for entry in parsed.get("models") or []:
+            if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+                continue
+            model = entry["name"]
+            for column in entry.get("columns") or []:
+                if not isinstance(column, dict) or not isinstance(
+                    column.get("name"), str
+                ):
+                    continue
+                col_name = column["name"]
+                tests = column.get("tests") or column.get("data_tests") or []
+                for test in tests:
+                    kind = test if isinstance(test, str) else None
+                    if isinstance(test, dict):
+                        if "relationships" in test:
+                            cfg = test.get("relationships")
+                            cfg = cfg if isinstance(cfg, dict) else {}
+                            to_model = _parse_relation_ref(cfg.get("to"))
+                            field = cfg.get("field")
+                            if to_model and isinstance(field, str) and field:
+                                defs.foreign_keys.append(
+                                    DeclaredForeignKey(
+                                        model=model,
+                                        column=col_name,
+                                        to_model=to_model,
+                                        to_column=field,
+                                        source="yaml",
+                                    )
+                                )
+                            continue
+                        kind = next(
+                            (k for k in ("unique", "not_null") if k in test), None
+                        )
+                    if kind in ("unique", "not_null"):
+                        key = keys.setdefault(
+                            (model, col_name),
+                            DeclaredKey(model=model, column=col_name, source="yaml"),
+                        )
+                        if kind == "unique":
+                            key.unique = True
+                        else:
+                            key.not_null = True
+
+    defs.declared_keys = list(keys.values())
+    defs.relationship_source = "yaml"
+    if defs.foreign_keys:
+        defs.notes.append(
+            "declared joins read from schema YAML (project not compiled); "
+            "physical resolution is name-based"
+        )
+
+
+def _read_semantic_manifest(project: Path) -> dict[str, Any] | None:
+    """``target/semantic_manifest.json`` when present and carrying semantic
+    models; an empty or unreadable artifact falls back to raw YAML."""
+
+    path = project / SEMANTIC_MANIFEST_PATH
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if isinstance(payload, dict) and payload.get("semantic_models"):
+        return payload
+    return None
+
+
+def _primary_entity_column(entities: Any) -> str | None:
+    """The declared grain: the primary entity's column, when it is a plain
+    column reference (bare ``expr``, or a name with no ``expr``)."""
+
+    for entity in entities or []:
+        if not isinstance(entity, dict):
+            continue
+        if str(entity.get("type", "")).lower() != "primary":
+            continue
+        return physical_column(entity)
+    return None
+
+
+def _semantic_from_manifest(payload: dict[str, Any], defs: ProjectDefinitions) -> None:
+    """Grain and metric lineage from the compiled semantic manifest, whose
+    ``node_relation`` also resolves each semantic model physically (useful even
+    when manifest.json is absent). ``input_measures`` is pre-resolved there, so
+    ratio/derived chains need no chasing."""
+
+    measure_owner: dict[str, str] = {}
+    for entry in payload.get("semantic_models") or []:
+        if not isinstance(entry, dict):
+            continue
+        node_relation = entry.get("node_relation")
+        node_relation = node_relation if isinstance(node_relation, dict) else {}
+        model = node_relation.get("alias") or _parse_relation_ref(
+            str(entry.get("model", ""))
+        )
+        if not isinstance(model, str) or not model:
+            continue
+        relation = node_relation.get("relation_name")
+        if isinstance(relation, str) and relation:
+            defs.model_relations.setdefault(model, _strip_relation_quoting(relation))
+        grain = _primary_entity_column(entry.get("entities"))
+        if grain:
+            defs.primary_entities[model] = grain
+        for measure in entry.get("measures") or []:
+            if isinstance(measure, dict) and isinstance(measure.get("name"), str):
+                measure_owner[measure["name"]] = model
+
+    reachable: set[str] = set()
+    for metric in payload.get("metrics") or []:
+        if not isinstance(metric, dict):
+            continue
+        params = metric.get("type_params")
+        params = params if isinstance(params, dict) else {}
+        for input_measure in params.get("input_measures") or []:
+            name = (
+                input_measure.get("name")
+                if isinstance(input_measure, dict)
+                else input_measure
+            )
+            owner = measure_owner.get(name) if isinstance(name, str) else None
+            if owner:
+                reachable.add(owner)
+    defs.metric_models = sorted(reachable)
+    defs.semantic_source = "manifest"
+
+
+def _semantic_from_yaml(
+    entries: list[tuple[str, dict[str, Any], str]], defs: ProjectDefinitions
+) -> None:
+    """The same grain and lineage from raw YAML entries. Ratio and derived
+    metrics reference other metrics, so lineage resolves transitively down to
+    measures (with a seen-set: a metric cycle is an authoring error, not a
+    reason to recurse forever)."""
+
+    if not entries:
+        return
+    measure_owner: dict[str, str] = {}
+    metric_graph: dict[str, tuple[list[str], list[str]]] = {}
+    for kind, entry, _path in entries:
+        if kind == "semantic_model":
+            model = _parse_relation_ref(str(entry.get("model", "")))
+            if not model:
+                continue
+            grain = _primary_entity_column(entry.get("entities"))
+            if grain:
+                defs.primary_entities[model] = grain
+            for measure in entry.get("measures") or []:
+                if isinstance(measure, dict) and isinstance(measure.get("name"), str):
+                    measure_owner[measure["name"]] = model
+        else:
+            metric_graph[str(entry["name"])] = metric_inputs(entry)
+
+    def grounded_measures(name: str, seen: set[str]) -> list[str]:
+        if name in seen:
+            return []
+        seen.add(name)
+        measures, metrics = metric_graph.get(name, ([], []))
+        grounded = list(measures)
+        for metric in metrics:
+            grounded.extend(grounded_measures(metric, seen))
+        return grounded
+
+    reachable: set[str] = set()
+    for name in metric_graph:
+        for measure in grounded_measures(name, set()):
+            owner = measure_owner.get(measure)
+            if owner:
+                reachable.add(owner)
+    defs.metric_models = sorted(reachable)
+    defs.semantic_source = "yaml"
+
+
+def _flag_stale_manifest(view: DbtProjectView, defs: ProjectDefinitions) -> None:
+    """A manifest older than the newest model source describes a project state
+    that may no longer exist; note it, never refuse on it."""
+
+    metadata = (view.manifest or {}).get("metadata")
+    generated = metadata.get("generated_at") if isinstance(metadata, dict) else None
+    if not isinstance(generated, str):
+        return
+    try:
+        generated_at = datetime.fromisoformat(generated.replace("Z", "+00:00"))
+    except ValueError:
+        return
+    if generated_at.tzinfo is None:
+        generated_at = generated_at.replace(tzinfo=UTC)
+
+    root = Path(view.root)
+    newest: float | None = None
+    for model_path in view.model_paths:
+        base = root / model_path
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*"):
+            if path.suffix not in {".sql", ".yml", ".yaml"} or not path.is_file():
+                continue
+            mtime = path.stat().st_mtime
+            if newest is None or mtime > newest:
+                newest = mtime
+    if newest is None:
+        return
+    if datetime.fromtimestamp(newest, tz=UTC) > generated_at:
+        defs.manifest_stale = True
+        defs.notes.append(
+            "compiled dbt artifacts are older than the model sources; "
+            "declared definitions may lag recent edits"
+        )

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 import argparse
 import json
 from datetime import UTC, datetime
+from pathlib import Path
 
-from .. import command_args
+from .. import command_args, dbt_project
 from .. import envelope as env
 from ..adapters import get_dialect
 from ..adapters.base import Adapter, ObjectMeta, QueryResult
-from ..cache import Dataset, DexCache, DexStore, match_identifier
+from ..cache import Dataset, DexCache, DexStore, Relationship, match_identifier
 from ..config import DexConfig, QueryLimits, load_config
 from ..guards.query_firewall import (
     InspectedQuery,
@@ -83,6 +84,8 @@ def cmd_inventory(args: argparse.Namespace) -> env.Envelope:
 
 
 def cmd_profile(args: argparse.Namespace) -> env.Envelope:
+    config = load_config(command_args.repo_root(args)) or DexConfig()
+    defs = _project_definitions(args, config)
     adapter = command_args.open_from_args(args)
     try:
         identifiers = _resolve_identifiers(adapter, args.objects)
@@ -97,7 +100,7 @@ def cmd_profile(args: argparse.Namespace) -> env.Envelope:
         command_args.stamp_spend(envelope, adapter)
     finally:
         adapter.close()
-    _annotate_grain(datasets)
+    _annotate_grain(datasets, defs)
     envelope.data["datasets"] = [d.model_dump(mode="json") for d in datasets]
     return envelope
 
@@ -105,6 +108,7 @@ def cmd_profile(args: argparse.Namespace) -> env.Envelope:
 def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
     verify = getattr(args, "verify", False)
     config = load_config(command_args.repo_root(args)) or DexConfig()
+    defs = _project_definitions(args, config)
 
     adapter = command_args.open_from_args(args)
     try:
@@ -144,9 +148,17 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
     finally:
         adapter.close()
 
-    declared = rel_mod.declared_relationships(command_args.repo_root(args))
-    rels = declared + inferred
-    notes = _relationship_notes(datasets, declared, inferred)
+    declared, declared_notes = rel_mod.declared_relationships(
+        defs, [d.identifier for d in datasets]
+    )
+    rels, confirmed = _merge_relationships(declared, inferred)
+    notes = _relationship_notes(datasets, declared, inferred, defs)
+    notes.extend(declared_notes)
+    notes.extend(defs.notes)
+    if confirmed:
+        notes.append(
+            f"{confirmed} inferred join(s) match declared tests; kept as declared"
+        )
     if verify and inferred:
         notes.append(
             f"verified {len(inferred)} inferred join(s) with aggregate overlap probes"
@@ -155,7 +167,7 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         {
             "relationships": [r.model_dump(mode="json") for r in rels],
             "declared_count": len(declared),
-            "inferred_count": len(inferred),
+            "inferred_count": len(rels) - len(declared),
             "notes": notes,
         }
     )
@@ -246,6 +258,8 @@ def cmd_query(args: argparse.Namespace) -> env.Envelope:
 def cmd_map(args: argparse.Namespace) -> env.Envelope:
     repo_root = command_args.repo_root(args)
     config = load_config(repo_root) or DexConfig()
+    defs = _project_definitions(args, config)
+    hints = _merged_hints(config.ranking_hints, defs.metric_models)
     full = getattr(args, "full", False)
 
     adapter = command_args.open_from_args(args)
@@ -253,7 +267,7 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         metas = inventory_mod.inventory(adapter)
         # First-pass rank on cheap signals (no connectivity yet) to choose what to
         # profile; re-ranked with connectivity once relationships are known.
-        first_pass = rank_mod.rank(metas, None, config.ranking_hints)
+        first_pass = rank_mod.rank(metas, None, hints)
         selected = _select_for_profiling(metas, first_pass, config, full)
         # Inventory and ranking are free, so an unconfirmed billed run repeats
         # them on re-issue; only the profiling scans below need the handshake.
@@ -273,7 +287,7 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         if unconfirmed is not None:
             return unconfirmed
         profiled = profile_mod.profile(adapter, [m.identifier for m in selected])
-        _annotate_grain(profiled)
+        _annotate_grain(profiled, defs)
         inferred = rel_mod.infer_relationships(profiled)
         if getattr(args, "verify", False):
             rel_mod.verify_relationships(
@@ -300,15 +314,17 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         profiled, inferred, dev_schemas
     )
 
-    declared = rel_mod.declared_relationships(repo_root)
-    relationships = declared + inferred
+    declared, declared_notes = rel_mod.declared_relationships(
+        defs, [m.identifier for m in metas]
+    )
+    relationships, confirmed = _merge_relationships(declared, inferred)
 
     store = DexStore(repo_root)
     now = datetime.now(UTC)
     prior = store.load_cache()
     # Prior profiles are only reusable when they came from the same connector.
     reusable = prior if prior and prior.provenance.connector == adapter.name else None
-    final_scores = rank_mod.rank(metas, relationships, config.ranking_hints)
+    final_scores = rank_mod.rank(metas, relationships, hints)
     datasets, carried = _compose_datasets(metas, profiled, final_scores, reusable)
 
     cache = DexCache(datasets=datasets, relationships=relationships)
@@ -320,7 +336,19 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
     )
     path = store.save_cache(cache, now=now)
 
-    notes = _relationship_notes(profiled, declared, inferred)
+    notes = _relationship_notes(profiled, declared, inferred, defs)
+    notes.extend(declared_notes)
+    notes.extend(defs.notes)
+    if confirmed:
+        notes.append(
+            f"{confirmed} inferred join(s) match declared tests; kept as declared"
+        )
+    metric_hint_count = len(hints) - len(config.ranking_hints)
+    if metric_hint_count > 0:
+        notes.append(
+            f"{metric_hint_count} model(s) back metric definitions; ranking "
+            "favors them alongside configured hints"
+        )
     skipped = len(metas) - len(profiled)
     if skipped > 0:
         notes.append(
@@ -420,22 +448,149 @@ def _shape_query_payload(
     }
 
 
-def _annotate_grain(datasets: list[Dataset]) -> None:
+def _project_definitions(
+    args: argparse.Namespace, config: DexConfig
+) -> dbt_project.ProjectDefinitions:
+    """The dbt project's declared definitions, honoring the config pin.
+
+    Exploration starts bare: warehouse observations stay independent of
+    whatever repo dex happens to run from, so the declared definitions fold in
+    only when ``--use-project`` asks for them. Without the flag, a present
+    project earns a discovery note instead of influence. With it, a repo
+    without a project (or with an ambiguous choice) degrades to the empty
+    view, so explore keeps working on raw warehouses.
+    """
+
+    repo_root = command_args.repo_root(args)
+    if not getattr(args, "use_project", False):
+        defs = dbt_project.ProjectDefinitions()
+        discovered = dbt_project.discover_projects(repo_root)
+        if discovered:
+            # project_dir marks "found but unused" so the empty-declared note
+            # can say so instead of claiming there is no project.
+            defs.project_dir = str(discovered[0])
+            defs.notes.append(
+                "a dbt project is present but unused; pass --use-project to "
+                "fold its declared joins, grain, and metric definitions into "
+                "exploration"
+            )
+        return defs
+    pin = Path(repo_root) / config.dbt_project_dir if config.dbt_project_dir else None
+    return dbt_project.definitions(repo_root, pin)
+
+
+def _merge_relationships(
+    declared: list[Relationship], inferred: list[Relationship]
+) -> tuple[list[Relationship], int]:
+    """Declared joins win over the same inferred edge.
+
+    Returns the merged list plus how many inferred edges the declared set
+    absorbed: inference independently agreeing with a declared test is worth a
+    note, and double-reporting the edge would inflate connectivity ranking.
+    """
+
+    def edge_key(rel: Relationship) -> tuple:
+        return (
+            rel.from_dataset.lower(),
+            tuple(c.lower() for c in rel.from_columns),
+            rel.to_dataset.lower(),
+            tuple(c.lower() for c in rel.to_columns),
+        )
+
+    declared_keys = {edge_key(rel) for rel in declared}
+    merged = list(declared)
+    confirmed = 0
+    for rel in inferred:
+        if edge_key(rel) in declared_keys:
+            confirmed += 1
+            continue
+        merged.append(rel)
+    return merged, confirmed
+
+
+def _merged_hints(user_hints: list[str], metric_models: list[str]) -> list[str]:
+    """User-configured ranking hints plus the models metric definitions ground
+    in. User hints come first and are never displaced; metric-backed models are
+    appended so the naming signal favors what the project measures."""
+
+    merged = list(user_hints)
+    seen = {h.strip().lower() for h in user_hints if isinstance(h, str)}
+    for model in metric_models:
+        if model.lower() not in seen:
+            merged.append(model)
+            seen.add(model.lower())
+    return merged
+
+
+def _annotate_grain(
+    datasets: list[Dataset], defs: dbt_project.ProjectDefinitions | None = None
+) -> None:
     """Attach the interpretation layer to raw profiles: candidate keys, the likely
     grain, and the data-quality warnings an analyst would write (non-unique own
     key, unknown grain). Shared by profile and map so a single-table profile
-    surfaces a broken grain without requiring a full map."""
+    surfaces a broken grain without requiring a full map.
+
+    With project definitions, the declared truth refines the heuristics: a
+    semantic model's primary entity overrides the detected grain (noting any
+    disagreement), and a profiled column contradicting its declared ``unique``
+    test gets a data-quality note. ``candidate_keys`` stays measurement-only:
+    an unmeasured declared key is a claim, and the cache is a drift baseline.
+    """
+
+    declared_grain: dict[str, str] = {}
+    declared_unique: dict[str, set[str]] = {}
+    if defs is not None and (defs.primary_entities or defs.declared_keys):
+        identifiers = [d.identifier for d in datasets]
+        for model, column in defs.primary_entities.items():
+            ident, _ambiguous = rel_mod.resolve_declared(
+                defs.model_relations.get(model), model, identifiers
+            )
+            if ident is not None:
+                declared_grain[ident.lower()] = column
+        for key in defs.declared_keys:
+            if not key.unique:
+                continue
+            ident, _ambiguous = rel_mod.resolve_declared(
+                key.relation, key.model, identifiers
+            )
+            if ident is not None:
+                declared_unique.setdefault(ident.lower(), set()).add(key.column.lower())
 
     for ds in datasets:
         ds.candidate_keys = rel_mod.candidate_keys(ds)
         ds.grain = rel_mod.detect_grain(ds)
         ds.data_quality.extend(rel_mod.data_quality_notes(ds))
 
+        grain_column = declared_grain.get(ds.identifier.lower())
+        if grain_column is not None:
+            profiled = next(
+                (c for c in ds.columns if c.name.lower() == grain_column.lower()),
+                None,
+            )
+            if profiled is not None:
+                declared = [profiled.name]
+                if ds.grain and ds.grain != declared:
+                    ds.data_quality.append(
+                        f"grain {profiled.name} comes from the project's declared "
+                        f"primary entity (heuristic suggested {', '.join(ds.grain)})"
+                    )
+                ds.grain = declared
+        for col in ds.columns:
+            if (
+                col.name.lower() in declared_unique.get(ds.identifier.lower(), set())
+                and col.is_unique is False
+            ):
+                ds.data_quality.append(
+                    f"{col.name} is declared unique in the dbt project but "
+                    "profiling found duplicates"
+                )
+
 
 def _relationship_notes(
     datasets: list[Dataset],
     declared: list,
     inferred: list,
+    defs: dbt_project.ProjectDefinitions | None = None,
 ) -> list[str]:
     """Explain the inference result so an empty array is distinguishable from
     'no relationships exist': what was examined and why nothing survived."""
@@ -446,9 +601,16 @@ def _relationship_notes(
         f"across {len(datasets)} profiled object(s)"
     ]
     if not declared:
-        notes.append(
-            "no declared relationships (no dbt project or no declared foreign keys)"
-        )
+        if defs is not None and defs.present and defs.foreign_keys:
+            # The project declares foreign keys, but none resolved here; the
+            # per-join notes from resolution say which and why.
+            notes.append("no declared relationships resolved against this connection")
+        elif defs is not None and not defs.present and defs.project_dir:
+            notes.append("no declared relationships (dbt project present but unused)")
+        else:
+            notes.append(
+                "no declared relationships (no dbt project or no declared foreign keys)"
+            )
     if fk_columns and not inferred:
         notes.append(
             "no id-shaped column matched a parent table by name; joins may exist "

--- a/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
@@ -13,7 +13,6 @@ work without a dbt project).
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 from ..adapters.base import Adapter
 from ..cache import (
@@ -21,7 +20,9 @@ from ..cache import (
     Dataset,
     Relationship,
     RelationshipKind,
+    match_identifier,
 )
+from ..dbt_project import ProjectDefinitions
 from .profile import NEAR_UNIQUE_RATIO
 
 # Warehouse-layer prefixes stripped from a table name before entity matching, so
@@ -411,20 +412,82 @@ def _quote_part(name: str) -> str:
     return f'"{escaped}"'
 
 
-def declared_relationships(repo_root: Path | str = ".") -> list[Relationship]:
-    """Declared joins from the dbt project. Returns empty when there is no dbt
-    project (the common explore-without-dbt case), which is not an error."""
+def declared_relationships(
+    defs: ProjectDefinitions, known_identifiers: list[str]
+) -> tuple[list[Relationship], list[str]]:
+    """Declared joins from the dbt project, resolved against this connection's
+    identifiers.
 
-    root = Path(repo_root)
-    has_project = (root / "dbt_project.yml").is_file() or (
-        root / "target" / "manifest.json"
-    ).is_file()
-    if not has_project:
-        return []
-    # Parsing declared relationships from the manifest lands with the dbt_project
-    # reader (transform phase). Until then, a present-but-unparsed project yields
-    # no declared joins rather than guessing.
-    return []
+    A ``relationships`` test is the project's own statement of a foreign key, so
+    every resolvable one is emitted at confidence 1.0. Resolution never guesses:
+    an endpoint matching nothing or matching more than one object yields a note
+    instead of an edge (a declared relation missing from the connection is a
+    drift signal worth surfacing, not an error). Empty definitions (the common
+    explore-without-dbt case) yield nothing.
+    """
+
+    relationships: list[Relationship] = []
+    notes: list[str] = []
+    seen: set[tuple[str, str, str, str]] = set()
+    for fk in defs.foreign_keys:
+        child, child_ambiguous = resolve_declared(
+            fk.relation, fk.model, known_identifiers
+        )
+        parent, parent_ambiguous = resolve_declared(
+            fk.to_relation, fk.to_model, known_identifiers
+        )
+        label = f"declared join {fk.model}.{fk.column} -> {fk.to_model}.{fk.to_column}"
+        if child is None or parent is None:
+            if child_ambiguous or parent_ambiguous:
+                notes.append(
+                    f"{label} matches more than one object here; skipped rather "
+                    "than guessed"
+                )
+            else:
+                notes.append(
+                    f"{label} references a relation not in this connection's inventory"
+                )
+            continue
+        key = (child.lower(), fk.column.lower(), parent.lower(), fk.to_column.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        relationships.append(
+            Relationship(
+                from_dataset=child,
+                from_columns=[fk.column],
+                to_dataset=parent,
+                to_columns=[fk.to_column],
+                kind=RelationshipKind.DECLARED,
+                confidence=1.0,
+            )
+        )
+    return relationships, notes
+
+
+def resolve_declared(
+    relation: str | None, name: str, known: list[str]
+) -> tuple[str | None, bool]:
+    """One declared endpoint as a unique known identifier, or why not.
+
+    Tries the most specific form first (the manifest's quote-stripped
+    ``db.schema.table``, or the model / ``source.table`` name from YAML), then
+    progressively shorter dotted suffixes: the manifest's database component
+    routinely disagrees with the adapter-normalized identifier (a DuckDB file
+    stem, a profile database alias), while the suffix still pins the object.
+    Returns ``(identifier, False)`` on a unique match, ``(None, True)`` when a
+    suffix matched several objects (shorter suffixes only widen, so stop), and
+    ``(None, False)`` when nothing matched at all.
+    """
+
+    parts = (relation or name).split(".")
+    for start in range(len(parts)):
+        matches = match_identifier(".".join(parts[start:]), known)
+        if len(matches) == 1:
+            return matches[0], False
+        if len(matches) > 1:
+            return None, True
+    return None, False
 
 
 def _match_parent(

--- a/packages/dex-core/src/exmergo_dex_core/maintain/snapshot.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/snapshot.py
@@ -25,23 +25,24 @@ pass deemed safe to record.
 from __future__ import annotations
 
 import json
-import re
 from typing import Any
 
-import yaml
 from pydantic import BaseModel, Field
 
 from ..adapters.base import Adapter
 from ..cache import ColumnProfile, Dataset, DexCache, Relationship, tool_version
-from ..dbt_project import DbtProjectView, content_hash
+from ..dbt_project import (
+    REF_PATTERN,
+    SOURCE_PATTERN,
+    DbtProjectView,
+    content_hash,
+    metric_inputs,
+    physical_column,
+    semantic_yaml_entries,
+    yaml_documents,
+)
 
 SNAPSHOT_SCHEMA_VERSION = 1
-
-_REF_PATTERN = re.compile(r"ref\(\s*['\"]([^'\"]+)['\"]")
-_SOURCE_PATTERN = re.compile(
-    r"source\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]"
-)
-_BARE_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 
 class WarehouseBaseline(BaseModel):
@@ -205,17 +206,17 @@ def transform_layer(view: DbtProjectView) -> TransformLayer:
         source_calls = sorted(
             {
                 f"{name}.{table}"
-                for name, table in _SOURCE_PATTERN.findall(source.content)
+                for name, table in SOURCE_PATTERN.findall(source.content)
             }
         )
-        ref_calls = sorted(set(_REF_PATTERN.findall(source.content)) - {model})
+        ref_calls = sorted(set(REF_PATTERN.findall(source.content)) - {model})
         if source_calls:
             model_sources[model] = source_calls
         if ref_calls:
             model_refs[model] = ref_calls
     models.sort()
     sources: list[SourceTable] = []
-    for parsed, path in _yaml_documents(view):
+    for parsed, path in yaml_documents(view):
         for src in parsed.get("sources") or []:
             if not isinstance(src, dict) or not src.get("name"):
                 continue
@@ -249,64 +250,30 @@ def semantic_layer(view: DbtProjectView) -> SemanticLayer:
 
     semantic_models: list[SemanticModelDef] = []
     metrics: list[MetricDef] = []
-    for parsed, path in _yaml_documents(view):
-        semantic_models.extend(
-            _semantic_model_def(entry, path)
-            for entry in parsed.get("semantic_models") or []
-            if isinstance(entry, dict) and entry.get("name")
-        )
-        metrics.extend(
-            _metric_def(entry, path)
-            for entry in parsed.get("metrics") or []
-            if isinstance(entry, dict) and entry.get("name")
-        )
+    for kind, entry, path in semantic_yaml_entries(view):
+        if kind == "semantic_model":
+            semantic_models.append(_semantic_model_def(entry, path))
+        else:
+            metrics.append(_metric_def(entry, path))
     return SemanticLayer(semantic_models=semantic_models, metrics=metrics)
 
 
 # --- helpers -----------------------------------------------------------------
 
 
-def _yaml_documents(view: DbtProjectView) -> list[tuple[dict[str, Any], str]]:
-    documents: list[tuple[dict[str, Any], str]] = []
-    for source in view.files.values():
-        if not source.path.endswith((".yml", ".yaml")):
-            continue
-        try:
-            parsed = yaml.safe_load(source.content)
-        except yaml.YAMLError:
-            continue  # a broken hand-written file is not this command's problem
-        if isinstance(parsed, dict):
-            documents.append((parsed, source.path))
-    return documents
-
-
 def _definition_hash(entry: dict[str, Any]) -> str:
     return content_hash(json.dumps(entry, sort_keys=True, default=str))
 
 
-def _physical_column(entry: Any) -> str | None:
-    """The single physical column a dimension/entity/measure references, if any."""
-
-    if not isinstance(entry, dict):
-        return None
-    expr = entry.get("expr")
-    if expr is None:
-        name = entry.get("name")
-        return name if isinstance(name, str) else None
-    if isinstance(expr, str) and _BARE_IDENTIFIER.fullmatch(expr.strip()):
-        return expr.strip()
-    return None
-
-
 def _semantic_model_def(entry: dict[str, Any], path: str) -> SemanticModelDef:
-    model_match = _REF_PATTERN.search(str(entry.get("model", "")))
+    model_match = REF_PATTERN.search(str(entry.get("model", "")))
     dimensions = [d for d in entry.get("dimensions") or [] if isinstance(d, dict)]
     measures = [m for m in entry.get("measures") or [] if isinstance(m, dict)]
     entities = [e for e in entry.get("entities") or [] if isinstance(e, dict)]
 
     def mapping_of(entries: list[dict[str, Any]]) -> dict[str, str | None]:
         return {
-            e["name"]: _physical_column(e)
+            e["name"]: physical_column(e)
             for e in entries
             if isinstance(e.get("name"), str)
         }
@@ -334,31 +301,7 @@ def _semantic_model_def(entry: dict[str, Any], path: str) -> SemanticModelDef:
 
 
 def _metric_def(entry: dict[str, Any], path: str) -> MetricDef:
-    metric_type = str(entry.get("type", "")).lower()
-    params = entry.get("type_params")
-    params = params if isinstance(params, dict) else {}
-    measures: list[str] = []
-    metrics: list[str] = []
-
-    def add(bucket: list[str], value: Any) -> None:
-        if isinstance(value, str):
-            bucket.append(value)
-        elif isinstance(value, dict) and isinstance(value.get("name"), str):
-            bucket.append(value["name"])
-
-    if metric_type in {"simple", "cumulative"}:
-        add(measures, params.get("measure"))
-    elif metric_type == "ratio":
-        add(metrics, params.get("numerator"))
-        add(metrics, params.get("denominator"))
-    elif metric_type == "derived":
-        for input_metric in params.get("metrics") or []:
-            add(metrics, input_metric)
-    elif metric_type == "conversion":
-        conversion = params.get("conversion_type_params")
-        if isinstance(conversion, dict):
-            add(measures, conversion.get("base_measure"))
-            add(measures, conversion.get("conversion_measure"))
+    measures, metrics = metric_inputs(entry)
     return MetricDef(
         name=entry["name"],
         path=path,

--- a/packages/dex-core/tests/conftest.py
+++ b/packages/dex-core/tests/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -225,6 +227,112 @@ def fake_pg_connection():
         ),
     ]
     return FakePostgresConnection(tables=tables, database="dexdb")
+
+
+def write_manifest(
+    project: Path,
+    *,
+    models: dict[str, str | None],
+    sources: dict[str, str] | None = None,
+    relationship_tests: list[tuple[str, str, str, str]] = (),
+    unique_tests: list[tuple[str, str]] = (),
+    not_null_tests: list[tuple[str, str]] = (),
+    generated_at: str | None = None,
+) -> Path:
+    """Write a minimal compiled manifest.json shaped like dbt's.
+
+    ``models`` maps model name to its relation_name (None for ephemeral).
+    ``sources`` maps ``"source_name.table"`` to a relation_name.
+    ``relationship_tests`` entries are ``(model, column, to, field)`` with
+    ``to`` as the literal test argument (``"ref('x')"`` / ``"source('a','b')"``).
+    ``unique_tests`` / ``not_null_tests`` entries are ``(model, column)``.
+    """
+
+    uid_of = {name: f"model.dex_test.{name}" for name in models}
+    nodes: dict[str, dict] = {
+        uid_of[name]: {
+            "resource_type": "model",
+            "name": name,
+            "relation_name": relation,
+            "config": {"enabled": True},
+        }
+        for name, relation in models.items()
+    }
+    source_nodes: dict[str, dict] = {}
+    for key, relation in (sources or {}).items():
+        source_name, table = key.split(".", 1)
+        uid = f"source.dex_test.{source_name}.{table}"
+        uid_of[key] = uid
+        source_nodes[uid] = {
+            "resource_type": "source",
+            "source_name": source_name,
+            "name": table,
+            "relation_name": relation,
+        }
+
+    def test_node(name: str, kwargs: dict, attached: str) -> dict:
+        return {
+            "resource_type": "test",
+            "name": name,
+            "test_metadata": {"name": name.split("__")[0], "kwargs": kwargs},
+            "attached_node": uid_of[attached],
+            "depends_on": {"nodes": [uid_of[attached]]},
+        }
+
+    for i, (model, column, to, field) in enumerate(relationship_tests):
+        nodes[f"test.dex_test.relationships_{i}"] = test_node(
+            f"relationships__{i}",
+            {"column_name": column, "to": to, "field": field},
+            model,
+        )
+    for i, (model, column) in enumerate(unique_tests):
+        nodes[f"test.dex_test.unique_{i}"] = test_node(
+            f"unique__{i}", {"column_name": column}, model
+        )
+    for i, (model, column) in enumerate(not_null_tests):
+        nodes[f"test.dex_test.not_null_{i}"] = test_node(
+            f"not_null__{i}", {"column_name": column}, model
+        )
+
+    target = project / "target"
+    target.mkdir(exist_ok=True)
+    path = target / "manifest.json"
+    path.write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "project_name": "dex_test",
+                    "generated_at": generated_at or datetime.now(UTC).isoformat(),
+                },
+                "nodes": nodes,
+                "sources": source_nodes,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def write_semantic_manifest(
+    project: Path, *, semantic_models: list[dict], metrics: list[dict]
+) -> Path:
+    """Write a minimal target/semantic_manifest.json (dbt's compiled semantic
+    layer artifact: pre-resolved node_relation and metric input_measures)."""
+
+    target = project / "target"
+    target.mkdir(exist_ok=True)
+    path = target / "semantic_manifest.json"
+    path.write_text(
+        json.dumps(
+            {
+                "semantic_models": semantic_models,
+                "metrics": metrics,
+                "project_configuration": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
 
 
 @pytest.fixture

--- a/packages/dex-core/tests/explore/test_explore.py
+++ b/packages/dex-core/tests/explore/test_explore.py
@@ -16,6 +16,7 @@ from exmergo_dex_core import envelope as env
 from exmergo_dex_core.cache import DexStore
 from exmergo_dex_core.cli import main
 from exmergo_dex_core.config import DexConfig, save_config
+from exmergo_dex_core.explore.commands import _merged_hints
 
 
 def _run(argv: list[str], capsys) -> dict:
@@ -325,3 +326,224 @@ def test_empty_table_and_view_profile_without_error(edge_duckdb: Path, capsys):
     assert any("empty" in note for note in empty["data_quality"])
     assert empty["columns"][0]["null_fraction"] is None  # no rows -> undefined
     assert "people_v" in ds  # a view profiles fine
+
+
+# --- free priors from the dbt project ------------------------------------------
+
+
+def _semantic_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """A warehouse plus a dbt project whose semantic layer declares a grain
+    (order_code, disagreeing with the id heuristic) and whose schema.yml
+    declares status unique (contradicted by the data)."""
+
+    duckdb = pytest.importorskip("duckdb")
+    db = tmp_path / "wh.duckdb"
+    conn = duckdb.connect(str(db))
+    conn.execute("CREATE TABLE orders (id INTEGER, order_code INTEGER, status VARCHAR)")
+    conn.execute(
+        "INSERT INTO orders VALUES (1, 101, 'open'), (2, 102, 'open'), "
+        "(3, 103, 'closed')"
+    )
+    conn.close()
+
+    repo = tmp_path / "repo"
+    (repo / "models").mkdir(parents=True)
+    (repo / "dbt_project.yml").write_text(
+        'name: dex_test\nversion: "1.0.0"\nmodel-paths: ["models"]\n',
+        encoding="utf-8",
+    )
+    (repo / "models" / "semantic.yml").write_text(
+        "semantic_models:\n"
+        "  - name: orders\n"
+        "    model: ref('orders')\n"
+        "    entities:\n"
+        "      - name: order\n"
+        "        type: primary\n"
+        "        expr: order_code\n",
+        encoding="utf-8",
+    )
+    (repo / "models" / "schema.yml").write_text(
+        "version: 2\n"
+        "models:\n"
+        "  - name: orders\n"
+        "    columns:\n"
+        "      - name: status\n"
+        "        tests: [unique]\n",
+        encoding="utf-8",
+    )
+    return db, repo
+
+
+def test_map_declared_grain_overrides_heuristic(tmp_path: Path, capsys):
+    db, repo = _semantic_repo(tmp_path)
+    _run(
+        [
+            "explore",
+            "map",
+            "--use-project",
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    cache = DexStore(repo).load_cache()
+    (orders,) = [d for d in cache.datasets if d.identifier.endswith(".orders")]
+    # The heuristic would pick the id-shaped key; the declared primary entity wins.
+    assert orders.grain == ["order_code"]
+    assert any("declared primary entity" in n for n in orders.data_quality)
+    assert any("heuristic suggested id" in n for n in orders.data_quality)
+
+
+def test_map_notes_declared_unique_contradiction(tmp_path: Path, capsys):
+    db, repo = _semantic_repo(tmp_path)
+    _run(
+        [
+            "explore",
+            "map",
+            "--use-project",
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    cache = DexStore(repo).load_cache()
+    (orders,) = [d for d in cache.datasets if d.identifier.endswith(".orders")]
+    assert any(
+        "status is declared unique" in n and "duplicates" in n
+        for n in orders.data_quality
+    )
+    # Measurement-only: the contradicted declared key must not appear as a
+    # candidate key just because the project claims it.
+    assert ["status"] not in orders.candidate_keys
+
+
+def test_profile_gets_declared_grain_too(tmp_path: Path, capsys):
+    db, repo = _semantic_repo(tmp_path)
+    payload = _run(
+        [
+            "explore",
+            "profile",
+            "orders",
+            "--use-project",
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    (orders,) = payload["data"]["datasets"]
+    assert orders["grain"] == ["order_code"]
+
+
+def test_exploration_starts_bare_and_discovers_the_project(tmp_path: Path, capsys):
+    """Without --use-project the warehouse is explored as-is: heuristic grain,
+    no declared influence, and a discovery note pointing at the flag."""
+
+    db, repo = _semantic_repo(tmp_path)
+    payload = _run(
+        ["explore", "map", "--path", str(db), "--repo-root", str(repo)],
+        capsys,
+    )
+    notes = payload["data"]["notes"]
+    assert any("--use-project" in n for n in notes)
+    # The empty-declared note adapts: the project exists, it just was not used.
+    assert not any("no dbt project" in n for n in notes)
+    cache = DexStore(repo).load_cache()
+    (orders,) = [d for d in cache.datasets if d.identifier.endswith(".orders")]
+    assert orders.grain == ["id"]
+    assert not any("declared" in n for n in orders.data_quality)
+
+
+def _metric_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """Two structurally identical tables; only beta_events backs a metric."""
+
+    duckdb = pytest.importorskip("duckdb")
+    db = tmp_path / "wh.duckdb"
+    conn = duckdb.connect(str(db))
+    for name in ("alpha_events", "beta_events"):
+        conn.execute(f"CREATE TABLE {name} (id INTEGER, amount INTEGER)")
+        conn.execute(f"INSERT INTO {name} VALUES (1, 10), (2, 20)")  # noqa: S608
+    conn.close()
+
+    repo = tmp_path / "repo"
+    (repo / "models").mkdir(parents=True)
+    (repo / "dbt_project.yml").write_text(
+        'name: dex_test\nversion: "1.0.0"\nmodel-paths: ["models"]\n',
+        encoding="utf-8",
+    )
+    (repo / "models" / "semantic.yml").write_text(
+        "semantic_models:\n"
+        "  - name: events\n"
+        "    model: ref('beta_events')\n"
+        "    entities:\n"
+        "      - name: id\n"
+        "        type: primary\n"
+        "    measures:\n"
+        "      - name: event_amount\n"
+        "        agg: sum\n"
+        "        expr: amount\n"
+        "metrics:\n"
+        "  - name: total_amount\n"
+        "    type: simple\n"
+        "    type_params:\n"
+        "      measure: event_amount\n",
+        encoding="utf-8",
+    )
+    return db, repo
+
+
+def test_map_metric_backed_table_outranks_equivalent(tmp_path: Path, capsys):
+    db, repo = _metric_repo(tmp_path)
+    payload = _run(
+        [
+            "explore",
+            "map",
+            "--use-project",
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    top = {
+        o["identifier"].split(".")[-1]: o["rank_score"]
+        for o in payload["data"]["top_objects"]
+    }
+    assert top["beta_events"] > top["alpha_events"]
+    assert any("back metric definitions" in n for n in payload["data"]["notes"])
+
+
+def test_map_metric_hints_do_not_displace_user_hints(tmp_path: Path, capsys):
+    db, repo = _metric_repo(tmp_path)
+    save_config(DexConfig(ranking_hints=["alpha_events"]), repo)
+    payload = _run(
+        [
+            "explore",
+            "map",
+            "--use-project",
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    top = {
+        o["identifier"].split(".")[-1]: o["rank_score"]
+        for o in payload["data"]["top_objects"]
+    }
+    # The user's hint keeps its full naming boost alongside the metric's.
+    assert top["alpha_events"] == top["beta_events"]
+
+
+def test_merged_hints_appends_without_displacing():
+    assert _merged_hints(["customer"], ["Customer", "orders"]) == [
+        "customer",
+        "orders",
+    ]

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -11,11 +11,20 @@ import json
 from pathlib import Path
 
 import pytest
+from conftest import write_manifest
 
-from exmergo_dex_core.cache import ColumnProfile, Dataset
+from exmergo_dex_core.cache import (
+    ColumnProfile,
+    Dataset,
+    Relationship,
+    RelationshipKind,
+)
 from exmergo_dex_core.cli import main
+from exmergo_dex_core.dbt_project import DeclaredForeignKey, ProjectDefinitions
+from exmergo_dex_core.explore.commands import _merge_relationships
 from exmergo_dex_core.explore.relationships import (
     data_quality_notes,
+    declared_relationships,
     detect_grain,
     fk_candidate_count,
     fold_replica_relationships,
@@ -532,3 +541,262 @@ def test_overlap_probe_transpiles_to_postgres_and_stays_select_only():
     # Portable shapes survive the rewrite; DuckDB-only FILTER syntax does not
     # appear (BigQuery lacks it and Postgres parses it differently).
     assert "order_items" in sql and "products" in sql
+
+
+# --- declared joins from the dbt project -----------------------------------------
+
+
+def _defs(foreign_keys) -> ProjectDefinitions:
+    return ProjectDefinitions(present=True, foreign_keys=foreign_keys)
+
+
+def _fk(
+    model, column, to_model, to_column, relation=None, to_relation=None, source="yaml"
+):
+    return DeclaredForeignKey(
+        model=model,
+        relation=relation,
+        column=column,
+        to_model=to_model,
+        to_relation=to_relation,
+        to_column=to_column,
+        source=source,
+    )
+
+
+def test_declared_resolves_manifest_relation_across_database_alias():
+    # The manifest says database "analytics"; the adapter normalized the same
+    # objects under the DuckDB file stem "wh". The schema.table suffix pins them.
+    defs = _defs(
+        [
+            _fk(
+                "orders",
+                "customer_id",
+                "customers",
+                "id",
+                relation="analytics.main.orders",
+                to_relation="analytics.main.customers",
+                source="manifest",
+            )
+        ]
+    )
+    known = ["wh.main.orders", "wh.main.customers"]
+    rels, notes = declared_relationships(defs, known)
+    assert notes == []
+    (rel,) = rels
+    assert rel.from_dataset == "wh.main.orders"
+    assert rel.to_dataset == "wh.main.customers"
+    assert rel.from_columns == ["customer_id"] and rel.to_columns == ["id"]
+    assert rel.kind.value == "declared"
+    assert rel.confidence == 1.0
+
+
+def test_declared_yaml_fallback_resolves_by_model_name():
+    defs = _defs([_fk("orders", "customer_id", "customers", "id")])
+    rels, notes = declared_relationships(defs, ["wh.main.orders", "wh.main.customers"])
+    assert notes == []
+    (rel,) = rels
+    assert rel.from_dataset == "wh.main.orders"
+
+
+def test_declared_ambiguous_match_is_skipped_with_a_note():
+    defs = _defs([_fk("orders", "customer_id", "customers", "id")])
+    known = ["wh.a.orders", "wh.b.orders", "wh.main.customers"]
+    rels, notes = declared_relationships(defs, known)
+    assert rels == []
+    assert any("more than one object" in n for n in notes)
+
+
+def test_declared_missing_relation_is_a_note_not_an_edge():
+    defs = _defs([_fk("orders", "payment_id", "payments", "id")])
+    rels, notes = declared_relationships(defs, ["wh.main.orders"])
+    assert rels == []
+    (note,) = notes
+    assert "payments.id" in note and "not in this connection's inventory" in note
+
+
+def test_declared_duplicate_edges_are_deduped():
+    fk = _fk("orders", "customer_id", "customers", "id")
+    defs = _defs([fk, fk.model_copy()])
+    rels, _ = declared_relationships(defs, ["wh.main.orders", "wh.main.customers"])
+    assert len(rels) == 1
+
+
+def test_merge_keeps_declared_over_matching_inferred():
+    declared = Relationship(
+        from_dataset="wh.main.orders",
+        from_columns=["customer_id"],
+        to_dataset="wh.main.customers",
+        to_columns=["id"],
+        kind=RelationshipKind.DECLARED,
+        confidence=1.0,
+    )
+    same_inferred = Relationship(
+        from_dataset="WH.MAIN.ORDERS",
+        from_columns=["CUSTOMER_ID"],
+        to_dataset="wh.main.customers",
+        to_columns=["ID"],
+        confidence=0.85,
+    )
+    other = Relationship(
+        from_dataset="wh.main.orders",
+        from_columns=["host_id"],
+        to_dataset="wh.main.hosts",
+        to_columns=["id"],
+        confidence=0.6,
+    )
+    merged, confirmed = _merge_relationships([declared], [same_inferred, other])
+    assert confirmed == 1
+    assert merged == [declared, other]
+
+
+def _declared_join_repo(tmp_path: Path, *, with_manifest: bool) -> tuple[Path, Path]:
+    """A DuckDB warehouse plus a dbt project declaring orders -> customers."""
+
+    duckdb = pytest.importorskip("duckdb")
+    db = tmp_path / "wh.duckdb"
+    conn = duckdb.connect(str(db))
+    conn.execute("CREATE TABLE orders (id INTEGER, customer_id INTEGER)")
+    conn.execute("INSERT INTO orders VALUES (1, 1), (2, 2), (3, 1)")
+    conn.execute("CREATE TABLE customers (id INTEGER)")
+    conn.execute("INSERT INTO customers VALUES (1), (2)")
+    conn.close()
+
+    repo = tmp_path / "repo"
+    (repo / "models").mkdir(parents=True)
+    (repo / "dbt_project.yml").write_text(
+        'name: dex_test\nversion: "1.0.0"\nmodel-paths: ["models"]\n',
+        encoding="utf-8",
+    )
+    (repo / "models" / "schema.yml").write_text(
+        "version: 2\n"
+        "models:\n"
+        "  - name: orders\n"
+        "    columns:\n"
+        "      - name: customer_id\n"
+        "        tests:\n"
+        "          - relationships:\n"
+        "              to: ref('customers')\n"
+        "              field: id\n",
+        encoding="utf-8",
+    )
+    if with_manifest:
+        # The manifest's database component ("analytics") deliberately differs
+        # from the adapter-normalized file stem ("wh"): resolution must absorb it.
+        write_manifest(
+            repo,
+            models={
+                "orders": '"analytics"."main"."orders"',
+                "customers": '"analytics"."main"."customers"',
+            },
+            relationship_tests=[("orders", "customer_id", "ref('customers')", "id")],
+        )
+    return db, repo
+
+
+def test_relationships_envelope_reports_declared_join(tmp_path: Path, capsys):
+    db, repo = _declared_join_repo(tmp_path, with_manifest=True)
+    payload = _run(
+        [
+            "explore",
+            "relationships",
+            "--use-project",
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    data = payload["data"]
+    assert data["declared_count"] == 1
+    declared = [r for r in data["relationships"] if r["kind"] == "declared"]
+    (rel,) = declared
+    assert rel["from_dataset"] == "wh.main.orders"
+    assert rel["confidence"] == 1.0
+    # Inference finds the same edge; the merge keeps only the declared one.
+    assert not any(
+        r["kind"] == "inferred"
+        and r["from_columns"] == ["customer_id"]
+        and r["to_dataset"] == "wh.main.customers"
+        for r in data["relationships"]
+    )
+    assert any("match declared tests" in n for n in data["notes"])
+
+
+def test_relationships_envelope_yaml_fallback_and_note(tmp_path: Path, capsys):
+    db, repo = _declared_join_repo(tmp_path, with_manifest=False)
+    payload = _run(
+        [
+            "explore",
+            "relationships",
+            "--use-project",
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    data = payload["data"]
+    assert data["declared_count"] == 1
+    assert any("name-based" in n for n in data["notes"])
+
+
+def test_relationships_envelope_notes_stale_manifest(tmp_path: Path, capsys):
+    db, repo = _declared_join_repo(tmp_path, with_manifest=False)
+    write_manifest(
+        repo,
+        models={
+            "orders": '"analytics"."main"."orders"',
+            "customers": '"analytics"."main"."customers"',
+        },
+        relationship_tests=[("orders", "customer_id", "ref('customers')", "id")],
+        generated_at="2020-01-01T00:00:00Z",
+    )
+    payload = _run(
+        [
+            "explore",
+            "relationships",
+            "--use-project",
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    assert any("older than the model sources" in n for n in payload["data"]["notes"])
+
+
+def test_relationships_envelope_unresolved_declared_is_a_signal(tmp_path: Path, capsys):
+    db, repo = _declared_join_repo(tmp_path, with_manifest=False)
+    (repo / "models" / "schema.yml").write_text(
+        "version: 2\n"
+        "models:\n"
+        "  - name: orders\n"
+        "    columns:\n"
+        "      - name: payment_id\n"
+        "        tests:\n"
+        "          - relationships:\n"
+        "              to: ref('payments')\n"
+        "              field: id\n",
+        encoding="utf-8",
+    )
+    payload = _run(
+        [
+            "explore",
+            "relationships",
+            "--use-project",
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    data = payload["data"]
+    assert data["declared_count"] == 0
+    notes = data["notes"]
+    assert any("no declared relationships resolved" in n for n in notes)
+    assert any("not in this connection's inventory" in n for n in notes)

--- a/packages/dex-core/tests/transform/test_dbt_project.py
+++ b/packages/dex-core/tests/transform/test_dbt_project.py
@@ -6,12 +6,15 @@ import json
 from pathlib import Path
 
 import pytest
+from conftest import write_manifest, write_semantic_manifest
+from maintain.conftest import SEMANTIC_YAML
 
 from exmergo_dex_core import dbt_project
 from exmergo_dex_core.dbt_project import (
     DbtProjectError,
     Edit,
     content_hash,
+    definitions,
     find_project,
     load,
     resolve_target,
@@ -233,3 +236,245 @@ def test_profiles_dir_env_override(
     )
     monkeypatch.setenv("DBT_PROFILES_DIR", str(override))
     assert dbt_project.profiles_dir(dbt_project_dir) == override
+
+
+# --- definitions(): the read view of declared and semantic definitions --------
+
+
+def test_definitions_reads_yaml_tests_without_manifest(dbt_project_dir: Path):
+    defs = definitions(dbt_project_dir)
+    assert defs.present is True
+    assert defs.relationship_source == "yaml"
+    assert defs.manifest_loaded is False
+    assert defs.foreign_keys == []
+    (key,) = defs.declared_keys
+    assert (key.model, key.column) == ("stg_customers", "id")
+    assert key.not_null is True and key.unique is False
+    assert key.source == "yaml"
+    # No semantic YAML in this project: the semantic half stays empty.
+    assert defs.semantic_source is None
+    assert defs.primary_entities == {}
+
+
+def test_definitions_yaml_relationships_test(dbt_project_dir: Path):
+    (dbt_project_dir / "models" / "staging" / "stg_orders.sql").write_text(
+        "select 1 as id, 1 as customer_id\n", encoding="utf-8"
+    )
+    (dbt_project_dir / "models" / "staging" / "orders_schema.yml").write_text(
+        "version: 2\n"
+        "models:\n"
+        "  - name: stg_orders\n"
+        "    columns:\n"
+        "      - name: customer_id\n"
+        "        tests:\n"
+        "          - relationships:\n"
+        "              to: ref('stg_customers')\n"
+        "              field: id\n",
+        encoding="utf-8",
+    )
+    defs = definitions(dbt_project_dir)
+    (fk,) = defs.foreign_keys
+    assert (fk.model, fk.column, fk.to_model, fk.to_column) == (
+        "stg_orders",
+        "customer_id",
+        "stg_customers",
+        "id",
+    )
+    assert fk.relation is None and fk.to_relation is None
+    assert fk.source == "yaml"
+    assert any("name-based" in note for note in defs.notes)
+
+
+def test_definitions_manifest_foreign_keys_and_key_merge(dbt_project_dir: Path):
+    write_manifest(
+        dbt_project_dir,
+        models={
+            "stg_customers": '"dev"."main"."stg_customers"',
+            "stg_orders": '"dev"."main"."stg_orders"',
+        },
+        relationship_tests=[
+            ("stg_orders", "customer_id", "ref('stg_customers')", "id")
+        ],
+        unique_tests=[("stg_customers", "id")],
+        not_null_tests=[("stg_customers", "id")],
+    )
+    defs = definitions(dbt_project_dir)
+    assert defs.relationship_source == "manifest"
+    assert defs.manifest_loaded is True
+    (fk,) = defs.foreign_keys
+    assert fk.relation == "dev.main.stg_orders"
+    assert fk.to_relation == "dev.main.stg_customers"
+    assert fk.source == "manifest"
+    # unique + not_null on the same column merge into one declared key. The
+    # YAML not_null on stg_customers.id is superseded by the manifest read.
+    (key,) = defs.declared_keys
+    assert (key.model, key.column) == ("stg_customers", "id")
+    assert key.unique is True and key.not_null is True
+    assert defs.model_relations["stg_orders"] == "dev.main.stg_orders"
+
+
+def test_definitions_manifest_source_parent_and_backtick_quoting(
+    dbt_project_dir: Path,
+):
+    write_manifest(
+        dbt_project_dir,
+        models={"stg_orders": "`proj.main.stg_orders`"},
+        sources={"raw.customers": '"dev"."raw"."customers"'},
+        relationship_tests=[
+            ("stg_orders", "customer_id", "source('raw', 'customers')", "id")
+        ],
+    )
+    defs = definitions(dbt_project_dir)
+    (fk,) = defs.foreign_keys
+    assert fk.relation == "proj.main.stg_orders"
+    assert fk.to_model == "raw.customers"
+    assert fk.to_relation == "dev.raw.customers"
+
+
+def test_definitions_ephemeral_model_has_no_relation(dbt_project_dir: Path):
+    write_manifest(
+        dbt_project_dir,
+        models={"stg_orders": '"dev"."main"."stg_orders"', "int_helper": None},
+        relationship_tests=[("stg_orders", "helper_id", "ref('int_helper')", "id")],
+    )
+    defs = definitions(dbt_project_dir)
+    assert "int_helper" not in defs.model_relations
+    (fk,) = defs.foreign_keys
+    assert fk.to_relation is None
+
+
+def test_definitions_stub_manifest_falls_back_to_yaml(dbt_project_dir: Path):
+    # The 2-key stub other tests use: metadata plus empty nodes must not be
+    # mistaken for a compiled project.
+    target = dbt_project_dir / "target"
+    target.mkdir()
+    (target / "manifest.json").write_text(
+        json.dumps({"metadata": {"project_name": "dex_test"}, "nodes": {}}),
+        encoding="utf-8",
+    )
+    defs = definitions(dbt_project_dir)
+    assert defs.relationship_source == "yaml"
+    assert defs.manifest_loaded is False
+    assert len(defs.declared_keys) == 1
+
+
+def test_definitions_flags_stale_manifest(dbt_project_dir: Path):
+    write_manifest(
+        dbt_project_dir,
+        models={"stg_customers": '"dev"."main"."stg_customers"'},
+        generated_at="2020-01-01T00:00:00Z",
+    )
+    defs = definitions(dbt_project_dir)
+    assert defs.manifest_stale is True
+    assert any("older than the model sources" in note for note in defs.notes)
+
+
+def test_definitions_fresh_manifest_is_not_stale(dbt_project_dir: Path):
+    write_manifest(
+        dbt_project_dir,
+        models={"stg_customers": '"dev"."main"."stg_customers"'},
+        generated_at="2099-01-01T00:00:00Z",
+    )
+    defs = definitions(dbt_project_dir)
+    assert defs.manifest_stale is False
+
+
+def test_definitions_degrades_without_a_project(tmp_path: Path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    defs = definitions(empty)
+    assert defs.present is False
+    assert defs.foreign_keys == [] and defs.declared_keys == []
+    assert defs.notes == []
+
+
+def test_definitions_degrades_on_multiple_projects(tmp_path: Path):
+    for name in ("one", "two"):
+        child = tmp_path / name
+        child.mkdir()
+        (child / "dbt_project.yml").write_text(f"name: {name}\n", encoding="utf-8")
+    defs = definitions(tmp_path)
+    assert defs.present is False
+    assert any("dbt_project_dir" in note for note in defs.notes)
+
+
+def test_definitions_honors_project_dir_pin(dbt_project_dir: Path, tmp_path: Path):
+    decoy = tmp_path / "decoy"
+    decoy.mkdir()
+    (decoy / "dbt_project.yml").write_text("name: decoy\n", encoding="utf-8")
+    defs = definitions(tmp_path, project_dir=dbt_project_dir)
+    assert defs.present is True
+    assert defs.project_dir == str(dbt_project_dir)
+    assert len(defs.declared_keys) == 1
+
+
+def test_definitions_degrades_on_corrupt_manifest(dbt_project_dir: Path):
+    target = dbt_project_dir / "target"
+    target.mkdir()
+    (target / "manifest.json").write_text("{not json", encoding="utf-8")
+    defs = definitions(dbt_project_dir)
+    assert defs.present is False
+    assert any("could not be read" in note for note in defs.notes)
+
+
+def test_definitions_semantic_from_yaml(dbt_project_dir: Path):
+    (dbt_project_dir / "models" / "staging" / "semantic.yml").write_text(
+        SEMANTIC_YAML, encoding="utf-8"
+    )
+    defs = definitions(dbt_project_dir)
+    assert defs.semantic_source == "yaml"
+    assert defs.primary_entities == {"stg_orders": "order_id"}
+    assert defs.metric_models == ["stg_orders"]
+
+
+def test_definitions_prefers_semantic_manifest(dbt_project_dir: Path):
+    # YAML on disk says stg_orders; the compiled artifact says the model landed
+    # as a different alias/relation and must win.
+    (dbt_project_dir / "models" / "staging" / "semantic.yml").write_text(
+        SEMANTIC_YAML, encoding="utf-8"
+    )
+    write_semantic_manifest(
+        dbt_project_dir,
+        semantic_models=[
+            {
+                "name": "orders",
+                "node_relation": {
+                    "alias": "orders_mart",
+                    "relation_name": '"dev"."main"."orders_mart"',
+                },
+                "entities": [{"name": "order_id", "type": "primary"}],
+                "measures": [{"name": "order_amount"}],
+            }
+        ],
+        metrics=[
+            {
+                "name": "revenue",
+                "type": "simple",
+                "type_params": {"input_measures": [{"name": "order_amount"}]},
+            }
+        ],
+    )
+    defs = definitions(dbt_project_dir)
+    assert defs.semantic_source == "manifest"
+    assert defs.primary_entities == {"orders_mart": "order_id"}
+    assert defs.metric_models == ["orders_mart"]
+    assert defs.model_relations["orders_mart"] == "dev.main.orders_mart"
+
+
+def test_definitions_yaml_derived_metric_lineage(dbt_project_dir: Path):
+    # A derived metric grounds through its input metrics down to measures.
+    (dbt_project_dir / "models" / "staging" / "semantic.yml").write_text(
+        SEMANTIC_YAML
+        + (
+            "  - name: revenue_growth\n"
+            "    label: Revenue growth\n"
+            "    type: derived\n"
+            "    type_params:\n"
+            "      expr: revenue - revenue\n"
+            "      metrics:\n"
+            "        - revenue\n"
+        ),
+        encoding="utf-8",
+    )
+    defs = definitions(dbt_project_dir)
+    assert defs.metric_models == ["stg_orders"]

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -155,6 +155,20 @@ inferred join with one aggregate overlap probe (non-null foreign keys, orphan
 count) and adjusts its confidence; the result carries `verified` and
 `orphan_fraction`.
 
+Exploration starts bare: by default the warehouse is observed as-is, and a dbt
+project in the repo earns only a discovery note. `explore profile`,
+`explore relationships`, and `explore map` accept `--use-project`, which folds
+the project's declared definitions into the result: `relationships` tests
+become declared joins at confidence 1.0 (resolved against the connection's
+inventory; a declared join that matches nothing or more than one object is
+reported in `notes`, never guessed, and a declared edge wins over the same
+inferred one), a semantic model's primary entity overrides the heuristic grain
+(disagreements and contradicted `unique` tests land in `data_quality`), and
+models reachable from metric definitions rank higher alongside the configured
+`ranking_hints`. The compiled manifest resolves names exactly when present;
+an uncompiled project falls back to name-based resolution and says so. A
+stale manifest (older than the model sources) is noted, not trusted silently.
+
 `explore map` never caps silently: past 50 objects it profiles the top
 `profile_top_n` (default 25) by rank and announces the cutoff in `notes`
 alongside `skipped_count` (`--full` profiles everything). Objects skipped on a


### PR DESCRIPTION
## What this changes

Introduce a new `--use-project` flag in explore commands to keep dbt project into consideration when exploring warehouses.

Commands
- `explore relationships --use-project`: folds in the dbt project's declared foreign keys at confidence 1.0
- `explore profile --use-project`: lets a semantic model's declared primary entity override the heuristic grain
- `explore map --use-project`: applies declared grain and ranks metric-backing models higher

## Related issues

Closes #65
Internally SCRUM-917
