### PR TITLE
Composite Key Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **Composite candidate-key detection in `explore profile`** ([#49]). When no
+  single column proves unique, the profiler now tests a small ranked set of
+  2-column combinations with exact distinct-combination counts, so fact tables
+  like TPCH `LINEITEM` report their true grain (`L_ORDERKEY, L_LINENUMBER`)
+  instead of "no candidate key detected; grain unknown". Pairs are pruned on a
+  necessary condition (the product of the members' distinct counts must reach
+  the row count), ranked id-shaped-first then smallest-product-first, and
+  capped at three probes issued as one statement. Works on all five connectors;
+  on metered ones the probe spends only inside the already-confirmed budget and
+  degrades to "grain unknown" with an explanatory note when the remaining
+  budget cannot cover it. Proven composite keys flow into `candidate_keys`,
+  `grain`, and downstream test scaffolding.
+- **Composite grain drift in `maintain grain`.** A snapshot whose baseline
+  carries a composite key now re-verifies the combination itself (estimated
+  and gated like every other grain scan) and reports a combination-level
+  `key_lost_uniqueness` finding; composite members are no longer checked one
+  at a time, which would have fabricated findings on every run.
+
 ## [1.1.1] - 2026-07-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   instead of "no candidate key detected; grain unknown". Pairs are pruned on a
   necessary condition (the product of the members' distinct counts must reach
   the row count), ranked id-shaped-first then smallest-product-first, and
-  capped at three probes issued as one statement. Works on all five connectors;
+  capped at three probes issued as one statement. Works on all connectors;
   on metered ones the probe spends only inside the already-confirmed budget and
   degrades to "grain unknown" with an explanatory note when the remaining
   budget cannot cover it. Proven composite keys flow into `candidate_keys`,

--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ experience first and treat the benchmark as a floor, not the goal.
 - Embedded analytical: **DuckDB**.
 - Operational database: **Postgres**.
 
-<img width="927" height="149" alt="image" src="https://github.com/user-attachments/assets/66060b8d-f56c-4de8-9c79-cc00252eb1b4" />
-
+<img width="1162" height="225" alt="image" src="https://github.com/user-attachments/assets/32d2311b-b85e-41a5-8431-4edb1f928346" />
 
 Credentials are discovered, never asked for: BigQuery through Application
 Default Credentials (`gcloud auth application-default login`), Snowflake

--- a/packages/dex-core/src/exmergo_dex_core/adapters/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/base.py
@@ -18,7 +18,7 @@ caps and truncates them before the envelope.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import date, datetime, time
@@ -162,6 +162,30 @@ def json_safe(value: object | None) -> object | None:
     return str(value)
 
 
+def distinct_combination_sql(
+    table_sql: str,
+    combinations: list[list[str]],
+    quote_ident: Callable[[str], str],
+) -> str:
+    """One statement counting each column combination's distinct tuples, one
+    scalar subquery per combination, results read back by alias ``d_{i}``.
+
+    The subquery form is the one shape every supported dialect accepts
+    (BigQuery has no multi-argument COUNT(DISTINCT); DuckDB needs a struct
+    variant); derived tables are aliased because Postgres requires it.
+    ``table_sql`` and the identifiers must already be quoted/escaped by the
+    calling adapter, which also guards the result as a read-only SELECT.
+    """
+
+    parts = [
+        "(SELECT COUNT(*) FROM (SELECT DISTINCT "  # noqa: S608
+        + ", ".join(quote_ident(name) for name in combo)
+        + f" FROM {table_sql}) AS q_{i}) AS d_{i}"
+        for i, combo in enumerate(combinations)
+    ]
+    return f"SELECT {', '.join(parts)}"
+
+
 @runtime_checkable
 class Adapter(Protocol):
     """Behavioral contract for a connector adapter.
@@ -213,6 +237,17 @@ class Adapter(Protocol):
         statements as possible. The engine calls this only for columns whose
         approximate distinct landed within noise of the non-null count, so the
         spend is bounded and deliberate; a metered adapter never self-escalates."""
+        ...
+
+    def distinct_combination_counts(
+        self, identifier: str, combinations: list[list[str]]
+    ) -> dict[tuple[str, ...], int]:
+        """Exact distinct count for each column combination, all in one
+        statement. The engine calls this only when no single-column key was
+        proven, with a small ranked set of combinations, so the spend is
+        bounded and deliberate; a metered adapter that cannot cover the scan
+        within the confirmed budget returns ``{}`` and explains itself through
+        a table note instead of self-escalating."""
         ...
 
     def run_query(

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -28,6 +28,7 @@ from .base import (
     ObjectMeta,
     QueryResult,
     blame,
+    distinct_combination_sql,
     json_safe,
     name_list,
 )
@@ -517,6 +518,35 @@ class BigQueryAdapter:
         _job, iterator = self._run(sql)
         rows = list(iterator)
         return {name: int(rows[0][f"d_{i}"]) for i, name in enumerate(columns)}
+
+    def distinct_combination_counts(
+        self, identifier: str, combinations: list[list[str]]
+    ) -> dict[tuple[str, ...], int]:
+        """Exact distinct count per column combination, spent only within the
+        already-confirmed budget: when the remaining budget cannot cover the
+        extra scan, return nothing and let the grain stay unknown. A metered
+        adapter never self-escalates past its ceiling."""
+
+        if self._unqueryable(identifier) or not combinations:
+            return {}
+        sql = assert_select_only(
+            distinct_combination_sql(
+                self._quote(identifier), combinations, _quote_ident
+            ),
+            dialect=self.dialect,
+        )
+        if not self.cost_gate.try_charge(self._dry_run(sql)):
+            self._note(
+                identifier,
+                "composite-key probe skipped: the remaining budget could not "
+                "cover the extra scan; grain stays unknown",
+            )
+            return {}
+        _job, iterator = self._run(sql)
+        rows = list(iterator)
+        return {
+            tuple(combo): int(rows[0][f"d_{i}"]) for i, combo in enumerate(combinations)
+        }
 
     # --- estimation (free dry-runs; feeds the confirm handshake) --------------
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
@@ -42,6 +42,7 @@ from .base import (
     ObjectMeta,
     QueryResult,
     blame,
+    distinct_combination_sql,
     json_safe,
     name_list,
 )
@@ -917,6 +918,39 @@ class DatabricksAdapter:
         rows, labels = self._run(sql)
         values = dict(zip(labels, rows[0], strict=True))
         return {name: int(values[f"d_{i}"]) for i, name in enumerate(columns)}
+
+    def distinct_combination_counts(
+        self, identifier: str, combinations: list[list[str]]
+    ) -> dict[tuple[str, ...], int]:
+        """Exact distinct count per column combination, spent only within the
+        already-confirmed budget: when the remaining budget cannot cover the
+        extra scans (one per combination), return nothing and let the grain
+        stay unknown. A metered adapter never self-escalates past its ceiling.
+        """
+
+        if not combinations:
+            return {}
+        self._ensure_detail(identifier)
+        meta, _ = self.table_metadata(identifier)
+        estimate = self._statement_seconds(meta.byte_size) * len(combinations)
+        if not self.cost_gate.try_charge(estimate):
+            self._note(
+                identifier,
+                "composite-key probe skipped: the remaining budget could not "
+                "cover the extra scan; grain stays unknown",
+            )
+            return {}
+        sql = assert_select_only(
+            distinct_combination_sql(
+                self._quote(identifier), combinations, _quote_ident
+            ),
+            dialect=self.dialect,
+        )
+        rows, labels = self._run(sql)
+        values = dict(zip(labels, rows[0], strict=True))
+        return {
+            tuple(combo): int(values[f"d_{i}"]) for i, combo in enumerate(combinations)
+        }
 
     # --- execution (the single billed door) --------------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/duckdb.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/duckdb.py
@@ -14,7 +14,14 @@ from pathlib import Path
 
 from ..envelope import Paradigm
 from ..guards.sql_guard import assert_select_only
-from .base import ColumnAggregate, ColumnMeta, ObjectMeta, QueryResult, json_safe
+from .base import (
+    ColumnAggregate,
+    ColumnMeta,
+    ObjectMeta,
+    QueryResult,
+    distinct_combination_sql,
+    json_safe,
+)
 
 # Conservative defaults so auto-invoked profiling cannot exhaust the machine.
 # Overridable from .dex/config.yml.
@@ -245,6 +252,24 @@ class DuckDBAdapter:
             for i, name in enumerate(batch):
                 results[name] = int(values[f"d_{i}"])
         return results
+
+    def distinct_combination_counts(
+        self, identifier: str, combinations: list[list[str]]
+    ) -> dict[tuple[str, ...], int]:
+        """Exact distinct count per column combination, all in one statement
+        (one scalar subquery each)."""
+
+        if not combinations:
+            return {}
+        sql = distinct_combination_sql(
+            self._quote(identifier), combinations, _quote_ident
+        )
+        row = self._run_select(assert_select_only(sql, dialect=self.dialect))[0]
+        labels = [d[0] for d in self._conn.description]
+        values = dict(zip(labels, row, strict=True))
+        return {
+            tuple(combo): int(values[f"d_{i}"]) for i, combo in enumerate(combinations)
+        }
 
     def _build_aggregate_sql(
         self, identifier: str, columns: list[ColumnMeta], safe: set[str]

--- a/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
@@ -48,6 +48,7 @@ from .base import (
     ObjectMeta,
     QueryResult,
     blame,
+    distinct_combination_sql,
     json_safe,
     name_list,
 )
@@ -745,6 +746,38 @@ class PostgresAdapter:
         values = dict(zip(labels, rows[0], strict=True))
         self._exact_rows[identifier] = int(values["n_total"])
         return {name: int(values[f"d_{i}"]) for i, name in enumerate(columns)}
+
+    def distinct_combination_counts(
+        self, identifier: str, combinations: list[list[str]]
+    ) -> dict[tuple[str, ...], int]:
+        """Exact distinct count per column combination, spent only within the
+        already-confirmed budget: when the remaining budget cannot cover the
+        extra scans (one per combination), return nothing and let the grain
+        stay unknown. A metered adapter never self-escalates past its ceiling.
+        """
+
+        if not combinations:
+            return {}
+        meta, _ = self.table_metadata(identifier)
+        estimate = self._scan_seconds(meta.byte_size) * len(combinations)
+        if not self.cost_gate.try_charge(estimate):
+            self._note(
+                identifier,
+                "composite-key probe skipped: the remaining budget could not "
+                "cover the extra scan; grain stays unknown",
+            )
+            return {}
+        sql = assert_select_only(
+            distinct_combination_sql(
+                self._quote(identifier), combinations, _quote_ident
+            ),
+            dialect=self.dialect,
+        )
+        rows, labels = self._run(sql)
+        values = dict(zip(labels, rows[0], strict=True))
+        return {
+            tuple(combo): int(values[f"d_{i}"]) for i, combo in enumerate(combinations)
+        }
 
     # --- execution (the single billed door) --------------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
@@ -53,6 +53,7 @@ from .base import (
     ObjectMeta,
     QueryResult,
     blame,
+    distinct_combination_sql,
     json_safe,
     name_list,
 )
@@ -828,6 +829,44 @@ class RedshiftAdapter:
         values = dict(zip(labels, rows[0], strict=True))
         self._exact_rows[identifier] = int(values["n_total"])
         return {name: int(values[f"d_{i}"]) for i, name in enumerate(columns)}
+
+    def distinct_combination_counts(
+        self, identifier: str, combinations: list[list[str]]
+    ) -> dict[tuple[str, ...], int]:
+        """Exact distinct count per column combination, spent only within the
+        already-confirmed budget: when the remaining budget cannot cover the
+        extra scans (one per combination), return nothing and let the grain
+        stay unknown. A metered adapter never self-escalates past its ceiling.
+        """
+
+        if not combinations:
+            return {}
+        meta, _ = self.table_metadata(identifier)
+        # Like the exact-distinct escalation, this can be a command's first
+        # billed statement, so the pending Serverless wake minimum rides the
+        # charge; on refusal it stays pending.
+        estimate = (
+            self._scan_seconds(meta.byte_size) * len(combinations) + self._wake_floor()
+        )
+        if not self.cost_gate.try_charge(estimate):
+            self._note(
+                identifier,
+                "composite-key probe skipped: the remaining budget could not "
+                "cover the extra scan; grain stays unknown",
+            )
+            return {}
+        self._consume_wake_floor()
+        sql = assert_select_only(
+            distinct_combination_sql(
+                self._quote(identifier), combinations, _quote_ident
+            ),
+            dialect=self.dialect,
+        )
+        rows, labels = self._run(sql)
+        values = dict(zip(labels, rows[0], strict=True))
+        return {
+            tuple(combo): int(values[f"d_{i}"]) for i, combo in enumerate(combinations)
+        }
 
     # --- execution (the single billed door) --------------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
@@ -40,6 +40,7 @@ from .base import (
     ObjectMeta,
     QueryResult,
     blame,
+    distinct_combination_sql,
     json_safe,
     name_list,
     scope_within,
@@ -831,6 +832,38 @@ class SnowflakeAdapter:
         rows, labels = self._run(sql)
         values = dict(zip(labels, rows[0], strict=True))
         return {name: int(values[f"d_{i}"]) for i, name in enumerate(columns)}
+
+    def distinct_combination_counts(
+        self, identifier: str, combinations: list[list[str]]
+    ) -> dict[tuple[str, ...], int]:
+        """Exact distinct count per column combination, spent only within the
+        already-confirmed budget: when the remaining budget cannot cover the
+        extra scans (one per combination), return nothing and let the grain
+        stay unknown. A metered adapter never self-escalates past its ceiling.
+        """
+
+        if not combinations:
+            return {}
+        meta, _ = self.table_metadata(identifier)
+        estimate = self._scan_seconds(meta.byte_size) * len(combinations)
+        if not self.cost_gate.try_charge(estimate):
+            self._note(
+                identifier,
+                "composite-key probe skipped: the remaining budget could not "
+                "cover the extra scan; grain stays unknown",
+            )
+            return {}
+        sql = assert_select_only(
+            distinct_combination_sql(
+                self._quote(identifier), combinations, _quote_ident
+            ),
+            dialect=self.dialect,
+        )
+        rows, labels = self._run(sql)
+        values = dict(zip(labels, rows[0], strict=True))
+        return {
+            tuple(combo): int(values[f"d_{i}"]) for i, combo in enumerate(combinations)
+        }
 
     # --- execution (the single billed door) --------------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/cache.py
+++ b/packages/dex-core/src/exmergo_dex_core/cache.py
@@ -89,6 +89,11 @@ class Dataset(BaseModel):
     columns: list[ColumnProfile] = Field(default_factory=list)
     candidate_keys: list[list[str]] = Field(default_factory=list)
     grain: list[str] | None = None
+    #: Column combinations proven unique by an exact profile-time probe, best
+    #: candidate first. Kept separate from ``candidate_keys`` (which the
+    #: annotation pass recomputes from column stats) so the proof survives
+    #: re-annotation and its provenance stays distinct from derived signals.
+    composite_keys: list[list[str]] = Field(default_factory=list)
     rank_score: float | None = None
     data_quality: list[str] = Field(default_factory=list)
     profiled_at: str | None = None

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -31,6 +31,11 @@ NEAR_UNIQUE_RATIO = 0.75
 # COUNT(DISTINCT) statement; the cap bounds the width of that statement.
 _EXACT_DISTINCT_CAP = 8
 
+# Composite-key probes are capped much tighter than single-column escalation:
+# each pair costs a full two-column DISTINCT scan (not one cheap aggregate),
+# and the ranking puts a real grain in the first slots when one exists.
+_COMPOSITE_PAIR_CAP = 3
+
 # Name patterns mapped to a PII category and a base confidence. Matched on the
 # snake-normalized column name (camelCase is split first, so "firstName" matches
 # the same as "first_name") with word-ish boundaries so "email" hits but
@@ -197,6 +202,9 @@ def profile(adapter: Adapter, identifiers: list[str]) -> list[Dataset]:
         aggregates = _escalate_near_unique(
             adapter, identifier, meta.row_count, aggregates
         )
+        composite_keys = _probe_composite_keys(
+            adapter, identifier, meta.row_count, aggregates
+        )
 
         profiles: list[ColumnProfile] = []
         data_quality: list[str] = []
@@ -236,6 +244,7 @@ def profile(adapter: Adapter, identifiers: list[str]) -> list[Dataset]:
                 row_count=meta.row_count,
                 byte_size=meta.byte_size,
                 columns=profiles,
+                composite_keys=composite_keys,
                 data_quality=data_quality,
                 profiled_at=datetime.now(UTC).isoformat(),
             )
@@ -296,6 +305,72 @@ def _escalate_near_unique(
             distinct_count_exact=True,
         )
     return escalated
+
+
+def _probe_composite_keys(
+    adapter: Adapter,
+    identifier: str,
+    row_count: int | None,
+    aggregates: dict[str, ColumnAggregate],
+) -> list[list[str]]:
+    """Prove 2-column keys on tables where no single column is one: the shape
+    of a fact table, whose grain is exactly what a profile must answer.
+
+    A pair can only be a key if the product of its members' distinct counts
+    reaches the row count, so pairs are pruned on that necessary condition
+    (relaxed per approximate member to absorb HLL undershoot) and ranked:
+    id-shaped members first (real grains are key-shaped), smallest product
+    next (a minimal grain sits just above the row count; a pair of two
+    near-unique columns lands near rows squared and is analytically useless
+    even when technically unique). Bounded to ``_COMPOSITE_PAIR_CAP`` pairs in
+    one batched adapter call; a pair is proven when its exact combination
+    count equals the row count. Adapters without
+    ``distinct_combination_counts`` degrade to no composite keys.
+    """
+
+    if not row_count:
+        return []
+    combo_counts = getattr(adapter, "distinct_combination_counts", None)
+    if combo_counts is None:
+        return []
+    for agg in aggregates.values():
+        if agg.is_unique and agg.null_fraction in (0.0, None):
+            return []  # a proven single-column key makes the probe waste
+
+    pool = [
+        agg
+        for agg in aggregates.values()
+        if agg.distinct_count and not agg.is_unique and agg.null_fraction in (0.0, None)
+    ]
+    if len(pool) < 2:
+        return []
+
+    # Imported here: relationships imports NEAR_UNIQUE_RATIO from this module,
+    # so a module-level import would be circular.
+    from .relationships import _is_id_shaped
+
+    ranked: list[tuple[int, int, tuple[str, str]]] = []
+    for i, a in enumerate(pool):
+        for b in pool[i + 1 :]:
+            product = a.distinct_count * b.distinct_count
+            n_approx = sum(1 for m in (a, b) if not m.distinct_count_exact)
+            if product < row_count * NEAR_UNIQUE_RATIO**n_approx:
+                continue
+            id_shaped = sum(1 for m in (a, b) if _is_id_shaped(m.name))
+            # Members ordered by descending cardinality so the key reads
+            # parent-then-line, e.g. (L_ORDERKEY, L_LINENUMBER).
+            members = sorted(
+                (a.name, b.name),
+                key=lambda n: (-(aggregates[n].distinct_count or 0), n),
+            )
+            ranked.append((-id_shaped, product, (members[0], members[1])))
+    if not ranked:
+        return []
+
+    ranked.sort()
+    chosen = [list(pair) for _ids, _product, pair in ranked[:_COMPOSITE_PAIR_CAP]]
+    exact = combo_counts(identifier, chosen)
+    return [combo for combo in chosen if exact.get(tuple(combo)) == row_count]
 
 
 def _refine_confidence(

--- a/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
@@ -86,36 +86,44 @@ def _is_id_shaped(column_name: str) -> bool:
 
 
 def candidate_keys(dataset: Dataset) -> list[list[str]]:
-    """Single-column candidate keys: unique and non-null. Composite keys deferred.
+    """Candidate keys: single columns first, proven composites after.
 
-    Uniqueness on near-unique columns is escalated to an exact COUNT(DISTINCT)
-    at profile time (``distinct_count_exact``), so these are proven where it
-    matters; a column whose uniqueness still rests on the approximate count is
-    a signal, not a proof.
+    Single-column keys are unique and non-null columns; uniqueness on
+    near-unique columns is escalated to an exact COUNT(DISTINCT) at profile
+    time (``distinct_count_exact``), so these are proven where it matters,
+    while a column whose uniqueness still rests on the approximate count is a
+    signal, not a proof. Composite keys come from ``dataset.composite_keys``,
+    each one proven by an exact distinct-combination probe at profile time.
     """
 
-    return [
+    singles = [
         [col.name]
         for col in dataset.columns
         if col.is_unique and (col.null_fraction in (0.0, None))
     ]
+    return singles + [list(key) for key in dataset.composite_keys]
 
 
 def detect_grain(dataset: Dataset) -> list[str] | None:
-    """The most likely grain: prefer an ``id`` / ``<entity>_id`` candidate key,
-    else the unique column with the smallest cardinality. None if no key."""
+    """The most likely grain: prefer an ``id`` / ``<entity>_id`` single-column
+    candidate key, else the unique column with the smallest cardinality. A
+    composite key is the grain only when no single column is one (the fact
+    table shape); composites arrive best-ranked first from the profile probe.
+    None if no key at all."""
 
     keys = candidate_keys(dataset)
-    if not keys:
-        return None
+    singles = [key for key in keys if len(key) == 1]
+    if not singles:
+        composites = [key for key in keys if len(key) > 1]
+        return composites[0] if composites else None
     entity = _entity(dataset.identifier.rsplit(".", 1)[-1])
-    for key in keys:
+    for key in singles:
         name = key[0].lower()
         if name in ("id", f"{entity}_id", f"{entity}id") or _is_id_shaped(key[0]):
             return key
     # Fall back to the lowest-cardinality unique column.
     by_card = sorted(
-        keys,
+        singles,
         key=lambda k: _distinct_of(dataset, k[0]) or float("inf"),
     )
     return by_card[0]
@@ -440,7 +448,10 @@ def _match_parent(
     parent_entities = {stripped.lower(), _singularize(stripped).lower()}
 
     parent_cols = {c.name.lower(): c for c in parent.columns}
-    parent_key_names = {k[0].lower() for k in parent_keys}
+    # Single-column keys only: a composite member alone is not unique, so
+    # treating it as the parent's key would inflate join confidence and invent
+    # many-to-one edges toward fact tables.
+    parent_key_names = {k[0].lower() for k in parent_keys if len(k) == 1}
     fk = col.name.lower()
     stem_l = stem.lower()
 

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -161,7 +161,7 @@ def cmd_grain(args: argparse.Namespace) -> env.Envelope:
             }
             scope = drift_mod.resolve_scope(scope_names, identifiers)
         plan = drift_mod.grain_plan(adapter, snap, scope)
-        if plan.key_checks or plan.fanout_pairs:
+        if plan.key_checks or plan.fanout_pairs or plan.composite_checks:
             estimate, per_table = drift_mod.grain_estimate(adapter, plan)
             unconfirmed = command_args.billed_handshake(
                 "maintain grain", adapter, estimate, per_table=per_table
@@ -171,9 +171,10 @@ def cmd_grain(args: argparse.Namespace) -> env.Envelope:
         findings = drift_mod.grain_drift(
             adapter, plan, timeout_seconds=config.query.timeout_seconds
         )
-        notes = _adapter_notes(
-            adapter, [dataset.identifier for dataset, _keys, _rows in plan.key_checks]
-        )
+        noted = {dataset.identifier for dataset, _keys, _rows in plan.key_checks} | {
+            dataset.identifier for dataset, _combos, _rows in plan.composite_checks
+        }
+        notes = _adapter_notes(adapter, sorted(noted))
         envelope = env.ok({})
         command_args.stamp_spend(envelope, adapter)
     finally:
@@ -306,7 +307,9 @@ def cmd_check(args: argparse.Namespace) -> env.Envelope:
 
         plan = drift_mod.grain_plan(adapter, snap)
         checks = drift_mod.cardinality_plan(current_semantic, snap)
-        scans_needed = bool(plan.key_checks or plan.fanout_pairs or checks)
+        scans_needed = bool(
+            plan.key_checks or plan.fanout_pairs or plan.composite_checks or checks
+        )
         if scans_needed and command_args.cost_gate(adapter) is not None:
             grain_total, grain_per = drift_mod.grain_estimate(adapter, plan)
             card_total, card_per = drift_mod.cardinality_estimate(adapter, checks)

--- a/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
@@ -25,7 +25,7 @@ from typing import NamedTuple
 
 from pydantic import BaseModel, Field
 
-from ..adapters.base import Adapter
+from ..adapters.base import Adapter, distinct_combination_sql
 from ..cache import Dataset, Relationship, match_identifier
 from ..explore import relationships as rel_mod
 from .snapshot import SemanticLayer, Snapshot, TransformLayer
@@ -338,6 +338,9 @@ class GrainPlan(NamedTuple):
 
     key_checks: list[tuple[Dataset, list[str], int]]
     fanout_pairs: list[tuple[Relationship, Relationship]]
+    # Proven multi-column keys re-verified as combinations: their members are
+    # not individually unique, so they never enter key_checks.
+    composite_checks: list[tuple[Dataset, list[list[str]], int]]
 
 
 def grain_plan(
@@ -353,21 +356,40 @@ def grain_plan(
         return described[identifier]
 
     key_checks: list[tuple[Dataset, list[str], int]] = []
+    composite_checks: list[tuple[Dataset, list[list[str]], int]] = []
     for dataset in snap.warehouse.datasets:
         if scope is not None and dataset.identifier not in scope:
             continue
         if dataset.identifier not in current:
             continue  # disappearance is the schema axis's story
+        # A composite grain contributes nothing to the single-column set: its
+        # members are not individually unique, and checking them one at a time
+        # would fabricate key_lost_uniqueness findings on every run.
         keys = sorted(
             {key[0] for key in dataset.candidate_keys if len(key) == 1}
-            | set(dataset.grain or [])
+            | (
+                set(dataset.grain)
+                if dataset.grain and len(dataset.grain) == 1
+                else set()
+            )
         )
-        if not keys:
+        composites: list[list[str]] = []
+        for combo in [k for k in dataset.candidate_keys if len(k) > 1] + (
+            [dataset.grain] if dataset.grain and len(dataset.grain) > 1 else []
+        ):
+            if list(combo) not in composites:
+                composites.append(list(combo))
+        if not keys and not composites:
             continue
         columns, row_count = describe(dataset.identifier)
         live_keys = [k for k in keys if k in columns]
+        # A combination with a vanished member is the schema axis's story,
+        # same as a vanished single key.
+        live_composites = [c for c in composites if set(c) <= columns]
         if live_keys and row_count:
             key_checks.append((dataset, live_keys, row_count))
+        if live_composites and row_count:
+            composite_checks.append((dataset, live_composites, row_count))
 
     fanout_pairs: list[tuple[Relationship, Relationship]] = []
     for rel in snap.warehouse.relationships:
@@ -381,7 +403,7 @@ def grain_plan(
         to_columns, _ = describe(rel.to_dataset)
         if rel.from_columns[0] in from_columns and rel.to_columns[0] in to_columns:
             fanout_pairs.append((rel, rel.model_copy(deep=True)))
-    return GrainPlan(key_checks, fanout_pairs)
+    return GrainPlan(key_checks, fanout_pairs, composite_checks)
 
 
 def grain_estimate(adapter: Adapter, plan: GrainPlan) -> tuple[float, dict[str, float]]:
@@ -394,6 +416,12 @@ def grain_estimate(adapter: Adapter, plan: GrainPlan) -> tuple[float, dict[str, 
     for dataset, keys, _row_count in plan.key_checks:
         per_table[dataset.identifier] = query_estimate(
             _distinct_count_sql(dataset.identifier, keys, adapter.dialect)
+        )
+    for dataset, combos, _row_count in plan.composite_checks:
+        per_table[dataset.identifier] = per_table.get(
+            dataset.identifier, 0.0
+        ) + query_estimate(
+            _distinct_combination_stand_in(dataset.identifier, combos, adapter.dialect)
         )
     probes = rel_mod.probe_statements(
         [live for _baseline, live in plan.fanout_pairs], adapter.dialect
@@ -443,6 +471,44 @@ def grain_drift(
                         "distinct_count": count,
                         "row_count": row_count,
                         "was_grain": bool(dataset.grain and key in dataset.grain),
+                    },
+                )
+            )
+
+    combo_counts = getattr(adapter, "distinct_combination_counts", None)
+    for dataset, combos, row_count in plan.composite_checks:
+        if combo_counts is None:
+            break  # an adapter without combination probes cannot re-verify
+        counts = combo_counts(dataset.identifier, combos)
+        live_meta, _ = adapter.table_metadata(dataset.identifier)
+        if live_meta.row_count is not None:
+            row_count = live_meta.row_count
+        for combo in combos:
+            count = counts.get(tuple(combo))
+            if count is None or count >= row_count:
+                continue
+            duplicates = row_count - count
+            members = ", ".join(combo)
+            findings.append(
+                DriftFinding(
+                    axis="grain",
+                    code="key_lost_uniqueness",
+                    identifier=dataset.identifier,
+                    column=members,
+                    severity="high",
+                    detail=(
+                        f"({members}) on {dataset.identifier} is no longer "
+                        f"unique: {count} distinct combinations over "
+                        f"{row_count} rows (~{duplicates} duplicate rows); "
+                        "joins on it will fan out"
+                    ),
+                    data={
+                        "columns": list(combo),
+                        "distinct_count": count,
+                        "row_count": row_count,
+                        "was_grain": bool(
+                            dataset.grain and list(combo) == list(dataset.grain)
+                        ),
                     },
                 )
             )
@@ -851,6 +917,25 @@ def _distinct_count_sql(identifier: str, columns: list[str], dialect: str) -> st
         f"COUNT(DISTINCT {quote(column)}) AS d_{i}" for i, column in enumerate(columns)
     )
     sql = f"SELECT {selects} FROM {table}"  # noqa: S608
+    if dialect == "duckdb":
+        return sql
+    import sqlglot
+
+    return sqlglot.transpile(sql, read="duckdb", write=dialect)[0]
+
+
+def _distinct_combination_stand_in(
+    identifier: str, combinations: list[list[str]], dialect: str
+) -> str:
+    """The estimation stand-in for ``adapter.distinct_combination_counts``:
+    the same combinations over the same table, so a dry-run prices what the
+    confirmed run scans. Never executed by dex; only dry-run."""
+
+    def quote(name: str) -> str:
+        return '"' + name.replace('"', '""') + '"'
+
+    table = ".".join(quote(part) for part in identifier.split("."))
+    sql = distinct_combination_sql(table, combinations, quote)
     if dialect == "duckdb":
         return sql
     import sqlglot

--- a/packages/dex-core/tests/adapters/test_connect_bigquery.py
+++ b/packages/dex-core/tests/adapters/test_connect_bigquery.py
@@ -407,6 +407,37 @@ def test_exact_distinct_counts_degrade_when_budget_cannot_cover(fake_bq_client):
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
 
+def test_distinct_combination_counts_batch_into_one_guarded_statement(fake_bq_client):
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    fake_bq_client.row_resolver = lambda sql: [{"d_0": 90, "d_1": 100}]
+    adapter = make_adapter(fake_bq_client)
+    counts = adapter.distinct_combination_counts(
+        "test-proj.shop.customers", [["id", "email"], ["email", "id"]]
+    )
+    assert counts == {("id", "email"): 90, ("email", "id"): 100}
+    billed = [c for c in fake_bq_client.query_calls if not c.dry_run]
+    assert len(billed) == 1
+    sql = billed[0].sql
+    assert "SELECT DISTINCT" in sql
+    assert assert_select_only(sql, dialect="bigquery") == sql
+    assert adapter.distinct_combination_counts("test-proj.shop.customers", []) == {}
+
+
+def test_distinct_combination_counts_degrade_when_budget_cannot_cover(fake_bq_client):
+    adapter = make_adapter(fake_bq_client, ceiling=100 * MB)
+    adapter.cost_gate.charge(100 * MB - 1_000)
+    result = adapter.distinct_combination_counts(
+        "test-proj.shop.customers", [["id", "email"]]
+    )
+    assert result == {}
+    assert any(
+        "composite-key probe skipped" in note
+        for note in adapter.table_notes("test-proj.shop.customers")
+    )
+    assert all(c.dry_run for c in fake_bq_client.query_calls)
+
+
 def test_sampling_kicks_in_above_the_threshold_and_voids_uniqueness(fake_bq_client):
     fake_bq_client.row_resolver = _aggregate_resolver
     adapter = make_adapter(

--- a/packages/dex-core/tests/adapters/test_connect_databricks.py
+++ b/packages/dex-core/tests/adapters/test_connect_databricks.py
@@ -518,6 +518,42 @@ def test_exact_distinct_counts_degrade_when_budget_cannot_cover(fake_databricks)
     assert data_statements(fake_databricks) == []
 
 
+def test_distinct_combination_counts_batch_into_one_guarded_statement(
+    fake_databricks,
+):
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    warm(fake_databricks)
+    fake_databricks.connection.row_resolver = lambda sql: [{"d_0": 97, "d_1": 100}]
+    adapter = make_adapter(fake_databricks, ceiling=100_000.0)
+    counts = adapter.distinct_combination_counts(
+        "shop.core.customers", [["id", "email"], ["email", "id"]]
+    )
+    assert counts == {("id", "email"): 97, ("email", "id"): 100}
+    stmts = data_statements(fake_databricks)
+    assert len(stmts) == 1
+    assert "SELECT DISTINCT" in stmts[0].sql
+    assert assert_select_only(stmts[0].sql, dialect="databricks") == stmts[0].sql
+    assert adapter.distinct_combination_counts("shop.core.customers", []) == {}
+
+
+def test_distinct_combination_counts_degrade_when_budget_cannot_cover(
+    fake_databricks,
+):
+    warm(fake_databricks)
+    adapter = make_adapter(fake_databricks, ceiling=100.0)
+    adapter.cost_gate.charge(99.5)
+    result = adapter.distinct_combination_counts(
+        "shop.core.customers", [["id", "email"]]
+    )
+    assert result == {}
+    assert any(
+        "composite-key probe skipped" in note
+        for note in adapter.table_notes("shop.core.customers")
+    )
+    assert data_statements(fake_databricks) == []
+
+
 # --- factory, dialect, and warehouse pin forms ----------------------------------------
 
 

--- a/packages/dex-core/tests/adapters/test_connect_duckdb.py
+++ b/packages/dex-core/tests/adapters/test_connect_duckdb.py
@@ -60,6 +60,18 @@ def test_exact_distinct_counts_is_exact_and_batched(duckdb_file: Path):
         adapter.close()
 
 
+def test_distinct_combination_counts_are_exact(duckdb_file: Path):
+    adapter = DuckDBAdapter(duckdb_file)
+    try:
+        counts = adapter.distinct_combination_counts(
+            "warehouse.main.orders", [["customer_id", "total"], ["id", "customer_id"]]
+        )
+        assert counts == {("customer_id", "total"): 3, ("id", "customer_id"): 3}
+        assert adapter.distinct_combination_counts("warehouse.main.orders", []) == {}
+    finally:
+        adapter.close()
+
+
 def test_open_adapter_requires_a_path():
     with pytest.raises(ValueError):
         open_adapter(connector="duckdb", path=None, repo_root="/nonexistent-root")

--- a/packages/dex-core/tests/adapters/test_connect_postgres.py
+++ b/packages/dex-core/tests/adapters/test_connect_postgres.py
@@ -487,6 +487,43 @@ def test_escalation_skipped_when_budget_cannot_cover(fake_pg_connection):
     assert any("escalation skipped" in note for note in notes)
 
 
+def test_distinct_combination_counts_batch_into_one_guarded_statement(
+    fake_pg_connection,
+):
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"d_0": 97, "d_1": 100}], seconds=0.5
+    )
+    adapter = make_adapter(fake_pg_connection)
+    counts = adapter.distinct_combination_counts(
+        "dexdb.shop.customers", [["id", "email"], ["email", "id"]]
+    )
+    assert counts == {("id", "email"): 97, ("email", "id"): 100}
+    stmts = fake_pg_connection.data_statements
+    assert len(stmts) == 1
+    sql = stmts[0].sql
+    assert "SELECT DISTINCT" in sql
+    # Postgres refuses an unaliased derived table; the portable shape carries
+    # the alias everywhere.
+    assert ") AS q_0" in sql
+    assert assert_select_only(sql, dialect="postgres") == sql
+    assert adapter.distinct_combination_counts("dexdb.shop.customers", []) == {}
+
+
+def test_composite_probe_skipped_when_budget_cannot_cover(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection, ceiling=1.0)
+    result = adapter.distinct_combination_counts(
+        "dexdb.shop.customers", [["id", "email"]]
+    )
+    assert result == {}
+    assert fake_pg_connection.data_statements == []
+    assert any(
+        "composite-key probe skipped" in note
+        for note in adapter.table_notes("dexdb.shop.customers")
+    )
+
+
 # --- run_query ----------------------------------------------------------------------
 
 

--- a/packages/dex-core/tests/adapters/test_connect_redshift.py
+++ b/packages/dex-core/tests/adapters/test_connect_redshift.py
@@ -676,6 +676,80 @@ def test_escalation_skipped_when_budget_cannot_cover(fake_redshift_connection):
     assert any("escalation skipped" in note for note in notes)
 
 
+def test_distinct_combination_counts_batch_into_one_guarded_statement(
+    fake_redshift_connection,
+):
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"d_0": 97, "d_1": 100}], seconds=0.5
+    )
+    adapter = make_adapter(fake_redshift_connection, ceiling=100_000.0)
+    counts = adapter.distinct_combination_counts(
+        "dexdb.shop.customers", [["id", "email"], ["email", "id"]]
+    )
+    assert counts == {("id", "email"): 97, ("email", "id"): 100}
+    stmts = fake_redshift_connection.data_statements
+    assert len(stmts) == 1
+    sql = stmts[0].sql
+    assert "SELECT DISTINCT" in sql
+    assert ") AS q_0" in sql
+    assert assert_select_only(sql, dialect="redshift") == sql
+    assert adapter.distinct_combination_counts("dexdb.shop.customers", []) == {}
+
+
+def test_composite_probe_skipped_when_budget_cannot_cover(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection, ceiling=1.0)
+    result = adapter.distinct_combination_counts(
+        "dexdb.shop.customers", [["id", "email"]]
+    )
+    assert result == {}
+    assert fake_redshift_connection.data_statements == []
+    assert any(
+        "composite-key probe skipped" in note
+        for note in adapter.table_notes("dexdb.shop.customers")
+    )
+
+
+def test_composite_probe_carries_the_wake_floor_when_it_bills_first(
+    fake_redshift_connection,
+):
+    """Like the exact-distinct escalation, the composite probe can be a
+    command's first billed statement, so the pending wake minimum rides its
+    charge (and stays pending on refusal). One probe over customers estimates
+    scan (100s) + floor (60s)."""
+
+    def resolve(sql):
+        if "SELECT DISTINCT" in sql:
+            return FakeResult(rows=[{"d_0": 100}], seconds=0.1)
+        return FakeResult(rows=[{"n": 1}], seconds=0.1)
+
+    fake_redshift_connection.row_resolver = resolve
+
+    # Covers the scan but not scan + floor: the probe must refuse rather than
+    # under-charge its way in, and the floor stays pending.
+    strict = make_adapter(fake_redshift_connection, ceiling=155.0)
+    assert (
+        strict.distinct_combination_counts("dexdb.shop.customers", [["id", "email"]])
+        == {}
+    )
+    assert fake_redshift_connection.data_statements == []
+    assert strict._wake_floor_pending is True
+
+    # Once charged, the floor is consumed: probe (100 + 60) plus a follow-up
+    # query (100, floorless) fit a 270s ceiling only if the second statement
+    # does not carry the floor again.
+    adapter = make_adapter(fake_redshift_connection, ceiling=270.0)
+    assert adapter.distinct_combination_counts(
+        "dexdb.shop.customers", [["id", "email"]]
+    ) == {("id", "email"): 100}
+    adapter.run_query(
+        "SELECT count(*) AS n FROM dexdb.shop.customers",
+        max_rows=10,
+        timeout_seconds=30.0,
+    )
+
+
 def test_escalation_carries_the_wake_floor_when_it_bills_first(
     fake_redshift_connection,
 ):

--- a/packages/dex-core/tests/adapters/test_connect_snowflake.py
+++ b/packages/dex-core/tests/adapters/test_connect_snowflake.py
@@ -451,6 +451,40 @@ def test_exact_distinct_counts_degrade_when_budget_cannot_cover(fake_sf_connecti
     assert data_statements(fake_sf_connection) == []
 
 
+def test_distinct_combination_counts_batch_into_one_guarded_statement(
+    fake_sf_connection,
+):
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    fake_sf_connection.row_resolver = lambda sql: [{"d_0": 97, "d_1": 100}]
+    adapter = make_adapter(fake_sf_connection, ceiling=100_000.0)
+    counts = adapter.distinct_combination_counts(
+        "SHOP.PUBLIC.CUSTOMERS", [["ID", "EMAIL"], ["EMAIL", "ID"]]
+    )
+    assert counts == {("ID", "EMAIL"): 97, ("EMAIL", "ID"): 100}
+    stmts = data_statements(fake_sf_connection)
+    assert len(stmts) == 1
+    assert "SELECT DISTINCT" in stmts[0].sql
+    assert assert_select_only(stmts[0].sql, dialect="snowflake") == stmts[0].sql
+    assert adapter.distinct_combination_counts("SHOP.PUBLIC.CUSTOMERS", []) == {}
+
+
+def test_distinct_combination_counts_degrade_when_budget_cannot_cover(
+    fake_sf_connection,
+):
+    adapter = make_adapter(fake_sf_connection, ceiling=100.0)
+    adapter.cost_gate.charge(99.5)
+    result = adapter.distinct_combination_counts(
+        "SHOP.PUBLIC.CUSTOMERS", [["ID", "EMAIL"]]
+    )
+    assert result == {}
+    assert any(
+        "composite-key probe skipped" in note
+        for note in adapter.table_notes("SHOP.PUBLIC.CUSTOMERS")
+    )
+    assert data_statements(fake_sf_connection) == []
+
+
 # --- factory and dialect --------------------------------------------------------
 
 

--- a/packages/dex-core/tests/explore/conftest.py
+++ b/packages/dex-core/tests/explore/conftest.py
@@ -70,6 +70,30 @@ def many_tables_duckdb(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def composite_grain_duckdb(tmp_path: Path) -> Path:
+    """A TPCH-shaped pair: a fact table whose only key is the composite
+    (order_key, line_number), where line_number alone has tiny cardinality
+    (the shape single-column detection can never resolve), next to a parent
+    with a clean surrogate key."""
+
+    duckdb = pytest.importorskip("duckdb")
+    path = tmp_path / "composite.duckdb"
+    conn = duckdb.connect(str(path))
+    conn.execute(
+        "CREATE TABLE orders AS "
+        "SELECT range::INTEGER AS order_key, 'open' AS status FROM range(1, 501)"
+    )
+    conn.execute(
+        "CREATE TABLE line_items AS "
+        "SELECT o.range::INTEGER AS order_key, l.range::INTEGER AS line_number, "
+        "(l.range % 2)::INTEGER AS quantity "
+        "FROM range(1, 501) o, range(1, 5) l"
+    )
+    conn.close()
+    return path
+
+
+@pytest.fixture
 def f1_duckdb(tmp_path: Path) -> Path:
     """A camelCase star schema: parents key on <entity>Id (not `id`), and the
     fact table's foreign keys use the same camelCase names."""

--- a/packages/dex-core/tests/explore/test_profile.py
+++ b/packages/dex-core/tests/explore/test_profile.py
@@ -206,15 +206,27 @@ def test_true_duplicates_still_warn_with_exact_counts(near_unique_duckdb: Path, 
 
 
 class _StubAdapter:
-    """Metadata-only double: crafted approximate aggregates, recorded escalations."""
+    """Metadata-only double: crafted approximate aggregates, recorded escalations
+    and composite probes. ``combos`` maps a column tuple to its exact distinct
+    combination count; unlisted tuples come back just below the row count, so
+    they read as probed-but-not-unique."""
 
     name = "stub"
     dialect = "duckdb"
 
-    def __init__(self, rows: int, approx: dict[str, int]):
+    def __init__(
+        self,
+        rows: int,
+        approx: dict[str, int],
+        nulls: dict[str, float] | None = None,
+        combos: dict[tuple[str, ...], int] | None = None,
+    ):
         self.rows = rows
         self.approx = approx
+        self.nulls = nulls or {}
+        self.combos = combos or {}
         self.calls: list[list[str]] = []
+        self.combo_calls: list[list[list[str]]] = []
 
     def table_metadata(self, identifier):
         from exmergo_dex_core.adapters.base import ColumnMeta, ObjectMeta
@@ -240,7 +252,7 @@ class _StubAdapter:
         return [
             ColumnAggregate(
                 name=c.name,
-                null_fraction=0.0,
+                null_fraction=self.nulls.get(c.name, 0.0),
                 distinct_count=self.approx[c.name],
                 is_unique=False,
                 min_value=None,
@@ -252,6 +264,12 @@ class _StubAdapter:
     def exact_distinct_counts(self, identifier, columns):
         self.calls.append(list(columns))
         return {n: (self.rows if n == "overshoot" else self.rows - 10) for n in columns}
+
+    def distinct_combination_counts(self, identifier, combinations):
+        self.combo_calls.append([list(c) for c in combinations])
+        return {
+            tuple(c): self.combos.get(tuple(c), self.rows - 10) for c in combinations
+        }
 
 
 def test_escalation_policy_is_bounded_and_targeted():
@@ -295,6 +313,113 @@ def test_adapter_without_exact_counts_degrades_gracefully():
     assert col.distinct_count_exact is False
     # In the noise band and unproven: no non-uniqueness verdict.
     assert not any("not unique" in n for n in datasets[0].data_quality)
+
+
+# --- composite-key probing ------------------------------------------------------
+
+
+def test_composite_probe_is_bounded_and_targeted():
+    """Pairs are pruned on the distinct-product necessary condition, nullable
+    columns never enter a key, the id-shaped/smallest-product ranking picks the
+    grain-shaped pair first, and only the pair whose exact combination count
+    equals the row count is proven."""
+
+    from exmergo_dex_core.explore import profile as profile_mod
+    from exmergo_dex_core.explore import relationships as rel_mod
+
+    adapter = _StubAdapter(
+        rows=1000,
+        approx={
+            "order_key": 250,
+            "line_no": 4,
+            "qty": 30,
+            "filler": 2,
+            "commentId": 900,  # high-cardinality but nullable: never a key member
+        },
+        nulls={"commentId": 0.2},
+        combos={("order_key", "line_no"): 1000},
+    )
+    datasets = profile_mod.profile(adapter, ["db.s.line_items"])
+
+    assert len(adapter.combo_calls) == 1, "all pairs batch into one adapter call"
+    probed = adapter.combo_calls[0]
+    # Survivors of the product test only (250*4 and 250*30 reach the row count
+    # within HLL slack; every filler pair falls short), best-ranked first,
+    # members ordered by descending cardinality.
+    assert probed == [["order_key", "line_no"], ["order_key", "qty"]]
+    assert not any("commentId" in pair for pair in probed)
+
+    ds = datasets[0]
+    assert ds.composite_keys == [["order_key", "line_no"]]
+    assert ["order_key", "line_no"] in rel_mod.candidate_keys(ds)
+    assert rel_mod.detect_grain(ds) == ["order_key", "line_no"]
+    assert not any("grain unknown" in n for n in rel_mod.data_quality_notes(ds))
+
+
+def test_composite_probe_caps_the_pair_count():
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    # Five interchangeable mid-cardinality columns: every pair survives the
+    # product test, so only the cap keeps the probe bounded.
+    adapter = _StubAdapter(rows=1000, approx={f"c{i}_id": 100 + i for i in range(5)})
+    profile_mod.profile(adapter, ["db.s.t"])
+    assert len(adapter.combo_calls) == 1
+    assert len(adapter.combo_calls[0]) == 3
+
+
+def test_composite_probe_skipped_when_single_key_exists():
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    # "overshoot" escalates to a proven unique single key, so the composite
+    # probe would be pure waste and must not fire.
+    adapter = _StubAdapter(
+        rows=1000, approx={"overshoot": 1010, "order_key": 250, "line_no": 4}
+    )
+    datasets = profile_mod.profile(adapter, ["db.s.t"])
+    assert adapter.combo_calls == []
+    assert datasets[0].composite_keys == []
+
+
+def test_adapter_without_combination_counts_degrades_gracefully():
+    from exmergo_dex_core.explore import profile as profile_mod
+    from exmergo_dex_core.explore import relationships as rel_mod
+
+    adapter = _StubAdapter(rows=1000, approx={"order_key": 250, "line_no": 4})
+    adapter.distinct_combination_counts = None  # shadow: adapter can't probe
+    datasets = profile_mod.profile(adapter, ["db.s.t"])
+    ds = datasets[0]
+    assert ds.composite_keys == []
+    assert rel_mod.candidate_keys(ds) == []
+    assert any("grain unknown" in n for n in rel_mod.data_quality_notes(ds))
+
+
+def test_composite_grain_detected_end_to_end(composite_grain_duckdb: Path, capsys):
+    """The TPCH LINEITEM shape: no single column is unique, the true grain is
+    (order_key, line_number), and the profile proves it instead of reporting
+    an unknown grain."""
+
+    payload = _run(
+        [
+            "explore",
+            "profile",
+            "orders,line_items",
+            "--path",
+            str(composite_grain_duckdb),
+        ],
+        capsys,
+    )
+    ds = {d["identifier"].split(".")[-1]: d for d in payload["data"]["datasets"]}
+
+    line_items = ds["line_items"]
+    assert line_items["composite_keys"] == [["order_key", "line_number"]]
+    assert ["order_key", "line_number"] in line_items["candidate_keys"]
+    assert line_items["grain"] == ["order_key", "line_number"]
+    assert not any("grain unknown" in n for n in line_items["data_quality"])
+
+    # The sibling with a clean surrogate key keeps its single-column grain.
+    orders = ds["orders"]
+    assert orders["grain"] == ["order_key"]
+    assert orders["composite_keys"] == []
 
 
 def test_row_count_refreshes_after_the_aggregate_scan():

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -15,6 +15,7 @@ import pytest
 from exmergo_dex_core.cache import ColumnProfile, Dataset
 from exmergo_dex_core.cli import main
 from exmergo_dex_core.explore.relationships import (
+    candidate_keys,
     data_quality_notes,
     detect_grain,
     fk_candidate_count,
@@ -401,6 +402,67 @@ def test_repeated_foreign_key_is_not_a_grain_defect():
 def test_empty_table_produces_no_grain_notes():
     empty = _ds("db.main.empty_t", [_col("id")], rows=0)
     assert data_quality_notes(empty) == []
+
+
+# --- composite keys --------------------------------------------------------------
+
+
+def test_candidate_keys_list_singles_before_composites():
+    ds = _ds(
+        "db.main.line_items",
+        [
+            _col("id", distinct=2000, unique=True),
+            _col("order_key", distinct=500),
+            _col("line_number", distinct=4),
+        ],
+        rows=2000,
+    )
+    ds.composite_keys = [["order_key", "line_number"]]
+    assert candidate_keys(ds) == [["id"], ["order_key", "line_number"]]
+
+
+def test_grain_prefers_a_single_key_over_a_composite():
+    ds = _ds(
+        "db.main.line_items",
+        [
+            _col("id", distinct=2000, unique=True),
+            _col("order_key", distinct=500),
+            _col("line_number", distinct=4),
+        ],
+        rows=2000,
+    )
+    ds.composite_keys = [["order_key", "line_number"]]
+    assert detect_grain(ds) == ["id"]
+
+
+def test_grain_falls_back_to_the_best_ranked_composite():
+    ds = _ds(
+        "db.main.line_items",
+        [
+            _col("order_key", distinct=500),
+            _col("line_number", distinct=4),
+            _col("quantity", distinct=30),
+        ],
+        rows=2000,
+    )
+    ds.composite_keys = [["order_key", "line_number"], ["order_key", "quantity"]]
+    assert detect_grain(ds) == ["order_key", "line_number"]
+    assert not any("grain unknown" in n for n in data_quality_notes(ds))
+
+
+def test_composite_member_is_not_a_unique_parent_key():
+    """A same-named foreign key must not join to a composite member as if it
+    were the parent's unique key: order_key alone repeats in line_items, so an
+    edge onto it would fan out."""
+
+    line_items = _ds(
+        "db.main.line_items",
+        [_col("order_key", distinct=500), _col("line_number", distinct=4)],
+        rows=2000,
+    )
+    line_items.composite_keys = [["order_key", "line_number"]]
+    shipments = _ds("db.main.shipments", [_col("order_key", distinct=400)], rows=450)
+    assert infer_relationships([line_items, shipments]) == []
 
 
 # --- envelope: the two field sessions ------------------------------------------

--- a/packages/dex-core/tests/maintain/test_grain.py
+++ b/packages/dex-core/tests/maintain/test_grain.py
@@ -137,6 +137,200 @@ def test_estimated_row_counts_cannot_fabricate_duplicates():
             return dict.fromkeys(columns, 1000)
 
     dataset = Dataset(identifier="db.s.t", candidate_keys=[["id"]], grain=["id"])
-    plan = GrainPlan(key_checks=[(dataset, ["id"], 1200)], fanout_pairs=[])
+    plan = GrainPlan(
+        key_checks=[(dataset, ["id"], 1200)], fanout_pairs=[], composite_checks=[]
+    )
     findings = grain_drift(EstimatingAdapter(), plan)
     assert findings == []
+
+
+# --- composite keys ---------------------------------------------------------------
+
+
+class _ComboAdapter:
+    """Stub for the composite path: serves metadata for one two-column table
+    and answers combination probes with a configured count."""
+
+    name = "stub"
+    dialect = "duckdb"
+
+    def __init__(self, rows: int, combo_count: int | None):
+        self.rows = rows
+        self.combo_count = combo_count
+        self.combo_calls: list[list[list[str]]] = []
+
+    def list_objects(self, *, include_views: bool = True):
+        meta, _ = self.table_metadata("db.s.line_items")
+        return [meta]
+
+    def table_metadata(self, identifier):
+        from exmergo_dex_core.adapters.base import ColumnMeta, ObjectMeta
+
+        meta = ObjectMeta(
+            identifier=identifier,
+            object_type="table",
+            schema="s",
+            name="line_items",
+            row_count=self.rows,
+            byte_size=None,
+            column_count=2,
+        )
+        columns = [
+            ColumnMeta(name=n, data_type="INTEGER", nullable=False, ordinal=i)
+            for i, n in enumerate(["order_key", "line_number"])
+        ]
+        return meta, columns
+
+    def exact_distinct_counts(self, identifier, columns):
+        raise AssertionError(
+            f"composite members must never be checked one at a time: {columns}"
+        )
+
+    def distinct_combination_counts(self, identifier, combinations):
+        self.combo_calls.append([list(c) for c in combinations])
+        return {tuple(c): self.combo_count for c in combinations}
+
+
+def _composite_snapshot():
+    from exmergo_dex_core.cache import Dataset
+    from exmergo_dex_core.maintain.snapshot import Snapshot, WarehouseBaseline
+
+    dataset = Dataset(
+        identifier="db.s.line_items",
+        candidate_keys=[["order_key", "line_number"]],
+        grain=["order_key", "line_number"],
+        composite_keys=[["order_key", "line_number"]],
+    )
+    snap = Snapshot.model_construct(
+        warehouse=WarehouseBaseline.model_construct(
+            datasets=[dataset], relationships=[]
+        )
+    )
+    return dataset, snap
+
+
+def test_composite_grain_plans_the_combination_never_the_members():
+    from exmergo_dex_core.maintain.drift import grain_plan
+
+    _dataset, snap = _composite_snapshot()
+    plan = grain_plan(_ComboAdapter(rows=1000, combo_count=1000), snap)
+    assert plan.key_checks == []
+    assert len(plan.composite_checks) == 1
+    _ds, combos, rows = plan.composite_checks[0]
+    assert combos == [["order_key", "line_number"]]
+    assert rows == 1000
+
+
+def test_composite_key_lost_uniqueness_is_detected():
+    from exmergo_dex_core.maintain.drift import GrainPlan, grain_drift
+
+    dataset, _snap = _composite_snapshot()
+    plan = GrainPlan(
+        key_checks=[],
+        fanout_pairs=[],
+        composite_checks=[(dataset, [["order_key", "line_number"]], 1000)],
+    )
+    adapter = _ComboAdapter(rows=1000, combo_count=950)
+    findings = grain_drift(adapter, plan)
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.code == "key_lost_uniqueness"
+    assert finding.column == "order_key, line_number"
+    assert "no longer unique" in finding.detail
+    assert finding.data == {
+        "columns": ["order_key", "line_number"],
+        "distinct_count": 950,
+        "row_count": 1000,
+        "was_grain": True,
+    }
+
+
+def test_composite_check_is_quiet_when_the_key_still_holds():
+    from exmergo_dex_core.maintain.drift import GrainPlan, grain_drift
+
+    dataset, _snap = _composite_snapshot()
+    plan = GrainPlan(
+        key_checks=[],
+        fanout_pairs=[],
+        composite_checks=[(dataset, [["order_key", "line_number"]], 1000)],
+    )
+    findings = grain_drift(_ComboAdapter(rows=1000, combo_count=1000), plan)
+    assert findings == []
+
+
+def test_adapter_without_combination_counts_skips_composite_checks():
+    from exmergo_dex_core.maintain.drift import GrainPlan, grain_drift
+
+    dataset, _snap = _composite_snapshot()
+    plan = GrainPlan(
+        key_checks=[],
+        fanout_pairs=[],
+        composite_checks=[(dataset, [["order_key", "line_number"]], 1000)],
+    )
+    adapter = _ComboAdapter(rows=1000, combo_count=950)
+    adapter.distinct_combination_counts = None  # shadow: adapter can't probe
+    assert grain_drift(adapter, plan) == []
+
+
+def test_composite_grain_drift_end_to_end(dex, tmp_path):
+    """A composite-grain fact table drifts: after the baseline, a duplicated
+    (order_key, line_number) row must surface as one combination-level finding,
+    with no per-member noise."""
+
+    import duckdb
+
+    root = tmp_path / "composite"
+    root.mkdir()
+    db_path = root / "warehouse.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE line_items AS "
+        "SELECT o.range::INTEGER AS order_key, l.range::INTEGER AS line_number, "
+        "(l.range % 2)::INTEGER AS quantity "
+        "FROM range(1, 501) o, range(1, 5) l"
+    )
+    conn.close()
+    (root / ".dex").mkdir()
+    (root / ".dex" / "config.yml").write_text(
+        f"connector: duckdb\nduckdb:\n  path: {db_path}\n", encoding="utf-8"
+    )
+    rc, _payload = dex("--repo-root", str(root), "explore", "map")
+    assert rc == 0
+    rc, _payload = dex("--repo-root", str(root), "maintain", "snapshot")
+    assert rc == 0
+
+    conn = duckdb.connect(str(db_path))
+    conn.execute("INSERT INTO line_items VALUES (1, 1, 1)")
+    conn.close()
+
+    rc, payload = dex("--repo-root", str(root), "maintain", "grain")
+    assert rc == 0 and payload["status"] == "ok"
+    findings = [
+        f for f in payload["data"]["findings"] if f["code"] == "key_lost_uniqueness"
+    ]
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["column"] == "order_key, line_number"
+    assert finding["data"]["columns"] == ["order_key", "line_number"]
+    assert finding["data"]["distinct_count"] == 2000
+    assert finding["data"]["row_count"] == 2001
+
+
+def test_grain_estimate_prices_composite_checks():
+    from exmergo_dex_core.maintain.drift import GrainPlan, grain_estimate
+
+    dataset, _snap = _composite_snapshot()
+    plan = GrainPlan(
+        key_checks=[],
+        fanout_pairs=[],
+        composite_checks=[(dataset, [["order_key", "line_number"]], 1000)],
+    )
+    priced: list[str] = []
+
+    adapter = _ComboAdapter(rows=1000, combo_count=1000)
+    adapter.query_estimate = lambda sql: priced.append(sql) or 7.0
+    total, per_table = grain_estimate(adapter, plan)
+    assert total == 7.0
+    assert per_table == {"db.s.line_items": 7.0}
+    assert len(priced) == 1
+    assert "SELECT DISTINCT" in priced[0]

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -52,6 +52,25 @@ def test_generated_sql_is_select_only(duckdb_file: Path):
     assert assert_select_only(sql) == sql
 
 
+def test_combination_probe_sql_is_select_only_in_every_dialect():
+    # The composite-key probe shares one SQL builder across the adapters; the
+    # statement must parse as a single read-only SELECT in each dialect.
+    from exmergo_dex_core.adapters.base import distinct_combination_sql
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    def quote(name: str) -> str:
+        return '"' + name.replace('"', '""') + '"'
+
+    sql = distinct_combination_sql(
+        '"db"."main"."line_items"',
+        [["order_key", "line_number"], ["order_key", "quantity"]],
+        quote,
+    )
+    assert sql.lstrip().upper().startswith("SELECT")
+    for dialect in ("duckdb", "bigquery", "snowflake", "databricks", "postgres"):
+        assert assert_select_only(sql, dialect=dialect) == sql
+
+
 def test_select_only_guard_rejects_writes():
     from exmergo_dex_core.guards.sql_guard import NotSelectOnlyError, assert_select_only
 

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -67,7 +67,8 @@ def test_combination_probe_sql_is_select_only_in_every_dialect():
         quote,
     )
     assert sql.lstrip().upper().startswith("SELECT")
-    for dialect in ("duckdb", "bigquery", "snowflake", "databricks", "postgres"):
+    dialects = ("duckdb", "bigquery", "snowflake", "databricks", "postgres", "redshift")
+    for dialect in dialects:
         assert assert_select_only(sql, dialect=dialect) == sql
 
 

--- a/references/methodology.md
+++ b/references/methodology.md
@@ -53,6 +53,17 @@ escalated count is marked exact, and only an exact count is allowed to confirm a
 key or a table's grain; downstream consumers (relationship fan-out notes included)
 never draw a hard conclusion from an approximation.
 
+When no single column proves unique (the shape of a fact table, whose grain is
+exactly what a profile must answer), profiling probes 2-column composite keys. A
+pair can only be a key if the product of its members' distinct counts reaches the
+row count, so pairs are pruned on that necessary condition using the counts
+already in hand, then ranked (id-shaped members first, smallest product next) and
+capped to a few probes issued as one exact distinct-combination statement. A pair
+whose combination count equals the row count is a proven composite key: it enters
+the candidate keys and, absent any single-column key, becomes the reported grain.
+On metered connectors the probe spends only inside the already-confirmed budget
+and skips with an explanatory note when the remaining budget cannot cover it.
+
 Two safety rules are enforced at the source, in the SQL that is generated:
 
 - **min and max are surfaced only where the extreme value is not itself
@@ -80,8 +91,11 @@ verify referential integrity, so it stays free and read-only at the cost of
 certainty, which is why every inferred join carries a confidence. A join is
 proposed when a foreign-key-shaped column name matches a parent object whose
 corresponding column is a candidate key and the types are compatible; confidence
-reflects how strong the name and key signals are. Single-column candidate keys and
-the most likely grain are derived from the uniqueness signals. Declared joins come
+reflects how strong the name and key signals are. Candidate keys and the most
+likely grain come from the uniqueness signals: single columns proven unique, plus
+the composite keys proven at profile time; a single-column key is always
+preferred as the grain, and a member of a composite key is never treated as
+unique on its own. Declared joins come
 from the dbt project when one is present; absent a dbt project, declared joins are
 simply empty, which is expected because explore is designed to work without one.
 

--- a/references/redshift.md
+++ b/references/redshift.md
@@ -142,7 +142,12 @@ for engine-cleared safe columns; never row values. Redshift keeps no usable
 planner distincts, so approximate distincts ride the billed batch, and an
 approximation is never a uniqueness verdict: near-unique keys escalate to an
 exact `COUNT(DISTINCT)` inside the confirmed budget, and that scan also
-upgrades the `SVV_TABLE_INFO` row estimate to an exact figure. `SUPER`,
+upgrades the `SVV_TABLE_INFO` row estimate to an exact figure. When no single
+column proves unique, the composite-key probe (a bounded batch of exact
+distinct-combination counts) spends inside the same confirmed budget, and
+like the escalation it carries the pending Serverless wake minimum when it
+bills first; when the remaining budget cannot cover it, the probe skips with
+a note and the grain stays unknown. `SUPER`,
 `VARBYTE`, `GEOMETRY`, `GEOGRAPHY`, and `HLLSKETCH` columns degrade to
 non-null counts. There is **no sampled-profiling threshold**: Redshift has
 no TABLESAMPLE, so a sampling knob would be a lie; the budget is the only


### PR DESCRIPTION
## What this changes

Add composite key detection. 

Explore
- `profiling` is where the detection happens
- `relationships` is where the detected composite key is used

Maintain
- `grain drift` detection now keeps composite keys into account

NOTE: Combo cap set to 3 in this PR. We could up it in the near-ish future

## Related issues

Closes #49 
Internally SCRUM-900