### PR TITLE
Amazon Redshift Connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       # The cloud extras are included so their unit tests and safety families
       # run here (they are offline against fake clients, but they importorskip
       # on the client libraries; without the extras they would silently skip).
-      - name: Sync (duckdb + bigquery + snowflake + databricks + postgres + dev extras)
-        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra databricks --extra postgres --extra dev --python ${{ matrix.python-version }}
+      - name: Sync (duckdb + bigquery + snowflake + databricks + postgres + redshift + dev extras)
+        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra databricks --extra postgres --extra redshift --extra dev --python ${{ matrix.python-version }}
       - name: Tier-1 unit tests
         run: uv run pytest -q
 
@@ -48,8 +48,8 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-      - name: Sync (duckdb + bigquery + snowflake + databricks + postgres + dev extras)
-        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra databricks --extra postgres --extra dev
+      - name: Sync (duckdb + bigquery + snowflake + databricks + postgres + redshift + dev extras)
+        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra databricks --extra postgres --extra redshift --extra dev
       - name: Safety-critical assertions
         run: uv run pytest -q tests/test_safety_spine.py
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,8 +6,8 @@ name: Integration
 # fork-runnable; this workflow answers "does the connector still work against
 # the real service" on main and on a schedule. Each suite reads shared/public
 # sample data, writes only to its scratch scope, and caps every statement
-# (bytes on BigQuery, seconds on Snowflake, Databricks, and Postgres), so a
-# worst-case run costs cents.
+# (bytes on BigQuery, seconds on Snowflake, Databricks, Redshift, and
+# Postgres), so a worst-case run costs cents.
 #
 # One-time setup (documented in CONTRIBUTING.md):
 #   BigQuery: scripts/setup_bigquery_ci.sh (Workload Identity Pool provider
@@ -25,6 +25,13 @@ name: Integration
 #   write only in the scratch catalog. No resource-monitor analogue exists, so
 #   the backstop is the smallest warehouse, auto-stop, per-statement
 #   STATEMENT_TIMEOUT, and a workspace budget alert).
+#   Redshift: scripts/setup_redshift_ci.sh (an IAM role whose trust policy
+#   accepts only GitHub OIDC tokens minted for this repo's
+#   redshift-integration environment, holding GetWorkgroup/GetNamespace/
+#   GetCredentials on the smallest Serverless workgroup; a seeded app schema
+#   read by dex_ro; a dbt_dev user writable only in its dev schema with a
+#   durable statement_timeout; an RPU-hours-per-day usage limit as the hard
+#   cost backstop).
 #   Postgres: no setup at all. The operational-database connector runs against
 #   a service container seeded from scripts/postgres_seed.sql (the same seed
 #   scripts/setup_postgres_dev.sh applies locally): free, keyless, and
@@ -225,6 +232,50 @@ jobs:
         run: uv sync --extra databricks --extra duckdb --extra dev
       - name: Live Databricks integration suite
         run: uv run pytest tests/integration -q -m databricks
+
+  redshift:
+    if: github.repository == 'exmergo/dex'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # The environment carries the AWS variables and, via its deployment branch
+    # policy (main only), refuses this job to a workflow modified on a branch
+    # before the role is assumed. The AWS-side pin mirrors it: the role's
+    # trust policy accepts only GitHub OIDC tokens whose subject names this
+    # repo + environment.
+    environment: redshift-integration
+    permissions:
+      contents: read
+      id-token: write # OIDC for AWS role assumption; no stored keys.
+    defaults:
+      run:
+        working-directory: packages/dex-core
+    env:
+      DEX_TEST_REDSHIFT_WORKGROUP: ${{ vars.DEX_TEST_REDSHIFT_WORKGROUP }}
+      DEX_TEST_REDSHIFT_DATABASE: ${{ vars.DEX_TEST_REDSHIFT_DATABASE }}
+      DEX_TEST_REDSHIFT_HOST: ${{ vars.DEX_TEST_REDSHIFT_HOST }}
+      DEX_TEST_REDSHIFT_MAX_SECONDS: "60"
+      # The transform suite's password path only; the engine itself stays
+      # keyless (IAM temporary credentials through the assumed role). The
+      # secret is readable only by this environment, whose deployments are
+      # pinned to main, so a pull request cannot reach it.
+      DEX_TEST_REDSHIFT_DEV_PASSWORD: ${{ secrets.DEX_TEST_REDSHIFT_DEV_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      # Assume the OIDC-trusted role, exporting AWS_* credentials into the
+      # default chain, which is exactly the discovery path the engine uses:
+      # no CI special-casing anywhere.
+      - name: Assume the Redshift integration role via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.DEX_TEST_REDSHIFT_ROLE_ARN }}
+          aws-region: ${{ vars.DEX_TEST_REDSHIFT_REGION }}
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync (redshift + duckdb + dev extras)
+        run: uv sync --extra redshift --extra duckdb --extra dev
+      - name: Live Redshift integration suite
+        run: uv run pytest tests/integration -q -m redshift
 
   postgres:
     # No repository gate and no environment: the target is a job-local service

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
       # The cloud extras stay in the gate: their safety families importorskip
       # on the client libraries, and a release gate that silently skips
       # safety-critical assertions is a hole, not a speedup.
-      - name: Sync (duckdb + bigquery + snowflake + databricks + postgres + dev extras)
-        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra databricks --extra postgres --extra dev
+      - name: Sync (duckdb + bigquery + snowflake + databricks + postgres + redshift + dev extras)
+        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra databricks --extra postgres --extra redshift --extra dev
       - name: Tier-1 + safety-critical gate
         run: uv run pytest -q
       # A safety-assertion regression blocks the release regardless of pass-rate;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ uv run scripts/run.py <subcommand> [flags]
 
 Install the engine with the connector extra you use: `exmergo-dex-core[duckdb]`
 for the zero-credential on-ramp, or `[snowflake]`, `[bigquery]`, `[databricks]`,
-`[postgres]`, or `[all]` for every connector at once. The shipped wrapper pins
+`[postgres]`, `[redshift]`, or `[all]` for every connector at once. The shipped wrapper pins
 only the engine version and selects that extra for you at runtime from the active
 connector (an explicit `--connector`, then `.dex/config.yml`, then DuckDB), so a
 release is connector-neutral.
@@ -90,26 +90,31 @@ Every command prints exactly one JSON object and nothing else:
 
 Cost is a preflight estimate surfaced **before** any spend. Any command that
 would spend requires an explicit `--confirm` and a session budget: on a
-metered connector (BigQuery, Snowflake, Databricks, and Postgres) the first
-call returns `needs_confirmation` with a free estimate, and the same command
-is re-issued with `--confirm --budget <magnitude>` once the user has agreed
-to the spend. The magnitude is paradigm-relative: **bytes** on BigQuery (an
-exact free dry-run figure), **warehouse-seconds** on Snowflake (a heuristic
-labeled `estimate_quality: "heuristic"`, with a credit translation alongside)
-and on Databricks (a floor labeled `estimate_quality: "low"` that sharpens
-itself inside the confirmed budget, with a DBU translation alongside),
-**database-seconds** on Postgres (nothing is billed in dollars; the guarded
-quantity is load on the operational database, estimated free via EXPLAIN). On
-every time paradigm the budget still binds exactly via a server-side
-statement timeout. Actual spend comes back under `data.spend` (`bytes_billed`
-or `seconds_billed`) and accumulates in the `.dex/spend.jsonl` ledger per
-connector. Credentials never appear in `data` (BigQuery authenticates via
-discovered Application Default Credentials, Snowflake via a discovered
-`connections.toml` entry, environment, or dbt profile, Databricks via the
-SDK's unified chain, Postgres via `pg_service.conf`, `DATABASE_URL`, the
-`PG*` environment, or a dbt profile; never a pasted key or token), and result
-values appear only in `explore query`'s columnar payload after the query
-firewall has cleared them.
+metered connector (BigQuery, Snowflake, Databricks, Redshift, and Postgres)
+the first call returns `needs_confirmation` with a free estimate, and the
+same command is re-issued with `--confirm --budget <magnitude>` once the user
+has agreed to the spend. The magnitude is paradigm-relative: **bytes** on
+BigQuery (an exact free dry-run figure), **warehouse-seconds** on Snowflake
+(a heuristic labeled `estimate_quality: "heuristic"`, with a credit
+translation alongside) and on Databricks (a floor labeled
+`estimate_quality: "low"` that sharpens itself inside the confirmed budget,
+with a DBU translation alongside), **compute-seconds** on Redshift (a
+heuristic with an RPU-hour translation alongside; Serverless estimates carry
+the 60-second wake minimum once), **database-seconds** on Postgres (nothing
+is billed in dollars; the guarded quantity is load on the operational
+database, estimated free via EXPLAIN). On every time paradigm the budget
+still binds exactly via a server-side statement timeout. Actual spend comes
+back under `data.spend` (`bytes_billed` or `seconds_billed`) and accumulates
+in the `.dex/spend.jsonl` ledger per connector. Credentials never appear in
+`data` (BigQuery authenticates via discovered Application Default
+Credentials, Snowflake via a discovered `connections.toml` entry,
+environment, or dbt profile, Databricks via the SDK's unified chain, Redshift
+via the AWS credential chain (a pinned Serverless workgroup mints IAM
+temporary database credentials) or the `REDSHIFT_*` environment, Postgres via
+`pg_service.conf`, `DATABASE_URL`, the `PG*` environment, or a dbt profile;
+never a pasted key or token), and result values appear only in
+`explore query`'s columnar payload after the query firewall has cleared
+them.
 
 ## Guardrails (non-negotiable, enforced in the engine)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **Amazon Redshift connector** (`[redshift]` extra), Serverless-first and
+  provisioned-compatible: Postgres-catalog metadata (a `pg_class` census
+  merged with `SVV_TABLE_INFO` size facts and `SVV_COLUMNS`, so empty tables
+  the view omits still appear), the compute-time cost paradigm in seconds
+  with an RPU-hour translation from the workgroup's base capacity (dollars
+  when `redshift.rpu_price_usd` is set), the 60-second Serverless wake
+  minimum floored into every estimate exactly once per command, and a
+  per-statement server-side `statement_timeout` wound down to the remaining
+  budget so a wrong heuristic cannot overrun the ceiling. Credential
+  discovery spans both of Redshift's worlds: a pinned Serverless
+  `redshift.workgroup` (or provisioned `cluster_identifier`) resolved through
+  the AWS default credential chain into IAM temporary database credentials,
+  the `REDSHIFT_*` environment, the committed non-secret config target
+  (password via `REDSHIFT_PASSWORD`), or a dbt profile. `transform init`
+  renders IAM or env-var-password dev profiles; the dev-target preflight asks
+  the Postgres privilege question of the profile's user. Profiling uses
+  `HLL(...)` approximate distincts (Redshift caps `APPROXIMATE
+  COUNT(DISTINCT)` at three per statement, verified live) with exact
+  escalation inside the confirmed budget; there is deliberately no
+  sampled-profiling knob because Redshift has no TABLESAMPLE. Session
+  read-only is attempted and reported honestly rather than assumed (verified
+  live: Redshift accepts and enforces it), and inventory degrades with a
+  named grant fix when an IAM-minted user cannot read `svv_table_info`. The
+  five safety families are extended to the new connector against a stateful
+  fake (`tests/fakes/redshift.py`), and `references/redshift.md` documents
+  the cost story, including that Serverless bills metadata activity. The
+  whole loop was verified live against a Redshift Serverless workgroup on
+  both auth paths, including a keyless `method: iam` dbt build.
+
+### Changed
+
+- The relationship-verification overlap probe now measures orphans with a
+  LEFT JOIN against the DISTINCT parent keys instead of a `NOT EXISTS`
+  projected into the SELECT list, which Redshift refuses outright (XX000:
+  correlated subquery pattern not supported). Same aggregate-only result on
+  every connector, same fanout safety, one dialect fewer surprises.
+
 ## [1.1.1] - 2026-07-12
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,38 @@ the ordinary `DATABRICKS_TOKEN` discovery path; the host, client id,
 warehouse, and catalog are environment variables, not secrets, for the same
 debuggability reason as the BigQuery job.
 
+## Live Redshift integration tests
+
+The same `tests/integration/` directory carries the Redshift suite:
+connection discovery (the AWS chain against a pinned Serverless workgroup,
+or the `REDSHIFT_*` environment), the compute-seconds handshake with the
+Serverless wake-minimum floor, the over-ceiling refusal, PII
+flag-not-surface, a firewalled query, and a dbt build into the dedicated dev
+schema as the `dbt_dev` user.
+
+One-time setup is automated by `scripts/setup_redshift_ci.sh` (run by a
+maintainer with AWS admin credentials, psql, and gh): the smallest Serverless
+namespace and workgroup (8 RPUs), a daily RPU-hours usage limit with a
+query-deactivating breach action as the hard cost backstop, the seeded `app`
+schema plus the `dex_ro` and `dbt_dev` users (the dbt user carries a durable
+`statement_timeout`, the per-statement cap dex cannot inject through
+dbt-redshift), an IAM role whose trust policy accepts only GitHub OIDC tokens
+minted for this repo's `redshift-integration` environment, and the
+environment with its variables and the rotated dbt password secret.
+
+Run the suite locally with your own AWS credentials:
+
+```
+DEX_TEST_REDSHIFT_WORKGROUP=dex-ci DEX_TEST_REDSHIFT_DATABASE=dev \
+    uv run pytest tests/integration -q -m redshift
+```
+
+The transform tests additionally need `DEX_TEST_REDSHIFT_HOST` and
+`DEX_TEST_REDSHIFT_DEV_PASSWORD` (they exercise the env-var password
+rendering; the engine itself stays keyless). In CI the suite runs from
+`.github/workflows/integration.yml` on an assumed OIDC role: keyless, never
+a merge gate.
+
 ## Live PostgreSQL integration tests
 
 The same `tests/integration/` directory carries the Postgres suite:
@@ -291,6 +323,13 @@ credentials:
   transient `DEX_CI` scratch database, and a key-pair dev user with a local
   `dex-ci` connection for running the live suite while developing), automated
   by `scripts/setup_snowflake_ci.sh`.
+- **Redshift integration CI:** one-time AWS and GitHub setup (the smallest
+  Serverless workgroup with a daily RPU-hours usage limit, the seeded `app`
+  schema with the `dex_ro`/`dbt_dev` users, an OIDC-trusted IAM role pinned
+  to this repo's `redshift-integration` environment, and the environment
+  with its variables and the rotated dbt password secret), automated by
+  `scripts/setup_redshift_ci.sh`; background in `CONTRIBUTING.md` under
+  "Live Redshift integration tests".
 - **Databricks integration CI:** one-time Databricks and GitHub setup (the
   `dex-ci` service principal with an account-level GitHub OIDC federation
   policy pinned to this repo's `databricks-integration` environment, the

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ experience first and treat the benchmark as a floor, not the goal.
 
 ## Connectors
 
-- Cloud warehouse: **Snowflake**, **BigQuery**, **Databricks**.
+- Cloud warehouse: **Snowflake**, **BigQuery**, **Databricks**, **Amazon Redshift** (Serverless-first).
 - Embedded analytical: **DuckDB**.
 - Operational database: **Postgres**.
 
@@ -109,16 +109,19 @@ Credentials are discovered, never asked for: BigQuery through Application
 Default Credentials (`gcloud auth application-default login`), Snowflake
 through `connections.toml`, `SNOWFLAKE_*` env, or a dbt profile, Databricks
 through the SDK's unified chain (`databricks auth login`, `DATABRICKS_*` env,
-or a dbt profile), Postgres through `pg_service.conf`, `DATABASE_URL`, the
-`PG*` environment, or a dbt profile. Every scan is estimated and confirmed
+or a dbt profile), Redshift through the AWS credential chain (a pinned
+Serverless workgroup mints IAM temporary database credentials) or `REDSHIFT_*`
+env, Postgres through `pg_service.conf`, `DATABASE_URL`, the `PG*`
+environment, or a dbt profile. Every scan is estimated and confirmed
 before it spends, capped server-side (`maximum_bytes_billed` on BigQuery; a
-per-statement statement timeout on Snowflake, Databricks, and Postgres, whose
-budgets are warehouse-seconds with credits or DBUs alongside and
-database-seconds respectively), and recorded in a local spend ledger.
+per-statement statement timeout on Snowflake, Databricks, Redshift, and
+Postgres, whose budgets are warehouse-seconds with credits or DBUs alongside,
+compute-seconds with RPU-hours alongside, and database-seconds respectively),
+and recorded in a local spend ledger.
 
 ### Upcoming Connectors
 
-- Cloud warehouse: **AWS Redshift**, **Microsoft Fabric**
+- Cloud warehouse: **Microsoft Fabric**
 
 ## The `exmergo-dex-core` package
 

--- a/evals/tests/test_wrapper.py
+++ b/evals/tests/test_wrapper.py
@@ -88,7 +88,13 @@ def test_defaults_to_duckdb_when_nothing_set(wrapper, tmp_path):
 def test_unknown_connector_falls_back_to_duckdb(wrapper, tmp_path):
     # A bad guess must not produce a bogus extra; installing duckdb lets the engine
     # emit its canonical "unknown connector" error instead.
-    assert wrapper._resolve_connector(["--connector", "redshift"], tmp_path) == "duckdb"
+    assert wrapper._resolve_connector(["--connector", "oracle"], tmp_path) == "duckdb"
+
+
+def test_redshift_resolves_to_its_own_extra(wrapper, tmp_path):
+    assert (
+        wrapper._resolve_connector(["--connector", "redshift"], tmp_path) == "redshift"
+    )
 
 
 def test_resolution_does_not_consume_forwarded_args(wrapper, tmp_path):

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -56,11 +56,17 @@ databricks = ["databricks-sql-connector>=3", "databricks-sdk>=0.30", "sqlglot>=2
 # Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
 # transform can build against a Postgres dev schema with one install.
 postgres = ["psycopg[binary]>=3", "sqlglot>=25", "dbt-postgres>=1.9"]
+# Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
+# transform can build against a Redshift dev schema with one install. boto3
+# rides alongside the driver: Serverless workgroup facts (endpoint, base
+# capacity) come from the control plane, and the driver mints IAM temporary
+# database credentials through the same chain.
+redshift = ["redshift-connector>=2.1", "boto3>=1.34", "sqlglot>=25", "dbt-redshift>=1.9"]
 # One command for users who want every connector at once (e.g. driving multiple
 # warehouses). Self-references the connector extras so their client lists stay
 # defined in exactly one place. Excludes dev, which is contributor tooling, not a
 # connector. The light default and the [duckdb] on-ramp are unchanged.
-all = ["exmergo-dex-core[bigquery,databricks,duckdb,postgres,snowflake]"]
+all = ["exmergo-dex-core[bigquery,databricks,duckdb,postgres,redshift,snowflake]"]
 dev = ["pytest>=8", "ruff==0.15.19"]
 
 [project.urls]
@@ -98,4 +104,5 @@ markers = [
   "snowflake: Snowflake-specific integration tests",
   "databricks: Databricks-specific integration tests",
   "postgres: PostgreSQL-specific integration tests",
+  "redshift: Redshift-specific integration tests",
 ]

--- a/packages/dex-core/src/exmergo_dex_core/adapters/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/__init__.py
@@ -1,4 +1,5 @@
-"""Connector adapters: DuckDB, BigQuery, Snowflake, Databricks, and Postgres.
+"""Connector adapters: DuckDB, BigQuery, Snowflake, Databricks, Postgres, and
+Redshift.
 
 ``get_adapter`` is the single entry point so callers never import a connector
 client directly; the client libraries stay behind their extras and are imported
@@ -19,6 +20,7 @@ _DIALECTS = {
     "snowflake": "snowflake",
     "databricks": "databricks",
     "postgres": "postgres",
+    "redshift": "redshift",
 }
 
 
@@ -45,6 +47,10 @@ def get_adapter(connector: str, **kwargs: Any):
         from .databricks import DatabricksAdapter
 
         return DatabricksAdapter(**kwargs)
+    if connector == "redshift":
+        from .redshift import RedshiftAdapter
+
+        return RedshiftAdapter(**kwargs)
     raise ValueError(f"unknown connector '{connector}'")
 
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
@@ -1,0 +1,1070 @@
+"""The Redshift adapter: compute-time billing over the Postgres catalog model.
+
+Amazon Redshift is Postgres-derived on the wire and in the catalog, but bills
+like a compute-time warehouse: Redshift Serverless charges RPU-hours whenever
+compute is active, with a 60-second minimum each time an idle workgroup wakes.
+So the guarded quantity is **seconds**, translated to RPU-hours (and dollars
+when ``redshift.rpu_price_usd`` is configured) through the workgroup's base
+capacity, and every billed statement is capped server-side by a
+``statement_timeout`` wound down to what remains of the budget, so a wrong
+estimate cannot overrun the ceiling: Redshift kills the statement. Actual
+spend is wall-clock seconds per statement, recorded to the ledger as
+``billed_seconds``. Provisioned clusters ride the same paths with seconds-only
+accounting (node-hours bill flat, so there is nothing to translate).
+
+Redshift has no dry-run, and on Serverless even ``EXPLAIN`` and catalog
+lookups count as billable activity (AWS bills every incoming query as user
+activity), so there is no genuinely free planner door to quote from. Estimates
+are therefore a documented heuristic: table bytes over a conservative
+capacity-scaled scan rate, floored once per command at the 60-second wake
+minimum on Serverless. The metadata paths (inventory, ``connect test``) stay
+ungated - they are engine-built catalog lookups measured in milliseconds - but
+``capabilities`` says plainly that touching an idle Serverless workgroup can
+incur the wake minimum.
+
+Profiling batches aggregates in single passes (COUNT(*), non-null counts,
+APPROXIMATE COUNT(DISTINCT), min/max only for engine-cleared safe columns):
+Redshift keeps no usable planner distincts, so approximate distincts ride the
+billed batch, and near-unique keys escalate to an exact COUNT(DISTINCT) inside
+the confirmed budget. There is no sampled-profiling knob: Redshift has no
+TABLESAMPLE, so the budget is the only bound.
+
+Read-only is enforced in depth: the SELECT-only guard in the redshift dialect
+on every data statement through one execution door, an adapter that issues no
+mutating statements (catalog SELECTs and session SETs only), a best-effort
+session read-only mode (probed, surfaced honestly when Redshift declines it),
+and the documented least-privilege grants.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from collections.abc import Callable
+from typing import Any
+
+from ..config import RedshiftTarget
+from ..envelope import Paradigm
+from ..guards.cost_guard import CostGate, OverCeilingError
+from ..guards.sql_guard import assert_select_only
+from .base import (
+    ColumnAggregate,
+    ColumnMeta,
+    ObjectMeta,
+    QueryResult,
+    blame,
+    json_safe,
+    name_list,
+)
+
+PARADIGM = "compute_time"
+DIALECT = "redshift"
+
+# Columns are profiled in batches so one statement against a very wide table
+# does not balloon (up to 4 expressions per column).
+_COLUMN_BATCH = 50
+
+# Redshift Serverless bills a minimum of 60 seconds of compute each time an
+# idle workgroup wakes. There is no API that says whether compute is currently
+# warm (and probing with a query is itself billable activity), so estimates on
+# Serverless carry this floor once per command, honestly labeled an upper
+# bound that actuals waive when compute was already active.
+_WAKE_MINIMUM_SECONDS = 60.0
+
+# The estimate heuristic: a deliberately conservative scan rate at the
+# reference capacity, scaled linearly by the workgroup's base RPUs (bigger
+# workgroups scan proportionally faster, so estimated seconds shrink while
+# estimated RPU-hours stay comparable).
+_REFERENCE_CAPACITY_RPUS = 8.0
+_BASE_SCAN_BYTES_PER_SECOND = 50 * 1024 * 1024
+
+# Every billed statement estimates at least this much.
+_MIN_STATEMENT_SECONDS = 1.0
+
+# SVV_TABLE_INFO reports size in 1 MB blocks.
+_TABLE_INFO_BLOCK_BYTES = 1024 * 1024
+
+# Types where distinct counts and min/max are invalid or meaningless: only a
+# non-null count is computed. Matched against SVV_COLUMNS data_type
+# (lowercase). VARBYTE surfaces as "binary varying" in the information-schema
+# vocabulary; both spellings are kept in case the catalog changes its mind.
+_DEGRADED_TYPE_PREFIXES = (
+    "super",
+    "varbyte",
+    "binary varying",
+    "geometry",
+    "geography",
+    "hllsketch",
+)
+
+# Schemas that are never sources and never count as visible.
+_SYSTEM_SCHEMAS = ("information_schema", "catalog_history", "pg_auto_copy")
+
+# redshift_connector reports column types as bare Postgres OIDs (verified
+# live: 1043, 20, ...); the common ones get their names back for the
+# envelope, unknowns stay the numeric token.
+_OID_TYPE_NAMES = {
+    16: "bool",
+    20: "int8",
+    21: "int2",
+    23: "int4",
+    25: "text",
+    700: "float4",
+    701: "float8",
+    1042: "bpchar",
+    1043: "varchar",
+    1082: "date",
+    1083: "time",
+    1114: "timestamp",
+    1184: "timestamptz",
+    1266: "timetz",
+    1700: "numeric",
+    2950: "uuid",
+    3802: "super",
+}
+
+_ESTIMATE_QUALITY_NOTE = (
+    "Redshift has no dry-run: the estimate is a heuristic (table bytes over a "
+    "conservative capacity-scaled scan rate); the confirmed budget is still "
+    "hard-enforced by a per-statement server-side statement_timeout"
+)
+
+_SIZE_FACTS_NOTE = (
+    "this user may not read SVV_TABLE_INFO, so table sizes and row counts are "
+    "unknown and scan estimates degrade to minimums (the budget still binds "
+    "via the server-side statement_timeout); grant it with: GRANT SELECT ON "
+    "svv_table_info TO <user>"
+)
+
+
+class RedshiftConnectionError(Exception):
+    """Raised when a queried object cannot be resolved in the configured
+    scope. The message always names the fix, never a credential."""
+
+
+class RedshiftAdapter:
+    """Holds one Redshift connection plus the cost gate for one command.
+
+    ``connection`` is injectable (class DI) so unit tests drive a fake; the
+    real connection is built by ``connect.py`` from discovered parameters
+    (autocommit, ``application_name=dex``). ``compute`` carries the facts
+    connect.py resolved from the control plane (serverless vs provisioned,
+    workgroup, base capacity); the adapter itself never talks to boto3, so
+    the fake stays a pure database double. ``clock`` is injectable so the
+    fake can simulate statement duration; it is what actual billed seconds
+    are measured with.
+    """
+
+    name = "redshift"
+    dialect = DIALECT
+    paradigm = Paradigm.COMPUTE_TIME
+
+    def __init__(
+        self,
+        *,
+        connection: Any,
+        cost_gate: CostGate,
+        target: RedshiftTarget | None = None,
+        compute: dict | None = None,
+        auth_method: str = "unknown",
+        scope_origin: str | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self._conn = connection
+        self.cost_gate = cost_gate
+        self.target = target or RedshiftTarget()
+        # {"kind": "serverless"|"provisioned", "workgroup": str|None,
+        #  "base_capacity_rpus": float|None}; None means connect.py could not
+        # resolve the control-plane facts (translation degrades, gating holds).
+        self.compute = compute or {}
+        self.auth_method = auth_method
+        # What the scope entries in the target came from, so a refusal names the
+        # thing the user has to go edit: a per-command flag or the committed
+        # allowlist. `narrow_target` has already collapsed the two by the time
+        # the adapter sees them, and the fix differs entirely.
+        self._scope_origin = scope_origin or "redshift.schemas in .dex/config.yml"
+        self._clock = clock
+        # Imported lazily (the caller constructed the connection, so the
+        # library is present); the error types drive refusal translation.
+        from redshift_connector import error as rs_errors
+
+        self._rs_errors = rs_errors
+        # Catalog results are cached per command: the estimate pass and the
+        # confirmed run share table facts, and each lookup is cheap but a
+        # round-trip.
+        self._objects: dict[str, dict] = {}
+        self._columns: dict[str, list[ColumnMeta]] = {}
+        self._exact_rows: dict[str, int] = {}
+        self._inventory_loaded = False
+        self._resolved_schemas: list[str] | None = None
+        self._visible_schemas: set[str] | None = None
+        self._database: str | None = None
+        self._notes: dict[str, list[str]] = {}
+        # The 60s wake minimum is charged once per command, by whichever
+        # billed statement runs first; only Serverless bills it.
+        self._wake_floor_pending = self._is_serverless()
+        self._wake_floor_quoted = False
+        self._session_prepared = False
+        self._session_read_only: bool | None = None
+        self._size_facts_denied = False
+
+    # --- capabilities (free-tier metadata) --------------------------------------
+
+    def capabilities(self) -> dict[str, object]:
+        # The probe round-trips to the server (current facts, not cached
+        # ones), so a stale or underprivileged credential fails here instead
+        # of reporting a healthy connection.
+        probe = self._catalog(
+            "SELECT current_database() AS db, version() AS server_version"
+        )[0]
+        self._database = str(probe["db"])
+        cost = self.cost_gate.cost()
+        serverless = self._is_serverless()
+        caps: dict[str, object] = {
+            "connector": self.name,
+            "dialect": self.dialect,
+            "read_only": True,
+            # Honest: Redshift may decline the session read-only mode; the
+            # SELECT-only guard and grants still hold either way.
+            "session_read_only": bool(self._session_read_only),
+            "paradigm": self.paradigm.value,
+            "auth_method": self.auth_method,
+            "database": self._database,
+            "server_version": self._version_token(str(probe["server_version"])),
+            "schema_count": len(self._schema_scope()),
+            "compute": {
+                "kind": self.compute.get("kind", "unknown"),
+                "workgroup": self.compute.get("workgroup"),
+                "base_capacity_rpus": self.compute.get("base_capacity_rpus"),
+            },
+            "required_grants": [
+                "USAGE on source schemas and SELECT on their tables",
+                "write only on the dedicated dbt dev schema (transform build)",
+            ],
+        }
+        budget: dict[str, object] = {
+            "ceiling_seconds": cost.ceiling,
+            "session_spent_today_seconds": self.cost_gate.session_spent,
+        }
+        if cost.ceiling is not None:
+            rpu_hours = self._to_rpu_hours(cost.ceiling)
+            if rpu_hours is not None:
+                budget["ceiling_rpu_hours"] = rpu_hours
+        caps["budget"] = budget
+        if serverless:
+            caps["warnings"] = [
+                "Redshift Serverless bills every incoming query as compute "
+                "activity, with a 60-second minimum each time an idle "
+                "workgroup wakes; even metadata commands can incur that "
+                "minimum when compute is idle"
+            ]
+        return caps
+
+    @staticmethod
+    def _version_token(raw: str) -> str:
+        # version() reads like "PostgreSQL 8.0.2 ... Redshift 1.0.12345";
+        # surface the Redshift token when present, else the first word pair.
+        # The driver hands the string back NUL-terminated (verified live), so
+        # strip control characters before tokenizing.
+        raw = raw.replace("\x00", " ").strip()
+        lowered = raw.lower()
+        if "redshift" in lowered:
+            tail = raw[lowered.index("redshift") :]
+            return " ".join(tail.split()[:2])
+        return " ".join(raw.split()[:2])
+
+    # --- introspection (cheap catalog metadata; no scans) -----------------------
+
+    def list_objects(self, *, include_views: bool = True) -> list[ObjectMeta]:
+        self._load_inventory()
+        objects = [
+            self._object_meta(entry)
+            for entry in self._objects.values()
+            if include_views or entry["object_type"] != "view"
+        ]
+        objects.sort(key=lambda o: o.identifier)
+        return objects
+
+    def table_metadata(self, identifier: str) -> tuple[ObjectMeta, list[ColumnMeta]]:
+        self._load_inventory()
+        entry = self._objects.get(identifier)
+        if entry is None:
+            raise RedshiftConnectionError(
+                f"object '{identifier}' not found in the configured scope; "
+                "check redshift.schemas in .dex/config.yml (identifiers are "
+                "database.schema.table against the connected database)"
+            )
+        return self._object_meta(entry), list(self._columns.get(identifier, []))
+
+    def table_notes(self, identifier: str) -> list[str]:
+        """Data-quality notes the profiling run accumulated for one object
+        (skipped escalations, missing size facts). Merged into the dataset's
+        ``data_quality`` by the profile engine."""
+
+        notes = list(self._notes.get(identifier, []))
+        if self._size_facts_denied:
+            notes.append(_SIZE_FACTS_NOTE)
+        return notes
+
+    def _load_inventory(self) -> None:
+        if self._inventory_loaded:
+            return
+        database = self._current_database()
+        # The resolved scopes, not the raw config: an entry that names nothing is
+        # refused before this filter drops it, which is the silent-empty-inventory
+        # bug the Postgres-shaped connectors are most exposed to. The scope is
+        # pushed into the census SQL (each name proven to exist by resolution,
+        # quote-escaped) so a one-schema scope in a wide warehouse does not
+        # transfer every other schema's rows just to drop them client-side;
+        # the client-side check stays as the belt to that suspender.
+        allowed = set(self._schema_scope()) if self.target.schemas else set()
+        scope_names = ", ".join(f"'{_escape_literal(s)}'" for s in sorted(allowed))
+
+        def scoped(column: str, lead: str = " AND") -> str:
+            return f"{lead} {column} IN ({scope_names})" if scope_names else ""
+
+        # pg_class is the object census (SVV_TABLE_INFO omits tables that hold
+        # no data, so it cannot be the census without silently losing empty
+        # tables); SVV_TABLE_INFO then contributes size and row facts.
+        # Interpolated parts are fixed system-schema names and resolved,
+        # escaped scope names, never agent values.
+        rows = self._catalog(
+            "SELECT n.nspname AS schema_name, c.relname AS object_name, "  # noqa: S608
+            "c.relkind AS kind "
+            "FROM pg_catalog.pg_class c "
+            "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE c.relkind IN ('r', 'v') "
+            f"AND {_schema_filter('n.nspname')}{scoped('n.nspname')}"
+        )
+        for row in rows:
+            schema = str(row["schema_name"])
+            if allowed and schema not in allowed:
+                continue
+            name = str(row["object_name"])
+            # Materialized views surface as a view plus an mv_tbl__ backing
+            # table; the backing table is an implementation detail, not a
+            # source object.
+            if name.startswith("mv_tbl__"):
+                continue
+            object_type = "view" if str(row["kind"]) == "v" else "table"
+            identifier = f"{database}.{schema}.{name}"
+            self._objects[identifier] = {
+                "identifier": identifier,
+                "object_type": object_type,
+                "schema": schema,
+                "name": name,
+                "row_count": None,
+                "byte_size": None,
+                "column_count": 0,
+            }
+        # Size and row facts: catalog-maintained, no scan. Absence means the
+        # table holds no data (SVV_TABLE_INFO omits empty tables by design).
+        # An auto-created IAM user can lack SELECT on the view (verified
+        # live); inventory then degrades to sizeless entries with a note
+        # rather than failing, and the server-side statement_timeout is what
+        # keeps the now-floored estimates from ever overrunning a budget.
+        try:
+            size_predicate = scoped('"schema"', lead=" WHERE")
+            size_rows = self._catalog(
+                'SELECT "schema" AS schema_name, "table" AS table_name, '  # noqa: S608
+                f"size, tbl_rows FROM svv_table_info{size_predicate}"
+            )
+        except Exception:
+            self._size_facts_denied = True
+            size_rows = []
+        for row in size_rows:
+            identifier = f"{database}.{row['schema_name']}.{row['table_name']}"
+            entry = self._objects.get(identifier)
+            if entry is None:
+                continue
+            size = row.get("size")
+            tbl_rows = row.get("tbl_rows")
+            entry["byte_size"] = (
+                int(size) * _TABLE_INFO_BLOCK_BYTES if size is not None else None
+            )
+            entry["row_count"] = int(float(tbl_rows)) if tbl_rows is not None else None
+        if not self._size_facts_denied:
+            for entry in self._objects.values():
+                if entry["object_type"] == "table" and entry["byte_size"] is None:
+                    entry["row_count"] = 0
+                    entry["byte_size"] = 0
+        # SVV_COLUMNS covers ordinary and late-binding relations alike, which
+        # pg_attribute cannot for late-binding views.
+        columns = self._catalog(
+            "SELECT table_schema AS schema_name, table_name AS object_name, "  # noqa: S608
+            "column_name, data_type, is_nullable "
+            "FROM svv_columns "
+            f"WHERE {_schema_filter('table_schema')}{scoped('table_schema')} "
+            "ORDER BY table_schema, table_name, ordinal_position"
+        )
+        for row in columns:
+            identifier = f"{database}.{row['schema_name']}.{row['object_name']}"
+            entry = self._objects.get(identifier)
+            if entry is None:
+                continue
+            metas = self._columns.setdefault(identifier, [])
+            metas.append(
+                ColumnMeta(
+                    name=str(row["column_name"]),
+                    data_type=str(row["data_type"]),
+                    nullable=str(row["is_nullable"]).upper() != "NO",
+                    ordinal=len(metas),
+                )
+            )
+            entry["column_count"] = len(metas)
+        self._inventory_loaded = True
+
+    def _object_meta(self, entry: dict) -> ObjectMeta:
+        # An exact count from a profiling scan supersedes the catalog estimate
+        # for the rest of the command, so uniqueness proofs and drift verdicts
+        # compare against real rows, not tbl_rows.
+        row_count = self._exact_rows.get(entry["identifier"], entry["row_count"])
+        return ObjectMeta(
+            identifier=entry["identifier"],
+            object_type=entry["object_type"],
+            schema=entry["schema"],
+            name=entry["name"],
+            row_count=row_count,
+            byte_size=entry["byte_size"],
+            column_count=entry["column_count"],
+        )
+
+    def _current_database(self) -> str:
+        if self._database is None:
+            row = self._catalog("SELECT current_database() AS db")[0]
+            self._database = str(row["db"])
+        return self._database
+
+    def _schema_scope(self) -> list[str]:
+        """Every source schema this command reads, proven to exist.
+
+        Resolution is one catalog SELECT (no scan) and cached for the command.
+        It runs before anything is estimated, because a scope that resolves to
+        nothing and silently falls back to the whole allowlist is a
+        cost-safety bug: the estimate the user confirms would cover tables
+        they never named.
+        """
+
+        if self._resolved_schemas is None:
+            self._resolved_schemas = self._resolve_schemas()
+        return self._resolved_schemas
+
+    def _resolve_schemas(self) -> list[str]:
+        visible = self._schemas()
+        if not self.target.schemas:
+            return sorted(visible)
+        with blame(self._scope_origin, RedshiftConnectionError):
+            return sorted(
+                {self._resolve_schema(entry, visible) for entry in self.target.schemas}
+            )
+
+    def _resolve_schema(self, entry: str, visible: set[str]) -> str:
+        """One scope entry, proven to exist. A Redshift scope is always a bare
+        schema in the connected database (dbt refuses cross-database
+        references outright), so there is nothing to qualify and nothing to
+        disambiguate."""
+
+        token = entry.strip()
+        if not token:
+            raise RedshiftConnectionError("empty scope entry")
+        if "." in token:
+            raise RedshiftConnectionError(
+                f"scope '{entry}' has too many parts; a Redshift source scope is "
+                "a bare <schema> in the connected database "
+                f"({self._current_database()}), never a database or a table"
+            )
+        if token not in visible:
+            raise RedshiftConnectionError(
+                f"scope '{entry}' names no schema in database "
+                f"{self._current_database()}; schemas there: "
+                f"{name_list(sorted(visible))}"
+            )
+        return token
+
+    def _schemas(self) -> set[str]:
+        """Every non-system schema in the connected database. Cheap (one
+        catalog SELECT, no scan), cached, and the live credential probe."""
+
+        if self._visible_schemas is None:
+            rows = self._catalog(
+                "SELECT nspname FROM pg_catalog.pg_namespace "  # noqa: S608
+                f"WHERE {_schema_filter('nspname')}"
+            )
+            self._visible_schemas = {str(row["nspname"]) for row in rows}
+        return self._visible_schemas
+
+    def missing_dev_namespaces(self, schema: str, *, role: str) -> list[str]:
+        """What stops ``role`` from building into the dev schema. Catalog
+        lookups and privilege predicates, no scan.
+
+        dbt creates the schema itself, so its absence is not fatal on its own:
+        what is fatal is the privilege to create it. ``role`` is the user in
+        the rendered profile rather than the connected user, because dex may
+        legitimately read as a read-only user while dbt writes as another, and
+        Redshift will answer a privilege question about any user.
+        """
+
+        if not self._user_exists(role):
+            raise RedshiftConnectionError(
+                f"the dbt user {role} does not exist in database "
+                f"{self._current_database()}; create it, or point the profile at "
+                "a user that exists"
+            )
+        who = f"'{_escape_literal(role)}'"
+        if schema not in self._schemas():
+            # dbt will issue CREATE SCHEMA IF NOT EXISTS on the first build,
+            # which needs CREATE on the database. Absent that, the build dies
+            # with a bare permission error naming neither the schema nor the
+            # grant.
+            row = self._catalog(
+                f"SELECT has_database_privilege({who}, current_database(), "
+                "'CREATE') AS may_create"
+            )[0]
+            return [] if _truthy(row["may_create"]) else [f'dev_schema "{schema}"']
+        where = f"{who}, '{_escape_literal(schema)}'"
+        row = self._catalog(
+            f"SELECT has_schema_privilege({where}, 'CREATE') AS may_create, "
+            f"has_schema_privilege({where}, 'USAGE') AS may_use"
+        )[0]
+        missing = [
+            privilege
+            for privilege, granted in (
+                ("USAGE", row["may_use"]),
+                ("CREATE", row["may_create"]),
+            )
+            if not _truthy(granted)
+        ]
+        return [f'{", ".join(missing)} on dev_schema "{schema}"'] if missing else []
+
+    def _user_exists(self, user: str) -> bool:
+        rows = self._catalog(
+            "SELECT 1 AS present FROM pg_catalog.pg_user "  # noqa: S608
+            f"WHERE usename = '{_escape_literal(user)}'"
+        )
+        return bool(rows)
+
+    # --- the RPU translation ------------------------------------------------------
+
+    def _is_serverless(self) -> bool:
+        return self.compute.get("kind") == "serverless"
+
+    def _to_rpu_hours(self, seconds: float) -> float | None:
+        """Seconds of active compute translated to RPU-hours through the
+        workgroup's base capacity, or ``None`` when the control-plane facts
+        were unavailable or the target is provisioned (flat node-hours have
+        nothing to translate)."""
+
+        capacity = self.compute.get("base_capacity_rpus")
+        if not self._is_serverless() or not capacity:
+            return None
+        return round(seconds * float(capacity) / 3600.0, 6)
+
+    def describe_estimate(
+        self, estimate: float, per_table: dict[str, float] | None = None
+    ) -> dict:
+        """The compute-time handshake payload: seconds are the binding number,
+        RPU-hours (and dollars when the price is configured) ride alongside as
+        the familiar translation."""
+
+        data: dict[str, object] = {
+            "estimated_seconds": estimate,
+            "estimate_quality": "heuristic",
+            "hint": (
+                "review the estimate, then re-run with --confirm --budget "
+                "<seconds> (the ceiling in compute-seconds; the same number "
+                "becomes the server-side statement_timeout)"
+            ),
+            "notes": [_ESTIMATE_QUALITY_NOTE],
+        }
+        if self._wake_floor() > 0:
+            data["notes"] = [
+                _ESTIMATE_QUALITY_NOTE,
+                "includes the 60-second Serverless wake minimum once (an "
+                "upper bound: actuals waive it when compute was already "
+                "active)",
+            ]
+        if per_table:
+            data["per_table_seconds"] = per_table
+        rpu_hours = self._to_rpu_hours(estimate)
+        if rpu_hours is not None:
+            data["estimated_rpu_hours"] = rpu_hours
+            data["rpu_rate"] = {
+                "workgroup": self.compute.get("workgroup"),
+                "base_capacity_rpus": self.compute.get("base_capacity_rpus"),
+                # Serverless can scale above base capacity, so the translation
+                # is a floor, not a promise.
+                "approximate": True,
+            }
+            if self.target.rpu_price_usd is not None:
+                data["estimated_usd"] = round(rpu_hours * self.target.rpu_price_usd, 4)
+        return data
+
+    def spend_display(self) -> dict:
+        """RPU translation of actual seconds, merged into ``data.spend``."""
+
+        summary: dict[str, object] = {}
+        rpu_hours = self._to_rpu_hours(self.cost_gate.spend_summary()["seconds_billed"])
+        if rpu_hours is not None:
+            summary["rpu_hours_billed"] = rpu_hours
+            if self.target.rpu_price_usd is not None:
+                summary["usd_billed"] = round(rpu_hours * self.target.rpu_price_usd, 4)
+        return summary
+
+    # --- estimation (feeds the confirm handshake; no scans) -----------------------
+
+    def profile_estimate(
+        self, identifiers: list[str]
+    ) -> tuple[float, dict[str, float]]:
+        """The heuristic compute-seconds estimate for profiling: per table,
+        its bytes over the capacity-scaled scan rate times the number of
+        aggregate batches; plus the 60-second wake minimum once on
+        Serverless. Everything comes from catalog metadata."""
+
+        per_table: dict[str, float] = {}
+        for identifier in identifiers:
+            meta, columns = self.table_metadata(identifier)
+            batches = max((len(columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
+            per_table[identifier] = batches * self._scan_seconds(meta.byte_size)
+        return sum(per_table.values()) + self._estimate_floor(), per_table
+
+    def query_estimate(self, sql: str) -> float:
+        """The heuristic estimate for one firewall-approved query: the summed
+        bytes of every referenced table over the scan rate, plus the wake
+        minimum once on Serverless."""
+
+        checked = assert_select_only(sql, dialect=self.dialect)
+        return self._statement_estimate(checked) + self._estimate_floor()
+
+    def _statement_estimate(self, sql: str) -> float:
+        # Unknown or empty referenced tables contribute nothing; _scan_seconds
+        # floors the zero-byte case to the per-statement minimum.
+        total_bytes = 0
+        self._load_inventory()
+        for identifier in self._referenced_tables(sql):
+            entry = self._objects.get(identifier)
+            if entry and entry["byte_size"] is not None:
+                total_bytes += entry["byte_size"]
+        return self._scan_seconds(total_bytes)
+
+    def _scan_seconds(self, byte_size: int | None) -> float:
+        if not byte_size:
+            return _MIN_STATEMENT_SECONDS
+        # Bigger workgroups scan proportionally faster; provisioned clusters
+        # (no capacity fact) use the reference rate unscaled.
+        capacity = self.compute.get("base_capacity_rpus")
+        factor = (
+            max(float(capacity) / _REFERENCE_CAPACITY_RPUS, 1.0) if capacity else 1.0
+        )
+        rate = _BASE_SCAN_BYTES_PER_SECOND * factor
+        return max(byte_size / rate, _MIN_STATEMENT_SECONDS)
+
+    def _wake_floor(self) -> float:
+        """60 once per command on Serverless (each wake bills a 60-second
+        minimum and warmth is unknowable without spending), else 0."""
+
+        return _WAKE_MINIMUM_SECONDS if self._wake_floor_pending else 0.0
+
+    def _estimate_floor(self) -> float:
+        """The wake minimum's share of an estimate: included exactly once per
+        command. A command that runs many statements wakes compute at most
+        once, so a sum of per-statement estimates (maintain sweeps a probe
+        per table) must not multiply the floor into it (verified live: a
+        twelve-probe sweep quoted 738 seconds of which 720 were floors)."""
+
+        if self._wake_floor() <= 0 or self._wake_floor_quoted:
+            return 0.0
+        self._wake_floor_quoted = True
+        return _WAKE_MINIMUM_SECONDS
+
+    def _referenced_tables(self, sql: str) -> set[str]:
+        try:
+            import sqlglot
+            from sqlglot import expressions as sqlglot_exp
+
+            parsed = sqlglot.parse_one(sql, read=self.dialect)
+        except Exception:
+            return set()
+        database = self._current_database()
+        identifiers = set()
+        for table in parsed.find_all(sqlglot_exp.Table):
+            parts = [p for p in (table.catalog, table.db, table.name) if p]
+            if len(parts) == 2:
+                parts.insert(0, database)
+            identifiers.add(".".join(parts))
+        return identifiers
+
+    # --- profiling (billed; every statement estimated and gated) ----------------
+
+    def column_aggregates(
+        self,
+        identifier: str,
+        columns: list[ColumnMeta],
+        *,
+        safe_min_max: set[str] | None = None,
+    ) -> list[ColumnAggregate]:
+        safe = safe_min_max or set()
+        meta, _ = self.table_metadata(identifier)
+        results: list[ColumnAggregate] = []
+        for start in range(0, len(columns), _COLUMN_BATCH):
+            batch = columns[start : start + _COLUMN_BATCH]
+            sql, plan = self._build_aggregate_sql(identifier, batch, safe)
+            rows, labels = self._execute(
+                sql, estimate=self._scan_seconds(meta.byte_size)
+            )
+            values = dict(zip(labels, rows[0], strict=True))
+            self._exact_rows[identifier] = int(values["n_total"])
+            results.extend(self._read_aggregates(values, plan))
+        return results
+
+    def _build_aggregate_sql(
+        self,
+        identifier: str,
+        columns: list[ColumnMeta],
+        safe: set[str],
+    ) -> tuple[str, list[tuple[int, ColumnMeta, bool, bool]]]:
+        # One aggregate statement per batch, a single pass: COUNT(*) once,
+        # then per column a non-null count, an approximate distinct (HLL),
+        # and min/max only where allowed. Pure (no connection), so the
+        # SELECT-only property is testable offline. Degraded types get the
+        # non-null count only: a distinct count over serialized SUPER or
+        # geometry values is not a meaningful cardinality even where the
+        # server accepts it (verified live: it does), and MIN/MAX would
+        # carry values.
+        select_parts = ["COUNT(*) AS n_total"]
+        plan: list[tuple[int, ColumnMeta, bool, bool]] = []
+        for i, col in enumerate(columns):
+            qcol = _quote_ident(col.name)
+            degraded = self._is_degraded(col.data_type)
+            select_parts.append(f"COUNT({qcol}) AS nn_{i}")
+            wants_distinct = not degraded
+            if wants_distinct:
+                # HLL(), not APPROXIMATE COUNT(DISTINCT): the same estimator,
+                # but Redshift refuses more than 3 APPROXIMATE COUNT branches
+                # per statement (verified live) while HLL() carries no such
+                # limit, so a wide batch stays a single pass.
+                select_parts.append(f"HLL({qcol}) AS nd_{i}")
+            wants_min_max = (col.name in safe) and not degraded
+            if wants_min_max:
+                select_parts.append(f"MIN({qcol}) AS mn_{i}")
+                select_parts.append(f"MAX({qcol}) AS mx_{i}")
+            plan.append((i, col, wants_distinct, wants_min_max))
+        # Interpolated parts are quoted identifiers and fixed aggregate
+        # keywords, never values; the result is guarded as a read-only SELECT.
+        sql = f"SELECT {', '.join(select_parts)} FROM {self._quote(identifier)}"  # noqa: S608
+        return assert_select_only(sql, dialect=self.dialect), plan
+
+    @staticmethod
+    def _is_degraded(data_type: str) -> bool:
+        return data_type.lower().startswith(_DEGRADED_TYPE_PREFIXES)
+
+    @staticmethod
+    def _read_aggregates(
+        values: dict,
+        plan: list[tuple[int, ColumnMeta, bool, bool]],
+    ) -> list[ColumnAggregate]:
+        n_total = int(values["n_total"])
+        aggregates: list[ColumnAggregate] = []
+        for i, col, wants_distinct, wants_min_max in plan:
+            nn = values.get(f"nn_{i}")
+            null_fraction = (
+                (1 - int(nn) / n_total) if nn is not None and n_total > 0 else None
+            )
+            distinct = (
+                int(values[f"nd_{i}"]) if wants_distinct and n_total > 0 else None
+            )
+            # An approximate distinct is never a uniqueness verdict on its
+            # own; the near-unique escalation proves keys with an exact scan.
+            aggregates.append(
+                ColumnAggregate(
+                    name=col.name,
+                    null_fraction=null_fraction,
+                    distinct_count=distinct,
+                    is_unique=None,
+                    min_value=(
+                        json_safe(values.get(f"mn_{i}")) if wants_min_max else None
+                    ),
+                    max_value=(
+                        json_safe(values.get(f"mx_{i}")) if wants_min_max else None
+                    ),
+                )
+            )
+        return aggregates
+
+    def exact_distinct_counts(
+        self, identifier: str, columns: list[str]
+    ) -> dict[str, int]:
+        """Exact COUNT(DISTINCT) for near-unique columns, spent only within the
+        already-confirmed budget: when the remaining budget cannot cover the
+        extra scan, return nothing and let uniqueness verdicts stay
+        approximate. A metered adapter never self-escalates past its ceiling.
+        """
+
+        if not columns:
+            return {}
+        meta, _ = self.table_metadata(identifier)
+        # The escalation can be a command's first billed statement (maintain
+        # grain runs key checks before any probe), so the pending Serverless
+        # wake minimum rides the charge; on refusal it stays pending.
+        estimate = self._scan_seconds(meta.byte_size) + self._wake_floor()
+        if not self.cost_gate.try_charge(estimate):
+            self._note(
+                identifier,
+                "distinct-count escalation skipped: the remaining budget could "
+                "not cover the extra scan; uniqueness verdicts stay approximate",
+            )
+            return {}
+        self._consume_wake_floor()
+        # COUNT(*) rides along so the same scan also upgrades the catalog's
+        # row estimate to an exact count (grain verdicts compare against it).
+        select_parts = ["COUNT(*) AS n_total"] + [
+            f"COUNT(DISTINCT {_quote_ident(name)}) AS d_{i}"
+            for i, name in enumerate(columns)
+        ]
+        sql = assert_select_only(
+            f"SELECT {', '.join(select_parts)} FROM {self._quote(identifier)}",  # noqa: S608
+            dialect=self.dialect,
+        )
+        rows, labels = self._run(sql)
+        values = dict(zip(labels, rows[0], strict=True))
+        self._exact_rows[identifier] = int(values["n_total"])
+        return {name: int(values[f"d_{i}"]) for i, name in enumerate(columns)}
+
+    # --- execution (the single billed door) --------------------------------------
+
+    def run_query(
+        self,
+        sql: str,
+        *,
+        max_rows: int,
+        timeout_seconds: float,
+    ) -> QueryResult:
+        """Execute one firewall-approved SELECT, bounded in rows, wall time,
+        and compute-seconds (client preflight plus the server-side statement
+        timeout, whichever is tighter)."""
+
+        checked = assert_select_only(sql, dialect=self.dialect)
+        self.cost_gate.charge(
+            self._statement_estimate(checked) + self._consume_wake_floor()
+        )
+        rows, labels, types = self._run_rows(
+            checked, timeout_seconds=timeout_seconds, fetch_rows=max_rows + 1
+        )
+        return QueryResult(
+            columns=labels,
+            types=types,
+            cells=[[json_safe(v) for v in row] for row in rows[:max_rows]],
+            truncated=len(rows) > max_rows,
+        )
+
+    def _execute(self, sql: str, *, estimate: float) -> tuple[list, list[str]]:
+        """SELECT-only guard, heuristic charge, then the timeout-capped run."""
+
+        assert_select_only(sql, dialect=self.dialect)
+        self.cost_gate.charge(estimate + self._consume_wake_floor())
+        return self._run(sql)
+
+    def _run(self, sql: str) -> tuple[list, list[str]]:
+        rows, labels, _types = self._run_rows(sql)
+        return rows, labels
+
+    def _run_rows(
+        self,
+        sql: str,
+        *,
+        timeout_seconds: float | None = None,
+        fetch_rows: int | None = None,
+    ) -> tuple[list, list[str], list[str]]:
+        """The single billed door past the gate: the server-side
+        statement_timeout is wound down to what remains of the budget (or the
+        wall-clock limit when that is tighter), and wall-clock elapsed is
+        recorded to the ledger."""
+
+        cursor, budget_bound = self._billed_cursor(timeout_seconds)
+        started = self._clock()
+        try:
+            cursor.execute(sql)
+            rows = (
+                cursor.fetchmany(fetch_rows)
+                if fetch_rows is not None
+                else cursor.fetchall()
+            )
+        except self._rs_errors.ProgrammingError as exc:
+            raise self._translate(exc, budget_bound, timeout_seconds) from exc
+        finally:
+            # In a finally, not per-branch: a dropped connection or an
+            # interrupt mid-statement still billed the seconds that ran, and
+            # spend the ledger never sees erodes the session ceiling.
+            self._record_elapsed(started, sql)
+        labels = [self._label(d) for d in cursor.description]
+        types = [self._description_type(d) for d in cursor.description]
+        return rows, labels, types
+
+    def _billed_cursor(self, timeout_seconds: float | None = None) -> tuple[Any, bool]:
+        """A cursor prepared for spend: the session prepared once, and the
+        server-side statement timeout wound down to what remains of the
+        budget, so even a wrong heuristic cannot overrun the ceiling. Returns
+        the cursor and whether the budget (not the wall clock) is the binding
+        bound."""
+
+        remaining = self.cost_gate.remaining_for_statement()
+        if remaining is not None and remaining < 1:
+            raise OverCeilingError(
+                "the remaining budget is under one compute-second; raise "
+                "--budget or narrow the work"
+            )
+        self._ensure_session()
+        cursor = self._conn.cursor()
+        timeout_ms: int | None = None
+        budget_bound = False
+        if remaining is not None:
+            timeout_ms = int(remaining) * 1000
+            budget_bound = True
+        if timeout_seconds is not None:
+            wall_ms = int(max(timeout_seconds, 1) * 1000)
+            if timeout_ms is None or wall_ms < timeout_ms:
+                timeout_ms = wall_ms
+                budget_bound = False
+        if timeout_ms is not None:
+            # Engine-built session statement, not agent SQL: the value is a
+            # computed integer of milliseconds.
+            cursor.execute(f"SET statement_timeout = {timeout_ms}")
+        return cursor, budget_bound
+
+    def _translate(
+        self, exc: Exception, budget_bound: bool, timeout_seconds: float | None
+    ) -> Exception:
+        # A statement_timeout kill surfaces as SQLSTATE 57014 (query_canceled)
+        # with the message "Query cancelled on user's request" (verified live:
+        # Redshift words the server-side kill as a user cancel), so the
+        # SQLSTATE in the error payload is the signal, with "statement
+        # timeout" as the fallback when no payload dict is present. A bare
+        # cancel-word match would be wrong: WLM query-monitoring rules and
+        # admin kills also say "canceled", and blaming those on the budget
+        # sends the user to raise --budget for a refusal it cannot fix.
+        payload = exc.args[0] if exc.args and isinstance(exc.args[0], dict) else {}
+        message = str(exc).lower()
+        timed_out = payload.get("C") == "57014" or "statement timeout" in message
+        if not timed_out:
+            return exc
+        if budget_bound:
+            return OverCeilingError(
+                "the statement hit the server-side statement_timeout derived "
+                "from the remaining budget; raise --budget or narrow the work"
+            )
+        limit = f"{timeout_seconds:g}s" if timeout_seconds is not None else "its limit"
+        return TimeoutError(
+            f"query exceeded {limit} and was cancelled; narrow it (tighter "
+            "filter, fewer columns) and retry"
+        )
+
+    def _record_elapsed(self, started: float, sql: str) -> None:
+        elapsed = max(self._clock() - started, 0.0)
+        self.cost_gate.record_billed(elapsed, job_id=None, statement=sql)
+
+    def _consume_wake_floor(self) -> float:
+        """The first billed statement of a command carries the 60-second wake
+        charge on Serverless; later ones do not."""
+
+        floor = self._wake_floor()
+        self._wake_floor_pending = False
+        return floor
+
+    def _ensure_session(self) -> None:
+        """Session preparation, once per command: a best-effort read-only mode
+        and the attribution tag. Engine-built constants, not agent SQL. Both
+        are tolerated when Redshift declines them (the SELECT-only guard and
+        grants still enforce read-only; ``capabilities`` reports the truth).
+        """
+
+        if self._session_prepared:
+            return
+        self._session_prepared = True
+        try:
+            self._conn.cursor().execute("SET default_transaction_read_only = on")
+            self._session_read_only = True
+        except Exception:
+            self._session_read_only = False
+        with contextlib.suppress(Exception):
+            self._conn.cursor().execute("SET query_group = 'dex'")
+
+    @staticmethod
+    def _label(description: Any) -> str:
+        name = description[0]
+        if isinstance(name, bytes):
+            name = name.decode("utf-8", errors="replace")
+        return str(name)
+
+    @classmethod
+    def _description_type(cls, description: Any) -> str:
+        type_code = description[1]
+        if isinstance(type_code, int) and type_code in _OID_TYPE_NAMES:
+            return _OID_TYPE_NAMES[type_code]
+        return str(getattr(type_code, "name", type_code))
+
+    # --- helpers ------------------------------------------------------------------
+
+    def _catalog(self, sql: str) -> list[dict]:
+        """Cheap metadata door: engine-built catalog SELECTs only (pg_catalog
+        and SVV lookups plus session settings, no table scans). Results come
+        back as dicts keyed by the column names."""
+
+        if not sql.lstrip().upper().startswith("SELECT"):
+            raise ValueError("only SELECT statements pass through the catalog door")
+        self._ensure_session()
+        cursor = self._conn.cursor()
+        cursor.execute(sql)
+        labels = [self._label(d) for d in cursor.description]
+        return [dict(zip(labels, row, strict=True)) for row in cursor.fetchall()]
+
+    def _note(self, identifier: str, note: str) -> None:
+        notes = self._notes.setdefault(identifier, [])
+        if note not in notes:
+            notes.append(note)
+
+    @staticmethod
+    def _split(identifier: str) -> tuple[str, str, str]:
+        parts = identifier.rsplit(".", 2)
+        if len(parts) != 3:
+            raise ValueError(f"expected database.schema.table, got '{identifier}'")
+        return parts[0], parts[1], parts[2]
+
+    def _quote(self, identifier: str) -> str:
+        # A three-part reference is valid Redshift only against the connected
+        # database, which is exactly what the namespace guarantees.
+        return ".".join(_quote_ident(p) for p in self._split(identifier))
+
+    def close(self) -> None:
+        close = getattr(self._conn, "close", None)
+        if close is not None:
+            close()
+
+
+def _schema_filter(column: str) -> str:
+    """The catalog predicate excluding system schemas, shared by every
+    inventory query so the object census, the column census, and the visible
+    set can never disagree about what a source schema is."""
+
+    names = ", ".join(f"'{name}'" for name in _SYSTEM_SCHEMAS)
+    return f"{column} NOT IN ({names}) AND {column} NOT LIKE 'pg\\_%'"
+
+
+def _truthy(value: Any) -> bool:
+    """Privilege predicates come back as bool from the driver but as 't'/'f'
+    strings from some fakes and older wire paths; both spell the same fact."""
+
+    if isinstance(value, str):
+        return value.lower() in ("t", "true", "on", "1")
+    return bool(value)
+
+
+def _quote_ident(name: str) -> str:
+    """Quote one identifier component with double quotes (preserving case,
+    which unquoted Redshift identifiers would fold to lower), doubling
+    embedded quotes."""
+
+    escaped = name.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _escape_literal(value: str) -> str:
+    return value.replace("'", "''")

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -151,6 +151,44 @@ class PostgresTarget(BaseModel):
     max_full_profile_bytes: int | None = None
 
 
+class RedshiftTarget(BaseModel):
+    """Non-secret Amazon Redshift connection target. Credentials are never
+    here: auth is discovered at runtime by connect.py (the AWS default
+    credential chain for IAM temporary database credentials, REDSHIFT_*
+    environment variables, or a dbt profile), and passwords or keys are never
+    written or logged.
+
+    ``workgroup`` pins the Redshift Serverless workgroup: with it set, IAM
+    auth resolves the endpoint and temporary database credentials from the
+    AWS credential chain, and RPU translation reads the workgroup's base
+    capacity. ``cluster_identifier`` is the provisioned-cluster analogue for
+    IAM auth. ``aws_profile`` pins a named ``~/.aws`` profile; unset means
+    the chain's default. ``host``/``port``/``dbname``/``user`` are an
+    optional committed non-secret target for native password auth (password
+    supplied by REDSHIFT_PASSWORD, never by this config). ``schemas`` is a
+    source allowlist of schema names inside the connected database; empty
+    means every non-system schema the user can see. ``dev_schema`` is where
+    dbt dev builds write, and is refused as a source so reads and writes
+    never share a schema. ``rpu_price_usd`` is the region-specific dollar
+    price of one RPU-hour; set it to see dollar figures next to the RPU
+    translation (it varies by region and contract, so dex never guesses).
+    There is no sampled-profiling threshold: Redshift has no TABLESAMPLE, so
+    the budget is the only bound on profiling cost.
+    """
+
+    workgroup: str | None = None
+    cluster_identifier: str | None = None
+    aws_profile: str | None = None
+    region: str | None = None
+    host: str | None = None
+    port: int | None = None
+    dbname: str | None = None
+    user: str | None = None
+    schemas: list[str] = Field(default_factory=list)
+    dev_schema: str | None = None
+    rpu_price_usd: float | None = None
+
+
 class QueryLimits(BaseModel):
     """Hard bounds on `explore query` results, enforced in the engine.
 
@@ -174,6 +212,7 @@ class DexConfig(BaseModel):
     snowflake: SnowflakeTarget | None = None
     databricks: DatabricksTarget | None = None
     postgres: PostgresTarget | None = None
+    redshift: RedshiftTarget | None = None
     dbt_target: str | None = None
     # Pins the dbt project directory (relative to the repo root) when discovery
     # would be ambiguous; by default the project is located automatically.

--- a/packages/dex-core/src/exmergo_dex_core/connect.py
+++ b/packages/dex-core/src/exmergo_dex_core/connect.py
@@ -13,13 +13,19 @@ chain: a config-pinned ``~/.databrickscfg`` profile, the ``DATABRICKS_*``
 environment (which is also how CI's OIDC federation arrives), the default
 profile, or a dbt profile. Postgres follows suit: a config-pinned
 ``pg_service.conf`` entry, ``DATABASE_URL``, the ``PG*`` environment (resolved
-natively by libpq, including ``~/.pgpass``), or a dbt profile. Every discovery
-failure names the fix; nothing is ever prompted for.
+natively by libpq, including ``~/.pgpass``), or a dbt profile. Redshift
+discovers along both of its worlds: a config-pinned Serverless workgroup (or
+provisioned cluster) resolved through the AWS default credential chain into
+IAM temporary database credentials, the ``REDSHIFT_*`` environment, the
+committed non-secret config target (password via ``REDSHIFT_PASSWORD``), or a
+dbt profile. Every discovery failure names the fix; nothing is ever prompted
+for.
 """
 
 from __future__ import annotations
 
 import os
+import re
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
@@ -34,6 +40,7 @@ from .config import (
     DatabricksTarget,
     DexConfig,
     PostgresTarget,
+    RedshiftTarget,
     SnowflakeTarget,
     load_config,
 )
@@ -60,12 +67,14 @@ _SCOPE_FIELDS = {
     "snowflake": "databases",
     "databricks": "catalogs",
     "postgres": "schemas",
+    "redshift": "schemas",
 }
 _SCOPE_GRAMMAR = {
     "bigquery": "--scope <dataset> (or <project>.<dataset>)",
     "snowflake": "--scope <schema>, <database>, or <database>.<schema>",
     "databricks": "--scope <catalog> (or <catalog>.<schema>)",
     "postgres": "--scope <schema>",
+    "redshift": "--scope <schema>",
 }
 
 
@@ -142,6 +151,16 @@ def open_adapter(
 
     if connector == "postgres":
         return _open_postgres(
+            config,
+            repo_root,
+            budget=budget,
+            confirmed=confirmed,
+            command=command,
+            scope_override=scopes,
+        )
+
+    if connector == "redshift":
+        return _open_redshift(
             config,
             repo_root,
             budget=budget,
@@ -980,6 +999,378 @@ def _postgres_from_dbt_profiles(repo_root: str | Path) -> dict | None:
                 if dbname:
                     params["dbname"] = dbname
                 return params
+    return None
+
+
+def _open_redshift(
+    config: DexConfig,
+    repo_root: str | Path,
+    *,
+    budget: float | None,
+    confirmed: bool,
+    command: str | None,
+    scope_override: list[str] | None = None,
+):
+    target = config.redshift or RedshiftTarget()
+    target = narrow_target(target, "redshift", scope_override)
+    params, method, compute = resolve_redshift_connection(target, os.environ, repo_root)
+
+    try:
+        import redshift_connector
+    except ImportError as exc:
+        raise CredentialDiscoveryError(
+            "the Redshift client is not installed; install the connector "
+            "extra: exmergo-dex-core[redshift]"
+        ) from exc
+
+    # application_name is the attribution tag (SYS_CONNECTION_LOG); the
+    # adapter additionally sets query_group and a best-effort session
+    # read-only mode before any statement runs. autocommit keeps session SETs
+    # (statement_timeout) outside any transaction the driver would otherwise
+    # open.
+    connection = redshift_connector.connect(**params, application_name="dex")
+    connection.autocommit = True
+
+    store = DexStore(repo_root)
+    utc_midnight = (
+        datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
+    )
+    gate = CostGate(
+        paradigm=Paradigm.COMPUTE_TIME,
+        ceiling=budget if budget is not None else config.budget.ceiling,
+        session_ceiling=config.budget.session_ceiling,
+        session_spent=store.spend_since(
+            utc_midnight, field="billed_seconds", connector="redshift"
+        ),
+        confirmed=confirmed,
+        connector="redshift",
+        command=command,
+        record=store.append_spend_log,
+    )
+    return get_adapter(
+        "redshift",
+        connection=connection,
+        cost_gate=gate,
+        target=target,
+        compute=compute,
+        auth_method=method,
+        scope_origin=scope_origin("redshift", "--scope" if scope_override else None),
+    )
+
+
+def resolve_redshift_connection(
+    target: RedshiftTarget,
+    env: dict | os._Environ,
+    repo_root: str | Path = ".",
+) -> tuple[dict, str, dict | None]:
+    """Discover Redshift connection parameters, never prompting.
+
+    Returns ``(params, auth_method, compute)`` where ``params`` feeds
+    ``redshift_connector.connect``, ``auth_method`` is a coarse class safe to
+    surface (iam_serverless / iam_cluster / environment / config_target /
+    dbt_profile, suffixed with the credential kind), and ``compute`` carries
+    the control-plane facts for the RPU translation (kind, workgroup, base
+    capacity) or ``None`` when they are unknowable. Parameter values,
+    including any password an environment legitimately holds, never leave the
+    engine process.
+
+    Order: the config-pinned Serverless ``workgroup`` (IAM temporary
+    credentials through the AWS default chain, endpoint and database
+    discovered from the control plane), the config-pinned provisioned
+    ``cluster_identifier`` (IAM, GetClusterCredentials), the ``REDSHIFT_*``
+    environment, the committed non-secret config target (password via
+    ``REDSHIFT_PASSWORD``), then a dbt profile's redshift target. Every
+    failure names the fix.
+    """
+
+    if target.workgroup:
+        return _redshift_serverless_iam(target, env)
+
+    if target.cluster_identifier:
+        if not target.dbname or not target.user:
+            raise CredentialDiscoveryError(
+                "IAM auth against a provisioned cluster needs the database "
+                "and user: set redshift.dbname and redshift.user in "
+                ".dex/config.yml alongside redshift.cluster_identifier"
+            )
+        params: dict = {
+            "iam": True,
+            "cluster_identifier": target.cluster_identifier,
+            "database": target.dbname,
+            "db_user": target.user,
+        }
+        if target.aws_profile:
+            params["profile"] = target.aws_profile
+        if target.region:
+            params["region"] = target.region
+        return (
+            params,
+            f"iam_cluster:{_aws_credential_kind(target, env)}",
+            _redshift_compute("provisioned"),
+        )
+
+    if env.get("REDSHIFT_HOST"):
+        params = {"host": env["REDSHIFT_HOST"]}
+        if env.get("REDSHIFT_PORT"):
+            params["port"] = int(env["REDSHIFT_PORT"])
+        if env.get("REDSHIFT_DATABASE"):
+            params["database"] = env["REDSHIFT_DATABASE"]
+        if env.get("REDSHIFT_USER"):
+            params["user"] = env["REDSHIFT_USER"]
+        if env.get("REDSHIFT_PASSWORD"):
+            params["password"] = env["REDSHIFT_PASSWORD"]
+        kind = "password" if env.get("REDSHIFT_PASSWORD") else "external"
+        return params, f"environment:{kind}", _redshift_host_compute(params["host"])
+
+    if target.host or target.dbname:
+        params = {
+            key: value
+            for key, value in (
+                ("host", target.host),
+                ("port", target.port),
+                ("database", target.dbname),
+                ("user", target.user),
+            )
+            if value is not None
+        }
+        if env.get("REDSHIFT_PASSWORD"):
+            params["password"] = env["REDSHIFT_PASSWORD"]
+            kind = "password"
+        else:
+            kind = "external"
+        return (
+            params,
+            f"config_target:{kind}",
+            _redshift_host_compute(target.host),
+        )
+
+    profile_params = _redshift_from_dbt_profiles(repo_root, env)
+    if profile_params:
+        kind = "password" if profile_params.get("password") else "external"
+        return (
+            profile_params,
+            f"dbt_profile:{kind}",
+            _redshift_host_compute(profile_params.get("host")),
+        )
+
+    raise CredentialDiscoveryError(
+        "no Redshift connection discovered; set redshift.workgroup in "
+        ".dex/config.yml (Serverless, IAM via the AWS credential chain), or "
+        "redshift.cluster_identifier plus dbname/user (provisioned, IAM), or "
+        "export REDSHIFT_HOST/REDSHIFT_DATABASE (password via "
+        "REDSHIFT_PASSWORD), or set redshift.host/dbname there, or keep a "
+        "redshift target in your dbt profiles.yml"
+    )
+
+
+def _redshift_serverless_iam(
+    target: RedshiftTarget, env: dict | os._Environ
+) -> tuple[dict, str, dict | None]:
+    """The Serverless IAM path: the workgroup pin plus the AWS default
+    credential chain resolve everything else (endpoint, port, database) from
+    the control plane, and GetCredentials mints temporary database
+    credentials inside the driver. Nothing is prompted; every failure names
+    the fix."""
+
+    try:
+        import boto3
+        from botocore.exceptions import BotoCoreError, ClientError
+    except ImportError as exc:
+        raise CredentialDiscoveryError(
+            "the Redshift client is not installed; install the connector "
+            "extra: exmergo-dex-core[redshift]"
+        ) from exc
+
+    session = boto3.Session(
+        profile_name=target.aws_profile or None,
+        region_name=target.region or None,
+    )
+    try:
+        client = session.client("redshift-serverless")
+        workgroup = client.get_workgroup(workgroupName=target.workgroup)["workgroup"]
+    except (BotoCoreError, ClientError, ValueError) as exc:
+        raise CredentialDiscoveryError(
+            f"could not resolve Redshift Serverless workgroup "
+            f"'{target.workgroup}': configure the AWS credential chain "
+            "(aws configure, AWS_* environment variables, or "
+            "redshift.aws_profile), set redshift.region when the default "
+            "region is wrong, and grant redshift-serverless:GetWorkgroup "
+            "and redshift-serverless:GetCredentials"
+        ) from exc
+
+    endpoint = workgroup.get("endpoint") or {}
+    host = endpoint.get("address")
+    if not host:
+        raise CredentialDiscoveryError(
+            f"workgroup '{target.workgroup}' has no reachable endpoint yet "
+            f"(status {workgroup.get('status', 'unknown')}); wait for it to "
+            "become AVAILABLE or check its network configuration"
+        )
+    database = target.dbname or _redshift_namespace_database(
+        client, workgroup.get("namespaceName")
+    )
+    if not database:
+        raise CredentialDiscoveryError(
+            "could not discover the database of workgroup "
+            f"'{target.workgroup}'; set redshift.dbname in .dex/config.yml "
+            "or grant redshift-serverless:GetNamespace"
+        )
+    params: dict = {
+        "iam": True,
+        "host": host,
+        "port": int(endpoint.get("port") or 5439),
+        "database": database,
+    }
+    if target.aws_profile:
+        params["profile"] = target.aws_profile
+    if target.region:
+        params["region"] = target.region
+    compute = _redshift_compute(
+        "serverless",
+        workgroup=str(workgroup.get("workgroupName", target.workgroup)),
+        base_capacity_rpus=(
+            float(workgroup["baseCapacity"])
+            if workgroup.get("baseCapacity") is not None
+            else None
+        ),
+    )
+    return params, f"iam_serverless:{_aws_credential_kind(target, env)}", compute
+
+
+def _redshift_namespace_database(client, namespace_name: str | None) -> str | None:
+    """The default database of a Serverless namespace, or ``None`` when it
+    cannot be read (the caller then requires ``redshift.dbname``). Takes the
+    already-built redshift-serverless client: constructing a second one per
+    connect would re-load the service model for nothing."""
+
+    if not namespace_name:
+        return None
+    try:
+        namespace = client.get_namespace(namespaceName=namespace_name)["namespace"]
+        return str(namespace["dbName"]) if namespace.get("dbName") else None
+    except Exception:
+        return None
+
+
+def _aws_credential_kind(target: RedshiftTarget, env: dict | os._Environ) -> str:
+    """The coarse AWS credential class for the envelope; never a value or an
+    identity. Deliberately coarse: a pinned profile, the environment, or
+    whatever else the default chain found (SSO, a role, instance metadata)."""
+
+    if target.aws_profile:
+        return "profile"
+    if env.get("AWS_ACCESS_KEY_ID"):
+        return "environment"
+    return "default_chain"
+
+
+def _redshift_compute(
+    kind: str,
+    *,
+    workgroup: str | None = None,
+    base_capacity_rpus: float | None = None,
+) -> dict:
+    """The compute-facts shape every discovery path returns. The adapter reads
+    exactly these three keys for the RPU translation, so one constructor keeps
+    the shape from drifting per path."""
+
+    return {
+        "kind": kind,
+        "workgroup": workgroup,
+        "base_capacity_rpus": base_capacity_rpus,
+    }
+
+
+def _redshift_host_compute(host: str | None) -> dict | None:
+    """Compute facts inferred from an endpoint host alone: a Serverless
+    endpoint is recognizable by its domain, but its workgroup and base
+    capacity are unknowable without the control plane, so the RPU translation
+    degrades and only the wake-minimum honesty remains."""
+
+    if not host:
+        return None
+    kind = "serverless" if ".redshift-serverless." in host else "provisioned"
+    return _redshift_compute(kind)
+
+
+_ENV_VAR_TEMPLATE = re.compile(r"\{\{\s*env_var\(\s*['\"]([^'\"]+)['\"]\s*\)\s*\}\}")
+
+
+def _profile_scalar(value, env: dict | os._Environ) -> str | None:
+    """A profiles.yml scalar with dbt's env_var indirection honored. dex's own
+    rendered profiles keep the password as ``{{ env_var('REDSHIFT_PASSWORD') }}``
+    (never a value), so a reference resolves from the environment the way dbt
+    would; any other unrendered template is unusable, never passed through as
+    a literal (the driver would misreport that as a wrong password)."""
+
+    if value is None:
+        return None
+    text = str(value)
+    if "{{" not in text:
+        return text
+    match = _ENV_VAR_TEMPLATE.fullmatch(text.strip())
+    if match:
+        return env.get(match.group(1)) or None
+    return None
+
+
+def _redshift_from_dbt_profiles(
+    repo_root: str | Path, env: dict | os._Environ
+) -> dict | None:
+    """Best-effort: the connection fields of a ``type: redshift`` output in
+    the discovered dbt project's profiles. Any failure means "not found"."""
+
+    try:
+        from .dbt_project import PROFILES_FILE, find_project, profiles_dir
+
+        project_dir = find_project(repo_root)
+        profiles_path = profiles_dir(project_dir) / PROFILES_FILE
+        profiles = yaml.safe_load(profiles_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return None
+    for profile in profiles.values():
+        if not isinstance(profile, dict):
+            continue
+        for output in (profile.get("outputs") or {}).values():
+            if not isinstance(output, dict) or output.get("type") != "redshift":
+                continue
+            if str(output.get("method") or "").lower() == "iam":
+                # An IAM output mints its credentials at dbt runtime; it
+                # carries nothing durable to connect with natively, and the
+                # workgroup/cluster config paths own that story.
+                continue
+            host = _profile_scalar(output.get("host"), env)
+            if not host:
+                continue
+            # A declared field the environment cannot render (dex's own
+            # profiles keep the password as {{ env_var(...) }}) makes the
+            # output unusable as discovered: skip it rather than connect
+            # with a hole where a credential should be, and let the terminal
+            # discovery error name the export that fixes it.
+            fields: dict = {}
+            unusable = False
+            for key in ("user", "password", "dbname", "database"):
+                raw = output.get(key)
+                if not raw:
+                    continue
+                value = _profile_scalar(raw, env)
+                if not value:
+                    unusable = True
+                    break
+                fields["database" if key == "database" else key] = value
+            if unusable:
+                continue
+            params: dict = {"host": host}
+            port = output.get("port")
+            if isinstance(port, int) or (isinstance(port, str) and port.isdigit()):
+                params["port"] = int(port)
+            for key in ("user", "password"):
+                if key in fields:
+                    params[key] = fields[key]
+            dbname = fields.get("dbname") or fields.get("database")
+            if dbname:
+                params["database"] = dbname
+            return params
     return None
 
 

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -302,6 +302,36 @@ def target_role(project_dir: Path | str, target: str | None = None) -> str | Non
     return str(role) if role else None
 
 
+def target_auth_method(
+    project_dir: Path | str, target: str | None = None
+) -> str | None:
+    """The auth ``method`` a profiles.yml target declares, or None.
+
+    Exists for one question: is this target IAM-authenticated? dbt-redshift's
+    ``method: iam`` mints a database user from the caller's identity at run
+    time, so the profile's ``user`` field is not a durable identity a privilege
+    preflight can interrogate. Overloading the user field for that signal (a
+    sentinel value) would misfire on profiles that carry a real user alongside
+    IAM auth, so the method gets read directly.
+    """
+
+    project = Path(project_dir)
+    try:
+        view_profile = load(project).profile_name
+        profiles = _load_profiles(project)
+    except (DbtProjectError, yaml.YAMLError):
+        return None
+    profile = profiles.get(view_profile)
+    if not isinstance(profile, dict):
+        return None
+    outputs = profile.get("outputs") or {}
+    output = outputs.get(target or profile.get("target"))
+    if not isinstance(output, dict):
+        return None
+    method = output.get("method")
+    return str(method) if method else None
+
+
 def duckdb_target_path(
     project_dir: Path | str, target: str | None = None
 ) -> Path | None:

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -293,6 +293,7 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
             config.snowflake.dev_schema if config.snowflake else None,
             config.databricks.dev_schema if config.databricks else None,
             config.postgres.dev_schema if config.postgres else None,
+            config.redshift.dev_schema if config.redshift else None,
         ]
         if name
     )

--- a/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
@@ -372,18 +372,18 @@ def _overlap_probe_sql(rel: Relationship) -> str:
     fk = _quote_part(rel.from_columns[0])
     key = _quote_part(rel.to_columns[0])
     # Aggregate-only by construction: two counts, no value in the projection.
-    # NOT EXISTS keeps the orphan count correct even when the parent key is not
-    # unique (a join would fan out and inflate it). Deliberately portable SQL:
-    # CASE inside COUNT rather than FILTER (which BigQuery lacks and sqlglot
-    # does not rewrite), with the EXISTS in a subselect so every dialect plans
-    # it as an anti-join.
+    # A LEFT JOIN against the DISTINCT parent keys keeps the orphan count
+    # correct even when the parent key is not unique (a bare join would fan
+    # out and inflate it). Deliberately portable SQL: CASE inside COUNT
+    # rather than FILTER (which BigQuery lacks and sqlglot does not rewrite),
+    # and a join rather than a projected NOT EXISTS, which Redshift refuses
+    # outright (XX000: correlated subquery pattern not supported).
     return (
-        f"SELECT COUNT(probe.fk) AS nonnull_fk, "  # noqa: S608
-        f"COUNT(CASE WHEN probe.orphan THEN 1 END) AS orphans FROM ("
-        f"SELECT c.{fk} AS fk, "
-        f"c.{fk} IS NOT NULL AND NOT EXISTS ("
-        f"SELECT 1 FROM {parent} p WHERE p.{key} = c.{fk}) AS orphan "
-        f"FROM {child} c) probe"
+        f"SELECT COUNT(c.{fk}) AS nonnull_fk, "  # noqa: S608
+        f"COUNT(CASE WHEN c.{fk} IS NOT NULL AND d.pk IS NULL THEN 1 END) "
+        f"AS orphans "
+        f"FROM {child} c LEFT JOIN ("
+        f"SELECT DISTINCT {key} AS pk FROM {parent}) d ON d.pk = c.{fk}"
     )
 
 

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -25,6 +25,20 @@ from . import plans as plans_mod
 from . import semantic as semantic_mod
 from .plans import EditKind, PlanEdit, PlanStore
 
+# What actually caps a dbt statement server-side, per compute-time connector:
+# a per-connector fact, kept out of the shared build arm so the next connector
+# adds an entry instead of nesting a conditional. dex cannot inject a per-build
+# cap through any of these dbt adapters.
+_COMPUTE_TIME_CAP_NOTES = {
+    "redshift": (
+        "a statement_timeout on the dbt dev user and a workgroup usage "
+        "limit are the server-side caps (dex cannot inject one per build)"
+    ),
+}
+_DEFAULT_COMPUTE_TIME_CAP_NOTE = (
+    "the warehouse-level statement timeout and auto-suspend are the server-side caps"
+)
+
 
 def cmd_init(args: argparse.Namespace) -> env.Envelope:
     from ..config import load_config
@@ -150,6 +164,7 @@ def cmd_build(args: argparse.Namespace) -> env.Envelope:
         "bigquery": Paradigm.BYTES_SCANNED,
         "snowflake": Paradigm.COMPUTE_TIME,
         "databricks": Paradigm.COMPUTE_TIME,
+        "redshift": Paradigm.COMPUTE_TIME,
         "postgres": Paradigm.DB_LOAD,
     }.get(connector, Paradigm.FREE_LOCAL)
 
@@ -195,14 +210,16 @@ def cmd_build(args: argparse.Namespace) -> env.Envelope:
         if billed:
             _record_build_spend(repo_root, connector, billed, "billed_bytes")
     elif paradigm is Paradigm.COMPUTE_TIME:
+        cap_note = _COMPUTE_TIME_CAP_NOTES.get(
+            connector, _DEFAULT_COMPUTE_TIME_CAP_NOTE
+        )
         notes = [
             "dbt has no dry-run, so this build's warehouse time could not be "
-            "estimated upfront; the warehouse-level statement timeout and "
-            "auto-suspend are the server-side caps",
+            f"estimated upfront; {cap_note}",
             *notes,
         ]
-        # dbt-snowflake and dbt-databricks report no billing figure; per-node
-        # execution time is the honest warehouse-seconds actual.
+        # dbt-snowflake, dbt-databricks, and dbt-redshift report no billing
+        # figure; per-node execution time is the honest compute-seconds actual.
         seconds = sum(
             float(node.get("execution_time") or 0) for node in summary.get("nodes", [])
         )

--- a/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
@@ -39,6 +39,7 @@ from ..config import CONFIG_FILE, DexConfig
 from ..dbt_project import (
     PROFILES_FILE,
     duckdb_target_path,
+    target_auth_method,
     target_identifiers,
     target_role,
 )
@@ -69,6 +70,7 @@ _DRIFT_FIELDS: dict[str, tuple[tuple[str, str, str], ...]] = {
         ("dev_schema", "databricks.dev_schema", "schema"),
     ),
     "postgres": (("dev_schema", "postgres.dev_schema", "schema"),),
+    "redshift": (("dev_schema", "redshift.dev_schema", "schema"),),
     "duckdb": (("path", "duckdb.path", "path"),),
 }
 
@@ -172,6 +174,8 @@ def _assert_namespace_exists(
         return _bigquery_namespace(config, repo_root)
     if config.connector == "postgres":
         return _postgres_namespace(project, target, config, repo_root)
+    if config.connector == "redshift":
+        return _redshift_namespace(project, target, config, repo_root)
     return []
 
 
@@ -382,6 +386,62 @@ def _postgres_namespace(
         f"  GRANT USAGE, CREATE ON SCHEMA {pg.dev_schema} TO {role};\n"
         "(dbt builds every model in that schema), or point postgres.dev_schema "
         "at a schema the role can write"
+    )
+
+
+def _redshift_namespace(
+    project: Path, target: str, config: DexConfig, repo_root: Path | str
+) -> list[str]:
+    """Cheap: catalog lookups and privilege predicates, no scan.
+
+    Redshift asks the Postgres question: dbt creates the dev schema, so its
+    absence is not the failure; the privilege to create it is. The user that
+    needs the privilege is the one in the rendered profile, not the one dex
+    connects as. A ``method: iam`` profile is the exception: its database user
+    is minted from the caller's identity at dbt runtime regardless of what the
+    profile's ``user`` field says, so there is no durable user to ask a
+    privilege question about and the check degrades to dbt's own error.
+    """
+
+    rs = config.redshift
+    if rs is None or not rs.dev_schema:
+        return []
+    role = target_role(project, target)
+    if not role or target_auth_method(project, target) == "iam":
+        # No rendered profile to read a user from, or IAM auth: an IAM target
+        # mints its database user from the caller's identity at dbt runtime,
+        # so whatever the user field says, there is no durable user to ask a
+        # privilege question about.
+        return []
+
+    adapter, note = _open_for_preflight("redshift", repo_root)
+    if adapter is None:
+        return [note]
+    try:
+        missing = adapter.missing_dev_namespaces(rs.dev_schema, role=role)
+    except Exception as exc:  # the profile's user does not exist in the database
+        raise DevTargetError(str(exc)) from exc
+    finally:
+        adapter.close()
+
+    if not missing:
+        return []
+    problem = missing[0]
+    if problem.startswith("dev_schema"):
+        raise DevTargetError(
+            f"redshift {problem} does not exist and user {role} may not create "
+            "it; create it with:\n"
+            f"  CREATE SCHEMA IF NOT EXISTS {rs.dev_schema} AUTHORIZATION "
+            f"{role};\n"
+            "(dbt creates its dev schema, but only if the user may, so the first "
+            "build otherwise dies on a bare permission error), or point "
+            "redshift.dev_schema at a schema the user can write"
+        )
+    raise DevTargetError(
+        f"redshift user {role} is missing {problem}; grant it with:\n"
+        f"  GRANT USAGE, CREATE ON SCHEMA {rs.dev_schema} TO {role};\n"
+        "(dbt builds every model in that schema), or point redshift.dev_schema "
+        "at a schema the user can write"
     )
 
 

--- a/packages/dex-core/src/exmergo_dex_core/transform/init.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/init.py
@@ -43,7 +43,14 @@ from ..config import (
 from ..dbt_project import PROFILES_FILE, PROJECT_FILE, discover_projects
 from ..diffs import file_diff
 
-VALID_CONNECTORS = ("duckdb", "snowflake", "bigquery", "databricks", "postgres")
+VALID_CONNECTORS = (
+    "duckdb",
+    "snowflake",
+    "bigquery",
+    "databricks",
+    "postgres",
+    "redshift",
+)
 
 
 class InitError(Exception):
@@ -101,7 +108,7 @@ def init_project(
         raise InitError(
             f"connector '{connector}' is not yet supported for init; run "
             "`transform init <name> --connector "
-            "duckdb|bigquery|snowflake|databricks|postgres`"
+            "duckdb|bigquery|snowflake|databricks|postgres|redshift`"
         )
 
     project_name = sanitize_project_name(name)
@@ -566,12 +573,127 @@ def _pg_connection_fields(target: Any, method: str) -> dict:
     return _postgres_from_dbt_profiles(".") or {}
 
 
+_DEFAULT_REDSHIFT_DEV_SCHEMA = "dbt_dev"
+
+
+def _redshift_profile(
+    project_name: str, path: str | None, config: DexConfig, root: Path
+) -> str:
+    """A single dbt-redshift ``dev`` target from the discovered connection,
+    with no secret ever rendered. IAM discovery renders ``method: iam`` (the
+    endpoint resolved from the workgroup, temporary credentials minted by the
+    dbt adapter at runtime); password discovery renders an ``env_var``
+    reference (``REDSHIFT_PASSWORD``), never a value. Writes go to a
+    dedicated dev schema, never to a source schema dex reads from."""
+
+    from ..config import RedshiftTarget
+    from ..connect import CredentialDiscoveryError, resolve_redshift_connection
+
+    target = config.redshift or RedshiftTarget()
+    try:
+        params, method, _compute = resolve_redshift_connection(target, os.environ, root)
+    except CredentialDiscoveryError as exc:
+        raise InitError(str(exc)) from exc
+
+    dev_schema = target.dev_schema or _DEFAULT_REDSHIFT_DEV_SCHEMA
+    if dev_schema in set(target.schemas):
+        raise InitError(
+            f"dev_schema '{dev_schema}' is also a source schema in "
+            "redshift.schemas; dbt builds must write where dex does not read "
+            "(set redshift.dev_schema to a dedicated schema)"
+        )
+
+    target.dev_schema = dev_schema
+    config.redshift = target
+
+    source = method.split(":", 1)[0]
+    output: dict[str, Any] = {"type": "redshift"}
+    if source == "iam_serverless":
+        output.update(
+            {
+                "method": "iam",
+                "host": str(params["host"]),
+                "port": int(params.get("port") or 5439),
+                # Serverless IAM derives the database user from the caller's
+                # identity; dbt-redshift still requires the field, and the
+                # sentinel keeps it honest about where identity comes from.
+                "user": str(target.user or "iam"),
+                "dbname": str(params["database"]),
+            }
+        )
+        if target.aws_profile:
+            output["iam_profile"] = str(target.aws_profile)
+        if target.region:
+            output["region"] = str(target.region)
+    elif source == "iam_cluster":
+        if not target.host:
+            raise InitError(
+                "dbt-redshift needs the cluster endpoint host alongside "
+                "cluster_identifier; set redshift.host in .dex/config.yml"
+            )
+        output.update(
+            {
+                "method": "iam",
+                "cluster_id": str(target.cluster_identifier),
+                "host": str(target.host),
+                "port": int(target.port or 5439),
+                "user": str(params["db_user"]),
+                "dbname": str(params["database"]),
+            }
+        )
+        if target.aws_profile:
+            output["iam_profile"] = str(target.aws_profile)
+        if target.region:
+            output["region"] = str(target.region)
+    else:
+        host = params.get("host")
+        dbname = params.get("database")
+        user = params.get("user")
+        if not host or not dbname or not user:
+            missing = ", ".join(
+                name
+                for name, value in (("host", host), ("dbname", dbname), ("user", user))
+                if not value
+            )
+            raise InitError(
+                f"the discovered Redshift connection does not name {missing}, "
+                "which dbt-redshift requires; export REDSHIFT_HOST/"
+                "REDSHIFT_DATABASE/REDSHIFT_USER, or complete redshift.host/"
+                "dbname/user in .dex/config.yml"
+            )
+        output.update(
+            {
+                "host": str(host),
+                "port": int(params.get("port") or 5439),
+                "user": str(user),
+                # Never persist a password: the profile reads it from the
+                # environment at dbt runtime (a Jinja reference, not a value).
+                "password": "{{ env_var('REDSHIFT_PASSWORD') }}",
+                "dbname": str(dbname),
+            }
+        )
+    output.update(
+        {
+            "schema": dev_schema,
+            # One thread keeps the workgroup from parallel bursts; compute
+            # seconds are the guarded quantity on compute-time gating.
+            "threads": 1,
+            "connect_timeout": 10,
+        }
+    )
+    return yaml.safe_dump(
+        {project_name: {"target": "dev", "outputs": {"dev": output}}},
+        sort_keys=False,
+    )
+
+
 _PROFILE_RENDERERS: dict[str, Callable[[str, str | None, DexConfig, Path], str]] = {
     "duckdb": _duckdb_profile,
     "bigquery": _bigquery_profile,
     "snowflake": _snowflake_profile,
     "databricks": _databricks_profile,
     "postgres": _postgres_profile,
+    "redshift": _redshift_profile,
 }
 
 

--- a/packages/dex-core/tests/adapters/test_connect_redshift.py
+++ b/packages/dex-core/tests/adapters/test_connect_redshift.py
@@ -1,0 +1,1137 @@
+"""The Redshift adapter against the stateful fake connection: metadata is
+cheap (pg_catalog and SVV lookups, no scans), every billed statement is
+estimated and gated in compute-seconds, the Serverless wake minimum is floored
+into estimates exactly once per command, and the budget binds at both the
+client (charge) and the simulated server (statement_timeout)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("redshift_connector")
+
+from fakes.redshift import (
+    FakeRedshiftConnection,
+    FakeRedshiftTable,
+    FakeResult,
+    FakeUser,
+)
+
+from exmergo_dex_core.adapters import get_adapter, get_dialect
+from exmergo_dex_core.adapters.redshift import (
+    _MIN_STATEMENT_SECONDS,
+    _WAKE_MINIMUM_SECONDS,
+    RedshiftAdapter,
+    RedshiftConnectionError,
+)
+from exmergo_dex_core.config import RedshiftTarget
+from exmergo_dex_core.connect import (
+    CredentialDiscoveryError,
+    resolve_redshift_connection,
+)
+from exmergo_dex_core.envelope import Paradigm
+from exmergo_dex_core.guards.cost_guard import (
+    ConfirmationRequiredError,
+    CostGate,
+    OverCeilingError,
+)
+
+SERVERLESS_8_RPU = {
+    "kind": "serverless",
+    "workgroup": "dex-wg",
+    "base_capacity_rpus": 8.0,
+}
+PROVISIONED = {"kind": "provisioned", "workgroup": None, "base_capacity_rpus": None}
+
+# The fixture's shop.customers is 5000 MB; at the 8-RPU reference rate
+# (50 MB/s) one aggregate batch over it estimates exactly 100 seconds.
+CUSTOMERS_SCAN_SECONDS = 100.0
+
+
+def make_adapter(
+    connection,
+    *,
+    ceiling: float | None = 600.0,
+    confirmed: bool = True,
+    session_ceiling: float | None = None,
+    session_spent: float = 0.0,
+    record=None,
+    target: RedshiftTarget | None = None,
+    compute: dict | None = None,
+    scope_origin: str | None = None,
+) -> RedshiftAdapter:
+    gate = CostGate(
+        paradigm=Paradigm.COMPUTE_TIME,
+        ceiling=ceiling,
+        session_ceiling=session_ceiling,
+        session_spent=session_spent,
+        confirmed=confirmed,
+        connector="redshift",
+        command="explore profile",
+        record=record,
+    )
+    return RedshiftAdapter(
+        connection=connection,
+        cost_gate=gate,
+        target=target or RedshiftTarget(),
+        compute=compute if compute is not None else dict(SERVERLESS_8_RPU),
+        auth_method="iam_serverless:default_chain",
+        scope_origin=scope_origin,
+        clock=connection.clock,
+    )
+
+
+# --- metadata (cheap) ---------------------------------------------------------------
+
+
+def test_capabilities_shape_and_free(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection)
+    caps = adapter.capabilities()
+    assert caps["connector"] == "redshift"
+    assert caps["dialect"] == "redshift"
+    assert caps["read_only"] is True
+    assert caps["session_read_only"] is True  # the SET took effect on the fake
+    assert caps["paradigm"] == "compute_time"
+    assert caps["auth_method"] == "iam_serverless:default_chain"
+    assert caps["database"] == "dexdb"
+    assert caps["server_version"] == "Redshift 1.0.12345"
+    assert caps["schema_count"] == 1  # shop
+    assert caps["compute"] == SERVERLESS_8_RPU
+    assert caps["budget"]["ceiling_seconds"] == 600.0
+    assert caps["budget"]["ceiling_rpu_hours"] == pytest.approx(600.0 * 8 / 3600)
+    # Serverless honesty: metadata is billable activity when compute is idle.
+    assert any("60-second minimum" in w for w in caps["warnings"])
+    # Capabilities is a cheap probe: no data statement ran.
+    assert fake_redshift_connection.data_statements == []
+
+
+def test_session_is_read_only_and_tagged_before_any_statement(
+    fake_redshift_connection,
+):
+    adapter = make_adapter(fake_redshift_connection)
+    adapter.list_objects()
+    prepared = [s.sql.lower() for s in fake_redshift_connection.statements[:2]]
+    assert any("set default_transaction_read_only = on" in sql for sql in prepared)
+    assert any("set query_group = 'dex'" in sql for sql in prepared)
+
+
+def test_declined_session_read_only_is_tolerated_and_reported():
+    connection = FakeRedshiftConnection(
+        tables=[
+            FakeRedshiftTable(
+                schema="shop", name="t", columns=[("id", "bigint", True)], size_mb=1
+            )
+        ],
+        reject_read_only=True,
+    )
+    adapter = make_adapter(connection)
+    caps = adapter.capabilities()
+    # The refusal is not fatal (SELECT-only and grants still hold); it is honest.
+    assert caps["session_read_only"] is False
+
+
+def test_list_objects_uses_cheap_catalog_metadata_only(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection)
+    objects = adapter.list_objects()
+    assert [o.identifier for o in objects] == [
+        "dexdb.shop.customers",
+        "dexdb.shop.events",
+        "dexdb.shop.signups",
+    ]
+    customers = next(o for o in objects if o.name == "customers")
+    assert customers.row_count == 100
+    assert customers.byte_size == 5_000 * 1024 * 1024
+    assert customers.column_count == 3
+    assert fake_redshift_connection.data_statements == []
+
+
+def test_empty_table_omitted_by_svv_table_info_still_appears(fake_redshift_connection):
+    """SVV_TABLE_INFO omits tables holding no data; the pg_class census is the
+    inventory of record precisely so those tables do not silently vanish."""
+
+    adapter = make_adapter(fake_redshift_connection)
+    signups, _ = adapter.table_metadata("dexdb.shop.signups")
+    assert signups.row_count == 0
+    assert signups.byte_size == 0
+
+
+def test_schema_allowlist_scopes_inventory(fake_redshift_connection):
+    fake_redshift_connection.tables.append(
+        FakeRedshiftTable(
+            schema="other",
+            name="noise",
+            columns=[("id", "bigint", True)],
+            size_mb=1,
+        )
+    )
+    adapter = make_adapter(
+        fake_redshift_connection, target=RedshiftTarget(schemas=["shop"])
+    )
+    assert {o.schema for o in adapter.list_objects()} == {"shop"}
+
+
+def test_the_resolved_scope_is_pushed_into_the_census_sql(fake_redshift_connection):
+    """A one-schema scope in a wide warehouse filters server-side: the three
+    censuses must not transfer every other schema's catalog rows just to drop
+    them client-side."""
+
+    adapter = make_adapter(
+        fake_redshift_connection, target=RedshiftTarget(schemas=["shop"])
+    )
+    adapter.list_objects()
+    census = [
+        s.sql
+        for s in fake_redshift_connection.statements
+        if "pg_class" in s.sql or "svv_table_info" in s.sql or "svv_columns" in s.sql
+    ]
+    assert len(census) == 3
+    assert all("IN ('shop')" in sql for sql in census)
+
+
+def test_views_carry_no_stored_size(fake_redshift_connection):
+    fake_redshift_connection.tables.append(
+        FakeRedshiftTable(
+            schema="shop",
+            name="v_totals",
+            columns=[("total", "numeric", True)],
+            kind="view",
+        )
+    )
+    adapter = make_adapter(fake_redshift_connection)
+    meta, _ = adapter.table_metadata("dexdb.shop.v_totals")
+    assert meta.object_type == "view"
+    assert meta.row_count is None
+    assert meta.byte_size is None
+
+
+def test_materialized_view_backing_tables_are_hidden(fake_redshift_connection):
+    fake_redshift_connection.tables.append(
+        FakeRedshiftTable(
+            schema="shop",
+            name="mv_tbl__totals__0",
+            columns=[("total", "numeric", True)],
+            size_mb=1,
+        )
+    )
+    adapter = make_adapter(fake_redshift_connection)
+    assert "dexdb.shop.mv_tbl__totals__0" not in {
+        o.identifier for o in adapter.list_objects()
+    }
+
+
+def test_unknown_object_names_the_fix(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection)
+    with pytest.raises(RedshiftConnectionError, match=r"redshift\.schemas"):
+        adapter.table_metadata("dexdb.shop.missing")
+
+
+def test_get_adapter_constructs_redshift(fake_redshift_connection):
+    gate = CostGate(
+        paradigm=Paradigm.COMPUTE_TIME,
+        ceiling=10.0,
+        session_ceiling=None,
+        session_spent=0.0,
+        confirmed=True,
+        connector="redshift",
+    )
+    adapter = get_adapter(
+        "redshift", connection=fake_redshift_connection, cost_gate=gate
+    )
+    assert isinstance(adapter, RedshiftAdapter)
+    assert get_dialect("redshift") == "redshift"
+
+
+def test_no_sampling_knob_exists():
+    """Redshift has no TABLESAMPLE, so a sampled-profiling threshold would be
+    a lie; the budget is the only bound."""
+
+    assert "max_full_profile_bytes" not in RedshiftTarget.model_fields
+
+
+# --- estimation (cheap; feeds the confirm handshake) ---------------------------------
+
+
+def test_profile_estimate_scales_with_bytes_and_floors_the_wake_minimum(
+    fake_redshift_connection,
+):
+    adapter = make_adapter(fake_redshift_connection)
+    total, per_table = adapter.profile_estimate(["dexdb.shop.customers"])
+    assert per_table["dexdb.shop.customers"] == pytest.approx(CUSTOMERS_SCAN_SECONDS)
+    assert total == pytest.approx(CUSTOMERS_SCAN_SECONDS + _WAKE_MINIMUM_SECONDS)
+    # Estimation is cheap: metadata only, no scan ran.
+    assert fake_redshift_connection.data_statements == []
+
+
+def test_no_wake_floor_on_provisioned(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection, compute=dict(PROVISIONED))
+    total, _ = adapter.profile_estimate(["dexdb.shop.customers"])
+    assert total == pytest.approx(CUSTOMERS_SCAN_SECONDS)
+
+
+def test_estimate_scales_with_base_capacity(fake_redshift_connection):
+    """A 16-RPU workgroup scans (an estimated) twice as fast as the 8-RPU
+    reference, so estimated seconds halve while estimated RPU-hours hold."""
+
+    adapter = make_adapter(
+        fake_redshift_connection,
+        compute={"kind": "serverless", "workgroup": "big", "base_capacity_rpus": 16.0},
+    )
+    _total, per_table = adapter.profile_estimate(["dexdb.shop.customers"])
+    assert per_table["dexdb.shop.customers"] == pytest.approx(
+        CUSTOMERS_SCAN_SECONDS / 2
+    )
+
+
+def test_query_estimate_sums_referenced_tables(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection)
+    estimate = adapter.query_estimate("SELECT count(*) FROM dexdb.shop.customers")
+    assert estimate == pytest.approx(CUSTOMERS_SCAN_SECONDS + _WAKE_MINIMUM_SECONDS)
+
+
+def test_estimate_floor_counts_once_across_many_estimates(fake_redshift_connection):
+    """A command that sweeps many statements (maintain probes one per table)
+    wakes compute at most once, so summing per-statement estimates must not
+    multiply the floor in (verified live: a twelve-probe sweep quoted 738
+    seconds of which 720 were floors)."""
+
+    adapter = make_adapter(fake_redshift_connection)
+    first = adapter.query_estimate("SELECT count(*) FROM dexdb.shop.customers")
+    second = adapter.query_estimate("SELECT count(*) FROM dexdb.shop.customers")
+    assert first == pytest.approx(CUSTOMERS_SCAN_SECONDS + _WAKE_MINIMUM_SECONDS)
+    assert second == pytest.approx(CUSTOMERS_SCAN_SECONDS)
+
+
+def test_query_estimate_qualifies_two_part_names(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection, compute=dict(PROVISIONED))
+    estimate = adapter.query_estimate("SELECT count(*) FROM shop.customers")
+    assert estimate == pytest.approx(CUSTOMERS_SCAN_SECONDS)
+
+
+def test_query_estimate_floors_small_statements(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection, compute=dict(PROVISIONED))
+    assert (
+        adapter.query_estimate("SELECT count(*) FROM dexdb.shop.not_registered")
+        == _MIN_STATEMENT_SECONDS
+    )
+
+
+def test_query_estimate_refuses_non_select(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection)
+    with pytest.raises(Exception, match="read-only"):
+        adapter.query_estimate("DELETE FROM dexdb.shop.customers")
+
+
+def test_describe_estimate_names_seconds_rpu_and_the_floor(fake_redshift_connection):
+    adapter = make_adapter(
+        fake_redshift_connection, target=RedshiftTarget(rpu_price_usd=0.36)
+    )
+    payload = adapter.describe_estimate(160.0, {"dexdb.shop.customers": 100.0})
+    assert payload["estimated_seconds"] == 160.0
+    assert payload["estimate_quality"] == "heuristic"
+    assert "--confirm --budget" in payload["hint"]
+    assert "statement_timeout" in payload["hint"]
+    assert payload["per_table_seconds"] == {"dexdb.shop.customers": 100.0}
+    assert any("wake minimum" in note for note in payload["notes"])
+    assert payload["estimated_rpu_hours"] == pytest.approx(160.0 * 8 / 3600, abs=1e-6)
+    assert payload["rpu_rate"]["base_capacity_rpus"] == 8.0
+    assert payload["rpu_rate"]["approximate"] is True
+    assert payload["estimated_usd"] == pytest.approx(160.0 * 8 / 3600 * 0.36, abs=1e-4)
+
+
+def test_no_rpu_translation_without_capacity_or_on_provisioned(
+    fake_redshift_connection,
+):
+    unknown = make_adapter(
+        fake_redshift_connection,
+        compute={"kind": "serverless", "workgroup": "wg", "base_capacity_rpus": None},
+    )
+    assert "estimated_rpu_hours" not in unknown.describe_estimate(60.0)
+    assert unknown.spend_display() == {}
+    provisioned = make_adapter(fake_redshift_connection, compute=dict(PROVISIONED))
+    assert "estimated_rpu_hours" not in provisioned.describe_estimate(60.0)
+    assert provisioned.spend_display() == {}
+
+
+def test_spend_display_translates_actual_seconds(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n": 1}], seconds=9.0
+    )
+    adapter = make_adapter(
+        fake_redshift_connection, target=RedshiftTarget(rpu_price_usd=0.36)
+    )
+    adapter.run_query(
+        "SELECT count(*) AS n FROM dexdb.shop.customers",
+        max_rows=10,
+        timeout_seconds=30.0,
+    )
+    display = adapter.spend_display()
+    assert display["rpu_hours_billed"] == pytest.approx(9.0 * 8 / 3600)
+    assert display["usd_billed"] == pytest.approx(9.0 * 8 / 3600 * 0.36, abs=1e-4)
+
+
+# --- the cost gate binds ------------------------------------------------------------
+
+
+def test_unconfirmed_scan_never_executes(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection, confirmed=False)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    with pytest.raises(ConfirmationRequiredError):
+        adapter.column_aggregates("dexdb.shop.customers", columns)
+    assert fake_redshift_connection.data_statements == []
+
+
+def test_over_ceiling_refuses_client_side(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection, ceiling=1.0)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    with pytest.raises(OverCeilingError):
+        adapter.column_aggregates("dexdb.shop.customers", columns)
+    assert fake_redshift_connection.data_statements == []
+
+
+def test_every_billed_statement_is_server_capped(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[
+            {
+                "n_total": 100,
+                "nn_0": 100,
+                "nd_0": 90,
+                "nn_1": 90,
+                "nd_1": 80,
+                "nn_2": 70,
+            }
+        ],
+        seconds=1.0,
+    )
+    adapter = make_adapter(fake_redshift_connection, ceiling=600.0)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    adapter.column_aggregates("dexdb.shop.customers", columns)
+    billed = fake_redshift_connection.data_statements
+    assert billed, "the aggregate batch must have run"
+    for statement in billed:
+        assert statement.session_timeout_ms is not None
+        assert statement.session_timeout_ms <= 600_000
+
+
+def test_server_timeout_translates_to_over_ceiling(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[], seconds=999.0
+    )
+    adapter = make_adapter(fake_redshift_connection, ceiling=200.0)
+    with pytest.raises(OverCeilingError, match="statement_timeout"):
+        adapter.run_query(
+            "SELECT count(*) FROM dexdb.shop.customers",
+            max_rows=10,
+            timeout_seconds=500.0,
+        )
+    # The killed statement still billed what ran (the timeout's worth).
+    assert fake_redshift_connection.clock.now == pytest.approx(200.0, abs=1.0)
+
+
+def test_wall_clock_timeout_translates_to_timeout_error(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[], seconds=999.0
+    )
+    adapter = make_adapter(fake_redshift_connection, ceiling=600.0)
+    with pytest.raises(TimeoutError, match="narrow it"):
+        adapter.run_query(
+            "SELECT count(*) FROM dexdb.shop.customers",
+            max_rows=10,
+            timeout_seconds=30.0,
+        )
+
+
+def test_a_wlm_cancel_is_not_blamed_on_the_budget(fake_redshift_connection):
+    """WLM query-monitoring rules and admin kills also say "canceled"; only a
+    statement_timeout kill (SQLSTATE 57014) may be translated into budget
+    advice, or the user is told to raise --budget for a refusal it cannot fix."""
+
+    from redshift_connector import error as rs_errors
+
+    def resolve(sql):
+        raise rs_errors.ProgrammingError(
+            {
+                "S": "ERROR",
+                "C": "XX000",
+                "M": "Query (12345) canceled by WLM query monitoring rule",
+            }
+        )
+
+    fake_redshift_connection.row_resolver = resolve
+    adapter = make_adapter(fake_redshift_connection, ceiling=600.0)
+    with pytest.raises(rs_errors.ProgrammingError, match="WLM"):
+        adapter.run_query(
+            "SELECT count(*) FROM dexdb.shop.customers",
+            max_rows=10,
+            timeout_seconds=30.0,
+        )
+
+
+def test_a_dropped_connection_still_records_billed_seconds(
+    fake_redshift_connection,
+):
+    """A statement that dies mid-flight (network drop, interrupt) billed the
+    seconds that ran; the ledger and session ceiling must see them even though
+    the exception is not a ProgrammingError."""
+
+    from redshift_connector import error as rs_errors
+
+    clock = fake_redshift_connection.clock
+
+    def resolve(sql):
+        clock.now += 50.0
+        raise rs_errors.InterfaceError("connection reset by peer")
+
+    fake_redshift_connection.row_resolver = resolve
+    adapter = make_adapter(
+        fake_redshift_connection, target=RedshiftTarget(rpu_price_usd=0.36)
+    )
+    with pytest.raises(rs_errors.InterfaceError):
+        adapter.run_query(
+            "SELECT count(*) FROM dexdb.shop.customers",
+            max_rows=10,
+            timeout_seconds=120.0,
+        )
+    display = adapter.spend_display()
+    assert display["rpu_hours_billed"] == pytest.approx(50.0 * 8 / 3600)
+
+
+def test_exhausted_budget_refuses_before_the_server(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n_total": 1}], seconds=99.4
+    )
+    adapter = make_adapter(
+        fake_redshift_connection, ceiling=100.0, compute=dict(PROVISIONED)
+    )
+    adapter.run_query(
+        "SELECT count(*) FROM dexdb.shop.not_registered",
+        max_rows=10,
+        timeout_seconds=500.0,
+    )
+    # 99.4 of 100 seconds billed; under one second remains.
+    with pytest.raises(OverCeilingError, match="under one compute-second"):
+        adapter.run_query(
+            "SELECT count(*) FROM dexdb.shop.not_registered",
+            max_rows=10,
+            timeout_seconds=500.0,
+        )
+
+
+def test_actual_seconds_land_in_the_ledger(fake_redshift_connection):
+    entries: list[dict] = []
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n": 1}], seconds=2.5
+    )
+    adapter = make_adapter(fake_redshift_connection, record=entries.append)
+    adapter.run_query(
+        "SELECT count(*) AS n FROM dexdb.shop.customers",
+        max_rows=10,
+        timeout_seconds=30.0,
+    )
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["connector"] == "redshift"
+    assert entry["billed_seconds"] == pytest.approx(2.5)
+    assert "billed_bytes" not in entry
+    assert entry["statement_sha256"]
+    assert "SELECT" not in str(entry.values())
+
+
+def test_session_ceiling_binds_across_commands(fake_redshift_connection):
+    adapter = make_adapter(
+        fake_redshift_connection,
+        ceiling=None,
+        session_ceiling=100.0,
+        session_spent=99.5,
+    )
+    with pytest.raises(OverCeilingError):
+        adapter.run_query(
+            "SELECT count(*) FROM dexdb.shop.customers",
+            max_rows=10,
+            timeout_seconds=30.0,
+        )
+
+
+def test_wake_floor_is_charged_exactly_once_per_command(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n": 1}], seconds=0.1
+    )
+    # customers estimates 100s; the floor adds 60 once. Two queries fit a 270s
+    # ceiling only if the second one does not carry the floor again
+    # (100 + 60 + 100 = 260 <= 270; a re-floored 320 would refuse).
+    adapter = make_adapter(fake_redshift_connection, ceiling=270.0)
+    for _ in range(2):
+        adapter.run_query(
+            "SELECT count(*) AS n FROM dexdb.shop.customers",
+            max_rows=10,
+            timeout_seconds=30.0,
+        )
+    # And the floor was genuinely charged the first time: the same single query
+    # is refused when the ceiling covers the scan but not the floor.
+    strict = make_adapter(fake_redshift_connection, ceiling=155.0)
+    with pytest.raises(OverCeilingError):
+        strict.run_query(
+            "SELECT count(*) AS n FROM dexdb.shop.customers",
+            max_rows=10,
+            timeout_seconds=30.0,
+        )
+
+
+# --- profiling ----------------------------------------------------------------------
+
+
+def _aggregate_rows(sql: str) -> FakeResult:
+    # COUNT(*) plus per-column aggregates; values keyed by alias.
+    aliases = [part.split(" AS ")[-1] for part in sql.split(",")]
+    row = {}
+    for alias in aliases:
+        alias = alias.split(" FROM ")[0].strip()
+        row[alias] = 100 if alias == "n_total" else 90
+    return FakeResult(rows=[row], seconds=0.5)
+
+
+def test_aggregates_use_hll_distinct_in_one_pass(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = _aggregate_rows
+    adapter = make_adapter(fake_redshift_connection)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    aggregates = adapter.column_aggregates(
+        "dexdb.shop.customers", columns, safe_min_max={"id"}
+    )
+    sql = fake_redshift_connection.data_statements[0].sql
+    assert "COUNT(*)" in sql
+    # HLL(), not APPROXIMATE COUNT(DISTINCT): Redshift caps the latter at 3
+    # per statement (verified live), so a wide batch must use the former.
+    assert 'HLL("id")' in sql
+    assert "COUNT(DISTINCT" not in sql
+    by_name = {a.name: a for a in aggregates}
+    assert by_name["id"].distinct_count == 90
+    assert by_name["id"].distinct_count_exact is False
+    assert by_name["id"].is_unique is None  # an approximation is never a proof
+    assert by_name["email"].null_fraction == pytest.approx(0.1)
+
+
+def test_degraded_types_get_non_null_counts_only(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = _aggregate_rows
+    adapter = make_adapter(fake_redshift_connection)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    aggregates = adapter.column_aggregates(
+        "dexdb.shop.customers", columns, safe_min_max={"payload"}
+    )
+    sql = fake_redshift_connection.data_statements[0].sql
+    by_name = {a.name: a for a in aggregates}
+    # payload is SUPER: no distinct, no min/max, only the non-null count.
+    assert by_name["payload"].distinct_count is None
+    assert by_name["payload"].min_value is None
+    assert 'MIN("payload")' not in sql
+    assert 'HLL("payload")' not in sql
+    assert by_name["payload"].null_fraction is not None
+
+
+def test_min_max_only_for_engine_cleared_columns(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = _aggregate_rows
+    adapter = make_adapter(fake_redshift_connection)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    adapter.column_aggregates("dexdb.shop.customers", columns, safe_min_max={"id"})
+    sql = fake_redshift_connection.data_statements[0].sql
+    assert 'MIN("id")' in sql
+    assert 'MIN("email")' not in sql
+
+
+def test_exact_count_from_scan_supersedes_tbl_rows(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[
+            {"n_total": 137, "nn_0": 137, "nd_0": 137, "nn_1": 1, "nd_1": 1, "nn_2": 1}
+        ],
+        seconds=0.5,
+    )
+    adapter = make_adapter(fake_redshift_connection)
+    meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    assert meta.row_count == 100  # the SVV_TABLE_INFO estimate
+    adapter.column_aggregates("dexdb.shop.customers", columns)
+    meta, _ = adapter.table_metadata("dexdb.shop.customers")
+    assert meta.row_count == 137  # the exact count the scan paid for
+
+
+def test_exact_distinct_counts_ride_with_count_star(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n_total": 120, "d_0": 120}], seconds=0.5
+    )
+    adapter = make_adapter(fake_redshift_connection)
+    counts = adapter.exact_distinct_counts("dexdb.shop.customers", ["id"])
+    assert counts == {"id": 120}
+    sql = fake_redshift_connection.data_statements[0].sql
+    assert 'COUNT(DISTINCT "id")' in sql
+    assert "COUNT(*)" in sql
+    meta, _ = adapter.table_metadata("dexdb.shop.customers")
+    assert meta.row_count == 120
+
+
+def test_escalation_skipped_when_budget_cannot_cover(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection, ceiling=1.0)
+    counts = adapter.exact_distinct_counts("dexdb.shop.customers", ["id"])
+    assert counts == {}
+    assert fake_redshift_connection.data_statements == []
+    notes = adapter.table_notes("dexdb.shop.customers")
+    assert any("escalation skipped" in note for note in notes)
+
+
+def test_escalation_carries_the_wake_floor_when_it_bills_first(
+    fake_redshift_connection,
+):
+    """The exact-distinct scan can be a command's first billed statement
+    (maintain grain runs key checks before any probe), so the pending wake
+    minimum rides its charge and is consumed for the statements that follow;
+    a refused charge leaves the floor pending."""
+
+    def resolve(sql):
+        if "COUNT(DISTINCT" in sql:
+            return FakeResult(rows=[{"n_total": 120, "d_0": 120}], seconds=0.1)
+        return FakeResult(rows=[{"n": 1}], seconds=0.1)
+
+    fake_redshift_connection.row_resolver = resolve
+
+    # The ceiling covers the scan (100s) but not scan + floor (160s): the
+    # escalation must refuse rather than under-charge its way in.
+    strict = make_adapter(fake_redshift_connection, ceiling=155.0)
+    assert strict.exact_distinct_counts("dexdb.shop.customers", ["id"]) == {}
+    assert fake_redshift_connection.data_statements == []
+
+    # And once charged, the floor is consumed: escalation (100 + 60) plus a
+    # follow-up query (100, floorless) fit a 270s ceiling only if the second
+    # statement does not carry the floor again.
+    adapter = make_adapter(fake_redshift_connection, ceiling=270.0)
+    assert adapter.exact_distinct_counts("dexdb.shop.customers", ["id"]) == {"id": 120}
+    adapter.run_query(
+        "SELECT count(*) AS n FROM dexdb.shop.customers",
+        max_rows=10,
+        timeout_seconds=30.0,
+    )
+
+
+# --- run_query ----------------------------------------------------------------------
+
+
+def test_run_query_truncates_and_reports(fake_redshift_connection):
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[{"n": i} for i in range(5)], seconds=0.1
+    )
+    adapter = make_adapter(fake_redshift_connection)
+    result = adapter.run_query(
+        "SELECT id AS n FROM dexdb.shop.customers",
+        max_rows=3,
+        timeout_seconds=30.0,
+    )
+    assert result.columns == ["n"]
+    assert len(result.cells) == 3
+    assert result.truncated is True
+
+
+def test_run_query_rejects_writes(fake_redshift_connection):
+    adapter = make_adapter(fake_redshift_connection)
+    with pytest.raises(Exception, match="read-only"):
+        adapter.run_query(
+            "UPDATE dexdb.shop.customers SET email = 'x'",
+            max_rows=10,
+            timeout_seconds=30.0,
+        )
+    assert fake_redshift_connection.data_statements == []
+
+
+# --- credential discovery -----------------------------------------------------------
+
+
+class _StubServerlessClient:
+    def __init__(self, *, base_capacity=8, endpoint=True, db_name="dexdb"):
+        self._base_capacity = base_capacity
+        self._endpoint = endpoint
+        self._db_name = db_name
+
+    def get_workgroup(self, workgroupName):  # noqa: N803 (boto3's spelling)
+        workgroup = {
+            "workgroupName": workgroupName,
+            "namespaceName": "dex-ns",
+            "status": "AVAILABLE",
+            "baseCapacity": self._base_capacity,
+        }
+        if self._endpoint:
+            workgroup["endpoint"] = {
+                "address": (
+                    f"{workgroupName}.123456789012.eu-central-1"
+                    ".redshift-serverless.amazonaws.com"
+                ),
+                "port": 5439,
+            }
+        return {"workgroup": workgroup}
+
+    def get_namespace(self, namespaceName):  # noqa: N803 (boto3's spelling)
+        return {"namespace": {"namespaceName": namespaceName, "dbName": self._db_name}}
+
+
+def _stub_boto3(monkeypatch, client: _StubServerlessClient):
+    class _Session:
+        def __init__(self, *, profile_name=None, region_name=None):
+            self.profile_name = profile_name
+            self.region_name = region_name
+
+        def client(self, service):
+            assert service == "redshift-serverless"
+            return client
+
+    import boto3
+
+    monkeypatch.setattr(boto3, "Session", _Session)
+
+
+def test_discovery_prefers_the_pinned_workgroup(monkeypatch, tmp_path: Path):
+    _stub_boto3(monkeypatch, _StubServerlessClient())
+    params, method, compute = resolve_redshift_connection(
+        RedshiftTarget(workgroup="dex-wg", aws_profile="dex"),
+        {"REDSHIFT_HOST": "ignored.example.com"},
+        tmp_path,
+    )
+    assert params["iam"] is True
+    assert params["host"].endswith(".redshift-serverless.amazonaws.com")
+    assert params["port"] == 5439
+    assert params["database"] == "dexdb"  # discovered from the namespace
+    assert params["profile"] == "dex"
+    assert method == "iam_serverless:profile"
+    assert compute == {
+        "kind": "serverless",
+        "workgroup": "dex-wg",
+        "base_capacity_rpus": 8.0,
+    }
+
+
+def test_discovery_workgroup_without_endpoint_names_the_state(
+    monkeypatch, tmp_path: Path
+):
+    _stub_boto3(monkeypatch, _StubServerlessClient(endpoint=False))
+    with pytest.raises(CredentialDiscoveryError, match="AVAILABLE"):
+        resolve_redshift_connection(RedshiftTarget(workgroup="dex-wg"), {}, tmp_path)
+
+
+def test_discovery_workgroup_failure_names_every_fix(monkeypatch, tmp_path: Path):
+    from botocore.exceptions import BotoCoreError
+
+    class _Broken:
+        def get_workgroup(self, workgroupName):  # noqa: N803 (boto3's spelling)
+            raise BotoCoreError()
+
+    _stub_boto3(monkeypatch, _Broken())
+    with pytest.raises(CredentialDiscoveryError) as excinfo:
+        resolve_redshift_connection(RedshiftTarget(workgroup="dex-wg"), {}, tmp_path)
+    message = str(excinfo.value)
+    for fix in ("aws configure", "AWS_*", "GetWorkgroup", "GetCredentials"):
+        assert fix in message
+
+
+def test_discovery_cluster_requires_dbname_and_user(tmp_path: Path):
+    with pytest.raises(CredentialDiscoveryError, match=r"redshift\.dbname"):
+        resolve_redshift_connection(
+            RedshiftTarget(cluster_identifier="prod-cluster"), {}, tmp_path
+        )
+
+
+def test_discovery_cluster_params(tmp_path: Path):
+    params, method, compute = resolve_redshift_connection(
+        RedshiftTarget(
+            cluster_identifier="prod-cluster",
+            dbname="shop",
+            user="dex_ro",
+            region="eu-central-1",
+        ),
+        {},
+        tmp_path,
+    )
+    assert params == {
+        "iam": True,
+        "cluster_identifier": "prod-cluster",
+        "database": "shop",
+        "db_user": "dex_ro",
+        "region": "eu-central-1",
+    }
+    assert method == "iam_cluster:default_chain"
+    assert compute["kind"] == "provisioned"
+
+
+def test_discovery_env_redshift_host(tmp_path: Path):
+    params, method, compute = resolve_redshift_connection(
+        RedshiftTarget(),
+        {
+            "REDSHIFT_HOST": "cluster.abc.eu-central-1.redshift.amazonaws.com",
+            "REDSHIFT_DATABASE": "shop",
+            "REDSHIFT_USER": "dex_ro",
+            "REDSHIFT_PASSWORD": "secret",
+        },
+        tmp_path,
+    )
+    assert params["host"] == "cluster.abc.eu-central-1.redshift.amazonaws.com"
+    assert params["database"] == "shop"
+    assert params["password"] == "secret"  # noqa: S105 (a fixture, not a credential)
+    assert method == "environment:password"
+    assert compute["kind"] == "provisioned"
+
+
+def test_discovery_env_serverless_host_flags_serverless(tmp_path: Path):
+    _params, _method, compute = resolve_redshift_connection(
+        RedshiftTarget(),
+        {
+            "REDSHIFT_HOST": (
+                "wg.123456789012.eu-central-1.redshift-serverless.amazonaws.com"
+            ),
+            "REDSHIFT_DATABASE": "shop",
+        },
+        tmp_path,
+    )
+    assert compute == {
+        "kind": "serverless",
+        "workgroup": None,
+        "base_capacity_rpus": None,
+    }
+
+
+def test_discovery_config_target(tmp_path: Path):
+    params, method, _compute = resolve_redshift_connection(
+        RedshiftTarget(host="db.internal", port=5440, dbname="shop", user="dex"),
+        {},
+        tmp_path,
+    )
+    assert params == {
+        "host": "db.internal",
+        "port": 5440,
+        "database": "shop",
+        "user": "dex",
+    }
+    assert method == "config_target:external"
+
+
+def test_discovery_dbt_profile_fallback(tmp_path: Path):
+    project = tmp_path / "analytics"
+    project.mkdir()
+    (project / "dbt_project.yml").write_text(
+        "name: analytics\nversion: '1.0.0'\nprofile: analytics\n", encoding="utf-8"
+    )
+    (project / "profiles.yml").write_text(
+        "analytics:\n"
+        "  target: dev\n"
+        "  outputs:\n"
+        "    dev:\n"
+        "      type: redshift\n"
+        "      host: wg.example.redshift-serverless.amazonaws.com\n"
+        "      port: 5439\n"
+        "      user: dbt\n"
+        "      password: hunter2\n"
+        "      dbname: shop\n",
+        encoding="utf-8",
+    )
+    params, method, compute = resolve_redshift_connection(
+        RedshiftTarget(), {}, tmp_path
+    )
+    assert params["host"] == "wg.example.redshift-serverless.amazonaws.com"
+    assert params["database"] == "shop"
+    assert method == "dbt_profile:password"
+    assert compute["kind"] == "serverless"
+
+
+def _write_dbt_profile(tmp_path: Path, output_lines: str) -> None:
+    project = tmp_path / "analytics"
+    project.mkdir()
+    (project / "dbt_project.yml").write_text(
+        "name: analytics\nversion: '1.0.0'\nprofile: analytics\n", encoding="utf-8"
+    )
+    (project / "profiles.yml").write_text(
+        "analytics:\n  target: dev\n  outputs:\n    dev:\n" + output_lines,
+        encoding="utf-8",
+    )
+
+
+def test_discovery_renders_the_profiles_env_var_password_like_dbt_would(
+    tmp_path: Path,
+):
+    """dex's own transform init writes the password as an env_var reference;
+    discovering that profile must resolve the reference, not send the literal
+    Jinja template to the driver as a password."""
+
+    _write_dbt_profile(
+        tmp_path,
+        "      type: redshift\n"
+        "      host: db.internal\n"
+        "      user: dbt\n"
+        "      password: \"{{ env_var('REDSHIFT_PASSWORD') }}\"\n"
+        "      dbname: shop\n",
+    )
+    params, method, _compute = resolve_redshift_connection(
+        RedshiftTarget(), {"REDSHIFT_PASSWORD": "s3cret"}, tmp_path
+    )
+    assert params["password"] == "s3cret"  # noqa: S105 (a test-only stand-in)
+    assert method == "dbt_profile:password"
+
+
+def test_discovery_skips_a_profile_whose_template_cannot_render(tmp_path: Path):
+    """With the referenced env var unset, the output cannot connect as
+    discovered: discovery falls through to the failure that names the fix
+    instead of attempting auth with a Jinja literal."""
+
+    _write_dbt_profile(
+        tmp_path,
+        "      type: redshift\n"
+        "      host: db.internal\n"
+        "      user: dbt\n"
+        "      password: \"{{ env_var('REDSHIFT_PASSWORD') }}\"\n"
+        "      dbname: shop\n",
+    )
+    with pytest.raises(CredentialDiscoveryError, match="REDSHIFT_PASSWORD"):
+        resolve_redshift_connection(RedshiftTarget(), {}, tmp_path)
+
+
+def test_discovery_skips_an_iam_profile_output(tmp_path: Path):
+    """A method: iam output mints credentials at dbt runtime; it carries
+    nothing durable for a native connection, so discovery must not treat its
+    host as a password-path candidate."""
+
+    _write_dbt_profile(
+        tmp_path,
+        "      type: redshift\n"
+        "      method: iam\n"
+        "      host: wg.example.redshift-serverless.amazonaws.com\n"
+        "      user: iam\n"
+        "      dbname: shop\n",
+    )
+    with pytest.raises(CredentialDiscoveryError):
+        resolve_redshift_connection(RedshiftTarget(), {}, tmp_path)
+
+
+def test_discovery_failure_names_every_fix(tmp_path: Path):
+    with pytest.raises(CredentialDiscoveryError) as excinfo:
+        resolve_redshift_connection(RedshiftTarget(), {}, tmp_path)
+    message = str(excinfo.value)
+    for fix in (
+        "redshift.workgroup",
+        "redshift.cluster_identifier",
+        "REDSHIFT_HOST",
+        "REDSHIFT_PASSWORD",
+        "profiles.yml",
+    ):
+        assert fix in message
+
+
+def test_discovery_never_surfaces_a_password(tmp_path: Path):
+    _params, method, _compute = resolve_redshift_connection(
+        RedshiftTarget(),
+        {
+            "REDSHIFT_HOST": "h.example.com",
+            "REDSHIFT_DATABASE": "shop",
+            "REDSHIFT_PASSWORD": "supersecret",
+        },
+        tmp_path,
+    )
+    assert "supersecret" not in method
+
+
+# --- scope resolution: an entry that names nothing is refused, not dropped ------------
+
+
+def test_nonexistent_schema_scope_is_refused_and_names_what_exists(
+    fake_redshift_connection,
+):
+    adapter = make_adapter(
+        fake_redshift_connection, target=RedshiftTarget(schemas=["no_such_schema"])
+    )
+    with pytest.raises(RedshiftConnectionError) as exc:
+        adapter.list_objects()
+    message = str(exc.value)
+    assert "no_such_schema" in message
+    assert "shop" in message  # the schemas that do exist
+    assert "[from redshift.schemas in .dex/config.yml]" in message
+    assert fake_redshift_connection.data_statements == []
+
+
+def test_scope_refusal_blames_the_flag_it_came_from(fake_redshift_connection):
+    adapter = make_adapter(
+        fake_redshift_connection,
+        target=RedshiftTarget(schemas=["nope"]),
+        scope_origin="--scope",
+    )
+    with pytest.raises(RedshiftConnectionError, match=r"\[from --scope\]"):
+        adapter.list_objects()
+
+
+def test_a_qualified_scope_is_refused_as_redshift_vocabulary(fake_redshift_connection):
+    """dbt refuses cross-database references outright, so a Redshift scope is
+    always a bare schema in the connected database."""
+
+    adapter = make_adapter(
+        fake_redshift_connection, target=RedshiftTarget(schemas=["dexdb.shop"])
+    )
+    with pytest.raises(RedshiftConnectionError, match="never a database or a table"):
+        adapter.list_objects()
+
+
+def test_a_valid_scope_still_bounds_the_inventory(fake_redshift_connection):
+    adapter = make_adapter(
+        fake_redshift_connection, target=RedshiftTarget(schemas=["shop"])
+    )
+    assert {o.schema for o in adapter.list_objects()} == {"shop"}
+    assert fake_redshift_connection.data_statements == []
+
+
+# --- the dev-target preflight (cheap): the privilege, not the object ------------------
+
+
+def _with_user(user: FakeUser) -> FakeRedshiftConnection:
+    return FakeRedshiftConnection(
+        tables=[
+            FakeRedshiftTable(
+                schema="shop",
+                name="customers",
+                columns=[("id", "bigint", False)],
+                size_mb=1,
+            )
+        ],
+        users=[user],
+        empty_schemas=["dbt_dev"],
+    )
+
+
+def test_a_writable_dev_schema_is_fine():
+    connection = _with_user(
+        FakeUser(name="dbt_dev", schema_privileges={"dbt_dev": {"USAGE", "CREATE"}})
+    )
+    adapter = make_adapter(connection)
+    assert adapter.missing_dev_namespaces("dbt_dev", role="dbt_dev") == []
+    assert connection.data_statements == []
+
+
+def test_a_dev_schema_the_user_cannot_write_is_reported():
+    connection = _with_user(
+        FakeUser(name="dbt_dev", schema_privileges={"dbt_dev": {"USAGE"}})
+    )
+    adapter = make_adapter(connection)
+    assert adapter.missing_dev_namespaces("dbt_dev", role="dbt_dev") == [
+        'CREATE on dev_schema "dbt_dev"'
+    ]
+
+
+def test_an_absent_dev_schema_is_fine_when_the_user_may_create_it():
+    """dbt creates the schema itself, so absence alone is not the failure."""
+
+    connection = _with_user(FakeUser(name="dbt_dev", may_create_in_database=True))
+    adapter = make_adapter(connection)
+    assert adapter.missing_dev_namespaces("not_there", role="dbt_dev") == []
+
+
+def test_an_absent_dev_schema_the_user_cannot_create_is_reported():
+    connection = _with_user(FakeUser(name="dbt_dev", may_create_in_database=False))
+    adapter = make_adapter(connection)
+    assert adapter.missing_dev_namespaces("not_there", role="dbt_dev") == [
+        'dev_schema "not_there"'
+    ]
+
+
+def test_a_profile_user_the_database_does_not_know_is_refused():
+    connection = _with_user(FakeUser(name="dbt_dev"))
+    adapter = make_adapter(connection)
+    with pytest.raises(RedshiftConnectionError) as exc:
+        adapter.missing_dev_namespaces("dbt_dev", role="ghost")
+    assert "ghost" in str(exc.value)

--- a/packages/dex-core/tests/adapters/test_scope_flags.py
+++ b/packages/dex-core/tests/adapters/test_scope_flags.py
@@ -15,6 +15,7 @@ from exmergo_dex_core.config import (
     BigQueryTarget,
     DatabricksTarget,
     PostgresTarget,
+    RedshiftTarget,
 )
 from exmergo_dex_core.connect import ScopeError, assert_scope_vocabulary, narrow_target
 
@@ -28,7 +29,9 @@ def _assert(connector, *, project=None, datasets=None, scopes=None):
 # --- vocabulary --------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("connector", ["snowflake", "databricks", "postgres"])
+@pytest.mark.parametrize(
+    "connector", ["snowflake", "databricks", "postgres", "redshift"]
+)
 @pytest.mark.parametrize(
     ("flag", "kwargs"),
     [("--project", {"project": "p"}), ("--dataset", {"datasets": ["d"]})],
@@ -58,7 +61,7 @@ def test_bigquery_accepts_its_own_flags():
 
 
 @pytest.mark.parametrize(
-    "connector", ["bigquery", "snowflake", "databricks", "postgres"]
+    "connector", ["bigquery", "snowflake", "databricks", "postgres", "redshift"]
 )
 def test_scope_is_accepted_on_every_warehouse_connector(connector):
     _assert(connector, scopes=["analytics"])
@@ -71,7 +74,14 @@ def test_bigquery_refuses_dataset_and_scope_together():
 
 
 def test_no_flags_is_always_fine():
-    for connector in ("duckdb", "bigquery", "snowflake", "databricks", "postgres"):
+    for connector in (
+        "duckdb",
+        "bigquery",
+        "snowflake",
+        "databricks",
+        "postgres",
+        "redshift",
+    ):
         _assert(connector)
 
 
@@ -113,6 +123,15 @@ def test_containment_is_case_insensitive():
 def test_a_coarser_scope_cannot_escape_a_finer_allowlist():
     with pytest.raises(ScopeError):
         narrow_target(DatabricksTarget(catalogs=["raw.events"]), "databricks", ["raw"])
+
+
+def test_redshift_scope_narrows_and_never_widens():
+    target = narrow_target(
+        RedshiftTarget(schemas=["shop", "billing"]), "redshift", ["shop"]
+    )
+    assert target.schemas == ["shop"]
+    with pytest.raises(ScopeError, match="never widens"):
+        narrow_target(RedshiftTarget(schemas=["shop"]), "redshift", ["billing"])
 
 
 def test_no_override_leaves_the_target_untouched():

--- a/packages/dex-core/tests/conftest.py
+++ b/packages/dex-core/tests/conftest.py
@@ -228,6 +228,52 @@ def fake_pg_connection():
 
 
 @pytest.fixture
+def fake_redshift_connection():
+    """The standard populated fake Redshift connection (see
+    tests/fakes/redshift.py).
+
+    Requires the real redshift_connector library (the [redshift] extra) for
+    its error types; skipped when absent, but CI and the release gate install
+    the extra, so the Redshift safety families run everywhere that matters.
+    ``customers`` carries SVV_TABLE_INFO facts; ``signups`` holds no data so
+    the view omits it (the census must still see it); ``events`` is the
+    50 GB table a non-trivial estimate comes from.
+    """
+
+    pytest.importorskip("redshift_connector")
+    from fakes.redshift import FakeRedshiftConnection, FakeRedshiftTable
+
+    tables = [
+        FakeRedshiftTable(
+            schema="shop",
+            name="customers",
+            columns=[
+                ("id", "bigint", False),
+                ("email", "character varying", True),
+                ("payload", "super", True),
+            ],
+            size_mb=5_000,  # 5 GB -> a non-trivial seconds estimate
+            tbl_rows=100.0,
+        ),
+        FakeRedshiftTable(
+            schema="shop",
+            name="signups",
+            columns=[("id", "bigint", True)],
+            # Holds no data: SVV_TABLE_INFO omits it, the pg_class census must not.
+            size_mb=None,
+        ),
+        FakeRedshiftTable(
+            schema="shop",
+            name="events",
+            columns=[("id", "bigint", True), ("payload", "super", True)],
+            size_mb=50_000,  # 50 GB
+            tbl_rows=1_000_000.0,
+        ),
+    ]
+    return FakeRedshiftConnection(tables=tables, database="dexdb")
+
+
+@pytest.fixture
 def dbt_project_dir(tmp_path: Path) -> Path:
     """A minimal dbt project with a project-local profiles.yml.
 

--- a/packages/dex-core/tests/fakes/redshift.py
+++ b/packages/dex-core/tests/fakes/redshift.py
@@ -1,0 +1,357 @@
+"""A stateful fake of the redshift_connector connection surface dex uses.
+
+Behavioral, not a mock: it records every statement in order, serves the
+catalog lookups (the ``pg_class`` census, ``SVV_TABLE_INFO`` size facts with
+the real view's empty-table omission, ``SVV_COLUMNS``, namespace scope, the
+capabilities probe, the dev-target privilege predicates) from a table
+registry, simulates per-statement duration by advancing an injectable clock
+(the adapter measures wall-clock elapsed through the same clock, so timing
+assertions are deterministic), tracks the session parameters the adapter sets
+(``statement_timeout``, ``query_group``, the best-effort read-only mode, with
+a knob to decline it the way a server without the parameter would), and
+enforces ``statement_timeout`` the way the server does: a real
+``redshift_connector.error.ProgrammingError`` raised at execute with the
+server's message shape, and the elapsed time capped at the timeout (a killed
+statement still bills what ran). Tests assert against observable behavior
+(statement ordering, session state, ledger effects), not call signatures.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from redshift_connector import error as rs_errors
+
+# Statements with no registered duration run this long on the fake clock.
+DEFAULT_STATEMENT_SECONDS = 0.2
+
+_TEXT_TYPE_CODE = 25
+
+
+class FakeClock:
+    """The adapter's injectable clock; the fake connection advances it by each
+    statement's simulated duration."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+@dataclass
+class FakeRedshiftTable:
+    schema: str
+    name: str
+    # (column_name, SVV_COLUMNS data_type, nullable), e.g. ("id", "bigint", False)
+    columns: list[tuple[str, str, bool]]
+    # SVV_TABLE_INFO facts. ``size_mb=None`` models the real view's documented
+    # behavior of omitting tables that hold no data.
+    size_mb: int | None = None
+    tbl_rows: float | None = None
+    kind: str = "table"  # "table" | "view"
+
+    @property
+    def relkind(self) -> str:
+        return {"table": "r", "view": "v"}[self.kind]
+
+    @property
+    def total_bytes(self) -> int:
+        return int(self.size_mb or 0) * 1024 * 1024
+
+
+@dataclass
+class FakeUser:
+    """A database user and what it may do, for the dev-target privilege
+    preflight. The preflight asks about the user in the rendered profile,
+    which need not be the user the connection authenticated as, so the fake
+    answers privilege questions per user rather than for one implicit current
+    user."""
+
+    name: str
+    # CREATE on the database: what dbt needs to create a dev schema that is
+    # not there yet.
+    may_create_in_database: bool = False
+    # schema name -> the privileges this user holds on it ({"USAGE", "CREATE"}).
+    schema_privileges: dict[str, set[str]] = field(default_factory=dict)
+
+
+@dataclass
+class FakeStatement:
+    sql: str
+    session_timeout_ms: int | None
+
+
+@dataclass
+class FakeResult:
+    """What one executed SELECT returns: dict rows keyed by alias, plus how
+    long the statement 'runs' on the fake clock."""
+
+    rows: list[dict]
+    seconds: float = DEFAULT_STATEMENT_SECONDS
+
+
+def _timeout_error() -> rs_errors.ProgrammingError:
+    """The server's statement_timeout kill, verbatim in shape (verified live
+    2026-07-13): the driver surfaces the backend error dict, and Redshift
+    words the server-side kill as a user cancel, so the SQLSTATE (57014) is
+    what the adapter's refusal translation keys on."""
+
+    return rs_errors.ProgrammingError(
+        {
+            "S": "ERROR",
+            "C": "57014",
+            "M": "Query cancelled on user's request",
+        }
+    )
+
+
+_CATALOG_MARKERS = (
+    "pg_catalog.",
+    "svv_table_info",
+    "svv_columns",
+    "current_database()",
+    "version()",
+    "has_schema_privilege",
+    "has_database_privilege",
+)
+
+
+def _is_catalog(sql: str) -> bool:
+    lowered = sql.lower()
+    return any(marker in lowered for marker in _CATALOG_MARKERS)
+
+
+class FakeCursor:
+    def __init__(self, conn: FakeRedshiftConnection):
+        self._conn = conn
+        self._rows: list[tuple] = []
+        # DB-API description tuples: (name, type_code, ...), which is what
+        # redshift_connector exposes and the adapter indexes into.
+        self.description: list[tuple] = []
+
+    def execute(self, sql: str):
+        stripped = sql.strip()
+        upper = stripped.upper()
+        self._record(sql)
+
+        if upper.startswith("SET "):
+            self._apply_session_parameter(stripped)
+            return self
+        if _is_catalog(stripped):
+            self._serve_catalog(stripped)
+            return self
+
+        # A data statement: simulate duration, enforce the session timeout the
+        # way the server does (kill and bill what ran).
+        result = self._conn.resolve(sql)
+        timeout_ms = self._conn.session_parameters.get("statement_timeout")
+        if timeout_ms is not None and result.seconds * 1000 > float(timeout_ms):
+            self._conn.clock.now += float(timeout_ms) / 1000.0
+            raise _timeout_error()
+        self._conn.clock.now += result.seconds
+        self._emit(result.rows)
+        return self
+
+    def fetchall(self) -> list[tuple]:
+        return list(self._rows)
+
+    def fetchmany(self, size: int) -> list[tuple]:
+        return list(self._rows[:size])
+
+    # --- internals -------------------------------------------------------------
+
+    def _record(self, sql: str) -> None:
+        timeout = self._conn.session_parameters.get("statement_timeout")
+        self._conn.statements.append(
+            FakeStatement(
+                sql=sql,
+                session_timeout_ms=int(timeout) if timeout is not None else None,
+            )
+        )
+
+    def _apply_session_parameter(self, sql: str) -> None:
+        # SET <param> = <value> (Redshift also accepts SET <param> TO <value>).
+        try:
+            assignment = sql.split(" ", 1)[1]
+            separator = "=" if "=" in assignment else " TO "
+            key, value = assignment.split(separator, 1)
+            key = key.strip().lower()
+            value = value.strip().strip("'")
+        except (IndexError, ValueError):
+            return
+        if key == "default_transaction_read_only" and self._conn.reject_read_only:
+            raise rs_errors.ProgrammingError(
+                {
+                    "S": "ERROR",
+                    "C": "42704",
+                    "M": (
+                        "unrecognized configuration parameter "
+                        '"default_transaction_read_only"'
+                    ),
+                }
+            )
+        self._conn.session_parameters[key] = (
+            int(value) if value.lstrip("-").isdigit() else value
+        )
+
+    def _serve_catalog(self, sql: str) -> None:
+        lowered = sql.lower()
+        # The privilege predicates come first: has_database_privilege names
+        # current_database() too, and would otherwise be answered as the
+        # capabilities probe.
+        if "has_database_privilege" in lowered:
+            user = self._conn.users.get(_first_literal(sql))
+            self._emit([{"may_create": bool(user and user.may_create_in_database)}])
+        elif "has_schema_privilege" in lowered:
+            # The adapter asks about both privileges in one round-trip, so the
+            # answer carries both: SELECT ... AS may_create, ... AS may_use.
+            literals = _literals(sql)
+            user = self._conn.users.get(literals[0] if literals else "")
+            held = user.schema_privileges.get(literals[1], set()) if user else set()
+            self._emit([{"may_create": "CREATE" in held, "may_use": "USAGE" in held}])
+        elif "version()" in lowered:
+            self._emit(
+                [
+                    {
+                        "db": self._conn.database,
+                        "server_version": self._conn.server_version,
+                    }
+                ]
+            )
+        elif "svv_table_info" in lowered:
+            rows = [
+                {
+                    "schema_name": t.schema,
+                    "table_name": t.name,
+                    "size": t.size_mb,
+                    "tbl_rows": t.tbl_rows,
+                }
+                for t in sorted(self._conn.tables, key=lambda t: (t.schema, t.name))
+                # The real view omits tables holding no data.
+                if t.kind == "table" and t.size_mb is not None
+            ]
+            self._emit(rows)
+        elif "svv_columns" in lowered:
+            rows = []
+            for t in sorted(self._conn.tables, key=lambda t: (t.schema, t.name)):
+                for col, data_type, nullable in t.columns:
+                    rows.append(
+                        {
+                            "schema_name": t.schema,
+                            "object_name": t.name,
+                            "column_name": col,
+                            "data_type": data_type,
+                            "is_nullable": "YES" if nullable else "NO",
+                        }
+                    )
+            self._emit(rows)
+        elif "pg_catalog.pg_class" in lowered:
+            rows = [
+                {
+                    "schema_name": t.schema,
+                    "object_name": t.name,
+                    "kind": t.relkind,
+                }
+                for t in sorted(self._conn.tables, key=lambda t: (t.schema, t.name))
+            ]
+            self._emit(rows)
+        elif "pg_catalog.pg_user" in lowered:
+            known = [name for name in self._conn.users if f"'{name}'" in sql]
+            self._emit([{"present": 1} for _ in known])
+        elif "pg_catalog.pg_namespace" in lowered:
+            names = sorted(
+                {t.schema for t in self._conn.tables} | self._conn.empty_schemas
+            )
+            self._emit([{"nspname": name} for name in names])
+        elif "current_database()" in lowered:
+            self._emit([{"db": self._conn.database}])
+        else:
+            self._emit([])
+
+    def _emit(self, rows: list[dict]) -> None:
+        # Every branch builds uniform dicts, so the first row names the
+        # columns; with no rows the adapter zips labels over nothing, so the
+        # placeholder is never observed.
+        keys = list(rows[0].keys()) if rows else ["name"]
+        self.description = [(key, _TEXT_TYPE_CODE) for key in keys]
+        self._rows = [tuple(row[key] for key in keys) for row in rows]
+
+
+def _literals(sql: str) -> list[str]:
+    """The single-quoted literals of an engine-built catalog query, in order."""
+
+    return re.findall(r"'([^']*)'", sql)
+
+
+def _first_literal(sql: str) -> str:
+    found = _literals(sql)
+    return found[0] if found else ""
+
+
+class FakeRedshiftConnection:
+    """Simulates exactly the connection surface the adapter touches; anything
+    else raises AttributeError, which is the point (the adapter must not grow
+    calls the fake does not vouch for)."""
+
+    def __init__(
+        self,
+        *,
+        tables: list[FakeRedshiftTable] | None = None,
+        database: str = "dexdb",
+        server_version: str = (
+            "PostgreSQL 8.0.2 on i686-pc-linux-gnu, compiled by GCC 3.4.2, "
+            "Redshift 1.0.12345"
+        ),
+        clock: FakeClock | None = None,
+        row_resolver: Callable[[str], FakeResult | list[dict]] | None = None,
+        users: list[FakeUser] | None = None,
+        empty_schemas: list[str] | None = None,
+        reject_read_only: bool = False,
+    ):
+        self.tables = tables or []
+        # Users the database knows, and their privileges: what the dev-target
+        # preflight interrogates. Schemas holding no table (a scratch dev
+        # schema before a first build) cannot come from the table registry, so
+        # they are declared here.
+        self.users = {user.name: user for user in (users or [])}
+        self.empty_schemas = set(empty_schemas or [])
+        self.database = database
+        self.server_version = server_version
+        self.clock = clock or FakeClock()
+        self.row_resolver = row_resolver
+        # A server that does not speak the session read-only parameter: the
+        # adapter must tolerate the refusal and report it honestly.
+        self.reject_read_only = reject_read_only
+        self.statements: list[FakeStatement] = []
+        self.session_parameters: dict[str, object] = {}
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
+
+    def resolve(self, sql: str) -> FakeResult:
+        if self.row_resolver is None:
+            return FakeResult(rows=[])
+        resolved = self.row_resolver(sql)
+        return resolved if isinstance(resolved, FakeResult) else FakeResult(resolved)
+
+    def close(self) -> None:
+        self.closed = True
+
+    # --- convenience for assertions ---------------------------------------------
+
+    @property
+    def data_statements(self) -> list[FakeStatement]:
+        """Statements that scan data: SELECTs that are not catalog lookups,
+        the capabilities probe, or the dev-target privilege predicates (those
+        answer from the catalog, scanning nothing)."""
+
+        return [
+            s
+            for s in self.statements
+            if s.sql.strip().upper().startswith("SELECT") and not _is_catalog(s.sql)
+        ]

--- a/packages/dex-core/tests/integration/conftest.py
+++ b/packages/dex-core/tests/integration/conftest.py
@@ -40,6 +40,20 @@ the whole thing up):
 
     DEX_TEST_PG_DSN=postgresql://dex_ro:dex_ro@localhost:5433/dex_dogfood \
         DEX_TEST_PG_DEV_PASSWORD=dbt_dev uv run pytest tests/integration -q
+
+Redshift (bills RPU time on the pinned Serverless workgroup; every confirmed
+budget derives from DEX_TEST_REDSHIFT_MAX_SECONDS, default 60 -- small fixed
+multiples covering the 60-second wake minimum plus the seeded scans -- and the
+budget-derived statement_timeout caps each statement server-side; the
+workgroup usage limit is the hard backstop). Auth is
+the AWS default credential chain (`aws configure` locally, an assumed OIDC
+role in CI; scripts/setup_redshift_ci.sh provisions the workgroup, the users,
+and the usage limit); transform additionally needs the dbt_dev user's
+password in DEX_TEST_REDSHIFT_DEV_PASSWORD unless the IAM profile path is in
+use:
+
+    DEX_TEST_REDSHIFT_WORKGROUP=dex-ci DEX_TEST_REDSHIFT_DATABASE=dev \
+        uv run pytest tests/integration -q
 """
 
 from __future__ import annotations
@@ -55,6 +69,8 @@ MAX_BYTES = int(os.environ.get("DEX_TEST_BQ_MAX_BYTES", str(100 * 1024 * 1024)))
 SF_MAX_SECONDS = float(os.environ.get("DEX_TEST_SNOWFLAKE_MAX_SECONDS", "60"))
 
 DBX_MAX_SECONDS = float(os.environ.get("DEX_TEST_DATABRICKS_MAX_SECONDS", "60"))
+
+RS_MAX_SECONDS = float(os.environ.get("DEX_TEST_REDSHIFT_MAX_SECONDS", "60"))
 
 
 def _snowflake_enabled() -> bool:
@@ -96,6 +112,18 @@ def _require_cloud_env(request):
             )
         pytest.importorskip("psycopg")
         return
+    if request.node.get_closest_marker("redshift"):
+        if not (
+            os.environ.get("DEX_TEST_REDSHIFT_WORKGROUP")
+            or os.environ.get("DEX_TEST_REDSHIFT_HOST")
+        ):
+            pytest.skip(
+                "Redshift integration disabled: set DEX_TEST_REDSHIFT_WORKGROUP "
+                "(IAM via the AWS credential chain) or DEX_TEST_REDSHIFT_HOST "
+                "plus REDSHIFT_* credentials"
+            )
+        pytest.importorskip("redshift_connector")
+        return
     missing = [name for name in REQUIRED_ENV if not os.environ.get(name)]
     if missing:
         pytest.skip(f"BigQuery integration disabled: set {', '.join(missing)}")
@@ -136,6 +164,27 @@ def dbx_warehouse() -> str:
 def dbx_scratch_catalog() -> str | None:
     # Needed by transform only; explore reads samples and writes nothing.
     return os.environ.get("DEX_TEST_DATABRICKS_CATALOG")
+
+
+@pytest.fixture
+def rs_workgroup() -> str | None:
+    return os.environ.get("DEX_TEST_REDSHIFT_WORKGROUP")
+
+
+@pytest.fixture
+def rs_host() -> str | None:
+    return os.environ.get("DEX_TEST_REDSHIFT_HOST")
+
+
+@pytest.fixture
+def rs_database() -> str | None:
+    return os.environ.get("DEX_TEST_REDSHIFT_DATABASE")
+
+
+@pytest.fixture
+def rs_dev_password() -> str | None:
+    # Needed by transform's password path only; IAM profiles need nothing.
+    return os.environ.get("DEX_TEST_REDSHIFT_DEV_PASSWORD")
 
 
 @pytest.fixture

--- a/packages/dex-core/tests/integration/test_redshift_connect.py
+++ b/packages/dex-core/tests/integration/test_redshift_connect.py
@@ -1,0 +1,97 @@
+"""Live `connect test` against Redshift: connection discovery (the AWS chain
+with a pinned Serverless workgroup, or the REDSHIFT_* environment),
+capabilities envelope, and the sanitizer, end to end. Cheap: capabilities is
+one catalog round-trip, no table scan (on an idle Serverless workgroup it can
+still incur the 60-second wake minimum, which is exactly what the envelope's
+warning says). The target is the seeded workgroup from
+scripts/setup_redshift_ci.sh, read as the dex_ro user or the IAM identity."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from exmergo_dex_core.cli import main
+
+pytestmark = [pytest.mark.integration, pytest.mark.redshift]
+
+
+def seed_repo(
+    root: Path,
+    *,
+    schemas: list[str] | None = None,
+    budget: float | None = None,
+) -> None:
+    """Commit a redshift config block wired to whichever live target the
+    environment provides: the workgroup pin (IAM) when
+    DEX_TEST_REDSHIFT_WORKGROUP is set, else nothing beyond the dev schema
+    (discovery then reads the REDSHIFT_* environment)."""
+
+    redshift: dict = {"dev_schema": "dbt_dev"}
+    if os.environ.get("DEX_TEST_REDSHIFT_WORKGROUP"):
+        redshift["workgroup"] = os.environ["DEX_TEST_REDSHIFT_WORKGROUP"]
+        if os.environ.get("DEX_TEST_REDSHIFT_DATABASE"):
+            redshift["dbname"] = os.environ["DEX_TEST_REDSHIFT_DATABASE"]
+    if schemas is not None:
+        redshift["schemas"] = schemas
+    config: dict = {"connector": "redshift", "redshift": redshift}
+    if budget is not None:
+        config["budget"] = {"ceiling": budget}
+    (root / ".dex").mkdir(parents=True, exist_ok=True)
+    (root / ".dex" / "config.yml").write_text(yaml.safe_dump(config), encoding="utf-8")
+
+
+def run_cli(argv: list[str], capsys) -> tuple[int, dict]:
+    rc = main(argv)
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1, "exactly one envelope line on stdout"
+    return rc, json.loads(out)
+
+
+def test_connect_test_discovers_connection_and_reports_read_only(
+    tmp_path: Path, capsys
+):
+    seed_repo(tmp_path)
+    rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
+    assert rc == 0, envelope
+    data = envelope["data"]
+    assert data["connector"] == "redshift"
+    assert data["dialect"] == "redshift"
+    assert data["read_only"] is True
+    # Whether Redshift honors the session read-only mode is probed, not
+    # assumed; the envelope reports the truth either way.
+    assert isinstance(data["session_read_only"], bool)
+    assert data["paradigm"] == "compute_time"
+    assert data["schema_count"] >= 1
+    assert data["compute"]["kind"] in {"serverless", "provisioned", "unknown"}
+    assert envelope["cost"]["paradigm"] == "compute_time"
+    # The auth method is coarse; no identity, key, or password crosses.
+    assert data["auth_method"].split(":")[0] in {
+        "iam_serverless",
+        "iam_cluster",
+        "environment",
+        "config_target",
+        "dbt_profile",
+    }
+    payload = json.dumps(envelope)
+    assert "AKIA" not in payload  # no access key id
+    assert not _identity_keys(data)
+
+
+def _identity_keys(value, path="data") -> list[str]:
+    """Every key in the payload that names an identity or credential."""
+
+    hits: list[str] = []
+    if isinstance(value, dict):
+        for key, sub in value.items():
+            if str(key).lower() in {"user", "username", "login", "login_name"}:
+                hits.append(f"{path}.{key}")
+            hits.extend(_identity_keys(sub, f"{path}.{key}"))
+    elif isinstance(value, list):
+        for i, sub in enumerate(value):
+            hits.extend(_identity_keys(sub, f"{path}[{i}]"))
+    return hits

--- a/packages/dex-core/tests/integration/test_redshift_explore.py
+++ b/packages/dex-core/tests/integration/test_redshift_explore.py
@@ -1,0 +1,164 @@
+"""Live explore against the seeded Redshift workgroup: cheap inventory, the
+strict compute-time handshake with the Serverless wake floor, PII
+flag-not-surface, and the query firewall. Spends nothing beyond the confirmed
+budgets; every scanning statement is capped server-side by the
+budget-derived statement_timeout."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from .conftest import RS_MAX_SECONDS
+from .test_redshift_connect import run_cli, seed_repo
+
+pytestmark = [pytest.mark.integration, pytest.mark.redshift]
+
+# The knob is DEX_TEST_REDSHIFT_MAX_SECONDS (default 60): confirmed budgets
+# are small fixed multiples of it, covering the Serverless wake minimum (60s)
+# plus the scans over the small seeded schema.
+MAP_BUDGET = RS_MAX_SECONDS * 4
+QUERY_BUDGET = RS_MAX_SECONDS + 60
+
+
+def test_inventory_is_ungated_and_scoped(tmp_path: Path, capsys):
+    seed_repo(tmp_path, schemas=["app"])
+    rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "inventory"], capsys
+    )
+    assert rc == 0, envelope
+    identifiers = {o["identifier"] for o in envelope["data"]["objects"]}
+    assert any(i.endswith("app.customers") for i in identifiers)
+    assert all(".app." in i for i in identifiers)
+    # Metadata runs immediately: no confirmation was required, nothing gated.
+    assert envelope["status"] == "ok"
+    assert "spend" not in envelope["data"]
+
+
+def test_unconfirmed_profile_returns_the_handshake_with_the_wake_floor(
+    tmp_path: Path, capsys, rs_workgroup
+):
+    seed_repo(tmp_path, schemas=["app"])
+    _rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "profile", "app.customers"],
+        capsys,
+    )
+    assert envelope["status"] == "needs_confirmation"
+    assert envelope["data"]["estimate_quality"] == "heuristic"
+    assert "--confirm --budget" in envelope["data"]["hint"]
+    if rs_workgroup:
+        # Serverless: the 60-second wake minimum is floored in exactly once.
+        assert envelope["data"]["estimated_seconds"] >= 60.0
+        assert any("wake minimum" in note for note in envelope["data"]["notes"])
+    else:
+        assert envelope["data"]["estimated_seconds"] > 0
+
+
+def test_over_ceiling_refusal_is_live_and_spends_nothing(tmp_path: Path, capsys):
+    seed_repo(tmp_path, schemas=["app"])
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "explore",
+            "profile",
+            "app.events",
+            "--confirm",
+            "--budget",
+            "0.01",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert "exceeds the ceiling" in envelope["errors"][0]
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
+
+
+def test_confirmed_map_profiles_flags_pii_and_records_spend(tmp_path: Path, capsys):
+    seed_repo(tmp_path, schemas=["app"], budget=MAP_BUDGET)
+    rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "map", "--confirm"], capsys
+    )
+    assert rc == 0, envelope
+    data = envelope["data"]
+    assert data["profiled_count"] >= 4
+    assert data["pii_column_count"] >= 1  # the seeded email at minimum
+    assert data["spend"]["seconds_billed"] > 0
+
+    cache = json.loads((tmp_path / ".dex" / "cache.json").read_text(encoding="utf-8"))
+    # PII is flagged with min/max suppressed: no example value in the cache.
+    customers = next(
+        d for d in cache["datasets"] if d["identifier"].endswith("app.customers")
+    )
+    email = next(c for c in customers["columns"] if c["name"] == "email")
+    assert email["pii"]["category"] == "email"
+    assert email["min_value"] is None and email["max_value"] is None
+    assert "@example.com" not in json.dumps(cache)
+
+
+def test_query_firewall_allows_measuring_and_refuses_pii_values(tmp_path: Path, capsys):
+    seed_repo(tmp_path, schemas=["app"], budget=MAP_BUDGET)
+    rc, _ = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "map", "--confirm"], capsys
+    )
+    assert rc == 0
+
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "explore",
+            "query",
+            "SELECT status, count(*) AS n FROM app.orders GROUP BY status",
+            "--confirm",
+            "--budget",
+            str(QUERY_BUDGET),
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+    assert envelope["data"]["row_count"] >= 1
+
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "explore",
+            "query",
+            "SELECT email FROM app.customers LIMIT 5",
+            "--confirm",
+            "--budget",
+            str(QUERY_BUDGET),
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert "PII" in envelope["errors"][0]
+
+
+# --- scope resolution against the live database (one catalog SELECT) -----------------
+
+
+def test_a_bogus_scope_is_refused_for_free(tmp_path: Path, capsys):
+    seed_repo(tmp_path, schemas=["__no_such_schema__"])
+    rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
+    assert rc == 1
+    assert envelope["status"] == "error"
+    error = envelope["errors"][0]
+    assert "__no_such_schema__" in error
+    # The refusal names what does exist, which a silent empty inventory never did.
+    assert "app" in error
+    assert "[from redshift.schemas in .dex/config.yml]" in error
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
+
+
+def test_scope_cannot_widen_the_committed_allowlist_live(tmp_path: Path, capsys):
+    seed_repo(tmp_path, schemas=["app"])
+    rc, envelope = run_cli(
+        ["--repo-root", str(tmp_path), "explore", "map", "--scope", "public"], capsys
+    )
+    assert rc == 1
+    assert "never widens" in envelope["errors"][0]
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()

--- a/packages/dex-core/tests/integration/test_redshift_transform.py
+++ b/packages/dex-core/tests/integration/test_redshift_transform.py
@@ -1,0 +1,162 @@
+"""Live transform against the seeded Redshift workgroup: init renders a
+secret-free dbt-redshift profile from the discovered connection, and a
+confirmed build lands only in the dedicated dbt_dev schema as the dbt_dev
+user, with actual compute-seconds recorded to the ledger. These tests use the
+password path (a dedicated dbt_dev user from scripts/setup_redshift_ci.sh)
+because it exercises the env_var rendering; the IAM profile path is dogfooded
+manually and needs no durable credential."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from .conftest import RS_MAX_SECONDS
+from .test_redshift_connect import run_cli
+
+pytestmark = [pytest.mark.integration, pytest.mark.redshift]
+
+# The knob is DEX_TEST_REDSHIFT_MAX_SECONDS (default 60): a dbt build wakes
+# the workgroup (60s minimum) and runs a handful of tiny models, so its
+# budget is a fixed multiple of the knob.
+BUILD_BUDGET = RS_MAX_SECONDS * 5
+
+
+@pytest.fixture
+def dev_env(rs_host, rs_database, rs_dev_password, monkeypatch) -> None:
+    """The REDSHIFT_* environment pointed at the dbt_dev user (builds need
+    write access to the dev schema; dex_ro deliberately has none). The
+    password travels via REDSHIFT_PASSWORD, exactly as the rendered profile
+    expects."""
+
+    if not rs_host or not rs_database or not rs_dev_password:
+        pytest.skip(
+            "set DEX_TEST_REDSHIFT_HOST, DEX_TEST_REDSHIFT_DATABASE, and "
+            "DEX_TEST_REDSHIFT_DEV_PASSWORD (the dbt_dev user's password)"
+        )
+    monkeypatch.setenv("REDSHIFT_HOST", rs_host)
+    monkeypatch.setenv("REDSHIFT_DATABASE", rs_database)
+    monkeypatch.setenv("REDSHIFT_USER", "dbt_dev")
+    monkeypatch.setenv("REDSHIFT_PASSWORD", rs_dev_password)
+
+
+def seed_repo_password_path(
+    root: Path, *, schemas: list[str], budget: float, dev_schema: str = "dbt_dev"
+) -> None:
+    """A config block without the workgroup pin, so discovery reads the
+    REDSHIFT_* environment (the password path the rendered profile uses)."""
+
+    config = {
+        "connector": "redshift",
+        "redshift": {"dev_schema": dev_schema, "schemas": schemas},
+        "budget": {"ceiling": budget},
+    }
+    (root / ".dex").mkdir(parents=True, exist_ok=True)
+    (root / ".dex" / "config.yml").write_text(yaml.safe_dump(config), encoding="utf-8")
+
+
+def test_init_and_build_write_only_the_dev_schema(tmp_path: Path, capsys, dev_env):
+    seed_repo_password_path(tmp_path, schemas=["app"], budget=BUILD_BUDGET)
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "init",
+            "analytics",
+            "--connector",
+            "redshift",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+
+    rendered = (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
+    profile = yaml.safe_load(rendered)["analytics"]["outputs"]["dev"]
+    assert profile["type"] == "redshift"
+    assert profile["schema"] == "dbt_dev"
+    assert profile["threads"] == 1
+    # Never a secret in the rendered profile: the password field is an
+    # env_var reference, not a value.
+    assert profile["password"] == "{{ env_var('REDSHIFT_PASSWORD') }}"  # noqa: S105
+    assert os.environ["REDSHIFT_PASSWORD"] not in rendered
+
+    (tmp_path / "analytics" / "models" / "staging" / "stg_orders.sql").write_text(
+        "SELECT id AS order_id, customer_id, status, total\nFROM app.orders\n",
+        encoding="utf-8",
+    )
+
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "build",
+            "--confirm",
+            "--budget",
+            str(BUILD_BUDGET),
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+    data = envelope["data"]
+    assert data["success"] is True
+    assert any(n["name"] == "stg_orders" for n in data["nodes"])
+    assert data["seconds_billed"] > 0
+    assert any("statement_timeout" in w for w in envelope["warnings"])
+
+    ledger = (tmp_path / ".dex" / "spend.jsonl").read_text(encoding="utf-8")
+    entry = json.loads(ledger.splitlines()[-1])
+    assert entry["connector"] == "redshift"
+    assert entry["command"] == "transform build"
+    assert entry["billed_seconds"] > 0
+
+
+def test_an_unwritable_dev_schema_is_refused_before_the_cost_gate(
+    tmp_path: Path, capsys, dev_env
+):
+    """dbt creates its dev schema, but only if the user may. The seeded
+    dbt_dev user holds CREATE on the dbt_dev schema and nothing else, so a
+    dev schema that does not exist yet cannot be created: the first build
+    would die on a bare permission error naming neither the schema nor the
+    grant. The preflight is cheap (catalog lookups and privilege predicates)
+    and runs before the confirm handshake, so this refuses without
+    `--confirm` and without spend."""
+
+    pytest.importorskip("dbt.adapters.redshift")
+    root = str(tmp_path)
+    seed_repo_password_path(
+        tmp_path,
+        schemas=["app"],
+        budget=BUILD_BUDGET,
+        dev_schema="dex_absent_dev_schema",
+    )
+
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            root,
+            "transform",
+            "init",
+            "analytics",
+            "--connector",
+            "redshift",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+
+    rc, envelope = run_cli(
+        ["--repo-root", root, "transform", "build", "--target", "dev"], capsys
+    )
+    assert rc == 1
+    assert envelope["status"] == "error"
+    error = envelope["errors"][0]
+    assert "dex_absent_dev_schema" in error
+    assert "may not create it" in error
+    assert "CREATE SCHEMA IF NOT EXISTS dex_absent_dev_schema AUTHORIZATION" in error
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -730,7 +730,7 @@ def test_snowflake_unresolvable_scope_never_falls_back_to_the_whole_allowlist(
 
 
 def test_an_unresolvable_scope_never_falls_back_on_any_connector(
-    fake_bq_client, fake_databricks, fake_pg_connection
+    fake_bq_client, fake_databricks, fake_pg_connection, fake_redshift_connection
 ):
     # Family 2: the same cost-safety bug, on every warehouse connector. A source
     # scope that names nothing must refuse, and must do so on the free metadata
@@ -749,7 +749,16 @@ def test_an_unresolvable_scope_never_falls_back_on_any_connector(
         PostgresAdapter,
         PostgresConnectionError,
     )
-    from exmergo_dex_core.config import BigQueryTarget, DatabricksTarget, PostgresTarget
+    from exmergo_dex_core.adapters.redshift import (
+        RedshiftAdapter,
+        RedshiftConnectionError,
+    )
+    from exmergo_dex_core.config import (
+        BigQueryTarget,
+        DatabricksTarget,
+        PostgresTarget,
+        RedshiftTarget,
+    )
     from exmergo_dex_core.guards.cost_guard import CostGate
 
     def gate(paradigm, connector):
@@ -781,6 +790,12 @@ def test_an_unresolvable_scope_never_falls_back_on_any_connector(
         target=PostgresTarget(schemas=["__not_a_schema__"]),
         clock=fake_pg_connection.clock,
     )
+    redshift = RedshiftAdapter(
+        connection=fake_redshift_connection,
+        cost_gate=gate(env.Paradigm.COMPUTE_TIME, "redshift"),
+        target=RedshiftTarget(schemas=["__not_a_schema__"]),
+        clock=fake_redshift_connection.clock,
+    )
 
     with pytest.raises(BigQueryConnectionError):
         bigquery.list_objects()
@@ -788,12 +803,15 @@ def test_an_unresolvable_scope_never_falls_back_on_any_connector(
         databricks.list_objects()
     with pytest.raises(PostgresConnectionError):
         postgres.list_objects()
+    with pytest.raises(RedshiftConnectionError):
+        redshift.list_objects()
 
     # Refused on the free path: nothing was queried, and no SQL session opened.
     assert fake_bq_client.query_calls == []
     assert fake_databricks.connection.data_statements == []
     assert fake_databricks.connect_count == 0
     assert fake_pg_connection.data_statements == []
+    assert fake_redshift_connection.data_statements == []
 
 
 def test_snowflake_generated_sql_is_select_only(fake_sf_connection):
@@ -989,6 +1007,13 @@ def test_ledgers_never_mix_paradigms(tmp_path: Path):
             "billed_seconds": 11.0,
         }
     )
+    store.append_spend_log(
+        {
+            "at": "2026-07-05T00:00:05+00:00",
+            "connector": "redshift",
+            "billed_seconds": 13.0,
+        }
+    )
     assert store.spend_since("2026-07-05T00:00:00+00:00", connector="bigquery") == 5000
     assert (
         store.spend_since(
@@ -1007,6 +1032,12 @@ def test_ledgers_never_mix_paradigms(tmp_path: Path):
             "2026-07-05T00:00:00+00:00", field="billed_seconds", connector="databricks"
         )
         == 11.0
+    )
+    assert (
+        store.spend_since(
+            "2026-07-05T00:00:00+00:00", field="billed_seconds", connector="redshift"
+        )
+        == 13.0
     )
 
 
@@ -1412,6 +1443,284 @@ def test_postgres_spend_ledger_holds_no_sql_or_values(
     store = DexStore(tmp_path)
     fake_pg_connection.row_resolver = lambda sql: [{"n": 1}]
     adapter = _pg_adapter(fake_pg_connection)
+    adapter.cost_gate._record = store.append_spend_log
+    adapter.run_query(
+        'SELECT COUNT(*) AS n FROM "dexdb"."shop"."customers"',
+        max_rows=10,
+        timeout_seconds=200,
+    )
+    lines = (tmp_path / ".dex" / "spend.jsonl").read_text().splitlines()
+    entry = json.loads(lines[-1])
+    assert "SELECT" not in json.dumps(entry)
+    assert entry["billed_seconds"] > 0
+    assert entry["statement_sha256"]
+
+
+# --- Redshift: the second compute-time connector exercises every family ---------
+#
+# These run against the fake connection (tests/fakes/redshift.py):
+# deterministic, offline, free. They importorskip on the [redshift] extra,
+# which CI and the release gate install, so trimming that extra from a
+# workflow would silently skip release-blocking families; keep
+# `--extra redshift` in ci.yml and release.yml.
+
+
+def _redshift_adapter(fake_redshift_connection, *, ceiling=600.0, confirmed=True):
+    from exmergo_dex_core.adapters.redshift import RedshiftAdapter
+    from exmergo_dex_core.config import RedshiftTarget
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    gate = CostGate(
+        paradigm=env.Paradigm.COMPUTE_TIME,
+        ceiling=ceiling,
+        session_ceiling=None,
+        session_spent=0.0,
+        confirmed=confirmed,
+        connector="redshift",
+    )
+    return RedshiftAdapter(
+        connection=fake_redshift_connection,
+        cost_gate=gate,
+        target=RedshiftTarget(),
+        compute={
+            "kind": "serverless",
+            "workgroup": "dex-wg",
+            "base_capacity_rpus": 8.0,
+        },
+        auth_method="iam_serverless:default_chain",
+        clock=fake_redshift_connection.clock,
+    )
+
+
+def test_redshift_generated_sql_is_select_only(fake_redshift_connection):
+    # Family 1: every data statement the adapter generates passes the
+    # SELECT-only guard in the redshift dialect (asserted at build time).
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    adapter = _redshift_adapter(fake_redshift_connection)
+    _meta, columns = adapter.table_metadata("dexdb.shop.customers")
+    sql, _plan = adapter._build_aggregate_sql("dexdb.shop.customers", columns, {"id"})
+    assert sql.lstrip().upper().startswith("SELECT")
+    assert assert_select_only(sql, dialect="redshift") == sql
+
+
+def test_redshift_session_read_only_is_best_effort_and_honest(
+    fake_redshift_connection,
+):
+    # Family 1: the session read-only mode is attempted before any statement;
+    # when Redshift declines it, the adapter tolerates the refusal and
+    # capabilities reports the truth rather than a comforting fiction.
+    adapter = _redshift_adapter(fake_redshift_connection)
+    adapter.capabilities()
+    first = fake_redshift_connection.statements[0].sql.lower()
+    assert "set default_transaction_read_only = on" in first
+
+    from fakes.redshift import FakeRedshiftConnection
+
+    declining = FakeRedshiftConnection(
+        tables=fake_redshift_connection.tables, reject_read_only=True
+    )
+    declined = _redshift_adapter(declining)
+    assert declined.capabilities()["session_read_only"] is False
+
+
+def test_select_only_guard_rejects_redshift_writes_ddl_and_movement():
+    # Family 2 of the dialect surface: Redshift DML/DDL, data movement
+    # (COPY/UNLOAD), and multi-statement forms are all refused when parsed in
+    # the redshift dialect.
+    from exmergo_dex_core.guards.sql_guard import NotSelectOnlyError, assert_select_only
+
+    for bad in (
+        "CREATE TABLE t AS SELECT 1",
+        "TRUNCATE TABLE shop.t",
+        "SELECT 1; SELECT 2",
+        "DELETE FROM shop.t WHERE TRUE",
+        "UPDATE shop.t SET x = 1",
+        "COPY shop.t FROM 's3://bucket/exfil' IAM_ROLE 'arn:aws:iam::1:role/r'",
+        "UNLOAD ('SELECT * FROM shop.t') TO 's3://bucket/exfil'",
+        "ALTER TABLE shop.t ADD COLUMN y varchar",
+        "DROP TABLE shop.t",
+    ):
+        with pytest.raises(NotSelectOnlyError):
+            assert_select_only(bad, dialect="redshift")
+
+
+def test_redshift_unconfirmed_scan_never_executes(fake_redshift_connection):
+    # Family 2: the strict handshake. Without --confirm nothing scans.
+    from exmergo_dex_core.guards.cost_guard import ConfirmationRequiredError
+
+    adapter = _redshift_adapter(fake_redshift_connection, confirmed=False)
+    with pytest.raises(ConfirmationRequiredError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "dexdb"."shop"."customers"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert fake_redshift_connection.data_statements == []
+
+
+def test_redshift_confirmed_run_without_a_ceiling_is_refused(fake_redshift_connection):
+    # Family 2: nothing executes unbudgeted; confirmation cannot stand in for
+    # a ceiling on a billed paradigm.
+    from exmergo_dex_core.guards.cost_guard import CostGuardError
+
+    adapter = _redshift_adapter(fake_redshift_connection, ceiling=None, confirmed=True)
+    with pytest.raises(CostGuardError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "dexdb"."shop"."customers"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert fake_redshift_connection.data_statements == []
+
+
+def test_redshift_over_ceiling_cannot_be_confirmed_through(fake_redshift_connection):
+    # Family 2: over-ceiling blocks first, even fully confirmed.
+    from exmergo_dex_core.guards.cost_guard import OverCeilingError
+
+    adapter = _redshift_adapter(fake_redshift_connection, ceiling=2.0, confirmed=True)
+    with pytest.raises(OverCeilingError):
+        adapter.run_query(
+            'SELECT COUNT(*) FROM "dexdb"."shop"."events"',
+            max_rows=10,
+            timeout_seconds=30,
+        )
+    assert fake_redshift_connection.data_statements == []
+
+
+def test_redshift_every_executed_statement_is_server_capped(fake_redshift_connection):
+    # Family 2: defense in depth past the client-side gate; a wrong heuristic
+    # cannot overrun the budget because statement_timeout kills the statement.
+    fake_redshift_connection.row_resolver = lambda sql: [{"n": 1}]
+    adapter = _redshift_adapter(fake_redshift_connection)
+    adapter.run_query(
+        'SELECT COUNT(*) AS n FROM "dexdb"."shop"."customers"',
+        max_rows=10,
+        timeout_seconds=200,
+    )
+    executed = fake_redshift_connection.data_statements
+    assert executed
+    assert all(s.session_timeout_ms is not None for s in executed)
+
+
+def test_query_firewall_blocks_redshift_value_carrying_shapes():
+    # Family 3: PII stays flagged-not-surfaced under the redshift dialect,
+    # including Redshift's own value-carrying aggregates.
+    from exmergo_dex_core.config import QueryLimits
+    from exmergo_dex_core.guards.query_firewall import (
+        QueryRefusedError,
+        inspect_query,
+    )
+
+    cache = _firewall_cache()
+    for bad in (
+        "SELECT LISTAGG(email, ',') FROM db.main.customers",
+        "SELECT MIN(email) FROM db.main.customers",
+        "SELECT ANY_VALUE(email) FROM db.main.customers",
+    ):
+        with pytest.raises(QueryRefusedError):
+            inspect_query(bad, cache, QueryLimits(), dialect="redshift")
+    # Measuring stays allowed in the redshift dialect too.
+    inspect_query(
+        "SELECT COUNT(DISTINCT email) FROM db.main.customers",
+        cache,
+        QueryLimits(),
+        dialect="redshift",
+    )
+
+
+def test_init_redshift_profile_is_dev_only_with_no_secrets(tmp_path: Path, monkeypatch):
+    # Family 4: the generated Redshift profile has a single dev target and, on
+    # the IAM path, no secret-shaped key anywhere (temporary credentials are
+    # minted by the dbt adapter at runtime).
+    import yaml
+
+    from exmergo_dex_core import transform
+    from exmergo_dex_core.cache import DEX_DIR
+    from exmergo_dex_core.config import CONFIG_FILE
+
+    class _Client:
+        def get_workgroup(self, workgroupName):  # noqa: N803 (boto3's spelling)
+            return {
+                "workgroup": {
+                    "workgroupName": workgroupName,
+                    "namespaceName": "ns",
+                    "status": "AVAILABLE",
+                    "baseCapacity": 8,
+                    "endpoint": {
+                        "address": "wg.1.eu.redshift-serverless.amazonaws.com",
+                        "port": 5439,
+                    },
+                }
+            }
+
+        def get_namespace(self, namespaceName):  # noqa: N803 (boto3's spelling)
+            return {"namespace": {"namespaceName": namespaceName, "dbName": "shop"}}
+
+    class _Session:
+        def __init__(self, **kwargs):
+            pass
+
+        def client(self, service):
+            return _Client()
+
+    import boto3
+
+    monkeypatch.setattr(boto3, "Session", _Session)
+    (tmp_path / DEX_DIR).mkdir()
+    (tmp_path / DEX_DIR / CONFIG_FILE).write_text(
+        "redshift:\n  workgroup: dex-wg\n", encoding="utf-8"
+    )
+    transform.init_project("analytics", "redshift", repo_root=tmp_path)
+    profiles = yaml.safe_load(
+        (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
+    )
+    profile = profiles["analytics"]
+    assert profile["target"] == "dev"
+    assert set(profile["outputs"]) == {"dev"}
+    assert profile["outputs"]["dev"]["method"] == "iam"
+    # The envelope sanitizer doubles as the secret-key scanner here.
+    env.sanitize(env.ok(profiles))
+
+
+def test_redshift_capabilities_pass_the_sanitizer(fake_redshift_connection, capsys):
+    # Family 5: the capabilities payload carries a coarse auth method, never
+    # an identity, key, or password, and survives the sanitizer end to end.
+    adapter = _redshift_adapter(fake_redshift_connection)
+    caps = adapter.capabilities()
+    env.emit(env.ok(caps))
+    out = capsys.readouterr().out
+    assert out
+    assert "@" not in out  # no user identity
+    assert caps["auth_method"].split(":")[0] in {
+        "iam_serverless",
+        "iam_cluster",
+        "environment",
+        "config_target",
+        "dbt_profile",
+        "unknown",
+    }
+    assert caps["auth_method"].split(":")[1] in {
+        "profile",
+        "environment",
+        "default_chain",
+        "password",
+        "external",
+        "unknown",
+    }
+
+
+def test_redshift_spend_ledger_holds_no_sql_or_values(
+    tmp_path: Path, fake_redshift_connection
+):
+    # Family 5: the audit trail is second counts and statement hashes only.
+    import json
+
+    from exmergo_dex_core.cache import DexStore
+
+    store = DexStore(tmp_path)
+    fake_redshift_connection.row_resolver = lambda sql: [{"n": 1}]
+    adapter = _redshift_adapter(fake_redshift_connection)
     adapter.cost_gate._record = store.append_spend_log
     adapter.run_query(
         'SELECT COUNT(*) AS n FROM "dexdb"."shop"."customers"',

--- a/packages/dex-core/tests/transform/test_dev_target.py
+++ b/packages/dex-core/tests/transform/test_dev_target.py
@@ -609,6 +609,113 @@ def test_the_postgres_privilege_is_asked_of_the_profile_role(
     assert "TO ci_builder;" in message
 
 
+def _redshift(dbt_project_dir: Path, user, *, profile_extra: str = ""):
+    pytest.importorskip("redshift_connector")
+    from fakes.redshift import FakeRedshiftConnection, FakeRedshiftTable
+
+    from exmergo_dex_core.adapters.redshift import RedshiftAdapter
+    from exmergo_dex_core.config import RedshiftTarget
+    from exmergo_dex_core.envelope import Paradigm
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    connection = FakeRedshiftConnection(
+        tables=[
+            FakeRedshiftTable(
+                schema="shop", name="orders", columns=[("id", "bigint", False)]
+            )
+        ],
+        users=[user],
+        empty_schemas=["dbt_dev"],
+    )
+    adapter = RedshiftAdapter(
+        connection=connection,
+        cost_gate=CostGate(
+            paradigm=Paradigm.COMPUTE_TIME,
+            ceiling=None,
+            session_ceiling=None,
+            session_spent=0.0,
+            confirmed=False,
+            connector="redshift",
+        ),
+        target=RedshiftTarget(),
+        clock=connection.clock,
+    )
+    _write_profile(
+        dbt_project_dir,
+        "      type: redshift\n"
+        f"      user: {user.name}\n"
+        "      dbname: dexdb\n"
+        "      schema: dbt_dev\n" + profile_extra,
+    )
+    config = DexConfig(
+        connector="redshift", redshift=RedshiftTarget(dev_schema="dbt_dev")
+    )
+    return connection, adapter, config
+
+
+def test_a_redshift_iam_profile_skips_the_preflight_whatever_its_user_says(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    """A method: iam target mints its database user from the caller's identity
+    at dbt runtime, so the profile's user field (a configured name or the
+    rendered placeholder) is not a durable user to interrogate. The autouse
+    no_warehouse fixture makes any attempted open fail, so a clean pass is
+    proof the preflight never opened a connection."""
+
+    pytest.importorskip("redshift_connector")
+    from exmergo_dex_core.config import RedshiftTarget
+
+    _write_profile(
+        dbt_project_dir,
+        "      type: redshift\n"
+        "      method: iam\n"
+        "      user: analyst\n"
+        "      dbname: dexdb\n"
+        "      schema: dbt_dev\n",
+    )
+    config = DexConfig(
+        connector="redshift", redshift=RedshiftTarget(dev_schema="dbt_dev")
+    )
+    assert dev_target.check(dbt_project_dir, "dev", config, tmp_path) == []
+
+
+def test_a_redshift_password_user_literally_named_iam_still_gets_the_preflight(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """The IAM skip keys on the profile's method, not on the user's name, so a
+    real database user that happens to be called iam keeps its privilege check."""
+
+    from fakes.redshift import FakeUser
+
+    user = FakeUser(name="iam", schema_privileges={"dbt_dev": {"USAGE"}})
+    connection, adapter, config = _redshift(dbt_project_dir, user)
+    _fake_open(monkeypatch, adapter)
+
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    message = str(exc.value)
+    assert "user iam is missing" in message
+    assert "GRANT USAGE, CREATE ON SCHEMA dbt_dev TO iam;" in message
+    assert connection.data_statements == []
+
+
+def test_an_unwritable_redshift_dev_schema_refuses_with_the_grant(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    from fakes.redshift import FakeUser
+
+    user = FakeUser(name="dbt_dev", schema_privileges={"dbt_dev": {"USAGE"}})
+    connection, adapter, config = _redshift(dbt_project_dir, user)
+    _fake_open(monkeypatch, adapter)
+
+    with pytest.raises(dev_target.DevTargetError) as exc:
+        dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    message = str(exc.value)
+    assert 'missing CREATE on dev_schema "dbt_dev"' in message
+    assert "GRANT USAGE, CREATE ON SCHEMA dbt_dev TO dbt_dev;" in message
+    assert connection.data_statements == []
+
+
 def test_an_unopenable_connection_degrades_to_a_note_on_every_connector(
     dbt_project_dir: Path, tmp_path: Path
 ):

--- a/packages/dex-core/tests/transform/test_init.py
+++ b/packages/dex-core/tests/transform/test_init.py
@@ -427,6 +427,79 @@ def test_init_postgres_without_a_connection_names_the_fixes(
     assert "DATABASE_URL" in envelope["errors"][0]
 
 
+def _seed_redshift_config(repo: Path, **target) -> None:
+    (repo / ".dex").mkdir(parents=True, exist_ok=True)
+    (repo / ".dex" / "config.yml").write_text(
+        yaml.safe_dump({"redshift": target}), encoding="utf-8"
+    )
+
+
+def test_init_redshift_bootstraps_a_password_profile(
+    tmp_path: Path, capsys, monkeypatch
+):
+    # The committed non-secret config target wins discovery when no workgroup
+    # is pinned; the password stays an env_var reference at dbt runtime.
+    pytest.importorskip("redshift_connector")
+    monkeypatch.setenv("REDSHIFT_PASSWORD", "hunter2-never-rendered")
+    _seed_redshift_config(
+        tmp_path,
+        host="wg.example.redshift-serverless.amazonaws.com",
+        port=5439,
+        dbname="shop",
+        user="dbt",
+    )
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "redshift"), capsys)
+    assert rc == 0, envelope
+    assert envelope["data"]["connector"] == "redshift"
+    rendered = (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
+    profile = yaml.safe_load(rendered)
+    output = profile["analytics"]["outputs"]["dev"]
+    assert output["type"] == "redshift"
+    assert output["host"] == "wg.example.redshift-serverless.amazonaws.com"
+    assert output["port"] == 5439
+    assert output["user"] == "dbt"
+    assert output["dbname"] == "shop"
+    assert output["schema"] == "dbt_dev"
+    assert output["threads"] == 1
+    # Never a password value: an env_var reference resolved at dbt runtime.
+    assert "hunter2" not in rendered
+    assert "env_var" in output["password"] and "REDSHIFT_PASSWORD" in output["password"]
+    # The dev schema choice is persisted for cmd_map's replica folding.
+    config = yaml.safe_load(
+        (tmp_path / ".dex" / "config.yml").read_text(encoding="utf-8")
+    )
+    assert config["redshift"]["dev_schema"] == "dbt_dev"
+
+
+def test_init_redshift_refuses_dev_schema_source_collision(
+    tmp_path: Path, capsys, monkeypatch
+):
+    pytest.importorskip("redshift_connector")
+    _seed_redshift_config(
+        tmp_path,
+        host="h.example.com",
+        dbname="shop",
+        user="dbt",
+        schemas=["app", "dbt_dev"],
+        dev_schema="dbt_dev",
+    )
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "redshift"), capsys)
+    assert rc == 1
+    assert "source schema" in envelope["errors"][0]
+    assert not (tmp_path / "analytics").exists()
+
+
+def test_init_redshift_without_a_connection_names_the_fixes(
+    tmp_path: Path, capsys, monkeypatch
+):
+    pytest.importorskip("redshift_connector")
+    for var in ("REDSHIFT_HOST", "REDSHIFT_DATABASE", "REDSHIFT_PASSWORD"):
+        monkeypatch.delenv(var, raising=False)
+    rc, envelope = _run(_init_argv(tmp_path, "--connector", "redshift"), capsys)
+    assert rc == 1
+    assert "redshift.workgroup" in envelope["errors"][0]
+
+
 def _seed_bigquery_config(repo: Path, **target) -> None:
     (repo / ".dex").mkdir(parents=True, exist_ok=True)
     (repo / ".dex" / "config.yml").write_text(

--- a/packages/dex-core/uv.lock
+++ b/packages/dex-core/uv.lock
@@ -93,6 +93,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.35"
 source = { registry = "https://pypi.org/simple" }
@@ -614,6 +627,25 @@ wheels = [
 ]
 
 [[package]]
+name = "dbt-redshift"
+version = "1.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "agate" },
+    { name = "dbt-adapters" },
+    { name = "dbt-common" },
+    { name = "dbt-core" },
+    { name = "dbt-postgres" },
+    { name = "redshift-connector" },
+    { name = "requests" },
+    { name = "sqlparse" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/05/ee1545088a0137f93b11b0ed366c9d05318641d2a5475961af59e2c2d52c/dbt_redshift-1.10.2.tar.gz", hash = "sha256:522dd110e2821e5c1e665c68b904e9ecfb90a1706b9061c615f36f1a099cd32b", size = 77392, upload-time = "2026-06-24T07:15:19.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/e9/9c95a92bbf1ac45a3691c46c29392e7fb7955eac0fb71a93d7793e4438ec/dbt_redshift-1.10.2-py3-none-any.whl", hash = "sha256:23eabb87adebf70b9f3cf9d4ea2dd250b270947a9b67eaf3e47893770f3b9481", size = 53794, upload-time = "2026-06-24T07:15:18.501Z" },
+]
+
+[[package]]
 name = "dbt-semantic-interfaces"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -750,16 +782,19 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "boto3" },
     { name = "databricks-sdk" },
     { name = "databricks-sql-connector" },
     { name = "dbt-bigquery" },
     { name = "dbt-databricks" },
     { name = "dbt-duckdb" },
     { name = "dbt-postgres" },
+    { name = "dbt-redshift" },
     { name = "dbt-snowflake" },
     { name = "duckdb" },
     { name = "google-cloud-bigquery" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "redshift-connector" },
     { name = "snowflake-connector-python" },
     { name = "sqlglot" },
 ]
@@ -788,6 +823,12 @@ postgres = [
     { name = "psycopg", extra = ["binary"] },
     { name = "sqlglot" },
 ]
+redshift = [
+    { name = "boto3" },
+    { name = "dbt-redshift" },
+    { name = "redshift-connector" },
+    { name = "sqlglot" },
+]
 snowflake = [
     { name = "dbt-snowflake" },
     { name = "snowflake-connector-python" },
@@ -796,6 +837,8 @@ snowflake = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", marker = "extra == 'all'", specifier = ">=1.34" },
+    { name = "boto3", marker = "extra == 'redshift'", specifier = ">=1.34" },
     { name = "databricks-sdk", marker = "extra == 'all'", specifier = ">=0.30" },
     { name = "databricks-sdk", marker = "extra == 'databricks'", specifier = ">=0.30" },
     { name = "databricks-sql-connector", marker = "extra == 'all'", specifier = ">=3" },
@@ -808,6 +851,8 @@ requires-dist = [
     { name = "dbt-duckdb", marker = "extra == 'duckdb'", specifier = ">=1.9" },
     { name = "dbt-postgres", marker = "extra == 'all'", specifier = ">=1.9" },
     { name = "dbt-postgres", marker = "extra == 'postgres'", specifier = ">=1.9" },
+    { name = "dbt-redshift", marker = "extra == 'all'", specifier = ">=1.9" },
+    { name = "dbt-redshift", marker = "extra == 'redshift'", specifier = ">=1.9" },
     { name = "dbt-snowflake", marker = "extra == 'all'", specifier = ">=1.9" },
     { name = "dbt-snowflake", marker = "extra == 'snowflake'", specifier = ">=1.9" },
     { name = "duckdb", marker = "extra == 'all'", specifier = ">=1" },
@@ -819,6 +864,8 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pyyaml", specifier = ">=6" },
+    { name = "redshift-connector", marker = "extra == 'all'", specifier = ">=2.1" },
+    { name = "redshift-connector", marker = "extra == 'redshift'", specifier = ">=2.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.19" },
     { name = "snowflake-connector-python", marker = "extra == 'all'", specifier = ">=3.17" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.17" },
@@ -827,9 +874,10 @@ requires-dist = [
     { name = "sqlglot", marker = "extra == 'databricks'", specifier = ">=25" },
     { name = "sqlglot", marker = "extra == 'duckdb'", specifier = ">=25" },
     { name = "sqlglot", marker = "extra == 'postgres'", specifier = ">=25" },
+    { name = "sqlglot", marker = "extra == 'redshift'", specifier = ">=25" },
     { name = "sqlglot", marker = "extra == 'snowflake'", specifier = ">=25" },
 ]
-provides-extras = ["all", "bigquery", "databricks", "dev", "duckdb", "postgres", "snowflake"]
+provides-extras = ["all", "bigquery", "databricks", "dev", "duckdb", "postgres", "redshift", "snowflake"]
 
 [[package]]
 name = "fastjsonschema"
@@ -1385,6 +1433,108 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/09/849cf129d7eae1e42f873f2dbd60323267c738390b686a7384fb3fb289ad/leather-0.4.1.tar.gz", hash = "sha256:67119c2aee93be821f077193bd8534e296c05b38bd174d9c5a80c4aa31d1a4d3", size = 44072, upload-time = "2025-12-15T19:01:42.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/d4/c4dcb02ed11f8884e169b3350fc40aa4c08edf8bed77a8f0f267542e6452/leather-0.4.1-py3-none-any.whl", hash = "sha256:ec61cba1ca3ccb96ed90e38b116fc58757d97d352171006b3288c47ce3fbd183", size = 30340, upload-time = "2025-12-15T19:01:40.823Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/b0/83f481780d1548750b8ce2ec824073deef2f452d9cd1a6faff8507e3d16d/lxml-6.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:53b7d2b7a10b1c35c0a5e21e9224accf60c1bbfba523990732e521b2b73adef2", size = 8526461, upload-time = "2026-05-18T19:17:25.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/30fa0f808002c7329397bfbb24e306789c0b29f04aa5842c07b174b4216f/lxml-6.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3f333630ab480244a1bff72043e511a91eb22e7595dead8653ee5612dd8f3d", size = 4595375, upload-time = "2026-05-18T19:17:34.555Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/d2/edb71cf0e561581a7c5eb2626244320eb04e9f8ce6d563184fd668b45073/lxml-6.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a4bbea04c97f6d78a48e3fbc1cb9116d2780b1b39e03a23f6eb9b603fd61f510", size = 4923654, upload-time = "2026-05-18T19:17:42.917Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/77/1bc7eeb0de4577d783fb625aa092cc9357883bba35845a3666bf1259f3dc/lxml-6.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db1d75f6617a49c1c01bc7023713e0ff59ab32c9579ae62a7674c0e34f3b0b0a", size = 5067921, upload-time = "2026-05-18T19:17:49.175Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3c/c0690d74bd2bc17bc03b5b0d093569ead597dd0bfa088bf99eef8c24e19c/lxml-6.1.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a12689be69a28ddaa0ab99a5a1137da2afd5f8f16df7b5680b66f616d3eda1d", size = 5002456, upload-time = "2026-05-18T19:17:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8d/d1b3271af0c0f1e27e8472a849e4d2c65bc7766884b9ad2da9e76e145c88/lxml-6.1.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b73c339ae29b90fd2d06e58ebd555a751bde9cd6bbd36cc0281b9a2c94e9d8", size = 5202776, upload-time = "2026-05-18T19:18:08.924Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/45/689824ffb237fd10125ad273f32b28ff04dc6203c2822c85ff65a93df65e/lxml-6.1.1-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:752d3bbfe874715ccd0aec7f88d7fc623c0f1fd7aa7b3238a084e017bad2a009", size = 5329945, upload-time = "2026-05-18T19:18:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c0/ef73af53767e958fd87d437c170f272e2f6e6c0f854939f133a895f1e711/lxml-6.1.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:6b1761fbf9ec984e2e9d9c589ef5f5fd684b7c19f92aadd567a26c5224958db6", size = 4659237, upload-time = "2026-05-18T19:18:18.657Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/e1158e40397585e91cb0472374a1f63d0926a1ddeaa92f13d1a1ffe306d5/lxml-6.1.1-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d680fbcb768404c601ecb43519ecd8461f6954cb11c06a78962f666832ccfca8", size = 5265904, upload-time = "2026-05-18T19:18:24.883Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/16/8687e5d1400ed1c0bc41dace232ebb7553952b618ea1f2e5fb6e2cfbbe23/lxml-6.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:162af1091cd785f2f27e62d3547ae9bc58ec5c86dd314d67021fd02463708d83", size = 5045225, upload-time = "2026-05-18T19:17:20.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/d877bd1ae2e5ffdfd4836565aba350db31feb2f2656d6ce70316ed66a05e/lxml-6.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e9308ff8241c532df3f3e570f9a5aeed6c853f888512ba4b75638d7c11c95ef6", size = 4712721, upload-time = "2026-05-18T19:17:40.512Z" },
+    { url = "https://files.pythonhosted.org/packages/44/4d/1f44fd1d770b10dacbf6b5c6e520f4d6e0708744930f719dc04e67cab981/lxml-6.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5f6994074ebae6ffb04447268e37dc16edc304f9859cf91acb86e0af6c1b395c", size = 5252549, upload-time = "2026-05-18T19:17:51.236Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5d/1d66b84f850089254c230ef6ea6b267a5a54e2e179a5d960036a05d501d7/lxml-6.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80c2dfadb855da477cf73373ad29a333535dedb9b12bad02c9814c8e2b43bf08", size = 5226877, upload-time = "2026-05-18T19:18:00.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/00/84c4b5302d42a2d0184f38d538c8a197f33b52a50bd4f7bcfe990bce3036/lxml-6.1.1-cp311-cp311-win32.whl", hash = "sha256:30a89d3ac8faec007453fb541f3f46807eeec88edd5826f6e3fe001752a2c621", size = 3594072, upload-time = "2026-05-18T19:17:12.714Z" },
+    { url = "https://files.pythonhosted.org/packages/61/9d/2e2f7d876349f45e0f3e29f72da311668853d59b58d473a2dea4f0160135/lxml-6.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:abbefa31eee84842140f67acef1c828e28bba8bbf0c3bc6e5492a9af88152c28", size = 4025469, upload-time = "2026-05-18T19:17:50.566Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/570e6390e4110331e6208b2ba83d1482cc9146808ee118b22824a34c1070/lxml-6.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:dcb292aa7fe485ceff7af4f92e46c5af397daec5dff64871a528f0fc47a3cc5b", size = 3667640, upload-time = "2026-05-19T19:22:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/32/86a3f0f724a3a402d4627937a7fc27b160e45e7012b4adf47f6e1e844511/lxml-6.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:31033dc34636ea6b7d5cc11b1ddbda78a14de858ba9d3e1ed4b69a3085bc521e", size = 3930127, upload-time = "2026-05-18T19:19:02.27Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/d832e82af08723761556d004b1d04d281c09f9a8cecd7d3148548c9941a3/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3893c14c4b6ac5b2d54ba8cf03e99fe5104e592de491f19bd6b82756c09f8004", size = 4210769, upload-time = "2026-05-18T19:20:41.427Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/39/0dc5949f759ed7d951e0bb8c2f2d9d7aca1908d22352fa84a8afd2ea54af/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c07da4cebf6889f03ebac8d238f62318e29f495de0aa18a51ea14e61ae907e2e", size = 4318163, upload-time = "2026-05-18T19:20:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/fb/8ab3845fe046ba4cbf74536bcf6801a774b7caf4350de1c5d37f1f0a9e90/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f0ce10945fab9c4c06ce14e22af9059d1a87493a9af4501a5b0b9187e21cf2", size = 4250945, upload-time = "2026-05-18T19:20:47.385Z" },
+    { url = "https://files.pythonhosted.org/packages/68/1b/7553ab136894374ffae8851ec06f98f511cd8e66246e41b6be059d0a7289/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf", size = 4401664, upload-time = "2026-05-18T19:20:50.489Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a4/441aee36c6f6b249823d20fd91f9be9ab89d7c5a8ae542a4a4ca6d342d56/lxml-6.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ed21202aec73cda4d55d1ce57b389aadb90ffb044e6cd1080b8347efe1b1ec84", size = 3508989, upload-time = "2026-05-18T19:18:38.158Z" },
 ]
 
 [[package]]
@@ -2467,6 +2617,25 @@ wheels = [
 ]
 
 [[package]]
+name = "redshift-connector"
+version = "2.1.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "lxml" },
+    { name = "packaging" },
+    { name = "pytz" },
+    { name = "requests" },
+    { name = "scramp" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/00/e5770c8a84fad8f9ab51a7481b971003a18195dfdc0fdb296d7dd6c554e0/redshift_connector-2.1.15-py3-none-any.whl", hash = "sha256:4e4b4b0e88a6f9dfe6c2ec9f81b328936ec1f32fc9549c6b960e1131364b3dd7", size = 157106, upload-time = "2026-06-09T19:20:23.369Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2683,6 +2852,18 @@ wheels = [
 ]
 
 [[package]]
+name = "scramp"
+version = "1.4.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asn1crypto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/0c/a7a7f217b83cb7439abe2189e0a65b648a81f1b72d6cd2a80161b74c1bae/scramp-1.4.12.tar.gz", hash = "sha256:94b38decf26005b835050d06541a5aefb9914497f4de789c6d82a0abc4b934de", size = 19179, upload-time = "2026-07-05T10:30:54.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/9c/23bbbe3202c61e5b03708967014c51ea69972ddfbcd73fa2c5c0211f16a7/scramp-1.4.12-py3-none-any.whl", hash = "sha256:6adb2828c5d64bd7785a6878eed30f66ce0fae60bf5fc07c26ce1f521db3ec3e", size = 14361, upload-time = "2026-07-05T10:30:53.177Z" },
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2794,6 +2975,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]

--- a/references/redshift.md
+++ b/references/redshift.md
@@ -1,0 +1,182 @@
+# Connector: Amazon Redshift
+
+The AWS warehouse, Serverless-first. Namespace: `database.schema.table` (one
+connection, one database; the first component is always the connected
+database). Cost paradigm: **compute-seconds**, translated to RPU-hours on
+Serverless. Read-only against data, enforced in depth. Provisioned clusters
+ride the same SQL and metadata paths with seconds-only accounting (node-hours
+bill flat, so there is nothing to translate); the cost gate is designed for
+Serverless.
+
+## Authentication: discover, don't ask
+
+The engine discovers a connection at runtime and never prompts for or
+persists a password. Discovery order:
+
+1. `redshift.workgroup` in `.dex/config.yml`: the Serverless pin. The AWS
+   default credential chain (`aws configure`, `AWS_*` env, SSO, an assumed
+   role, instance metadata; `redshift.aws_profile` pins a named profile)
+   resolves the endpoint, port, and database from the control plane, and the
+   driver mints IAM **temporary database credentials** (`GetCredentials`) at
+   connect time. Nothing durable exists to leak.
+2. `redshift.cluster_identifier` plus `dbname`/`user`: the provisioned IAM
+   analogue (`GetClusterCredentials`).
+3. the `REDSHIFT_*` environment (`REDSHIFT_HOST`, `REDSHIFT_DATABASE`,
+   `REDSHIFT_USER`, password via `REDSHIFT_PASSWORD`)
+4. the committed non-secret `redshift.host`/`port`/`dbname`/`user` config
+   target (password still supplied by `REDSHIFT_PASSWORD`)
+5. the `host` of a `type: redshift` target in a discovered dbt `profiles.yml`
+
+Only a coarse method is ever surfaced (for example `iam_serverless:profile`
+or `config_target:password`); identities, keys, and passwords never cross the
+envelope. Every discovery failure names all the fixes, including the IAM
+permissions the workgroup path needs (`redshift-serverless:GetWorkgroup`,
+`GetCredentials`, and `GetNamespace` for database discovery).
+
+## Config
+
+```yaml
+# .dex/config.yml
+connector: redshift
+redshift:
+  workgroup: dex-wg              # the Serverless pin; IAM auth + RPU facts
+  aws_profile: null              # a named ~/.aws profile; default chain if unset
+  region: null                   # when the chain's default region is wrong
+  schemas:                       # source allowlist; empty means all visible
+    - shop
+  dev_schema: dbt_dev            # where dbt dev builds write (never a source)
+  rpu_price_usd: null            # your region's RPU-hour price; set it to see dollars
+budget:
+  ceiling: 300                   # per-command compute-seconds; --budget overrides
+  session_ceiling: 3600          # cumulative seconds per UTC day
+```
+
+Point dex at a read-only database user (or let IAM mint one); the documented
+grant shape is USAGE on source schemas plus SELECT on their tables and on
+`svv_table_info` (an IAM-minted user starts without it, and without it table
+sizes are unknown and estimates degrade to minimums), with write access only
+on the dedicated dev schema for the dbt user.
+
+## Scoping a command
+
+`redshift.schemas` is the committed source allowlist. `--scope` narrows it
+for one command and is repeatable; a Redshift scope is a bare `<schema>` in
+the connected database (dbt refuses cross-database references, so there is
+nothing to qualify). Resolution is a catalog lookup and happens before
+anything is estimated: a scope that names no schema is refused with the
+schemas that do exist listed, never quietly dropped, and `--scope` narrows
+the committed allowlist, never widens it. `--project` and `--dataset` are
+BigQuery vocabulary and error here.
+
+## Cost model: compute-seconds, honestly floored
+
+Redshift Serverless charges RPU-hours whenever compute is active, with a
+**60-second minimum** each time an idle workgroup wakes, and AWS treats every
+incoming query as billable activity. Two consequences dex states plainly
+rather than hides:
+
+- **Metadata is cheap, not free.** Inventory, `connect test`, estimation,
+  and the free axes of `maintain check` read only catalogs
+  (`pg_catalog`, `SVV_TABLE_INFO`, `SVV_COLUMNS`) and are not gated, but
+  touching an idle workgroup can incur the wake minimum; `connect test`
+  carries that warning on Serverless.
+- **Estimates carry the wake floor once per command.** There is no API that
+  says whether compute is warm (and probing would itself bill), so every
+  estimate on Serverless includes the 60-second minimum exactly once,
+  labeled an upper bound that actuals waive when compute was already active.
+
+**Metered:** profiling aggregates, `explore query`, relationship
+verification probes, distinct-count escalations, and `transform build`.
+
+Budgets (`budget.ceiling`, `--budget`, `budget.session_ceiling`) are
+compute-seconds: the number you budget is the number the server enforces.
+Every cost surface also carries the translation to **RPU-hours**
+(`seconds x base_capacity / 3600`, base capacity from the workgroup via the
+control plane, labeled approximate because Serverless can scale above it)
+and to dollars when `redshift.rpu_price_usd` is set. dex never guesses a
+dollar price: the RPU-hour rate varies by region and agreement.
+
+**Estimates are a heuristic, honestly labeled.** Redshift has no dry-run,
+and its EXPLAIN costs are relative units with no honest translation to
+seconds, so estimates come from table bytes (`SVV_TABLE_INFO`) over a
+conservative capacity-scaled scan rate; every handshake payload carries
+`estimate_quality: "heuristic"`.
+
+**The budget is hard-enforced regardless of estimate quality.** Before every
+metered statement the session's `statement_timeout` is set to the remaining
+budget, so a wrong heuristic cannot overrun the ceiling: Redshift kills the
+statement and dex reports the over-ceiling refusal. Actual spend is
+wall-clock seconds per statement (a killed statement still bills what ran),
+recorded to `.dex/spend.jsonl` as `billed_seconds` and summed into the daily
+session ceiling. Every session connects as `application_name = 'dex'`
+(`SYS_CONNECTION_LOG`) and sets `query_group = 'dex'` for attribution.
+
+The handshake is the same strict two-step as every metered connector: a
+scanning command without `--confirm` returns `needs_confirmation` carrying
+the seconds estimate (per table where relevant) and its RPU translation;
+re-issue with `--confirm --budget <seconds>`. Nothing executes unconfirmed
+or without a ceiling, and an estimate over the ceiling is refused outright.
+
+## Read-only, enforced in depth
+
+- Every data statement passes the SELECT-only guard parsed in the redshift
+  dialect through one execution door (DML, DDL, `COPY`, `UNLOAD`, and
+  multi-statement forms all refuse).
+- The adapter issues no mutating statements: catalog SELECTs and session
+  `SET`s only.
+- The session attempts `default_transaction_read_only = on`; whether Redshift
+  honors it is probed rather than assumed, and `connect test` reports the
+  truth as `session_read_only` (the guard and grants hold either way).
+- The documented grant shape is a least-privilege read-only user; dbt dev
+  builds write to `dev_schema` (default `dbt_dev`), which is refused as a
+  source, and the generated profile renders one thread and IAM or an
+  `env_var` password reference, never a value.
+
+## Profiling behavior
+
+Profiling is batched aggregates in single passes: `COUNT(*)`, per-column
+non-null counts, `HLL(...)` approximate distincts (Redshift refuses more
+than three `APPROXIMATE COUNT(DISTINCT)` expressions per statement, so the
+equivalent HLL aggregate keeps a wide batch a single pass), and min/max only
+for engine-cleared safe columns; never row values. Redshift keeps no usable
+planner distincts, so approximate distincts ride the billed batch, and an
+approximation is never a uniqueness verdict: near-unique keys escalate to an
+exact `COUNT(DISTINCT)` inside the confirmed budget, and that scan also
+upgrades the `SVV_TABLE_INFO` row estimate to an exact figure. `SUPER`,
+`VARBYTE`, `GEOMETRY`, `GEOGRAPHY`, and `HLLSKETCH` columns degrade to
+non-null counts. There is **no sampled-profiling threshold**: Redshift has
+no TABLESAMPLE, so a sampling knob would be a lie; the budget is the only
+bound. Empty tables are inventoried from `pg_class` even though
+`SVV_TABLE_INFO` omits them.
+
+## dbt builds
+
+`transform init` renders a `type: redshift` dev profile from whichever
+source won discovery: IAM discovery renders `method: iam` (temporary
+credentials minted by dbt-redshift at runtime, nothing persisted), password
+discovery renders `password: "{{ env_var('REDSHIFT_PASSWORD') }}"` (a Jinja
+reference, not a value), both with `schema` pinned to the dedicated dev
+schema and one thread. Before the cost gate, and for free, `transform build`
+refuses config that has drifted from the rendered profile, and a dev schema
+the profile's user lacks the privilege to create or write (the Postgres
+question: dbt creates the schema, but only if the user may). dbt has no
+dry-run and dex cannot inject a per-build server cap through dbt-redshift,
+so the honest layering is: per-node execution time summed into
+`billed_seconds` on the ledger, a durable `ALTER USER dbt_dev SET
+statement_timeout` applied by the setup script, and a workgroup usage limit
+(RPU-hours per day) as the account-level backstop. Keep one dev schema per
+building user: dbt swaps a rebuilt relation in place, and a relation another
+user owns breaks the swap with a bare `relation already exists` (verified
+live), so two identities sharing `dbt_dev` will trip over each other's
+views.
+
+## Testing
+
+Offline: a stateful fake connection (`tests/fakes/redshift.py`) that records
+statement ordering, serves the catalog census (including SVV_TABLE_INFO's
+empty-table omission), simulates timing on an injected clock, and enforces
+`statement_timeout` with redshift_connector's real error shape. Live: an
+env-gated integration suite (`DEX_TEST_REDSHIFT_*`) against a seeded
+Serverless workgroup, run in CI on a schedule via GitHub OIDC role assumption
+(no stored keys), never as a merge gate; `scripts/setup_redshift_ci.sh`
+provisions the workgroup, users, and the usage-limit backstop.

--- a/scripts/setup_redshift_ci.sh
+++ b/scripts/setup_redshift_ci.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # One-time provisioning for the Redshift connector: the local dev/test loop
 # and the live integration suite (.github/workflows/integration.yml). Run by a
-# maintainer whose AWS credentials can administer Redshift Serverless and IAM,
-# with psql on PATH (Redshift speaks the Postgres wire protocol) and gh
-# authenticated against the repository.
+# maintainer whose AWS credentials can administer Redshift Serverless, IAM, and
+# Secrets Manager (the seed connects as the namespace admin, whose password is
+# read from the managed secret; creating database users is superuser-only on
+# Redshift), with psql on PATH (Redshift speaks the Postgres wire protocol) and
+# gh authenticated against the repository.
 #
 # What it sets up, keyless wherever the platform allows it:
 #   - a Redshift Serverless namespace + workgroup at the smallest base
@@ -27,26 +29,32 @@
 #     GetWorkgroup/GetNamespace/GetCredentials on this workgroup only (the
 #     engine then authenticates exactly as a developer laptop does: the AWS
 #     default chain plus IAM temporary database credentials; no stored keys)
+#   - dex_ci_reader: a database role with the same read access as dex_ro,
+#     granted to the CI role's minted database user (IAMR:<role-name>), which
+#     is what GetCredentials mints when the job assumes the role. Without it
+#     the CI identity would connect with no privileges; dex_ro's grants do not
+#     reach it because Serverless names the user after the IAM identity.
 #   - the GitHub environment (deployments restricted to main) carrying the
 #     variables the workflow reads and the dbt password secret
 #
 # Everything account-specific is a parameter, so nothing private lives in this
 # script. Idempotent: safe to re-run; existing resources are left in place and
-# the trust pinning, the seed, and the grants are refreshed. The one exception
-# is the dbt_dev password, which is rotated on every run: both halves (the
-# database user and the GitHub secret) are replaced together, so they cannot
-# drift apart.
+# the trust pinning, the seed, and the grants are refreshed. The admin password
+# is managed in Secrets Manager (enabled on first run, rotating any manually
+# set one) and fetched with the operator's AWS credentials, never stored here.
+# The dbt_dev password is rotated on every run: both halves (the database user
+# and the GitHub secret) are replaced together, so they cannot drift apart.
 #
 # Usage:
 #   scripts/setup_redshift_ci.sh \
-#     --region eu-central-1 \
+#     --region us-east-1 \
 #     [--workgroup dex-ci] [--namespace dex-ci] [--database dev] \
 #     [--repo exmergo/dex] [--environment redshift-integration] \
 #     [--daily-rpu-hours 4] [--skip-github]
 
 set -euo pipefail
 
-REGION=""
+REGION="us-east-1"
 WORKGROUP="dex-ci"
 NAMESPACE="dex-ci"
 DATABASE="dev"
@@ -174,23 +182,91 @@ aws iam put-role-policy --role-name "$ROLE_NAME" \
   --policy-name dex-redshift-integration --policy-document "$POLICY"
 ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
 
-echo "==> seeding the database as an IAM temporary credential"
-DBT_DEV_PASSWORD=$(python3 -c "import secrets, string; print('Aa1' + ''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(29)))")
-CREDS=$(aws redshift-serverless get-credentials --workgroup-name "$WORKGROUP" \
-  --db-name "$DATABASE" --duration-seconds 900)
-DB_USER=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['dbUser'])" "$CREDS")
-DB_PASSWORD=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['dbPassword'])" "$CREDS")
+# The seed creates database users, which on Redshift is a superuser-only
+# operation, and the only superuser on a Serverless namespace is its admin
+# (an IAM-minted user cannot be one: Redshift forbids a superuser with the
+# disabled password IAM identities carry). So the seed connects as the admin.
+# It stays keyless for the operator: the admin password is managed in Secrets
+# Manager and fetched with the operator's own AWS credentials, never stored on
+# this machine. Enabling management here is idempotent and rotates any
+# manually-set admin password into the secret.
+echo "==> ensuring the namespace admin password is managed in Secrets Manager"
+SECRET_ARN=$(aws redshift-serverless get-namespace --namespace-name "$NAMESPACE" \
+  --query 'namespace.adminPasswordSecretArn' --output text)
+if [[ "$SECRET_ARN" == "None" || -z "$SECRET_ARN" ]]; then
+  aws redshift-serverless update-namespace --namespace-name "$NAMESPACE" \
+    --manage-admin-password >/dev/null
+  echo "    waiting for the managed secret to populate..."
+  for _ in $(seq 1 30); do
+    NS_STATUS=$(aws redshift-serverless get-namespace --namespace-name "$NAMESPACE" \
+      --query 'namespace.status' --output text)
+    SECRET_ARN=$(aws redshift-serverless get-namespace --namespace-name "$NAMESPACE" \
+      --query 'namespace.adminPasswordSecretArn' --output text)
+    [[ "$NS_STATUS" == "AVAILABLE" && "$SECRET_ARN" != "None" && -n "$SECRET_ARN" ]] && break
+    sleep 10
+  done
+  [[ "$SECRET_ARN" != "None" && -n "$SECRET_ARN" ]] || {
+    echo "managed admin secret never appeared" >&2; exit 1; }
+fi
 
-# Redshift has no CREATE USER IF NOT EXISTS, and users survive the schema
-# rebuild below, so creation is tolerated on its own: a re-run reaches the
-# strict block either way, which refreshes the grants and rotates the dbt
-# password (the header's idempotency contract).
-PGPASSWORD="$DB_PASSWORD" psql "host=$HOST port=5439 dbname=$DATABASE user=$DB_USER sslmode=require" \
-  -c "CREATE USER dex_ro PASSWORD DISABLE" \
-  || echo "    dex_ro already exists; grants are refreshed below"
-PGPASSWORD="$DB_PASSWORD" psql "host=$HOST port=5439 dbname=$DATABASE user=$DB_USER sslmode=require" \
-  -c "CREATE USER dbt_dev PASSWORD '${DBT_DEV_PASSWORD}'" \
-  || echo "    dbt_dev already exists; its password is rotated below"
+echo "==> seeding the database as the namespace admin (superuser)"
+DBT_DEV_PASSWORD=$(python3 -c "import secrets, string; print('Aa1' + ''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(29)))")
+ADMIN_SECRET=$(aws secretsmanager get-secret-value --secret-id "$SECRET_ARN" \
+  --query SecretString --output text)
+DB_USER=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['username'])" "$ADMIN_SECRET")
+DB_PASSWORD=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['password'])" "$ADMIN_SECRET")
+
+# An idle Serverless workgroup drops the first connection while it resumes
+# from cold ("server closed the connection unexpectedly"), so wait for it to
+# accept a trivial query before seeding; raw psql, unlike redshift_connector,
+# does not retry the resume itself.
+echo "    waiting for the workgroup to accept connections (resume from cold)..."
+for _ in $(seq 1 18); do
+  if PGPASSWORD="$DB_PASSWORD" psql \
+      "host=$HOST port=5439 dbname=$DATABASE user=$DB_USER sslmode=require" \
+      -tAc "SELECT 1" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 10
+done
+PGPASSWORD="$DB_PASSWORD" psql \
+  "host=$HOST port=5439 dbname=$DATABASE user=$DB_USER sslmode=require" \
+  -tAc "SELECT 1" >/dev/null || {
+    echo "workgroup did not accept connections; check it is AVAILABLE and the" >&2
+    echo "security group allows 5439 from this host" >&2
+    exit 1
+  }
+
+# Redshift has no CREATE USER/ROLE IF NOT EXISTS, and users and roles survive
+# the schema rebuild below, so creation is tolerated on its own: a re-run
+# reaches the strict block either way, which refreshes the grants and rotates
+# the dbt password (the header's idempotency contract). Only an "already
+# exists" failure is forgiven; anything else (a connection timeout, a
+# permission error) still aborts, rather than being mislabeled as existing.
+run_tolerating_exists() {
+  local statement="$1" label="$2" err
+  if err=$(PGPASSWORD="$DB_PASSWORD" psql \
+      "host=$HOST port=5439 dbname=$DATABASE user=$DB_USER sslmode=require" \
+      -v ON_ERROR_STOP=1 -c "$statement" 2>&1); then
+    return 0
+  fi
+  if [[ "$err" == *"already exists"* ]]; then
+    echo "    $label already exists; refreshed below"
+    return 0
+  fi
+  echo "$err" >&2
+  return 1
+}
+run_tolerating_exists "CREATE USER dex_ro PASSWORD DISABLE" dex_ro
+run_tolerating_exists "CREATE USER dbt_dev PASSWORD '${DBT_DEV_PASSWORD}'" dbt_dev
+# The CI job authenticates by assuming the OIDC role, so GetCredentials mints
+# the database user IAMR:<role-name>, not dex_ro (Serverless derives the user
+# from the IAM identity and cannot mint a PASSWORD DISABLE user by name). Give
+# that identity the same read access through a database role, pre-creating the
+# user so the grant lands before its first login.
+CI_DB_USER="IAMR:${ROLE_NAME}"
+run_tolerating_exists "CREATE ROLE dex_ci_reader" "role dex_ci_reader"
+run_tolerating_exists "CREATE USER \"${CI_DB_USER}\" PASSWORD DISABLE" "CI role db user"
 
 PGPASSWORD="$DB_PASSWORD" psql "host=$HOST port=5439 dbname=$DATABASE user=$DB_USER sslmode=require" \
   -v ON_ERROR_STOP=1 <<SQL
@@ -283,6 +359,15 @@ CREATE TABLE app.events AS
 GRANT USAGE ON SCHEMA app TO dex_ro;
 GRANT SELECT ON ALL TABLES IN SCHEMA app TO dex_ro;
 GRANT SELECT ON svv_table_info TO dex_ro;
+
+-- The CI identity (IAMR:${ROLE_NAME}, created above) gets the same read access
+-- through the dex_ci_reader role. The table grants are re-applied here because
+-- DROP SCHEMA app CASCADE above dropped them with the old tables; the role
+-- grant to the user is cluster-level and survives, re-granted idempotently.
+GRANT USAGE ON SCHEMA app TO ROLE dex_ci_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA app TO ROLE dex_ci_reader;
+GRANT SELECT ON svv_table_info TO ROLE dex_ci_reader;
+GRANT ROLE dex_ci_reader TO "IAMR:${ROLE_NAME}";
 
 -- The dbt user (created above): reads app, writes only its dev schema, and
 -- carries the durable per-statement cap dex cannot inject through

--- a/scripts/setup_redshift_ci.sh
+++ b/scripts/setup_redshift_ci.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# One-time provisioning for the Redshift connector: the local dev/test loop
+# and the live integration suite (.github/workflows/integration.yml). Run by a
+# maintainer whose AWS credentials can administer Redshift Serverless and IAM,
+# with psql on PATH (Redshift speaks the Postgres wire protocol) and gh
+# authenticated against the repository.
+#
+# What it sets up, keyless wherever the platform allows it:
+#   - a Redshift Serverless namespace + workgroup at the smallest base
+#     capacity (8 RPUs), created only when absent
+#   - a daily RPU-hours usage limit with a query-deactivating breach action:
+#     the hard cost backstop; nothing dex does can outspend it
+#   - the seeded `app` schema (the same shape as scripts/postgres_seed.sql:
+#     PII columns for flag-not-surface, a deliberately undeclared FK for
+#     relationship inference, a SUPER column for type degradation, an events
+#     table big enough to exercise the cost gate) plus the empty dbt_dev
+#     schema
+#   - dex_ro: the read-only database user dex connects as (USAGE + SELECT on
+#     app only)
+#   - dbt_dev: the database user dbt builds as (reads app, writes only schema
+#     dbt_dev, a durable statement_timeout as the per-statement cap dex
+#     cannot inject through dbt-redshift). Its password is rotated on every
+#     run and goes straight into the GitHub environment as a secret; it is
+#     never written to this machine.
+#   - an IAM role for CI whose trust policy accepts only GitHub OIDC tokens
+#     minted for this repository's redshift-integration environment, holding
+#     GetWorkgroup/GetNamespace/GetCredentials on this workgroup only (the
+#     engine then authenticates exactly as a developer laptop does: the AWS
+#     default chain plus IAM temporary database credentials; no stored keys)
+#   - the GitHub environment (deployments restricted to main) carrying the
+#     variables the workflow reads and the dbt password secret
+#
+# Everything account-specific is a parameter, so nothing private lives in this
+# script. Idempotent: safe to re-run; existing resources are left in place and
+# the trust pinning, the seed, and the grants are refreshed. The one exception
+# is the dbt_dev password, which is rotated on every run: both halves (the
+# database user and the GitHub secret) are replaced together, so they cannot
+# drift apart.
+#
+# Usage:
+#   scripts/setup_redshift_ci.sh \
+#     --region eu-central-1 \
+#     [--workgroup dex-ci] [--namespace dex-ci] [--database dev] \
+#     [--repo exmergo/dex] [--environment redshift-integration] \
+#     [--daily-rpu-hours 4] [--skip-github]
+
+set -euo pipefail
+
+REGION=""
+WORKGROUP="dex-ci"
+NAMESPACE="dex-ci"
+DATABASE="dev"
+REPO="exmergo/dex"
+ENVIRONMENT="redshift-integration"
+DAILY_RPU_HOURS="4"
+SKIP_GITHUB="false"
+ROLE_NAME="dex-redshift-integration"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region) REGION="$2"; shift 2 ;;
+    --workgroup) WORKGROUP="$2"; shift 2 ;;
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --database) DATABASE="$2"; shift 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    --environment) ENVIRONMENT="$2"; shift 2 ;;
+    --daily-rpu-hours) DAILY_RPU_HOURS="$2"; shift 2 ;;
+    --skip-github) SKIP_GITHUB="true"; shift ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$REGION" ]] || { echo "--region is required" >&2; exit 2; }
+for tool in aws psql python3; do
+  command -v "$tool" >/dev/null || { echo "$tool is required on PATH" >&2; exit 2; }
+done
+if [[ "$SKIP_GITHUB" != "true" ]]; then
+  command -v gh >/dev/null || { echo "gh is required (or pass --skip-github)" >&2; exit 2; }
+fi
+
+export AWS_DEFAULT_REGION="$REGION"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+echo "==> namespace + workgroup (smallest base capacity)"
+if ! aws redshift-serverless get-namespace --namespace-name "$NAMESPACE" >/dev/null 2>&1; then
+  aws redshift-serverless create-namespace \
+    --namespace-name "$NAMESPACE" --db-name "$DATABASE" >/dev/null
+fi
+if ! aws redshift-serverless get-workgroup --workgroup-name "$WORKGROUP" >/dev/null 2>&1; then
+  aws redshift-serverless create-workgroup \
+    --workgroup-name "$WORKGROUP" --namespace-name "$NAMESPACE" \
+    --base-capacity 8 --publicly-accessible >/dev/null
+fi
+echo "    waiting for the workgroup to become AVAILABLE..."
+for _ in $(seq 1 60); do
+  STATUS=$(aws redshift-serverless get-workgroup --workgroup-name "$WORKGROUP" \
+    --query 'workgroup.status' --output text)
+  [[ "$STATUS" == "AVAILABLE" ]] && break
+  sleep 10
+done
+[[ "$STATUS" == "AVAILABLE" ]] || { echo "workgroup never became AVAILABLE" >&2; exit 1; }
+
+WORKGROUP_ARN=$(aws redshift-serverless get-workgroup --workgroup-name "$WORKGROUP" \
+  --query 'workgroup.workgroupArn' --output text)
+HOST=$(aws redshift-serverless get-workgroup --workgroup-name "$WORKGROUP" \
+  --query 'workgroup.endpoint.address' --output text)
+
+echo "==> daily RPU-hours usage limit (the hard cost backstop)"
+EXISTING_LIMIT=$(aws redshift-serverless list-usage-limits --resource-arn "$WORKGROUP_ARN" \
+  --query 'usageLimits[?usageType==`serverless-compute`].usageLimitId' --output text)
+if [[ -z "$EXISTING_LIMIT" ]]; then
+  aws redshift-serverless create-usage-limit \
+    --resource-arn "$WORKGROUP_ARN" --usage-type serverless-compute \
+    --amount "$DAILY_RPU_HOURS" --period daily --breach-action deactivate >/dev/null
+else
+  aws redshift-serverless update-usage-limit \
+    --usage-limit-id "$EXISTING_LIMIT" \
+    --amount "$DAILY_RPU_HOURS" --breach-action deactivate >/dev/null
+fi
+
+echo "==> GitHub OIDC provider + the CI role (trust pinned to repo + environment)"
+OIDC_ARN="arn:aws:iam::${ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com"
+if ! aws iam get-open-id-connect-provider --open-id-connect-provider-arn "$OIDC_ARN" >/dev/null 2>&1; then
+  aws iam create-open-id-connect-provider \
+    --url https://token.actions.githubusercontent.com \
+    --client-id-list sts.amazonaws.com >/dev/null
+fi
+TRUST=$(python3 - "$OIDC_ARN" "$REPO" "$ENVIRONMENT" <<'PY'
+import json, sys
+oidc, repo, environment = sys.argv[1:4]
+print(json.dumps({
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Principal": {"Federated": oidc},
+        "Action": "sts:AssumeRoleWithWebIdentity",
+        "Condition": {
+            "StringEquals": {
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                "token.actions.githubusercontent.com:sub":
+                    f"repo:{repo}:environment:{environment}",
+            }
+        },
+    }],
+}))
+PY
+)
+if aws iam get-role --role-name "$ROLE_NAME" >/dev/null 2>&1; then
+  aws iam update-assume-role-policy --role-name "$ROLE_NAME" \
+    --policy-document "$TRUST"
+else
+  aws iam create-role --role-name "$ROLE_NAME" \
+    --assume-role-policy-document "$TRUST" >/dev/null
+fi
+NAMESPACE_ARN="arn:aws:redshift-serverless:${REGION}:${ACCOUNT_ID}:namespace/$(aws redshift-serverless get-namespace --namespace-name "$NAMESPACE" --query 'namespace.namespaceId' --output text)"
+POLICY=$(python3 - "$WORKGROUP_ARN" "$NAMESPACE_ARN" <<'PY'
+import json, sys
+workgroup_arn, namespace_arn = sys.argv[1:3]
+print(json.dumps({
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Action": [
+            "redshift-serverless:GetWorkgroup",
+            "redshift-serverless:GetNamespace",
+            "redshift-serverless:GetCredentials",
+        ],
+        "Resource": [workgroup_arn, namespace_arn],
+    }],
+}))
+PY
+)
+aws iam put-role-policy --role-name "$ROLE_NAME" \
+  --policy-name dex-redshift-integration --policy-document "$POLICY"
+ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+
+echo "==> seeding the database as an IAM temporary credential"
+DBT_DEV_PASSWORD=$(python3 -c "import secrets, string; print('Aa1' + ''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(29)))")
+CREDS=$(aws redshift-serverless get-credentials --workgroup-name "$WORKGROUP" \
+  --db-name "$DATABASE" --duration-seconds 900)
+DB_USER=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['dbUser'])" "$CREDS")
+DB_PASSWORD=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['dbPassword'])" "$CREDS")
+
+# Redshift has no CREATE USER IF NOT EXISTS, and users survive the schema
+# rebuild below, so creation is tolerated on its own: a re-run reaches the
+# strict block either way, which refreshes the grants and rotates the dbt
+# password (the header's idempotency contract).
+PGPASSWORD="$DB_PASSWORD" psql "host=$HOST port=5439 dbname=$DATABASE user=$DB_USER sslmode=require" \
+  -c "CREATE USER dex_ro PASSWORD DISABLE" \
+  || echo "    dex_ro already exists; grants are refreshed below"
+PGPASSWORD="$DB_PASSWORD" psql "host=$HOST port=5439 dbname=$DATABASE user=$DB_USER sslmode=require" \
+  -c "CREATE USER dbt_dev PASSWORD '${DBT_DEV_PASSWORD}'" \
+  || echo "    dbt_dev already exists; its password is rotated below"
+
+PGPASSWORD="$DB_PASSWORD" psql "host=$HOST port=5439 dbname=$DATABASE user=$DB_USER sslmode=require" \
+  -v ON_ERROR_STOP=1 <<SQL
+-- The same shape as scripts/postgres_seed.sql, in Redshift vocabulary (no
+-- enums or arrays; SUPER carries the semi-structured column). Idempotent:
+-- schemas are rebuilt from scratch on every run.
+DROP SCHEMA IF EXISTS app CASCADE;
+CREATE SCHEMA app;
+CREATE SCHEMA IF NOT EXISTS dbt_dev;
+
+CREATE TABLE app.customers (
+    id          bigint IDENTITY(1, 1) PRIMARY KEY,
+    email       varchar(256) NOT NULL,
+    first_name  varchar(128) NOT NULL,
+    last_name   varchar(128) NOT NULL,
+    phone       varchar(64),
+    address     varchar(256),
+    city        varchar(128),
+    created_at  timestamptz NOT NULL DEFAULT sysdate
+);
+
+CREATE TABLE app.products (
+    id        bigint IDENTITY(1, 1) PRIMARY KEY,
+    name      varchar(256) NOT NULL,
+    category  varchar(32) NOT NULL,
+    price     numeric(10, 2) NOT NULL,
+    attrs     super
+);
+
+CREATE TABLE app.orders (
+    id           bigint IDENTITY(1, 1) PRIMARY KEY,
+    customer_id  bigint NOT NULL REFERENCES app.customers (id),
+    status       varchar(16) NOT NULL DEFAULT 'pending',
+    total        numeric(12, 2) NOT NULL DEFAULT 0,
+    ordered_at   timestamptz NOT NULL DEFAULT sysdate
+);
+
+-- product_id deliberately carries no foreign key: relationship inference must
+-- find it from names and profiles.
+CREATE TABLE app.order_items (
+    id          bigint IDENTITY(1, 1) PRIMARY KEY,
+    order_id    bigint NOT NULL REFERENCES app.orders (id),
+    product_id  bigint NOT NULL,
+    quantity    integer NOT NULL,
+    unit_price  numeric(10, 2) NOT NULL
+);
+
+CREATE VIEW app.v_order_totals AS
+    SELECT o.id AS order_id, o.customer_id, o.status, SUM(i.quantity * i.unit_price) AS total
+    FROM app.orders o JOIN app.order_items i ON i.order_id = o.id
+    GROUP BY o.id, o.customer_id, o.status;
+
+INSERT INTO app.customers (email, first_name, last_name, phone, address, city) VALUES
+    ('ada@example.com',   'Ada',   'Lovelace',  '+1-555-0100', '1 Analytical Way', 'London'),
+    ('grace@example.com', 'Grace', 'Hopper',    '+1-555-0101', '2 Compiler Ct',    'Arlington'),
+    ('edgar@example.com', 'Edgar', 'Codd',      '+1-555-0102', '3 Relational Rd',  'Fortuneswell'),
+    ('barbara@example.com', 'Barbara', 'Liskov', NULL,          NULL,               'Los Angeles'),
+    ('margaret@example.com', 'Margaret', 'Hamilton', '+1-555-0104', '5 Apollo Ave', 'Paoli');
+
+INSERT INTO app.products (name, category, price, attrs) VALUES
+    ('Laptop',   'electronics', 1200.00, JSON_PARSE('{"warranty_months": 24}')),
+    ('Coffee',   'grocery',        9.50, JSON_PARSE('{"organic": true}')),
+    ('T-shirt',  'apparel',       19.90, JSON_PARSE('{"sizes": ["S", "M", "L"]}')),
+    ('Desk',     'home',         310.00, JSON_PARSE('{"material": "oak"}'));
+
+INSERT INTO app.orders (customer_id, status, total) VALUES
+    (1, 'paid', 1209.50), (1, 'shipped', 19.90), (2, 'paid', 310.00),
+    (3, 'pending', 9.50), (4, 'cancelled', 1200.00), (5, 'paid', 39.80);
+
+INSERT INTO app.order_items (order_id, product_id, quantity, unit_price) VALUES
+    (1, 1, 1, 1200.00), (1, 2, 1, 9.50), (2, 3, 1, 19.90),
+    (3, 4, 1, 310.00), (4, 2, 1, 9.50), (5, 1, 1, 1200.00),
+    (6, 3, 2, 19.90);
+
+-- ~65k rows: enough that an unbudgeted full profile is visibly refused and
+-- the statement_timeout has something to kill. Built by cross join because
+-- generate_series is leader-node-only on Redshift.
+CREATE TABLE app.events AS
+    SELECT
+        ROW_NUMBER() OVER () AS id,
+        (ROW_NUMBER() OVER ()) % 5 + 1 AS customer_id,
+        CASE (ROW_NUMBER() OVER ()) % 3 WHEN 0 THEN 'view' WHEN 1 THEN 'cart' ELSE 'purchase' END AS kind,
+        sysdate AS occurred_at
+    FROM app.order_items a, app.order_items b, app.order_items c,
+         app.order_items d, app.order_items e;
+
+-- The read-only user dex connects as (created above). svv_table_info is not
+-- readable by default for non-admin users, and without it table sizes are
+-- unknown and cost estimates degrade to minimums.
+GRANT USAGE ON SCHEMA app TO dex_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA app TO dex_ro;
+GRANT SELECT ON svv_table_info TO dex_ro;
+
+-- The dbt user (created above): reads app, writes only its dev schema, and
+-- carries the durable per-statement cap dex cannot inject through
+-- dbt-redshift. The ALTER is the rotation: it lands together with the GitHub
+-- secret update below, so the two halves cannot drift apart.
+ALTER USER dbt_dev PASSWORD '${DBT_DEV_PASSWORD}';
+GRANT USAGE ON SCHEMA app TO dbt_dev;
+GRANT SELECT ON ALL TABLES IN SCHEMA app TO dbt_dev;
+GRANT USAGE, CREATE ON SCHEMA dbt_dev TO dbt_dev;
+ALTER USER dbt_dev SET statement_timeout TO 300000;
+SQL
+
+if [[ "$SKIP_GITHUB" != "true" ]]; then
+  echo "==> GitHub environment, variables, and the dbt password secret"
+  gh api -X PUT "repos/${REPO}/environments/${ENVIRONMENT}" \
+    -F "deployment_branch_policy[protected_branches]=false" \
+    -F "deployment_branch_policy[custom_branch_policies]=true" >/dev/null
+  gh api -X POST "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies" \
+    -f name=main >/dev/null 2>&1 || true
+  for pair in \
+    "DEX_TEST_REDSHIFT_WORKGROUP=$WORKGROUP" \
+    "DEX_TEST_REDSHIFT_DATABASE=$DATABASE" \
+    "DEX_TEST_REDSHIFT_HOST=$HOST" \
+    "DEX_TEST_REDSHIFT_ROLE_ARN=$ROLE_ARN" \
+    "DEX_TEST_REDSHIFT_REGION=$REGION"; do
+    gh variable set "${pair%%=*}" --env "$ENVIRONMENT" --repo "$REPO" --body "${pair#*=}"
+  done
+  gh secret set DEX_TEST_REDSHIFT_DEV_PASSWORD --env "$ENVIRONMENT" --repo "$REPO" \
+    --body "$DBT_DEV_PASSWORD"
+fi
+
+echo "==> done"
+echo "    workgroup: $WORKGROUP ($HOST)"
+echo "    role:      $ROLE_ARN"
+echo "    local runs: DEX_TEST_REDSHIFT_WORKGROUP=$WORKGROUP DEX_TEST_REDSHIFT_DATABASE=$DATABASE uv run pytest tests/integration -q -m redshift"

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -57,21 +57,23 @@ measuring (COUNT, APPROX_COUNT_DISTINCT, AVG(LENGTH(...))), never value-carrying
 (MIN, ANY_VALUE, STRING_AGG). Never fall back to raw Python or a database CLI to
 run SQL; the firewall path is the only sanctioned one.
 
-## Cloud and database targets (BigQuery, Snowflake, Databricks, Postgres)
+## Cloud and database targets (BigQuery, Snowflake, Databricks, Postgres, Redshift)
 
 A remote warehouse or database replaces `--path` with connector config. Start
 with `connect test --connector <name>` (or set `connector:` plus the matching
 block in `.dex/config.yml`: `bigquery:` with `project` and a `datasets`
 allowlist, `snowflake:` with the pinned `warehouse` and a `databases`
 allowlist, `databricks:` with the pinned SQL `warehouse` and a `catalogs`
-allowlist, `postgres:` with a `schemas` allowlist). Credentials are
+allowlist, `postgres:` with a `schemas` allowlist, `redshift:` with the
+Serverless `workgroup` and a `schemas` allowlist). Credentials are
 discovered, never asked for: if the envelope reports missing or expired
 credentials, relay the fix it names (for BigQuery
 `gcloud auth application-default login`; for Snowflake a `connections.toml`
 entry or `SNOWFLAKE_*` env; for Databricks `databricks auth login` or
 `DATABRICKS_*` env; for Postgres `DATABASE_URL`, `PG*` env, or a
-`pg_service.conf` entry) and never ask the user to paste a key, token, or
-password.
+`pg_service.conf` entry; for Redshift the AWS credential chain
+(`aws configure`, `AWS_*` env) or `REDSHIFT_*` env) and never ask the user to
+paste a key, token, or password.
 
 On a metered connector, scanning commands (`profile`, `map`, `relationships`,
 `query`) run a two-step handshake. The first call returns
@@ -80,8 +82,10 @@ breakdown where relevant): an exact dry-run byte figure on BigQuery, a
 heuristic labeled `estimate_quality: "heuristic"` in warehouse-seconds on
 Snowflake (credits alongside), a floor labeled `estimate_quality: "low"` in
 warehouse-seconds on Databricks (DBUs alongside; it sharpens itself inside
-the confirmed budget), and database-seconds on Postgres (no dollars;
-the guarded quantity is load on the operational database). Surface the
+the confirmed budget), a heuristic in compute-seconds on Redshift (RPU-hours
+alongside; Serverless estimates carry the 60-second wake minimum once), and
+database-seconds on Postgres (no dollars; the guarded quantity is load on
+the operational database). Surface the
 estimate to the user in human units, get an explicit budget from them, and
 re-issue the same command with `--confirm` and `--budget <magnitude>` in the
 paradigm's unit. Never invent a budget the user did not agree to, and never
@@ -93,7 +97,7 @@ When an estimate is larger than the work deserves, narrow the scope rather than
 raise the budget. `--scope` (repeatable) bounds a command to part of the
 configured source allowlist, in the connector's own vocabulary: a dataset on
 BigQuery, a `schema` or `database.schema` on Snowflake, a `catalog.schema` on
-Databricks, a schema on Postgres. It is free to resolve, it can only narrow what
+Databricks, a schema on Postgres or Redshift. It is free to resolve, it can only narrow what
 `.dex/config.yml` already allows, and a scope that names nothing is refused with
 the schemas that do exist listed. So `explore map --scope <schema>` is the first
 thing to reach for on a warehouse whose full map would be expensive.

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -45,7 +45,14 @@ DEX_CORE_VERSION = "1.1.1"
 # extras share names, so this is the identity set today. An unknown or unset
 # connector falls back to the light DuckDB on-ramp and lets the installed engine
 # emit the canonical error rather than the wrapper guessing wrong.
-_KNOWN_CONNECTORS = ("duckdb", "snowflake", "bigquery", "databricks", "postgres")
+_KNOWN_CONNECTORS = (
+    "duckdb",
+    "snowflake",
+    "bigquery",
+    "databricks",
+    "postgres",
+    "redshift",
+)
 _DEFAULT_CONNECTOR = "duckdb"
 
 

--- a/skills/maintain/SKILL.md
+++ b/skills/maintain/SKILL.md
@@ -62,7 +62,7 @@ depth, then `reconcile` to get the proposed fix.
 ## Per-axis cost: what is free and what scans
 
 Detection is read-only, but read-only is not the same as free on a metered
-connector (BigQuery, Snowflake, Databricks, Postgres). The axes split:
+connector (BigQuery, Snowflake, Databricks, Postgres, Redshift). The axes split:
 
 - **Schema, volume, and the reference/definition half of semantic are free**
   everywhere: they read metadata and the snapshot, and run immediately.
@@ -72,9 +72,9 @@ connector (BigQuery, Snowflake, Databricks, Postgres). The axes split:
   breakdown). Surface it to the user in human units, get an explicit budget, and
   re-issue the same command with `--confirm --budget <magnitude>` in the
   paradigm's unit (bytes on BigQuery, warehouse-seconds on Snowflake and
-  Databricks, database-seconds on Postgres). Never invent a budget the user
-  did not agree to, and never retry with a raised budget on an over-ceiling
-  refusal without asking.
+  Databricks, compute-seconds on Redshift, database-seconds on Postgres).
+  Never invent a budget the user did not agree to, and never retry with a
+  raised budget on an over-ceiling refusal without asking.
 - **`check` is two-phase on a metered connector**: the free axes complete
   immediately and their findings ride along in the `needs_confirmation` envelope,
   with one combined estimate for the scanning axes. Confirm to complete the sweep.

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -45,7 +45,14 @@ DEX_CORE_VERSION = "1.1.1"
 # extras share names, so this is the identity set today. An unknown or unset
 # connector falls back to the light DuckDB on-ramp and lets the installed engine
 # emit the canonical error rather than the wrapper guessing wrong.
-_KNOWN_CONNECTORS = ("duckdb", "snowflake", "bigquery", "databricks", "postgres")
+_KNOWN_CONNECTORS = (
+    "duckdb",
+    "snowflake",
+    "bigquery",
+    "databricks",
+    "postgres",
+    "redshift",
+)
 _DEFAULT_CONNECTOR = "duckdb"
 
 

--- a/skills/transform/SKILL.md
+++ b/skills/transform/SKILL.md
@@ -50,22 +50,26 @@ records `connector`, `dbt_project_dir`, and `dbt_target: dev` in
 `.dex/config.yml`; do not hand-write these files yourself. Init never assumes a
 connector: it errors rather than defaulting, so always pass the user's confirmed
 choice (a `connector:` already committed in `.dex/config.yml` also counts).
-Every connector is supported: DuckDB, BigQuery, Snowflake, Databricks, and
-Postgres. DuckDB needs a warehouse path (`--path`, or the `duckdb.path`
-config). BigQuery needs a GCP project (usually `bigquery.project` in
-`.dex/config.yml`; confirm it with the user) and writes builds to a dedicated
-dev dataset (`bigquery.dev_dataset`, default `dbt_dev`); auth is Application
-Default Credentials, so if credentials are missing tell the user to run
-`gcloud auth application-default login`, never ask for a key. Snowflake
-writes builds to a dedicated `snowflake.dev_database`/`dev_schema` on the
-pinned warehouse; Databricks writes builds to a dedicated
-`databricks.dev_catalog`/`dev_schema` on the pinned SQL warehouse (if
-credentials are missing tell the user to run `databricks auth login`, never
-ask for a token); Postgres writes builds to a dedicated `postgres.dev_schema`
-(default `dbt_dev`), with the password reaching dbt only through the
-`PGPASSWORD` environment variable. All of them discover their connections and
-refuse with the fix named when none resolves. Init refuses if any dbt project
-already exists.
+Every connector is supported: DuckDB, BigQuery, Snowflake, Databricks,
+Postgres, and Redshift. DuckDB needs a warehouse path (`--path`, or the
+`duckdb.path` config). BigQuery needs a GCP project (usually
+`bigquery.project` in `.dex/config.yml`; confirm it with the user) and writes
+builds to a dedicated dev dataset (`bigquery.dev_dataset`, default
+`dbt_dev`); auth is Application Default Credentials, so if credentials are
+missing tell the user to run `gcloud auth application-default login`, never
+ask for a key. Snowflake writes builds to a dedicated
+`snowflake.dev_database`/`dev_schema` on the pinned warehouse; Databricks
+writes builds to a dedicated `databricks.dev_catalog`/`dev_schema` on the
+pinned SQL warehouse (if credentials are missing tell the user to run
+`databricks auth login`, never ask for a token); Postgres writes builds to a
+dedicated `postgres.dev_schema` (default `dbt_dev`), with the password
+reaching dbt only through the `PGPASSWORD` environment variable. Redshift
+writes builds to a dedicated `redshift.dev_schema` (default `dbt_dev`): with
+a `redshift.workgroup` pinned the profile renders IAM auth (temporary
+credentials from the AWS chain, nothing persisted), otherwise the password
+reaches dbt only through the `REDSHIFT_PASSWORD` environment variable. All
+of them discover their connections and refuse with the fix named when none
+resolves. Init refuses if any dbt project already exists.
 
 ### dbt SQL models
 
@@ -114,7 +118,9 @@ and both files. Edit one to match the other. The engine never rewrites
 **A dev target that does not exist.** On Snowflake, dbt creates schemas but never
 databases, so a missing `dev_database` is refused with the `CREATE DATABASE`
 statement to run; dex will not create it for you, because its only writes are
-reviewable diffs inside the repo. On DuckDB the dev target is a database file,
+reviewable diffs inside the repo. On Postgres and Redshift, dbt creates the dev
+schema but only if the profile's user may, so the missing privilege is what gets
+refused, with the `CREATE SCHEMA`/`GRANT` statement to run. On DuckDB the dev target is a database file,
 and dbt would happily create an empty one, then fail every `source()` relation
 with a confusing catalog error. The convention there: copy the shared source
 warehouse to the dev target path (for example

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -45,7 +45,14 @@ DEX_CORE_VERSION = "1.1.1"
 # extras share names, so this is the identity set today. An unknown or unset
 # connector falls back to the light DuckDB on-ramp and lets the installed engine
 # emit the canonical error rather than the wrapper guessing wrong.
-_KNOWN_CONNECTORS = ("duckdb", "snowflake", "bigquery", "databricks", "postgres")
+_KNOWN_CONNECTORS = (
+    "duckdb",
+    "snowflake",
+    "bigquery",
+    "databricks",
+    "postgres",
+    "redshift",
+)
 _DEFAULT_CONNECTOR = "duckdb"
 
 


### PR DESCRIPTION
## What this changes

Adds Amazon Redshift as dex's sixth connector, Serverless-first and
provisioned-compatible. The mental model: Postgres wire and catalog mechanics
plus Snowflake compute-time gating, billed in seconds with an RPU-hours (and
optional USD) translation. Dogfooded end to end against a live Serverless
workgroup throughout: every empirical claim below (error shapes, wake billing,
HLL limits, SVV semantics, dbt IAM builds) was verified live, not assumed.

### Cost model (the part to review hardest)

- `Paradigm.COMPUTE_TIME`, budgets in seconds, ledger field `billed_seconds`.
  RPU-hours translate via the workgroup's `baseCapacity` (free control-plane
  call); dollars only when `redshift.rpu_price_usd` is set.
- Serverless bills a 60-second minimum per wake, and warmth is unknowable
  without spending. Estimates include the floor exactly once per command
  (latched, so multi-probe maintain sweeps do not multiply it: a 12-probe
  sweep used to quote 738s of which 720 were floors), and execution charges
  it exactly once, by whichever billed statement runs first.
- The budget is hard-enforced regardless of estimate quality: before every
  billed statement, `SET statement_timeout` is wound down to the remaining
  budget. A server kill surfaces as SQLSTATE 57014 and is translated to the
  over-ceiling refusal; other cancellations (WLM rules, admin kills) pass
  through untranslated so the user is never told to raise a budget that is
  not the problem.
- Estimates are byte-rate heuristics from SVV_TABLE_INFO (labeled
  `estimate_quality: "heuristic"`); Redshift has no dry run and EXPLAIN costs
  are relative units. No sampling knob: Redshift has no TABLESAMPLE, so the
  budget is the bound.

### Auth (discover, don't ask)

Discovery order: `redshift.workgroup` (Serverless IAM via the AWS default
chain, endpoint and database resolved from the control plane, temporary DB
credentials minted at connect time), `cluster_identifier` (provisioned IAM),
`REDSHIFT_*` env, committed host config plus `REDSHIFT_PASSWORD`, then a dbt
profiles.yml target (env_var references rendered like dbt would; unrenderable
templates and `method: iam` outputs are skipped). Only a coarse method string
ever crosses the envelope; every failure names all the fixes.

### Where to look

- `packages/dex-core/src/exmergo_dex_core/adapters/redshift.py`: the adapter
  (catalog census via pg_class + SVV_TABLE_INFO + SVV_COLUMNS, HLL profiling,
  wake floor, the single billed door, error translation).
- `connect.py`: discovery chain, control-plane resolution, CostGate wiring.
- `transform/{init,commands,dev_target}.py`: dbt profile rendering (IAM and
  env_var password variants, never a secret), COMPUTE_TIME build accounting,
  dev-schema privilege preflight (skipped for `method: iam` profiles, whose
  DB user is minted at runtime).
- `explore/relationships.py`: the relationship verify probe was rewritten
  from a projected NOT EXISTS to a LEFT JOIN against a deduplicated key set,
  for all connectors; Redshift refuses projected correlated subqueries.
  Verified semantically equivalent on every dialect (NULL FKs, non-unique
  parents, empty parents).
- `tests/fakes/redshift.py` + `tests/adapters/test_connect_redshift.py`
  (66 tests) + safety-spine additions: a stateful fake with the driver's real
  error shapes, injectable clock, and server-side timeout simulation.
- `references/redshift.md`: the connector reference, including the honest
  Serverless notes (metadata is cheap but not free; one dev schema per
  building user or view swaps break).

### Review hardening

A full multi-angle review ran before this PR; all confirmed findings are
fixed in-branch with regression tests. Highlights: the escalation scan now
charges the wake floor; the dev-target preflight keys on the profile's
`method: iam` instead of a magic user name; WLM cancels are no longer blamed
on the budget; billed seconds are recorded even when a statement dies
mid-flight; scope is pushed into the census SQL; the CI seed script is
genuinely idempotent. Known follow-ups (out of scope here): Snowflake has the
same per-estimate resume-floor overcounting fixed here for Redshift, and the
Postgres/Snowflake dbt-profile readers share the Jinja-password gap fixed
here for Redshift.

## How to test

CI: unit jobs just need the `redshift` extra (already wired). The scheduled
live job needs the `redshift-integration` GitHub environment with
`DEX_TEST_REDSHIFT_{WORKGROUP,DATABASE,HOST,ROLE_ARN,REGION}` variables and the
`DEX_TEST_REDSHIFT_DEV_PASSWORD` secret. `scripts/setup_redshift_ci.sh`
provisions all of it (workgroup, usage-limit backstop, OIDC role, seed, users,
the `dex_ci_reader` CI grant, and the GitHub environment), is safe to re-run,
and needs an operator with AWS admin over Redshift Serverless, IAM, and Secrets
Manager plus `psql` and `gh` on PATH.

## Related Issues
This implements https://github.com/exmergo/dex/issues/39#issue

## Checklist

- [x] Engine tests pass (`uv run pytest` in `packages/dex-core`) - 795 passed
- [x] Eval scoring-core tests pass (`uvx pytest evals`) - 26 passed
- [x] If a safety path is touched, the spine still holds: read-only against data,
      cost-guarded, PII flagged not surfaced, propose-don't-impose
      (per-connector safety-spine section added; live suite 10/10)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free (checked in CI)
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures
