### PR TITLE
Persist explore profile and relationships results to the .dex/ cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`explore profile` and `explore relationships` now persist their results
+  to `.dex/cache.json`**, merging into any existing cache instead of
+  discarding the scan they just paid for. Previously only `explore map` wrote
+  the cache, so `explore query` on an already-profiled table demanded a
+  second, redundant warehouse scan via `map`, and the query firewall's own
+  refusal messages ("run `explore profile <table>` first") promised a path
+  that did not work. The merge is keyed by identifier: refreshed datasets
+  carry forward `map`'s rank score, untouched prior datasets keep their older
+  `profiled_at` (and `profile` preserves prior relationships, while
+  `relationships` replaces them with its authoritative full-set inference),
+  `provenance.created_at` survives, and a prior cache built for a different
+  connector is replaced wholesale with a loud note rather than poisoned by
+  mixing. `relationships` also annotates candidate keys and grain before
+  persisting, so its cached datasets match `map`'s shape. Known asymmetry:
+  `relationships` does not fold same-lineage replica edges the way `map`
+  does, mirroring the two commands' existing envelope behavior.
+
 ### Added
 
 - **`--use-project`: explore can read the dbt project, on request.**

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -4,7 +4,8 @@ Each ``cmd_*`` opens the adapter, drives the explore engine, and shapes the resu
 into the sanitized envelope. Keeping this here (not in ``cli.py``) keeps dispatch
 thin and keeps ``map``'s composition (it runs inventory, profile, and relationships
 together) out of the CLI layer. These are the only explore commands that hold an
-adapter; ``map`` is the only one that writes, and only to the ``.dex/`` cache.
+adapter; ``map``, ``profile``, and ``relationships`` all persist what they learned,
+and only to the ``.dex/`` cache, so a scan is never paid for twice.
 """
 
 from __future__ import annotations
@@ -84,7 +85,8 @@ def cmd_inventory(args: argparse.Namespace) -> env.Envelope:
 
 
 def cmd_profile(args: argparse.Namespace) -> env.Envelope:
-    config = load_config(command_args.repo_root(args)) or DexConfig()
+    repo_root = command_args.repo_root(args)
+    config = load_config(repo_root) or DexConfig()
     defs = _project_definitions(args, config)
     adapter = command_args.open_from_args(args)
     try:
@@ -96,18 +98,37 @@ def cmd_profile(args: argparse.Namespace) -> env.Envelope:
         if unconfirmed is not None:
             return unconfirmed
         datasets = profile_mod.profile(adapter, identifiers)
+        connector = adapter.name
         envelope = env.ok({})
         command_args.stamp_spend(envelope, adapter)
     finally:
         adapter.close()
     _annotate_grain(datasets, defs)
-    envelope.data["datasets"] = [d.model_dump(mode="json") for d in datasets]
+
+    # Persist what the scan already paid for: after profiling a table, `explore
+    # query` on that table must work without a second warehouse scan (the query
+    # firewall's own refusal messages promise exactly this). Prior relationships
+    # are preserved because profile runs no inference pass.
+    store = DexStore(repo_root)
+    now = datetime.now(UTC)
+    cache, stats = _merge_profiles(store.load_cache(), datasets, connector, now)
+    path = store.save_cache(cache, now=now)
+
+    envelope.data.update(
+        {
+            "datasets": [d.model_dump(mode="json") for d in datasets],
+            "cache_path": str(path),
+            "updated_at": now.isoformat(),
+            "notes": [_persist_note(stats, len(datasets), keeps_relationships=True)],
+        }
+    )
     return envelope
 
 
 def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
     verify = getattr(args, "verify", False)
-    config = load_config(command_args.repo_root(args)) or DexConfig()
+    repo_root = command_args.repo_root(args)
+    config = load_config(repo_root) or DexConfig()
     defs = _project_definitions(args, config)
 
     adapter = command_args.open_from_args(args)
@@ -138,6 +159,7 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         if unconfirmed is not None:
             return unconfirmed
         datasets = profile_mod.profile(adapter, identifiers)
+        connector = adapter.name
         inferred = rel_mod.infer_relationships(datasets)
         if verify:
             rel_mod.verify_relationships(
@@ -147,6 +169,9 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         command_args.stamp_spend(envelope, adapter)
     finally:
         adapter.close()
+    # Annotate before persisting so cached datasets carry candidate_keys and
+    # grain, the same shape a `map`-written cache has.
+    _annotate_grain(datasets, defs)
 
     declared, declared_notes = rel_mod.declared_relationships(
         defs, [d.identifier for d in datasets]
@@ -163,11 +188,25 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         notes.append(
             f"verified {len(inferred)} inferred join(s) with aggregate overlap probes"
         )
+
+    # Persist the profiles this run already paid for. Because relationships
+    # inventories and profiles the full set and infers across all of it, its
+    # relationship set is authoritative for this run and replaces the prior one.
+    store = DexStore(repo_root)
+    now = datetime.now(UTC)
+    cache, stats = _merge_profiles(
+        store.load_cache(), datasets, connector, now, relationships=rels
+    )
+    path = store.save_cache(cache, now=now)
+    notes.append(_persist_note(stats, len(datasets), keeps_relationships=False))
+
     envelope.data.update(
         {
             "relationships": [r.model_dump(mode="json") for r in rels],
             "declared_count": len(declared),
             "inferred_count": len(rels) - len(declared),
+            "cache_path": str(path),
+            "updated_at": now.isoformat(),
             "notes": notes,
         }
     )
@@ -675,6 +714,99 @@ def _compose_datasets(
         ds.rank_score = scores.get(meta.identifier)
         datasets.append(ds)
     return datasets, carried
+
+
+# Sentinel: preserve the prior cache's relationships (profile has no inference
+# pass, so it has no business touching them).
+_KEEP_RELATIONSHIPS = object()
+
+
+def _merge_profiles(
+    prior: DexCache | None,
+    profiled: list[Dataset],
+    connector: str,
+    now: datetime,
+    *,
+    relationships=_KEEP_RELATIONSHIPS,
+) -> tuple[DexCache, dict]:
+    """Fold freshly profiled datasets into a prior cache, keyed by identifier.
+
+    Unlike ``_compose_datasets`` (inventory-driven: it iterates metas and
+    manufactures inventory-only stubs), this merges over prior datasets plus
+    the freshly profiled set and never fabricates stubs or drops prior entries.
+
+    A same-connector prior is reusable; a mismatched-connector prior is dropped
+    wholesale (mirrors ``cmd_map``'s reuse gate: mixing connectors would poison
+    the PII policy and the maintain baseline, and `.dex/` is non-canonical
+    scratch that one `explore map` rebuilds). A refreshed dataset carries
+    forward the prior ``rank_score``, because profile and relationships do not
+    compute rank. Relationships are preserved by default (profile) or replaced
+    with the passed set (relationships, whose full-inventory inference is
+    authoritative for its run).
+    """
+
+    reusable = prior if prior and prior.provenance.connector == connector else None
+    by_id = {d.identifier: d for d in profiled}
+    datasets: list[Dataset] = []
+    consumed: set[str] = set()
+    if reusable is not None:
+        for old in reusable.datasets:
+            fresh = by_id.get(old.identifier)
+            if fresh is not None:
+                fresh.rank_score = old.rank_score  # keep map's connectivity ranking
+                datasets.append(fresh)
+                consumed.add(old.identifier)
+            else:
+                datasets.append(old)  # untouched; keeps its older profiled_at
+    # Anything left over is newly profiled and inserted; rank_score stays None.
+    datasets.extend(ds for ds in profiled if ds.identifier not in consumed)
+    if relationships is _KEEP_RELATIONSHIPS:
+        rels = list(reusable.relationships) if reusable else []
+    else:
+        rels = relationships
+    cache = DexCache(datasets=datasets, relationships=rels)
+    cache.provenance.connector = connector
+    cache.provenance.created_at = (
+        reusable.provenance.created_at
+        if reusable and reusable.provenance.created_at
+        else now.isoformat()
+    )
+    stats = {
+        "connector": connector,
+        "merged": reusable is not None,
+        "refreshed": len(consumed),
+        "added": len(profiled) - len(consumed),
+        "replaced_connector": (
+            prior.provenance.connector if prior and reusable is None else None
+        ),
+    }
+    return cache, stats
+
+
+def _persist_note(stats: dict, count: int, *, keeps_relationships: bool) -> str:
+    """One sentence saying what the cache write did, driven by merge stats."""
+
+    if stats["replaced_connector"]:
+        return (
+            f"prior cache was built for connector '{stats['replaced_connector']}'; "
+            f"profiling on '{stats['connector']}' replaced it with a fresh cache "
+            f"of the {count} profiled object(s); run `explore map` to rebuild "
+            "the full landscape"
+        )
+    if stats["merged"]:
+        preserved = (
+            "other datasets and relationships preserved"
+            if keeps_relationships
+            else "other datasets preserved"
+        )
+        return (
+            f"merged {count} profiled object(s) into the existing cache "
+            f"({stats['refreshed']} refreshed, {stats['added']} added); {preserved}"
+        )
+    return (
+        f"created .dex/cache.json with {count} profiled object(s); run "
+        "`explore map` to add the full inventory and relationships"
+    )
 
 
 def _resolve_identifiers(adapter: Adapter, requested: list[str]) -> list[str]:

--- a/packages/dex-core/tests/explore/conftest.py
+++ b/packages/dex-core/tests/explore/conftest.py
@@ -9,6 +9,15 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _isolated_repo_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`explore profile` and `explore relationships` persist to `.dex/` under the
+    repo root, which defaults to the CWD; tests that omit --repo-root must land
+    that write in tmp_path, never in the checkout."""
+
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.fixture
 def airbnb_duckdb(tmp_path: Path) -> Path:
     """Three raw tables: person-name and free-text columns that must be flagged,

--- a/packages/dex-core/tests/explore/test_profile.py
+++ b/packages/dex-core/tests/explore/test_profile.py
@@ -8,11 +8,19 @@ Airbnb-style raw export with bare `NAME`, `REVIEWER_NAME`, and free-text
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
-from exmergo_dex_core.cache import PIICategory
+from exmergo_dex_core.cache import (
+    ColumnProfile,
+    Dataset,
+    DexCache,
+    DexStore,
+    PIICategory,
+    Relationship,
+)
 from exmergo_dex_core.cli import main
 from exmergo_dex_core.explore.profile import detect_pii, is_min_max_safe
 
@@ -173,6 +181,229 @@ def test_profile_accepts_comma_separated_objects(airbnb_duckdb: Path, capsys):
     )
     names = {d["identifier"].split(".")[-1] for d in payload["data"]["datasets"]}
     assert names == {"RAW_HOSTS", "RAW_LISTINGS", "RAW_REVIEWS"}
+
+
+# --- persistence: profile writes through to the .dex/ cache ---------------------
+
+
+def _profile(objects: list[str], db: Path, repo: Path, capsys) -> dict:
+    return _run(
+        ["explore", "profile", *objects, "--path", str(db), "--repo-root", str(repo)],
+        capsys,
+    )
+
+
+def _map(db: Path, repo: Path, capsys) -> dict:
+    return _run(["explore", "map", "--path", str(db), "--repo-root", str(repo)], capsys)
+
+
+def _dataset(cache: DexCache, suffix: str) -> Dataset:
+    return next(d for d in cache.datasets if d.identifier.endswith(f".{suffix}"))
+
+
+def test_profile_writes_cache_when_none_exists(
+    airbnb_duckdb: Path, tmp_path: Path, capsys
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    payload = _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys)
+
+    assert (repo / ".dex" / "cache.json").is_file()
+    assert payload["data"]["cache_path"].endswith("cache.json")
+    assert payload["data"]["updated_at"]
+    assert any("created .dex/cache.json" in n for n in payload["data"]["notes"])
+    assert any("explore map" in n for n in payload["data"]["notes"])
+
+    cache = DexStore(repo).load_cache()
+    assert [d.identifier.split(".")[-1] for d in cache.datasets] == ["RAW_HOSTS"]
+    assert cache.datasets[0].columns, "the firewall needs columns to allow queries"
+    assert cache.relationships == []
+    assert cache.provenance.connector == "duckdb"
+    assert cache.provenance.created_at == cache.provenance.updated_at
+
+
+def test_profile_merges_into_existing_map_preserving_relationships_and_rank(
+    airbnb_duckdb: Path, tmp_path: Path, capsys
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _map(airbnb_duckdb, repo, capsys)
+    store = DexStore(repo)
+    before = store.load_cache()
+    rels_before = [r.model_dump() for r in before.relationships]
+    assert rels_before, "the airbnb fixture has inferable joins"
+    hosts_before = _dataset(before, "RAW_HOSTS")
+    assert hosts_before.rank_score is not None
+
+    payload = _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys)
+    after = store.load_cache()
+
+    assert [r.model_dump() for r in after.relationships] == rels_before
+    assert {d.identifier for d in after.datasets} == {
+        d.identifier for d in before.datasets
+    }
+    hosts_after = _dataset(after, "RAW_HOSTS")
+    assert hosts_after.rank_score == hosts_before.rank_score
+    assert after.provenance.created_at == before.provenance.created_at
+    assert after.provenance.updated_at >= before.provenance.updated_at
+    note = next(n for n in payload["data"]["notes"] if "merged" in n)
+    assert "1 refreshed, 0 added" in note
+    assert "relationships preserved" in note
+
+
+def test_profile_refreshes_stale_profile_updates_profiled_at(
+    airbnb_duckdb: Path, tmp_path: Path, capsys
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _map(airbnb_duckdb, repo, capsys)
+    store = DexStore(repo)
+    before = store.load_cache()
+    old = _dataset(before, "RAW_HOSTS")
+    reviews_stamp = _dataset(before, "RAW_REVIEWS").profiled_at
+    assert old.profiled_at is not None
+
+    _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys)
+    after = store.load_cache()
+    new = _dataset(after, "RAW_HOSTS")
+    assert new.profiled_at > old.profiled_at, "the fresh measurement wins"
+    assert new.rank_score == old.rank_score
+    # A table not re-profiled keeps its older stamp, which marks its age.
+    assert _dataset(after, "RAW_REVIEWS").profiled_at == reviews_stamp
+
+
+def test_profile_inserts_new_dataset(airbnb_duckdb: Path, tmp_path: Path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys)
+    payload = _profile(["RAW_LISTINGS"], airbnb_duckdb, repo, capsys)
+
+    cache = DexStore(repo).load_cache()
+    names = {d.identifier.split(".")[-1] for d in cache.datasets}
+    assert names == {"RAW_HOSTS", "RAW_LISTINGS"}
+    assert _dataset(cache, "RAW_LISTINGS").rank_score is None
+    note = next(n for n in payload["data"]["notes"] if "merged" in n)
+    assert "0 refreshed, 1 added" in note
+
+
+def test_profile_connector_mismatch_replaces_cache(
+    airbnb_duckdb: Path, tmp_path: Path, capsys
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    seeded = DexCache(
+        datasets=[
+            Dataset(
+                identifier="proj.ds.t",
+                columns=[ColumnProfile(name="id", data_type="INTEGER")],
+            )
+        ],
+        relationships=[
+            Relationship(
+                from_dataset="proj.ds.t",
+                from_columns=["id"],
+                to_dataset="proj.ds.u",
+                to_columns=["id"],
+            )
+        ],
+    )
+    seeded.provenance.connector = "bigquery"
+    seeded.provenance.created_at = "2020-01-01T00:00:00+00:00"
+    DexStore(repo).save_cache(seeded)
+
+    payload = _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys)
+    cache = DexStore(repo).load_cache()
+    assert cache.provenance.connector == "duckdb"
+    assert [d.identifier.split(".")[-1] for d in cache.datasets] == ["RAW_HOSTS"]
+    assert cache.relationships == []
+    assert cache.provenance.created_at != "2020-01-01T00:00:00+00:00"
+    note = next(n for n in payload["data"]["notes"] if "bigquery" in n)
+    assert "explore map" in note
+
+
+def test_merge_profiles_carries_rank_and_preserves_relationships():
+    from exmergo_dex_core.explore.commands import _merge_profiles
+
+    def _prior() -> DexCache:
+        prior = DexCache(
+            datasets=[
+                Dataset(
+                    identifier="db.s.a",
+                    rank_score=0.9,
+                    columns=[ColumnProfile(name="id", data_type="INTEGER")],
+                    profiled_at="2026-01-01T00:00:00+00:00",
+                ),
+                Dataset(
+                    identifier="db.s.b",
+                    rank_score=0.5,
+                    columns=[ColumnProfile(name="id", data_type="INTEGER")],
+                    profiled_at="2026-01-01T00:00:00+00:00",
+                ),
+            ],
+            relationships=[
+                Relationship(
+                    from_dataset="db.s.b",
+                    from_columns=["a_id"],
+                    to_dataset="db.s.a",
+                    to_columns=["id"],
+                )
+            ],
+        )
+        prior.provenance.connector = "duckdb"
+        prior.provenance.created_at = "2026-01-01T00:00:00+00:00"
+        return prior
+
+    now = datetime(2026, 7, 13, tzinfo=UTC)
+
+    def _fresh() -> list[Dataset]:
+        # A fresh list per scenario: the merge carries rank onto these objects.
+        return [
+            Dataset(
+                identifier="db.s.a",
+                columns=[ColumnProfile(name="id", data_type="INTEGER")],
+                profiled_at=now.isoformat(),
+            ),
+            Dataset(
+                identifier="db.s.c",
+                columns=[ColumnProfile(name="id", data_type="INTEGER")],
+                profiled_at=now.isoformat(),
+            ),
+        ]
+
+    cache, stats = _merge_profiles(_prior(), _fresh(), "duckdb", now)
+    by_id = {d.identifier: d for d in cache.datasets}
+    assert by_id["db.s.a"].rank_score == 0.9, "map's ranking is carried forward"
+    assert by_id["db.s.a"].profiled_at == now.isoformat()
+    assert by_id["db.s.b"].profiled_at == "2026-01-01T00:00:00+00:00", "untouched"
+    assert by_id["db.s.c"].rank_score is None, "never ranked"
+    assert len(cache.relationships) == 1, "preserved by default"
+    assert cache.provenance.created_at == "2026-01-01T00:00:00+00:00"
+    assert stats["merged"] is True
+    assert stats["refreshed"] == 1 and stats["added"] == 1
+    assert stats["replaced_connector"] is None
+
+    # Connector mismatch: the prior is dropped wholesale, created_at resets.
+    cache, stats = _merge_profiles(_prior(), [_fresh()[0]], "postgres", now)
+    assert [d.identifier for d in cache.datasets] == ["db.s.a"]
+    assert cache.datasets[0].rank_score is None
+    assert cache.relationships == []
+    assert cache.provenance.connector == "postgres"
+    assert cache.provenance.created_at == now.isoformat()
+    assert stats["replaced_connector"] == "duckdb"
+
+    # Passing relationships replaces the prior set (the relationships command).
+    replacement = [
+        Relationship(
+            from_dataset="db.s.c",
+            from_columns=["a_id"],
+            to_dataset="db.s.a",
+            to_columns=["id"],
+        )
+    ]
+    cache, _ = _merge_profiles(
+        _prior(), _fresh(), "duckdb", now, relationships=replacement
+    )
+    assert cache.relationships == replacement
 
 
 # --- exact-count escalation ----------------------------------------------------

--- a/packages/dex-core/tests/explore/test_query.py
+++ b/packages/dex-core/tests/explore/test_query.py
@@ -63,6 +63,77 @@ def test_query_without_cache_is_refused_with_the_fix(
     assert not (repo / ".dex").exists(), "a refused gate writes nothing"
 
 
+# --- a profile-built cache unblocks query -----------------------------------------
+
+
+def _profiled_repo(
+    objects: list[str], airbnb_duckdb: Path, tmp_path: Path, capsys
+) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(
+        [
+            "explore",
+            "profile",
+            *objects,
+            "--path",
+            str(airbnb_duckdb),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    return repo
+
+
+def test_profile_then_query_with_no_prior_map_succeeds(
+    airbnb_duckdb: Path, tmp_path: Path, capsys
+):
+    """The scan `profile` paid for must be enough: no `explore map` ever ran."""
+
+    repo = _profiled_repo(["RAW_LISTINGS"], airbnb_duckdb, tmp_path, capsys)
+    payload = _query(
+        "SELECT HOST_ID, COUNT(*) AS n FROM RAW_LISTINGS GROUP BY 1 ORDER BY 1",
+        airbnb_duckdb,
+        repo,
+        capsys,
+    )
+    assert payload["data"]["cells"] == [[1, 1], [2, 1]]
+
+
+def test_query_on_unprofiled_table_after_profile_is_refused(
+    airbnb_duckdb: Path, tmp_path: Path, capsys
+):
+    """A partial cache scopes the firewall to exactly the profiled tables."""
+
+    repo = _profiled_repo(["RAW_LISTINGS"], airbnb_duckdb, tmp_path, capsys)
+    payload = _query(
+        "SELECT COUNT(*) FROM RAW_HOSTS",
+        airbnb_duckdb,
+        repo,
+        capsys,
+        expect_error=True,
+    )
+    message = payload["errors"][0]
+    assert "not in the .dex cache" in message
+    assert "explore profile" in message
+
+
+def test_profile_built_cache_enforces_pii(airbnb_duckdb: Path, tmp_path: Path, capsys):
+    """PII flags must survive the profile -> cache -> firewall path."""
+
+    repo = _profiled_repo(["RAW_HOSTS"], airbnb_duckdb, tmp_path, capsys)
+    payload = _query(
+        "SELECT MIN(NAME) FROM RAW_HOSTS",
+        airbnb_duckdb,
+        repo,
+        capsys,
+        expect_error=True,
+    )
+    message = payload["errors"][0]
+    assert "RAW_HOSTS.NAME" in message and "(name)" in message
+
+
 # --- allowed queries -------------------------------------------------------------
 
 

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -16,6 +16,7 @@ from conftest import write_manifest
 from exmergo_dex_core.cache import (
     ColumnProfile,
     Dataset,
+    DexStore,
     Relationship,
     RelationshipKind,
 )
@@ -499,6 +500,66 @@ def test_verify_demotes_a_join_with_heavy_orphans(tmp_path: Path, capsys):
     assert rel["verified"] is True
     assert rel["orphan_fraction"] == 0.6
     assert rel["confidence"] < 0.5, "measured non-containment demotes the guess"
+
+
+def test_relationships_persists_datasets_and_relationships(
+    airbnb_duckdb: Path, tmp_path: Path, capsys
+):
+    """The profiles and inference this run already paid for land in the cache,
+    in the same annotated shape a `map`-written cache has."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    payload = _run(
+        [
+            "explore",
+            "relationships",
+            "--path",
+            str(airbnb_duckdb),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    assert payload["data"]["cache_path"].endswith("cache.json")
+    assert payload["data"]["updated_at"]
+
+    cache = DexStore(repo).load_cache()
+    names = {d.identifier.split(".")[-1] for d in cache.datasets}
+    assert names == {"RAW_HOSTS", "RAW_LISTINGS", "RAW_REVIEWS"}
+    assert all(d.columns for d in cache.datasets)
+    listings = next(d for d in cache.datasets if d.identifier.endswith(".RAW_LISTINGS"))
+    assert listings.grain == ["ID"], "grain-annotated before persisting, like map"
+    assert len(cache.relationships) == len(payload["data"]["relationships"]) == 2
+
+
+def test_relationships_then_query_succeeds(airbnb_duckdb: Path, tmp_path: Path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(
+        [
+            "explore",
+            "relationships",
+            "--path",
+            str(airbnb_duckdb),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    payload = _run(
+        [
+            "explore",
+            "query",
+            "SELECT COUNT(*) AS n FROM RAW_REVIEWS",
+            "--path",
+            str(airbnb_duckdb),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    assert payload["data"]["cells"] == [[2]]
 
 
 def test_empty_result_is_explained_not_silent(tmp_path: Path, capsys):


### PR DESCRIPTION
## What

`explore profile` and `explore relationships` now persist their results to
`.dex/cache.json` by default, merging into any existing cache. Previously only
`explore map` wrote the cache.

Closes #53.

## Why

The connector's whole thesis is cost governance, and today it charges twice for
the same scan. `profile` computes per-column profiles, PII flags, grain, and
data-quality notes, returns them in its envelope, then throws them away.
`relationships` does the same after profiling every object and inferring joins.
Because `explore query` requires the cache, a user who has already profiled the
exact tables they care about must re-scan them via `map` just to make `query`
work.

The contract was already advertised in code: the query firewall's own refusal
messages tell users to run `explore profile <table>` so its "columns and PII
flags are known" (`guards/query_firewall.py`). That promise was false until now.
This change makes the code honor a contract it already prints.

## What changed

- **`cmd_profile`** annotates grain (now project-aware, consistent with `map`)
  and persists the profiled datasets. Prior relationships are preserved, because
  `profile` runs no inference pass.
- **`cmd_relationships`** annotates grain before persisting (so its cached
  datasets carry `candidate_keys`/`grain` like `map`'s do) and writes the
  profiled datasets plus its relationship set. Because it inventories and
  profiles the full object set and infers across all of it, its relationships
  are authoritative for the run and replace the prior set. This composes with
  the `--use-project` work from #66: declared joins from the dbt project are
  folded in and persisted too.
- **New `_merge_profiles` helper**, keyed by exact identifier:
  - Refreshed dataset (profiled this run, present in prior): fresh measurement
    wins, except `rank_score`, which is carried forward so `map`'s connectivity
    ranking survives.
  - New dataset: inserted with `rank_score=None`.
  - Untouched prior dataset: kept verbatim, including its older `profiled_at`
    age marker.
  - `created_at` is preserved from a reusable prior; `updated_at` is bumped by
    `save_cache`.
  - **Connector mismatch** (prior built for A, now profiling B): the prior is
    dropped wholesale and a fresh cache scoped to B is written, with a loud note
    naming the dropped connector. Mixing connectors would poison the PII policy
    and the maintain baseline, and `.dex/` is non-canonical scratch that one
    `explore map` rebuilds. It never refuses, since refusing would break the
    firewall promise this change exists to keep.

## Tests

- `test_profile.py`: fresh-cache write, merge-preserves-relationships-and-rank,
  stale-profile refresh advances `profiled_at`, new-dataset insert,
  connector-mismatch replacement, and an in-memory `_merge_profiles` unit test
  (carry-rank, preserve-relationships, mismatch, and replace variants).
- `test_query.py`: profile-then-query with no prior `map` succeeds; querying an
  unprofiled table is still refused (partial-cache scoping); PII flags flow from
  a profile-built cache into the firewall.
- `test_relationships.py`: datasets and relationships persist in the annotated
  shape; relationships-then-query succeeds.
- `conftest.py`: an autouse `chdir(tmp_path)` fixture, because the repo root
  defaults to the CWD and several existing CLI tests omit `--repo-root`; without
  it these now-persisting commands would write `.dex/` into the checkout.

Full `dex-core` suite: 751 passed, 41 skipped. Explore suite: 126 passed.

## Verification

Manually confirmed end to end against a fixture DuckDB:

1. `explore profile RAW_HOSTS` in an empty repo writes `.dex/cache.json`, then
   `explore query "SELECT COUNT(*) FROM RAW_HOSTS"` is allowed with no prior
   `map` (previously refused with "run explore map first").
2. A PII-projecting query stays refused from a profile-built cache, so the flags
   survive the profile -> cache -> firewall path.
3. `map`, then `profile <one-table>`: relationships and all other datasets stay
   intact, only the profiled table is refreshed, its prior `rank_score` and the
   cache's `created_at` are retained, and `updated_at` advances.

## Known follow-up (out of scope)

`map` folds same-lineage/replica duplicate edges before caching
(`fold_replica_relationships`); `relationships` does not. A cache last written by
`relationships` may therefore contain replica-duplicate edges a `map` run would
fold. This mirrors the two commands' existing envelope behavior; duplicating the
fold logic would need dev-schema config plumbing that `relationships` lacks.
