### PR TITLE
Fold replica edges in explore relationships and fix dev-schema matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`explore relationships` now folds same-lineage/replica duplicate edges
+  before caching, matching `explore map`** ([#70]). `relationships` profiles
+  the full inventory, so it is even more likely than `map` to pull a
+  dev/replica schema into scope alongside its source; without folding, a
+  cache last written by `relationships` could carry replica-duplicate edges
+  that a `map` run would have folded away. The folded set now flows into both
+  the envelope and the persisted cache, and a note reports how many edges were
+  folded and how many objects mirror source lineage. Dev-schema matching is
+  also fixed for two cases the original folding logic missed: a BigQuery-style
+  qualified `dev_dataset` (`project.dataset`) is compared by its bare schema
+  name, and schema names are compared case-insensitively so a lower-cased
+  configured `dev_schema` still matches an upper-cased warehouse schema
+  (Snowflake, Redshift).
+
 ## [1.2.0] - 2026-07-14
 
 ### Fixed

--- a/packages/dex-core/README.md
+++ b/packages/dex-core/README.md
@@ -24,6 +24,7 @@ exmergo-dex-core[duckdb]       # the on-ramp and the eval/benchmark engine
 exmergo-dex-core[snowflake]
 exmergo-dex-core[bigquery]
 exmergo-dex-core[databricks]
+exmergo-dex-core[redshift]
 exmergo-dex-core[postgres]
 exmergo-dex-core[all]          # every connector at once
 ```
@@ -46,13 +47,18 @@ the full surface and the envelope spec.
 ## Status
 
 Early and under active development; expect pre-release versions. Today the engine
-runs Explore and Transform end to end on DuckDB and on BigQuery.
+runs Explore, Transform, and Maintain end to end on every connector: DuckDB,
+BigQuery, Snowflake, Databricks, Amazon Redshift, and Postgres.
 
 Explore: ranks what matters in an unfamiliar warehouse, profiles columns
 selectively, flags PII, surfaces grain and data-quality warnings, infers joins
 and verifies them with overlap probes (`--verify`), and executes agent-authored
 ad-hoc SELECTs behind a PII-aware query firewall (`explore query`), all
-read-only.
+read-only. It starts bare by default; with `--use-project` it reads an existing
+dbt project, promoting declared `relationships` joins, honoring declared grain
+and `unique` tests, and letting metric-backing models surface first in the
+ranking. A repeatable `--scope` narrows the source scope per command without
+writing back to `.dex/config.yml`.
 
 Transform: bootstraps a dbt project where none exists (`transform init`, with an
 explicit connector, never a default), turns agent-authored edits and
@@ -97,6 +103,22 @@ same `.dex/spend.jsonl` ledger. Billed work runs only on the SQL warehouse
 the config pins. dbt builds go to a dedicated dev catalog.schema via
 dbt-databricks, which the `[databricks]` extra carries. See
 [`references/databricks.md`](../../references/databricks.md).
+
+Amazon Redshift: Serverless-first and provisioned-compatible. Connects through
+the AWS default credential chain (a pinned Serverless `workgroup` or provisioned
+`cluster_identifier` mints IAM temporary database credentials), the `REDSHIFT_*`
+environment, the committed non-secret target (password via `REDSHIFT_PASSWORD`),
+or a dbt profile; dex never asks for or persists a password. Metadata comes from
+the Postgres catalog (`pg_class` merged with `SVV_TABLE_INFO` and `SVV_COLUMNS`,
+so empty tables still appear). The guarded quantity is compute time, so budgets
+are **compute-seconds** with RPU-hours shown alongside (dollars when
+`redshift.rpu_price_usd` is set), floored once by the 60-second Serverless wake
+minimum; the budget is hard-enforced by a per-statement server-side
+`statement_timeout`, and actual seconds land in the same `.dex/spend.jsonl`
+ledger. Profiling uses `HLL(...)` approximate distincts with exact escalation
+in-budget; the session is read-only at the server. dbt builds go to a dedicated
+dev schema via dbt-redshift, which the `[redshift]` extra carries. See
+[`references/redshift.md`](../../references/redshift.md).
 
 PostgreSQL: the operational-database connector. Connects through discovered
 credentials (`pg_service.conf`, `DATABASE_URL`, the `PG*` environment, or a

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -45,6 +45,21 @@ def _profile_estimate(
     return estimate(identifiers)
 
 
+def _dev_schemas(config: DexConfig) -> frozenset[str]:
+    """Dev/replica namespaces declared per connector (where dbt dev builds write)."""
+    return frozenset(
+        name
+        for name in [
+            config.bigquery.dev_dataset if config.bigquery else None,
+            config.snowflake.dev_schema if config.snowflake else None,
+            config.databricks.dev_schema if config.databricks else None,
+            config.postgres.dev_schema if config.postgres else None,
+            config.redshift.dev_schema if config.redshift else None,
+        ]
+        if name
+    )
+
+
 def cmd_inventory(args: argparse.Namespace) -> env.Envelope:
     adapter = command_args.open_from_args(args)
     try:
@@ -173,6 +188,14 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
     # grain, the same shape a `map`-written cache has.
     _annotate_grain(datasets, defs)
 
+    # Fold same-lineage duplicates before the merge, as `map` does, so the folded
+    # set flows into both the cache and the envelope. Relationships profiles the
+    # full inventory, so it is even more likely than map to pull a dev/replica
+    # schema into scope alongside its source.
+    inferred, folded_edges, mirrored_objects = rel_mod.fold_replica_relationships(
+        datasets, inferred, _dev_schemas(config)
+    )
+
     declared, declared_notes = rel_mod.declared_relationships(
         defs, [d.identifier for d in datasets]
     )
@@ -187,6 +210,12 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
     if verify and inferred:
         notes.append(
             f"verified {len(inferred)} inferred join(s) with aggregate overlap probes"
+        )
+    if folded_edges > 0:
+        notes.append(
+            f"folded {folded_edges} same-lineage duplicate relationship(s); "
+            f"{mirrored_objects} object(s) mirror source lineage (a dev/replica "
+            "dataset mapped alongside its source)"
         )
 
     # Persist the profiles this run already paid for. Because relationships
@@ -339,19 +368,8 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
     # Fold same-lineage duplicates before they reach the cache: a dev/replica
     # dataset mapped alongside its source otherwise inflates one real foreign key
     # into source, replica, and cross-dataset lookalike edges.
-    dev_schemas = frozenset(
-        name
-        for name in [
-            config.bigquery.dev_dataset if config.bigquery else None,
-            config.snowflake.dev_schema if config.snowflake else None,
-            config.databricks.dev_schema if config.databricks else None,
-            config.postgres.dev_schema if config.postgres else None,
-            config.redshift.dev_schema if config.redshift else None,
-        ]
-        if name
-    )
     inferred, folded_edges, mirrored_objects = rel_mod.fold_replica_relationships(
-        profiled, inferred, dev_schemas
+        profiled, inferred, _dev_schemas(config)
     )
 
     declared, declared_notes = rel_mod.declared_relationships(

--- a/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
@@ -184,8 +184,13 @@ def fold_replica_relationships(
     def bare(identifier: str) -> str:
         return identifier.rsplit(".", 1)[-1]
 
+    # Compare case-insensitive short names on both sides: a BigQuery dev_dataset
+    # may be configured qualified (`project.dataset`), and Snowflake/Redshift
+    # schema identifiers are often cased differently from the configured value.
+    dev_short = {s.rsplit(".", 1)[-1].casefold() for s in dev_schemas}
+
     def is_dev(schema: str) -> bool:
-        return schema.rsplit(".", 1)[-1] in dev_schemas
+        return schema.rsplit(".", 1)[-1].casefold() in dev_short
 
     # An entity+columns fingerprint held by more than one schema is a mirrored
     # entity; a dev schema is a replica by declaration even without a structural

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -264,7 +264,7 @@ def test_dealiased_match_skips_when_stripped_to_a_bare_suffix():
 # --- same-lineage / replica folding --------------------------------------------
 
 
-def _mirror_world() -> list[Dataset]:
+def _mirror_world(dev_schema: str = "dbt_dev") -> list[Dataset]:
     """A source schema and a dev/replica schema holding the same entities: the
     shape that inflated one foreign key into several edges in the field."""
 
@@ -276,11 +276,15 @@ def _mirror_world() -> list[Dataset]:
         ),
         _ds("db.main.customers", [_col("id", distinct=2, unique=True)], rows=2),
         _ds(
-            "db.dbt_dev.stg_orders",
+            f"db.{dev_schema}.stg_orders",
             [_col("id", distinct=3, unique=True), _col("customer_id", distinct=2)],
             rows=3,
         ),
-        _ds("db.dbt_dev.dim_customers", [_col("id", distinct=2, unique=True)], rows=2),
+        _ds(
+            f"db.{dev_schema}.dim_customers",
+            [_col("id", distinct=2, unique=True)],
+            rows=2,
+        ),
     ]
 
 
@@ -329,6 +333,38 @@ def test_fold_is_a_noop_without_a_mirror():
     assert mirrored == 0
 
 
+def test_fold_matches_qualified_dev_dataset_config():
+    """A BigQuery-style qualified dev_dataset (`project.dataset`) must still mark
+    the replica schema, so the source edge is kept as canonical."""
+
+    datasets = _mirror_world()
+    rels = infer_relationships(datasets)
+    kept, folded, mirrored = fold_replica_relationships(
+        datasets, rels, frozenset({"db.dbt_dev"})
+    )
+    assert folded == 3
+    assert len(kept) == 1
+    assert kept[0].from_dataset == "db.main.orders"
+    assert kept[0].to_dataset == "db.main.customers"
+    assert mirrored == 2
+
+
+def test_fold_matches_dev_schema_case_insensitively():
+    """A lower-case configured dev_schema must match an upper-cased warehouse
+    schema (Snowflake/Redshift casing), keeping the source edge as canonical."""
+
+    datasets = _mirror_world(dev_schema="DBT_DEV")
+    rels = infer_relationships(datasets)
+    kept, folded, mirrored = fold_replica_relationships(
+        datasets, rels, frozenset({"dbt_dev"})
+    )
+    assert folded == 3
+    assert len(kept) == 1
+    assert kept[0].from_dataset == "db.main.orders"
+    assert kept[0].to_dataset == "db.main.customers"
+    assert mirrored == 2
+
+
 def test_map_folds_mirrored_lineage_and_notes_it(tmp_path: Path, capsys):
     duckdb = pytest.importorskip("duckdb")
     db = tmp_path / "mirror.duckdb"
@@ -352,6 +388,47 @@ def test_map_folds_mirrored_lineage_and_notes_it(tmp_path: Path, capsys):
     assert any("mirror source lineage" in n for n in payload["data"]["notes"])
     # One real foreign key survives instead of the inflated cross-schema fan-out.
     assert payload["data"]["relationship_count"] <= 2
+
+
+def test_relationships_folds_mirrored_lineage_and_persists_folded_set(
+    tmp_path: Path, capsys
+):
+    """`explore relationships` must fold replica duplicates exactly as `map` does,
+    in both the envelope and the persisted cache — the coverage gap that let the
+    two commands' caches disagree."""
+
+    duckdb = pytest.importorskip("duckdb")
+    db = tmp_path / "mirror.duckdb"
+    conn = duckdb.connect(str(db))
+    conn.execute("CREATE TABLE orders (id INTEGER, customer_id INTEGER)")
+    conn.execute("INSERT INTO orders VALUES (1, 1), (2, 2), (3, 1)")
+    conn.execute("CREATE TABLE customers (id INTEGER)")
+    conn.execute("INSERT INTO customers VALUES (1), (2)")
+    conn.execute("CREATE SCHEMA dbt_dev")
+    conn.execute("CREATE TABLE dbt_dev.stg_orders (id INTEGER, customer_id INTEGER)")
+    conn.execute("INSERT INTO dbt_dev.stg_orders VALUES (1, 1), (2, 2), (3, 1)")
+    conn.execute("CREATE TABLE dbt_dev.dim_customers (id INTEGER)")
+    conn.execute("INSERT INTO dbt_dev.dim_customers VALUES (1), (2)")
+    conn.close()
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    payload = _run(
+        ["explore", "relationships", "--path", str(db), "--repo-root", str(repo)],
+        capsys,
+    )
+    data = payload["data"]
+    assert any("mirror source lineage" in n for n in data["notes"])
+    # One real foreign key survives instead of the inflated cross-schema fan-out.
+    assert len(data["relationships"]) == 1
+
+    cache = DexStore(repo).load_cache()
+    assert len(cache.relationships) == 1
+    envelope_edge = data["relationships"][0]
+    assert (cache.relationships[0].from_dataset, cache.relationships[0].to_dataset) == (
+        envelope_edge["from_dataset"],
+        envelope_edge["to_dataset"],
+    )
 
 
 # --- grain and data-quality notes ----------------------------------------------


### PR DESCRIPTION
# Fold replica edges in `explore relationships`; fix dev-schema matching

## Summary

`explore map` folds same-lineage/replica duplicate relationship edges before
writing `.dex/cache.json`, but `explore relationships` didn't — since #69
persisted its output to the same cache, this let replica-duplicate edges
written by `relationships` disagree with what a `map` run would produce for
the same warehouse. This was worse for `relationships` since it profiles the
full inventory (vs. map's top-ranked subset), making it more likely to pull a
dev/replica schema into scope.

- Extracted the inline `dev_schemas` frozenset construction from `cmd_map`
  into a shared `_dev_schemas` helper, used by both commands so they can't
  drift apart again.
- `cmd_relationships` now calls `fold_replica_relationships` before merging
  declared joins, so the folded set flows into both the persisted cache and
  the envelope, with the same fold note `map` emits.
- Fixed two latent bugs in `fold_replica_relationships`'s dev-schema matching:
  qualified config values (e.g. BigQuery `project.dataset`) never matched,
  and matching was case-sensitive (breaking on Snowflake/Redshift's typical
  casing). Both sides now compare case-insensitive short (last-segment)
  names.
## Related issues

Closes #70 .

## Tests

- New command-level test: `explore relationships` on a mirrored warehouse
  folds duplicates and persists the folded set.
- New engine tests: qualified dev-dataset config and case-mismatched
  dev-schema config both match correctly.
- Confirmed the existing no-op regression test (non-mirror fixture) still
  passes.

## Verification

- `uv run pytest` — 841 passed, 51 skipped.
- End-to-end: ran `explore relationships` then `explore map` against the same
  mirrored fixture; resulting `.dex/cache.json` relationship sets are now
  identical.