### PR TITLE
Incremental cache persistence for explore profiling runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **`explore map`, `explore relationships`, and `explore profile` now persist
+  each object's profile as it completes on billed connectors** ([#75]).
+  Previously the cache was written exactly once, at the very end of the command,
+  after the whole profiling pass plus inference and ranking finished. When a run
+  against a billed connector (BigQuery, Snowflake, Redshift, Postgres,
+  Databricks) exhausted its budget partway through, the cost gate raised mid-pass
+  and none of the profiling already paid for reached `.dex/cache.json` — real
+  spend, no cache. Each of the three commands now checkpoints every fully
+  profiled object to the cache as it completes, so a run that dies at object 60
+  of 90 leaves 60 objects' worth of raw profile behind, and reports how many of
+  how many objects were saved. A fully successful run still overwrites the
+  checkpoints with the authoritative composed cache (relationships, ranking,
+  carry-forward), and the free DuckDB path is unchanged (its re-runs are free, so
+  it never checkpoints).
 - **`explore relationships` now folds same-lineage/replica duplicate edges
   before caching, matching `explore map`** ([#70]). `relationships` profiles
   the full inventory, so it is even more likely than `map` to pull a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   after the whole profiling pass plus inference and ranking finished. When a run
   against a billed connector (BigQuery, Snowflake, Redshift, Postgres,
   Databricks) exhausted its budget partway through, the cost gate raised mid-pass
-  and none of the profiling already paid for reached `.dex/cache.json` — real
+  and none of the profiling already paid for reached `.dex/cache.json` real
   spend, no cache. Each of the three commands now checkpoints every fully
   profiled object to the cache as it completes, so a run that dies at object 60
   of 90 leaves 60 objects' worth of raw profile behind, and reports how many of

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -19,8 +20,16 @@ from .. import command_args, dbt_project
 from .. import envelope as env
 from ..adapters import get_dialect
 from ..adapters.base import Adapter, ObjectMeta, QueryResult
-from ..cache import Dataset, DexCache, DexStore, Relationship, match_identifier
+from ..cache import (
+    CACHE_FILE,
+    Dataset,
+    DexCache,
+    DexStore,
+    Relationship,
+    match_identifier,
+)
 from ..config import DexConfig, QueryLimits, load_config
+from ..guards.cost_guard import OverCeilingError
 from ..guards.query_firewall import (
     InspectedQuery,
     QueryRefusedError,
@@ -104,6 +113,13 @@ def cmd_profile(args: argparse.Namespace) -> env.Envelope:
     config = load_config(repo_root) or DexConfig()
     defs = _project_definitions(args, config)
     adapter = command_args.open_from_args(args)
+    # Capture pre-run cache state before any checkpoint write, so the success-path
+    # compose reads the pre-run cache rather than a checkpoint this run wrote.
+    store = DexStore(repo_root)
+    now = datetime.now(UTC)
+    prior = store.load_cache()
+    accumulated: list[Dataset] = []
+    over_ceiling = False
     try:
         identifiers = _resolve_identifiers(adapter, args.objects)
         estimate, per_table = _profile_estimate(adapter, identifiers)
@@ -112,21 +128,35 @@ def cmd_profile(args: argparse.Namespace) -> env.Envelope:
         )
         if unconfirmed is not None:
             return unconfirmed
-        datasets = profile_mod.profile(adapter, identifiers)
         connector = adapter.name
+        # Checkpoint per object only on billed connectors: DuckDB can never
+        # exhaust budget and its re-runs are free, so the extra full-file writes
+        # (and O(n^2) serialization on large warehouses) are scoped precisely to
+        # the population the bug affects.
+        checkpoint = None
+        if command_args.cost_gate(adapter) is not None:
+            checkpoint, accumulated = _profile_checkpointer(
+                store, prior, connector, now
+            )
+        try:
+            datasets = profile_mod.profile(adapter, identifiers, on_complete=checkpoint)
+        except OverCeilingError:
+            over_ceiling = True
         envelope = env.ok({})
         command_args.stamp_spend(envelope, adapter)
     finally:
         adapter.close()
+    if over_ceiling:
+        envelope = _over_ceiling_error(store, accumulated, len(identifiers))
+        command_args.stamp_spend(envelope, adapter)
+        return envelope
     _annotate_grain(datasets, defs)
 
     # Persist what the scan already paid for: after profiling a table, `explore
     # query` on that table must work without a second warehouse scan (the query
     # firewall's own refusal messages promise exactly this). Prior relationships
     # are preserved because profile runs no inference pass.
-    store = DexStore(repo_root)
-    now = datetime.now(UTC)
-    cache, stats = _merge_profiles(store.load_cache(), datasets, connector, now)
+    cache, stats = _merge_profiles(prior, datasets, connector, now)
     path = store.save_cache(cache, now=now)
 
     envelope.data.update(
@@ -147,6 +177,13 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
     defs = _project_definitions(args, config)
 
     adapter = command_args.open_from_args(args)
+    # Capture pre-run cache state before any checkpoint write, so the success-path
+    # compose reads the pre-run cache rather than a checkpoint this run wrote.
+    store = DexStore(repo_root)
+    now = datetime.now(UTC)
+    prior = store.load_cache()
+    accumulated: list[Dataset] = []
+    over_ceiling = False
     try:
         # Relationship inference needs uniqueness signals, so profile every object
         # first (free and local on DuckDB), then infer across the full set.
@@ -173,17 +210,31 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         )
         if unconfirmed is not None:
             return unconfirmed
-        datasets = profile_mod.profile(adapter, identifiers)
         connector = adapter.name
-        inferred = rel_mod.infer_relationships(datasets)
-        if verify:
-            rel_mod.verify_relationships(
-                adapter, inferred, timeout_seconds=config.query.timeout_seconds
+        # Billed-connector-gated per-object checkpointing (see cmd_profile).
+        checkpoint = None
+        if command_args.cost_gate(adapter) is not None:
+            checkpoint, accumulated = _profile_checkpointer(
+                store, prior, connector, now
             )
+        try:
+            datasets = profile_mod.profile(adapter, identifiers, on_complete=checkpoint)
+        except OverCeilingError:
+            over_ceiling = True
+        if not over_ceiling:
+            inferred = rel_mod.infer_relationships(datasets)
+            if verify:
+                rel_mod.verify_relationships(
+                    adapter, inferred, timeout_seconds=config.query.timeout_seconds
+                )
         envelope = env.ok({})
         command_args.stamp_spend(envelope, adapter)
     finally:
         adapter.close()
+    if over_ceiling:
+        envelope = _over_ceiling_error(store, accumulated, len(identifiers))
+        command_args.stamp_spend(envelope, adapter)
+        return envelope
     # Annotate before persisting so cached datasets carry candidate_keys and
     # grain, the same shape a `map`-written cache has.
     _annotate_grain(datasets, defs)
@@ -221,11 +272,7 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
     # Persist the profiles this run already paid for. Because relationships
     # inventories and profiles the full set and infers across all of it, its
     # relationship set is authoritative for this run and replaces the prior one.
-    store = DexStore(repo_root)
-    now = datetime.now(UTC)
-    cache, stats = _merge_profiles(
-        store.load_cache(), datasets, connector, now, relationships=rels
-    )
+    cache, stats = _merge_profiles(prior, datasets, connector, now, relationships=rels)
     path = store.save_cache(cache, now=now)
     notes.append(_persist_note(stats, len(datasets), keeps_relationships=False))
 
@@ -331,6 +378,13 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
     full = getattr(args, "full", False)
 
     adapter = command_args.open_from_args(args)
+    # Capture pre-run cache state before any checkpoint write, so the success-path
+    # compose reads the pre-run cache rather than a checkpoint this run wrote.
+    store = DexStore(repo_root)
+    now = datetime.now(UTC)
+    prior = store.load_cache()
+    accumulated: list[Dataset] = []
+    over_ceiling = False
     try:
         metas = inventory_mod.inventory(adapter)
         # First-pass rank on cheap signals (no connectivity yet) to choose what to
@@ -354,17 +408,33 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         )
         if unconfirmed is not None:
             return unconfirmed
-        profiled = profile_mod.profile(adapter, [m.identifier for m in selected])
-        _annotate_grain(profiled, defs)
-        inferred = rel_mod.infer_relationships(profiled)
-        if getattr(args, "verify", False):
-            rel_mod.verify_relationships(
-                adapter, inferred, timeout_seconds=config.query.timeout_seconds
+        # Billed-connector-gated per-object checkpointing (see cmd_profile).
+        checkpoint = None
+        if command_args.cost_gate(adapter) is not None:
+            checkpoint, accumulated = _profile_checkpointer(
+                store, prior, adapter.name, now
             )
+        try:
+            profiled = profile_mod.profile(
+                adapter, [m.identifier for m in selected], on_complete=checkpoint
+            )
+        except OverCeilingError:
+            over_ceiling = True
+        if not over_ceiling:
+            _annotate_grain(profiled, defs)
+            inferred = rel_mod.infer_relationships(profiled)
+            if getattr(args, "verify", False):
+                rel_mod.verify_relationships(
+                    adapter, inferred, timeout_seconds=config.query.timeout_seconds
+                )
         envelope = env.ok({})
         command_args.stamp_spend(envelope, adapter)
     finally:
         adapter.close()
+    if over_ceiling:
+        envelope = _over_ceiling_error(store, accumulated, len(selected))
+        command_args.stamp_spend(envelope, adapter)
+        return envelope
     # Fold same-lineage duplicates before they reach the cache: a dev/replica
     # dataset mapped alongside its source otherwise inflates one real foreign key
     # into source, replica, and cross-dataset lookalike edges.
@@ -376,10 +446,6 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         defs, [m.identifier for m in metas]
     )
     relationships, confirmed = _merge_relationships(declared, inferred)
-
-    store = DexStore(repo_root)
-    now = datetime.now(UTC)
-    prior = store.load_cache()
     # Prior profiles are only reusable when they came from the same connector.
     reusable = prior if prior and prior.provenance.connector == adapter.name else None
     final_scores = rank_mod.rank(metas, relationships, hints)
@@ -737,6 +803,54 @@ def _compose_datasets(
 
 # Sentinel: preserve the prior cache's relationships (profile has no inference
 # pass, so it has no business touching them).
+def _profile_checkpointer(
+    store: DexStore,
+    prior: DexCache | None,
+    connector: str,
+    now: datetime,
+) -> tuple[Callable[[Dataset], None], list[Dataset]]:
+    """Persist each profiled dataset as it completes, so a budget-exhaustion
+    failure mid-run still leaves the objects already paid for in the cache.
+
+    Reuses ``_merge_profiles`` (KEEP_RELATIONSHIPS), so a partial write is exactly
+    a ``cmd_profile``-shaped result: fresh profiles folded over the same-connector
+    prior, prior relationships preserved, no fabricated stubs. ``accumulated`` is
+    returned so the failure handler can report "N of M".
+    """
+
+    accumulated: list[Dataset] = []
+
+    def checkpoint(ds: Dataset) -> None:
+        accumulated.append(ds)
+        cache, _ = _merge_profiles(prior, accumulated, connector, now)
+        store.save_cache(cache, now=now)
+
+    return checkpoint, accumulated
+
+
+def _over_ceiling_error(
+    store: DexStore, accumulated: list[Dataset], selected: int
+) -> env.Envelope:
+    """The partial-completion error envelope for a mid-run budget exhaustion.
+
+    Because ``charge()`` fires before an object's ``Dataset`` is appended,
+    ``accumulated`` holds only fully-profiled objects — a truthful "N of M"."""
+
+    n = len(accumulated)
+    if n == 0:
+        return env.error(
+            f"budget exhausted before the first of {selected} object(s) finished "
+            "profiling; no partial profiles were saved — raise --budget or narrow "
+            "scope, then re-run"
+        )
+    cache_path = store.dex_dir / CACHE_FILE
+    return env.error(
+        f"budget exhausted after profiling {n} of {selected} object(s); partial "
+        f"profiles saved to {cache_path} — raise --budget or narrow scope, then "
+        "re-run"
+    )
+
+
 _KEEP_RELATIONSHIPS = object()
 
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -11,6 +11,7 @@ source so the value never leaves the engine.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from dataclasses import replace
 from datetime import UTC, datetime
 
@@ -175,8 +176,19 @@ def is_min_max_safe(data_type: str, pii: PIIFlag | None) -> bool:
     )
 
 
-def profile(adapter: Adapter, identifiers: list[str]) -> list[Dataset]:
-    """Profile each object into a Dataset of aggregate-derived ColumnProfiles."""
+def profile(
+    adapter: Adapter,
+    identifiers: list[str],
+    *,
+    on_complete: Callable[[Dataset], None] | None = None,
+) -> list[Dataset]:
+    """Profile each object into a Dataset of aggregate-derived ColumnProfiles.
+
+    ``on_complete`` is invoked with each raw Dataset as soon as it is fully
+    profiled, so callers can checkpoint budget-paid work before a later object's
+    cost gate can abort the run. It fires *after* the object is appended and only
+    for fully-profiled objects, never a half-scanned one.
+    """
 
     datasets: list[Dataset] = []
     for identifier in identifiers:
@@ -237,18 +249,19 @@ def profile(adapter: Adapter, identifiers: list[str]) -> list[Dataset]:
                 )
             )
 
-        datasets.append(
-            Dataset(
-                identifier=identifier,
-                object_type=meta.object_type,
-                row_count=meta.row_count,
-                byte_size=meta.byte_size,
-                columns=profiles,
-                composite_keys=composite_keys,
-                data_quality=data_quality,
-                profiled_at=datetime.now(UTC).isoformat(),
-            )
+        ds = Dataset(
+            identifier=identifier,
+            object_type=meta.object_type,
+            row_count=meta.row_count,
+            byte_size=meta.byte_size,
+            columns=profiles,
+            composite_keys=composite_keys,
+            data_quality=data_quality,
+            profiled_at=datetime.now(UTC).isoformat(),
         )
+        datasets.append(ds)
+        if on_complete is not None:
+            on_complete(ds)
     return datasets
 
 

--- a/packages/dex-core/tests/explore/test_incremental_checkpoint.py
+++ b/packages/dex-core/tests/explore/test_incremental_checkpoint.py
@@ -1,0 +1,286 @@
+"""Incremental cache persistence for billed profiling runs.
+
+When a billed connector exhausts its budget partway through a profiling pass, the
+cost gate raises mid-run. Every explore command that profiles (`map`,
+`relationships`, `profile`) must still leave the objects already paid for in
+`.dex/cache.json`, and report how many of how many objects were saved. A fully
+successful run overwrites those checkpoints with the authoritative composed cache
+(relationships + ranking + carry-forward). DuckDB, being free, never checkpoints.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("google.cloud.bigquery")
+
+from google.cloud import bigquery
+
+from exmergo_dex_core import command_args
+from exmergo_dex_core.adapters.bigquery import BigQueryAdapter
+from exmergo_dex_core.cache import DexStore
+from exmergo_dex_core.config import BigQueryTarget
+from exmergo_dex_core.envelope import Paradigm
+from exmergo_dex_core.explore import commands as explore_cmds
+from exmergo_dex_core.guards.cost_guard import CostGate, OverCeilingError
+
+MB = 1024 * 1024
+
+
+def _aggregate_resolver(sql: str):
+    """Answer the column-aggregate / exact-distinct SQL with unique-looking
+    numbers (mirrors test_billed_handshake's resolver), enough for a full
+    profile of a small table to complete and be checkpointed."""
+
+    values = {"n_total": 100}
+    for i in range(10):
+        values[f"nn_{i}"] = 100
+        values[f"nd_{i}"] = 100 if i == 0 else 40
+        values[f"mn_{i}"] = 1
+        values[f"mx_{i}"] = 100
+        values[f"d_{i}"] = 100
+    values["nonnull_fk"] = 100
+    values["orphans"] = 0
+    return [values]
+
+
+@pytest.fixture
+def two_table_client():
+    """A deterministic two-table billed warehouse: `customers` (a clean surrogate
+    key) and `orders` (a customer_id foreign key), both cheap and queryable so a
+    map/relationships/profile pass profiles exactly two objects in a known order."""
+
+    from fakes.bigquery import FakeBigQueryClient, FakeTable
+
+    tables = [
+        FakeTable(
+            project="test-proj",
+            dataset_id="shop",
+            table_id="customers",
+            schema=[
+                bigquery.SchemaField("id", "INTEGER", mode="REQUIRED"),
+                bigquery.SchemaField("email", "STRING"),
+            ],
+            num_rows=100,
+            num_bytes=5_000,
+        ),
+        FakeTable(
+            project="test-proj",
+            dataset_id="shop",
+            table_id="orders",
+            schema=[
+                bigquery.SchemaField("id", "INTEGER", mode="REQUIRED"),
+                bigquery.SchemaField("customer_id", "INTEGER"),
+            ],
+            num_rows=100,
+            num_bytes=5_000,
+        ),
+    ]
+    client = FakeBigQueryClient(project="test-proj", tables=tables)
+    client.row_resolver = _aggregate_resolver
+    return client
+
+
+def _install(
+    monkeypatch, client, *, confirmed=True, budget=float(100 * MB), record=None
+):
+    def opener(args):
+        gate = CostGate(
+            paradigm=Paradigm.BYTES_SCANNED,
+            ceiling=budget,
+            session_ceiling=None,
+            session_spent=0.0,
+            confirmed=confirmed,
+            connector="bigquery",
+            command="explore",
+            record=record,
+        )
+        return BigQueryAdapter(
+            project="test-proj",
+            cost_gate=gate,
+            target=BigQueryTarget(),
+            client=client,
+            principal_type="user",
+        )
+
+    monkeypatch.setattr(command_args, "open_from_args", opener)
+
+
+def _raise_on_nth_object(monkeypatch, n: int):
+    """Make the (n-th) object's column_aggregates raise OverCeilingError, exactly
+    as the cost gate's charge() would when the accumulated estimate crosses the
+    ceiling. Because charge() fires before the Dataset is appended, the objects
+    before the n-th are fully profiled and checkpointed; the n-th is not."""
+
+    original = BigQueryAdapter.column_aggregates
+    state = {"count": 0}
+
+    def wrapped(self, identifier, columns, *, safe_min_max=None):
+        state["count"] += 1
+        if state["count"] >= n:
+            raise OverCeilingError("simulated ceiling crossed mid-run")
+        return original(self, identifier, columns, safe_min_max=safe_min_max)
+
+    monkeypatch.setattr(BigQueryAdapter, "column_aggregates", wrapped)
+    return state
+
+
+def _args(tmp_path: Path, **extra) -> argparse.Namespace:
+    base = {
+        "connector": "bigquery",
+        "path": None,
+        "repo_root": str(tmp_path),
+        "confirm": True,
+        "budget": float(100 * MB),
+        "group": "explore",
+    }
+    base.update(extra)
+    return argparse.Namespace(**base)
+
+
+# --- 1. mid-run budget exhaustion leaves a partial cache ---------------------
+
+
+def test_map_mid_run_exhaustion_saves_partial_cache(
+    two_table_client, monkeypatch, tmp_path
+):
+    _install(monkeypatch, two_table_client)
+    _raise_on_nth_object(monkeypatch, 2)  # object 1 completes, object 2 trips the gate
+
+    envelope = explore_cmds.cmd_map(_args(tmp_path, subcommand="map"))
+
+    assert envelope.status.value == "error"
+    message = envelope.errors[0]
+    assert "1 of 2" in message
+    assert ".dex" in message and "cache.json" in message
+    # Spend was stamped after the adapter closed (the finally ran).
+    assert "spend" in envelope.data
+
+    cache = DexStore(tmp_path).load_cache()
+    assert cache is not None
+    assert len(cache.datasets) == 1
+    # The paid-for profile is real: columns are present on the checkpointed object.
+    assert cache.datasets[0].columns
+
+
+def test_relationships_mid_run_exhaustion_saves_partial_cache(
+    two_table_client, monkeypatch, tmp_path
+):
+    _install(monkeypatch, two_table_client)
+    _raise_on_nth_object(monkeypatch, 2)
+
+    envelope = explore_cmds.cmd_relationships(
+        _args(tmp_path, subcommand="relationships")
+    )
+
+    assert envelope.status.value == "error"
+    assert "1 of 2" in envelope.errors[0]
+    cache = DexStore(tmp_path).load_cache()
+    assert cache is not None and len(cache.datasets) == 1
+    assert cache.datasets[0].columns
+
+
+def test_profile_mid_run_exhaustion_saves_partial_cache(
+    two_table_client, monkeypatch, tmp_path
+):
+    _install(monkeypatch, two_table_client)
+    _raise_on_nth_object(monkeypatch, 2)
+
+    envelope = explore_cmds.cmd_profile(
+        _args(tmp_path, subcommand="profile", objects=["customers", "orders"])
+    )
+
+    assert envelope.status.value == "error"
+    assert "1 of 2" in envelope.errors[0]
+    cache = DexStore(tmp_path).load_cache()
+    assert cache is not None and len(cache.datasets) == 1
+    assert cache.datasets[0].columns
+
+
+# --- 2. first-object failure saves nothing -----------------------------------
+
+
+def test_map_first_object_failure_saves_nothing(
+    two_table_client, monkeypatch, tmp_path
+):
+    _install(monkeypatch, two_table_client)
+    _raise_on_nth_object(monkeypatch, 1)  # the first object trips the gate
+
+    envelope = explore_cmds.cmd_map(_args(tmp_path, subcommand="map"))
+
+    assert envelope.status.value == "error"
+    message = envelope.errors[0]
+    assert "no partial profiles were saved" in message
+    assert "cache.json" not in message  # no path when nothing was written
+    assert not (tmp_path / ".dex" / "cache.json").exists()
+
+
+def test_profile_first_object_failure_saves_nothing(
+    two_table_client, monkeypatch, tmp_path
+):
+    _install(monkeypatch, two_table_client)
+    _raise_on_nth_object(monkeypatch, 1)
+
+    envelope = explore_cmds.cmd_profile(
+        _args(tmp_path, subcommand="profile", objects=["customers", "orders"])
+    )
+
+    assert envelope.status.value == "error"
+    assert "no partial profiles were saved" in envelope.errors[0]
+    assert not (tmp_path / ".dex" / "cache.json").exists()
+
+
+# --- 3. a successful billed run overwrites checkpoints with the composed cache -
+
+
+def test_successful_map_overwrites_checkpoints_with_composed_cache(
+    two_table_client, monkeypatch, tmp_path
+):
+    _install(monkeypatch, two_table_client)  # no wrap: the run completes
+
+    envelope = explore_cmds.cmd_map(_args(tmp_path, subcommand="map"))
+
+    assert envelope.status.value == "ok"
+    cache = DexStore(tmp_path).load_cache()
+    assert cache is not None
+    assert len(cache.datasets) == 2
+    # Ranking and relationship inference ran: signals a checkpoint never carries.
+    assert all(d.rank_score is not None for d in cache.datasets)
+    assert cache.relationships  # orders.customer_id -> customers.id
+
+
+# --- 4. the free DuckDB path never checkpoints -------------------------------
+
+
+def test_duckdb_map_does_not_checkpoint(airbnb_duckdb, monkeypatch, tmp_path):
+    """DuckDB has no cost gate, so the checkpointer is never built: a single
+    authoritative save at the end, exactly as before this change."""
+
+    saves: list[int] = []
+    original = DexStore.save_cache
+
+    def counting_save(self, cache, *, now=None):
+        saves.append(len(cache.datasets))
+        return original(self, cache, now=now)
+
+    monkeypatch.setattr(DexStore, "save_cache", counting_save)
+
+    from exmergo_dex_core.cli import main
+
+    rc = main(
+        [
+            "explore",
+            "map",
+            "--full",
+            "--path",
+            str(airbnb_duckdb),
+            "--repo-root",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    # Exactly one save — the final authoritative one — with no per-object writes.
+    assert len(saves) == 1


### PR DESCRIPTION
## What changed

### 1. `profile()` gains an optional per-object callback
[packages/dex-core/src/exmergo_dex_core/explore/profile.py](packages/dex-core/src/exmergo_dex_core/explore/profile.py)

- Added `from collections.abc import Callable`.
- New signature:
  `def profile(adapter, identifiers, *, on_complete: Callable[[Dataset], None] | None = None) -> list[Dataset]`.
- Each fully-profiled `Dataset` is bound to `ds`, appended, then handed to
  `on_complete`. The return contract (`list[Dataset]`) is unchanged, so existing
  callers are untouched.
- The callback receives the **raw** dataset. Because the cost gate's `charge()`
  fires *inside* an object's `column_aggregates` — before that object's `Dataset`
  is appended — the callback only ever checkpoints fully-profiled objects, never
  a half-scanned one.

### 2. Shared checkpointer + partial-failure helpers
[packages/dex-core/src/exmergo_dex_core/explore/commands.py](packages/dex-core/src/exmergo_dex_core/explore/commands.py)

- Imports: `Callable`, `CACHE_FILE`, `OverCeilingError`.
- `_profile_checkpointer(store, prior, connector, now) -> (checkpoint, accumulated)`
  persists each dataset as it completes, reusing `_merge_profiles`
  (KEEP_RELATIONSHIPS). A partial write is therefore exactly a
  `cmd_profile`-shaped result: fresh profiles folded over the same-connector
  prior, prior relationships preserved, no fabricated stubs. `accumulated` is
  returned so the failure handler can report "N of M".
- `_over_ceiling_error(store, accumulated, selected)` builds the
  partial-completion error envelope:
  - N > 0: names "N of M" and the cache path.
  - N == 0: says no partial profiles were saved and omits the path.

### 3. Wired into `cmd_map`, `cmd_relationships`, `cmd_profile`

In each command:

- **State capture moved up**: `store`, `now`, and `prior = store.load_cache()`
  are captured once, before the first checkpoint write, so the success-path
  compose still reads the pre-run cache (not a checkpoint the run itself wrote).
- **Billed-connector gate**: the checkpointer is built only when
  `command_args.cost_gate(adapter) is not None`; otherwise `on_complete=None`.
  DuckDB (`FREE_LOCAL`) never checkpoints — it can't exhaust budget and its
  re-runs are free, which also avoids O(n²) full-file writes on large local
  warehouses.
- **`OverCeilingError` handling**: caught specifically (not the `CostGuardError`
  base) around the profile call. On catch, the command skips the rest of the
  success path and, after `adapter.close()`, returns
  `_over_ceiling_error(...)` with spend stamped (`stamp_spend` reads the gate,
  valid after close). Non-budget exceptions still propagate to `cli.py`.
- **Success path unchanged**: `_annotate_grain`, inference, folding, ranking, and
  the final authoritative `save_cache` are untouched. The final save overwrites
  the checkpoints with the composed, ranked, relationship-bearing cache.

### 4. CHANGELOG
[CHANGELOG.md](CHANGELOG.md) — added a `### Fixed` entry under `## [Unreleased]`
(issue #75).

## Design decision: raw checkpoints

Checkpoints persist **un-annotated** profiles:

- `_annotate_grain` appends to `data_quality` and is **not idempotent** —
  annotating on the checkpoint would double notes when the success path
  re-annotates the full list.
- Per-object annotation would pass a single-element `identifiers` to
  `resolve_declared`, changing declared-key/grain ambiguity resolution versus the
  authoritative full-list pass.
- The budget-paid signals (aggregates, PII flags, exact-distinct escalations,
  `composite_keys`) are all on the raw `Dataset`. `candidate_keys`/`grain` are
  cheap local derivations any later run recomputes for free.

Accepted tradeoff: after a mid-run failure the partial cache carries only
`profile()`-level `data_quality` notes (empty-table, adapter notes), not the
grain/candidate-key interpretation, which regenerates on the next successful run.
The partial cache is still fully valid for its main consumer, `explore query`'s
firewall, which needs only columns + PII flags.

## Files modified

- `packages/dex-core/src/exmergo_dex_core/explore/profile.py`
- `packages/dex-core/src/exmergo_dex_core/explore/commands.py`
- `CHANGELOG.md`
- `packages/dex-core/tests/explore/test_incremental_checkpoint.py` (new)

## Verification

| Check | Result |
| --- | --- |
| New checkpoint tests (`test_incremental_checkpoint.py`) | 7 passed |
| Full explore suite (`tests/explore`) | 145 passed |
| Full suite (`uv run pytest`) | 876 passed, 51 skipped |
| `ruff check` / `ruff format` on touched files | clean |

The 51 skips are the pre-existing "connector extra not installed" skips,
unrelated to this change.

### Test coverage (all five plan cases)

1. Mid-run budget exhaustion leaves a partial cache — `map`, `relationships`,
   `profile` (asserts "1 of 2", cache path in message, one full profile in cache).
2. First-object failure saves nothing — `map`, `profile` (asserts "no partial
   profiles were saved" and `.dex/cache.json` absent).
3. Successful billed `map` overwrites checkpoints with the composed cache
   (ranking + relationships present).
4. DuckDB `map --full` never checkpoints (exactly one save; no per-object writes).
