### PR TITLE
Seed the explore cluster sample and flag degenerate clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,16 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   scanning commands. Only aggregates cross the boundary: per-cluster sizes and
   fractions, centroids (feature means), inertia, and the silhouette score;
   with `-k` omitted the engine sweeps k and reports the silhouette it chose
-  from. scikit-learn rides behind a new `[cluster]` extra, lazy-imported so the
-  light default install stays light and the explore skill wrapper adds it
-  automatically for this subcommand.
+  from. The sample is seeded where the dialect allows it (`cluster.sample_seed`,
+  default 0; DuckDB `REPEATABLE`), because a re-drawn sample is a different
+  dataset and can change the chosen k, not just the rounding. Where an engine
+  has no seedable sample, nothing is invented: `sample_repeatable` is false and
+  a note says the run cannot be compared to another. A cluster holding under 1%
+  of the sample is called out as an outlier pocket rather than a segment, since
+  it inflates the silhouette and a high score on it otherwise reads as a
+  confident segmentation. scikit-learn rides behind a new `[cluster]` extra,
+  lazy-imported so the light default install stays light and the explore skill
+  wrapper adds it automatically for this subcommand.
 - **`pii_overrides` in `.dex/config.yml`: a durable, reviewable way to clear a
   false-positive PII flag.** Each entry names a fully qualified column
   (`db.schema.table.column`, case-insensitive, no wildcards) with an optional

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -215,7 +215,12 @@ class ClusterLimits(BaseModel):
     ``k_min``/``k_max`` bound the silhouette sweep when ``-k`` is not given;
     ``silhouette_sample`` caps the (quadratic) silhouette computation.
     ``max_features`` bounds the feature width. ``random_state`` fixes the
-    scikit-learn seed so a run is reproducible and tests are deterministic.
+    scikit-learn seed, and ``sample_seed`` fixes the sample draw: both are
+    needed for a reproducible run, because re-drawing the sample changes the
+    answer (a different draw can change the chosen k, not just the rounding).
+    Only some dialects can seed a sample; where the engine cannot, the envelope
+    says the result is not reproducible rather than implying it is. Set
+    ``sample_seed`` to null for a fresh draw per run.
     """
 
     sample_rows: int = 20000
@@ -225,6 +230,7 @@ class ClusterLimits(BaseModel):
     silhouette_sample: int = 5000
     max_features: int = 20
     random_state: int = 0
+    sample_seed: int | None = 0
     timeout_seconds: float = 60.0
 
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/cluster.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/cluster.py
@@ -29,6 +29,11 @@ from sqlglot import exp
 # not round to zero percent (which reads the whole table on some engines).
 _MIN_SAMPLE_PERCENT = 0.01
 
+# Below this share of the sample, a cluster is an outlier pocket rather than a
+# segment. Engine-fixed, not configurable: it decides only what the notes say,
+# never what the clustering does, so there is nothing here for a caller to tune.
+_DEGENERATE_CLUSTER_FRACTION = 0.01
+
 
 class ClusterError(Exception):
     """A clustering request that cannot be satisfied (too few rows, too few
@@ -39,8 +44,22 @@ class ClusterDependencyError(Exception):
     """scikit-learn (the ``[cluster]`` extra) is not installed."""
 
 
+# Dialects whose sample clause accepts a seed, each verified against the engine
+# itself rather than assumed from its docs. Everything else re-draws per run, and
+# `sample_is_repeatable` is what makes the envelope say so out loud: a seed knob
+# that silently does nothing on four of six connectors would be a lie, the same
+# reason `references/redshift.md` refuses to ship a sampling threshold there.
+_SEEDABLE_DIALECTS = frozenset({"duckdb"})
+
+
+def sample_is_repeatable(dialect: str, seed: int | None) -> bool:
+    """Whether this dialect's sample clause draws the same rows twice."""
+
+    return seed is not None and dialect in _SEEDABLE_DIALECTS
+
+
 def _sample_parts(
-    dialect: str, sample_rows: int, row_count: int | None
+    dialect: str, sample_rows: int, row_count: int | None, seed: int | None = None
 ) -> tuple[str, str, str]:
     """The dialect-specific sampling pieces: a suffix attached to the table in
     the FROM, a tail appended after WHERE, and a human note naming the method.
@@ -61,6 +80,14 @@ def _sample_parts(
         return max(_MIN_SAMPLE_PERCENT, round(100.0 * n / row_count, 4))
 
     if dialect == "duckdb":
+        if seed is not None:
+            # The seeded form needs the explicit reservoir(...) spelling; DuckDB
+            # rejects REPEATABLE on the bare `USING SAMPLE n ROWS`.
+            return (
+                "",
+                f" USING SAMPLE reservoir({n} ROWS) REPEATABLE ({seed})",
+                f"USING SAMPLE {n} ROWS (reservoir, repeatable seed {seed})",
+            )
         return "", f" USING SAMPLE {n} ROWS", f"USING SAMPLE {n} ROWS (reservoir)"
     if dialect == "snowflake":
         return f" SAMPLE ({n} ROWS)", "", f"SAMPLE ({n} ROWS)"
@@ -92,6 +119,7 @@ def build_sample_sql(
     dialect: str,
     sample_rows: int,
     row_count: int | None,
+    seed: int | None = None,
 ) -> tuple[str, str]:
     """Build the read-only feature-sample SELECT and describe how it samples.
 
@@ -124,7 +152,7 @@ def build_sample_sql(
         f"{render(exp.column(name))} IS NOT NULL" for name in feature_names
     )
 
-    table_suffix, tail, method = _sample_parts(dialect, sample_rows, row_count)
+    table_suffix, tail, method = _sample_parts(dialect, sample_rows, row_count, seed)
     sql = f"SELECT {cols_sql} FROM {table_ref}{table_suffix} WHERE {where_sql}{tail}"  # noqa: S608
     return sql, method
 
@@ -343,6 +371,18 @@ def cluster_features(
         notes.append(
             f"silhouette computed on a {silhouette_sample}-row subsample of the "
             f"{n_samples}-row sample"
+        )
+
+    tiny = [c for c in clusters if c["fraction"] < _DEGENERATE_CLUSTER_FRACTION]
+    if tiny and len(tiny) < k:
+        worst = min(c["fraction"] for c in tiny)
+        notes.append(
+            f"{len(tiny)} of {k} cluster(s) hold under "
+            f"{_DEGENERATE_CLUSTER_FRACTION:.0%} of the sample (smallest: "
+            f"{worst:.2%}, {min(c['size'] for c in tiny)} row(s)); a cluster that "
+            "small is an outlier pocket rather than a segment, and it inflates "
+            "the silhouette. Read this as outlier detection, or re-run with -k "
+            "to force a split of the bulk"
         )
 
     return ClusterResult(

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -688,7 +688,12 @@ def cmd_cluster(args: argparse.Namespace) -> env.Envelope:
             dialect=adapter.dialect,
             sample_rows=limits.sample_rows,
             row_count=dataset.row_count,
+            seed=limits.sample_seed,
         )
+        repeatable = cluster_mod.sample_is_repeatable(
+            adapter.dialect, limits.sample_seed
+        )
+        adapter_name = adapter.name
         query_estimate = getattr(adapter, "query_estimate", None)
         estimate = query_estimate(sample_sql) if query_estimate else 0.0
         unconfirmed = command_args.billed_handshake(
@@ -732,11 +737,18 @@ def cmd_cluster(args: argparse.Namespace) -> env.Envelope:
             f"the sample hit the {limits.sample_rows}-row cap (the table has more "
             "rows); raise cluster.sample_rows in .dex/config.yml to widen it"
         )
+    if not repeatable and dataset.row_count and dataset.row_count > limits.sample_rows:
+        notes.append(
+            f"this sample is not reproducible on {adapter_name}: re-running can "
+            "draw different rows and reach a different k. Compare runs only with "
+            "an identical sample"
+        )
     envelope.data.update(
         {
             "object": dataset.identifier,
             "total_rows": dataset.row_count,
             "sample_method": sample_method,
+            "sample_repeatable": repeatable,
             **data,
             "notes": notes,
         }

--- a/packages/dex-core/tests/explore/test_cluster.py
+++ b/packages/dex-core/tests/explore/test_cluster.py
@@ -88,6 +88,72 @@ def _mapped_repo(db: Path, tmp_path: Path, capsys) -> Path:
     return repo
 
 
+def _cluster_table(db: Path, repo: Path, table: str, *args: str, capsys):
+    """`_cluster` for a table other than `customers`."""
+
+    rc = main(
+        [
+            "explore",
+            "cluster",
+            table,
+            *args,
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ]
+    )
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert rc == 0 and payload["status"] == "ok", payload
+    return payload
+
+
+@pytest.fixture
+def sampled_duckdb(tmp_path: Path) -> Path:
+    """A table comfortably over the 20000-row sample cap, so the sample clause
+    actually draws (a table under the cap is read whole and would be trivially
+    reproducible, proving nothing). Three blobs, deterministic."""
+
+    duckdb = pytest.importorskip("duckdb")
+    path = tmp_path / "wide.duckdb"
+    conn = duckdb.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE wide AS
+        SELECT
+            CASE i % 3 WHEN 0 THEN 10.0 WHEN 1 THEN 50.0 ELSE 90.0 END
+                + (i % 7) * 0.1 AS spend,
+            CASE i % 3 WHEN 0 THEN 1.0 WHEN 1 THEN 5.0 ELSE 9.0 END
+                + (i % 7) * 0.1 AS visits
+        FROM range(60000) t(i)
+        """
+    )
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def outlier_duckdb(tmp_path: Path) -> Path:
+    """One dense blob plus 3 extreme rows in 3000: the shape that makes k-means
+    peel off a sub-1% cluster and report a high silhouette for it."""
+
+    duckdb = pytest.importorskip("duckdb")
+    path = tmp_path / "spikes.duckdb"
+    conn = duckdb.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE spikes AS
+        SELECT
+            CASE WHEN i < 3 THEN 500000.0 ELSE 10.0 + (i % 5) * 0.1 END AS amount,
+            CASE WHEN i < 3 THEN 400000.0 ELSE 5.0 + (i % 5) * 0.1 END AS duration
+        FROM range(3000) t(i)
+        """
+    )
+    conn.close()
+    return path
+
+
 # --- the cache gate ----------------------------------------------------------
 
 
@@ -414,6 +480,124 @@ def test_sample_sql_skips_percent_sampling_when_row_count_unknown():
     assert "TABLESAMPLE" not in sql
     assert "no sample clause" in method
     assert_select_only(sql, dialect="bigquery")
+
+
+# --- a seeded sample draws the same rows twice -------------------------------
+
+
+def test_duckdb_seeded_sample_emits_a_repeatable_reservoir():
+    """DuckDB rejects REPEATABLE on the bare `USING SAMPLE n ROWS`, so the seeded
+    form has to spell out reservoir(...). Pinned because the two spellings look
+    interchangeable and only one parses."""
+
+    sql, method = cluster_mod.build_sample_sql(
+        "db.main.customers",
+        ["spend", "visits"],
+        dialect="duckdb",
+        sample_rows=100,
+        row_count=1000,
+        seed=7,
+    )
+    assert sql.rstrip().endswith("USING SAMPLE reservoir(100 ROWS) REPEATABLE (7)")
+    assert "repeatable seed 7" in method
+    assert_select_only(sql, dialect="duckdb")
+    assert cluster_mod.sample_is_repeatable("duckdb", 7) is True
+
+
+def test_seed_is_omitted_where_the_dialect_cannot_honor_it():
+    """No seed clause is invented for an engine that has none, and the engine
+    reports the sample as not repeatable rather than implying otherwise."""
+
+    for dialect in ("snowflake", "bigquery", "postgres", "redshift", "databricks"):
+        sql, _ = cluster_mod.build_sample_sql(
+            "db.sch.customers",
+            ["spend", "visits"],
+            dialect=dialect,
+            sample_rows=100,
+            row_count=1000,
+            seed=7,
+        )
+        assert "REPEATABLE" not in sql.upper(), dialect
+        assert cluster_mod.sample_is_repeatable(dialect, 7) is False, dialect
+        assert_select_only(sql, dialect=dialect)
+
+
+def test_a_null_seed_opts_out_of_repeatability():
+    sql, _ = cluster_mod.build_sample_sql(
+        "db.main.customers",
+        ["spend", "visits"],
+        dialect="duckdb",
+        sample_rows=100,
+        row_count=1000,
+        seed=None,
+    )
+    assert "REPEATABLE" not in sql.upper()
+    assert cluster_mod.sample_is_repeatable("duckdb", None) is False
+
+
+@requires_sklearn
+def test_two_identical_runs_return_identical_clusters(
+    sampled_duckdb: Path, tmp_path: Path, capsys
+):
+    """The regression this exists for: with the sample unseeded, the same command
+    on the same table returned a different k run to run, because a re-drawn
+    sample is a different dataset. Uses a table well over the sample cap, so a
+    sample is genuinely drawn rather than the whole table read."""
+
+    repo = _mapped_repo(sampled_duckdb, tmp_path, capsys)
+    first = _cluster_table(sampled_duckdb, repo, "wide", capsys=capsys)["data"]
+    second = _cluster_table(sampled_duckdb, repo, "wide", capsys=capsys)["data"]
+
+    assert first["sample_repeatable"] is True
+    assert first["k"] == second["k"]
+    assert first["silhouette"] == second["silhouette"]
+    assert first["clusters"] == second["clusters"]
+
+
+@requires_sklearn
+def test_an_unrepeatable_sample_says_so(sampled_duckdb: Path, tmp_path: Path, capsys):
+    """With the seed off, the result is still valid but no longer comparable
+    across runs, and the envelope has to admit that rather than let a reader
+    diff two runs and think the data moved."""
+
+    repo = _mapped_repo(sampled_duckdb, tmp_path, capsys)
+    (repo / ".dex" / "config.yml").write_text("cluster:\n  sample_seed: null\n")
+    payload = _cluster_table(sampled_duckdb, repo, "wide", capsys=capsys)
+
+    assert payload["data"]["sample_repeatable"] is False
+    assert "not reproducible" in " ".join(payload["data"]["notes"])
+
+
+# --- a tiny cluster is an outlier pocket, not a segment -----------------------
+
+
+@requires_sklearn
+def test_a_degenerate_cluster_is_called_out(
+    outlier_duckdb: Path, tmp_path: Path, capsys
+):
+    """A handful of extreme rows split off as their own cluster and drive the
+    silhouette up, which reads as a confident segmentation when it is really
+    outlier detection. The score alone cannot tell those apart, so the note
+    must."""
+
+    repo = _mapped_repo(outlier_duckdb, tmp_path, capsys)
+    data = _cluster_table(outlier_duckdb, repo, "spikes", capsys=capsys)["data"]
+
+    tiny = [c for c in data["clusters"] if c["fraction"] < 0.01]
+    assert tiny, "fixture must produce a sub-1% cluster"
+    assert data["silhouette"] > 0.7, "and it must look confident"
+    note = " ".join(data["notes"])
+    assert "outlier pocket rather than a segment" in note
+    assert "inflates" in note
+
+
+@requires_sklearn
+def test_even_clusters_are_not_called_degenerate(
+    clusterable_duckdb: Path, tmp_path: Path, capsys
+):
+    repo = _mapped_repo(clusterable_duckdb, tmp_path, capsys)
+    payload = _cluster(clusterable_duckdb, repo, capsys=capsys)
+    assert "outlier pocket" not in " ".join(payload["data"]["notes"])
 
 
 # --- the pure clustering engine ---------------------------------------------

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -69,7 +69,14 @@ Subcommands, in the usual order:
    inferred), and the columns named like one; prefer `map` over a bare
    `profile` here, because without inferred joins a foreign key is caught only
    if its name gives it away. The notes name every excluded column, so check
-   them before trusting a result. Only aggregates cross the
+   them before trusting a result. Two things the silhouette alone will not tell
+   you, both of which the notes will. A cluster holding under 1% of the sample
+   is an outlier pocket, not a segment, and it pushes the score up precisely
+   because it sits so far out: report that as outlier detection, or re-run with
+   `-k` to split the bulk. And on connectors that cannot seed a sample the draw
+   changes per run, so two runs can disagree on k; the envelope's
+   `sample_repeatable` says which case you are in, and comparing runs across
+   different draws is meaningless. Only aggregates cross the
    boundary: the sample rows are clustered in-process and never enter context.
    On a metered connector it takes the same cost handshake as the scanning
    commands below (only the feature columns are scanned, and a dialect-aware


### PR DESCRIPTION
Two things `explore cluster` got wrong, both found by running it against the ADE-bench warehouses.

**It wasn't reproducible.** The sample was unseeded, so the same command on the same table returned a different answer each run. `f1.lap_times` gave k=2/silhouette 0.95 on one run and k=4/0.37 on the next — not a wobble, a different conclusion about the data. The config docstring already claimed `random_state` made runs reproducible; seeding sklearn is pointless when the sample underneath re-draws.

**A high silhouette can mean the opposite of what it looks like.** On `lap_times`, silhouette 0.95 was k-means peeling off 3 rows in 20,000 (0.01%) — the 28-minute red-flag laps. That's outlier detection wearing a segmentation score, and nothing in the envelope said so. Same failure mode as the FK bug in #91: the number looks confident, the answer misleads.

## Changed

- `cluster.sample_seed` (default `0`; null opts out) seeds the draw. DuckDB emits `USING SAMPLE reservoir(N ROWS) REPEATABLE (seed)` — the bare `USING SAMPLE n ROWS REPEATABLE (...)` is a parser error, so the `reservoir(...)` spelling is pinned by a test
- Only DuckDB seeds, because it's the only dialect verified against a live engine. The other five emit no seed clause, report `sample_repeatable: false`, and say so in the notes rather than implying a reproducibility they don't have (same reasoning as `references/redshift.md` refusing a sampling threshold it can't honor)
- New `sample_repeatable` field in the envelope
- A cluster under 1% of the sample is named an outlier pocket that inflates the silhouette, with the fix (read as outlier detection, or force `-k`)

