### PR TITLE
Confirmation checkpoint for the verify phase

### DIFF
--- a/packages/dex-core/src/exmergo_dex_core/command_args.py
+++ b/packages/dex-core/src/exmergo_dex_core/command_args.py
@@ -11,6 +11,7 @@ instead of re-deriving it.
 from __future__ import annotations
 
 import argparse
+import math
 from pathlib import Path
 
 from . import envelope as env
@@ -96,14 +97,84 @@ def billed_handshake(
     return None
 
 
+def verify_handshake(
+    command: str,
+    adapter: Adapter,
+    estimate: float,
+    *,
+    candidate_count: int,
+    object_count: int,
+) -> env.Envelope | None:
+    """The mid-command checkpoint for the verify phase on billed connectors.
+
+    Verify probes can only be priced after profiling finds the candidate
+    relationships, so this runs after inference on an already-confirmed
+    command: the probes are dry-run priced (free), and only when that estimate
+    does not fit what remains of the confirmed budget does it return the
+    ``needs_confirmation`` envelope — otherwise the confirmed budget already
+    covers verify and the command proceeds in one pass.
+    """
+
+    gate = cost_gate(adapter)
+    if gate is None or candidate_count == 0:
+        return None
+    try:
+        gate.preflight_phase(estimate)
+    except ConfirmationRequiredError as exc:
+        # Same aggregate key maintain grain uses for probe pricing, so agents
+        # see one vocabulary for overlap-probe cost across commands.
+        per_table = {"(join overlap probes)": estimate}
+        describe = getattr(adapter, "describe_estimate", None)
+        if describe is not None:
+            data = {"command": command, **describe(estimate, per_table)}
+        else:
+            data = {
+                "command": command,
+                "estimated_bytes": estimate,
+                "per_table_bytes": per_table,
+            }
+        data.update(
+            {
+                "phase": "verify",
+                "candidate_count": candidate_count,
+                "object_count": object_count,
+                "hint": (
+                    f"found {candidate_count} candidate relationship(s) across "
+                    f"{object_count} object(s); verifying them all is estimated "
+                    f"at {estimate:.0f} {gate.paradigm.value} beyond what "
+                    "remains of the confirmed budget. Profiles and unverified "
+                    "relationships are saved to .dex/cache.json; re-run the "
+                    "same command with --confirm --budget "
+                    f"{math.ceil(exc.cost.estimate)} to profile and verify in "
+                    "one pass (a re-run re-profiles first)"
+                ),
+            }
+        )
+        if (
+            gate.session_ceiling is not None
+            and gate.session_ceiling - gate.session_spent < exc.cost.estimate
+        ):
+            data.setdefault("notes", [])
+            data["notes"] = [
+                *data["notes"],
+                "the session budget is the binding ceiling; raising --budget "
+                "alone will not unlock this, raise the session budget in "
+                ".dex/config.yml instead",
+            ]
+        return env.needs_confirmation(data, cost=exc.cost)
+    return None
+
+
 def stamp_spend(envelope: env.Envelope, adapter: Adapter) -> env.Envelope:
     """Stamp the preflight cost and the actual spend onto an OK envelope. The
     ``cost`` field stays a preflight estimate by contract; actual billed bytes
-    live in ``data.spend``."""
+    live in ``data.spend``. An envelope already carrying a cost (a phase
+    checkpoint) keeps it; only the spend summary is refreshed."""
 
     gate = cost_gate(adapter)
     if gate is not None:
-        envelope.cost = gate.cost()
+        if envelope.cost.estimate is None:
+            envelope.cost = gate.cost()
         spend = gate.spend_summary()
         display = getattr(adapter, "spend_display", None)
         if display is not None:

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -27,6 +27,7 @@ from ..cache import (
     DexCache,
     DexStore,
     Relationship,
+    RelationshipKind,
     match_identifier,
 )
 from ..config import DexConfig, QueryLimits, load_config, pii_override_paths
@@ -105,6 +106,25 @@ def _profile_estimate(
     if estimate is None:
         return 0.0, {}
     return estimate(identifiers)
+
+
+def _verify_estimate(
+    adapter: Adapter, relationships: list[Relationship]
+) -> tuple[float, int, int]:
+    """Free dry-run pricing of the overlap probes verify would run, plus the
+    candidate/object counts for the checkpoint payload; zero-cost on free
+    adapters or when inference found nothing to probe."""
+
+    candidates = [r for r in relationships if r.kind is RelationshipKind.INFERRED]
+    objects = {r.from_dataset for r in candidates} | {r.to_dataset for r in candidates}
+    query_estimate = getattr(adapter, "query_estimate", None)
+    if query_estimate is None or not candidates:
+        return 0.0, len(candidates), len(objects)
+    total = sum(
+        query_estimate(sql)
+        for sql in rel_mod.probe_statements(candidates, adapter.dialect)
+    )
+    return total, len(candidates), len(objects)
 
 
 def _reporter(total: int, label: str, noun: str) -> ProgressReporter:
@@ -261,6 +281,8 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
     prior = store.load_cache()
     accumulated: list[Dataset] = []
     over_ceiling = False
+    verify_pending: env.Envelope | None = None
+    verify_warning: str | None = None
     try:
         # Relationship inference needs uniqueness signals, so profile every object
         # first (free and local on DuckDB), then infer across the full set.
@@ -274,9 +296,10 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         ]
         if verify:
             handshake_notes.append(
-                "--verify overlap probes depend on what inference finds, so "
-                "they are billed within the confirmed budget, not in this "
-                "upfront estimate"
+                "--verify overlap probes depend on what inference finds; they "
+                "are priced after profiling, and if their estimate exceeds "
+                "what remains of this budget a second confirmation checkpoint "
+                "appears before any probe runs"
             )
         unconfirmed = command_args.billed_handshake(
             "explore relationships",
@@ -312,15 +335,35 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         if not over_ceiling:
             inferred = rel_mod.infer_relationships(datasets)
             if verify:
-                verify_reporter = _reporter(len(inferred), "verified", "joins")
-                rel_mod.verify_relationships(
+                probe_cost, candidates, objects = _verify_estimate(adapter, inferred)
+                verify_pending = command_args.verify_handshake(
+                    "explore relationships",
                     adapter,
-                    inferred,
-                    timeout_seconds=config.query.timeout_seconds,
-                    progress=verify_reporter,
+                    probe_cost,
+                    candidate_count=candidates,
+                    object_count=objects,
                 )
-                verify_reporter.done()
-        envelope = env.ok({})
+                if verify_pending is None:
+                    verify_reporter = _reporter(len(inferred), "verified", "joins")
+                    try:
+                        rel_mod.verify_relationships(
+                            adapter,
+                            inferred,
+                            timeout_seconds=config.query.timeout_seconds,
+                            progress=verify_reporter,
+                        )
+                        verify_reporter.done()
+                    except OverCeilingError:
+                        # Estimate drift mid-loop; the relationship set itself
+                        # is complete, so finish with a warning (see cmd_map).
+                        done = sum(1 for r in inferred if r.verified)
+                        verify_warning = (
+                            f"budget exhausted after verifying {done} of "
+                            f"{len(inferred)} candidate join(s); verified "
+                            "results are saved; raise --budget and re-run to "
+                            "finish verification"
+                        )
+        envelope = verify_pending or env.ok({})
         command_args.stamp_spend(envelope, adapter)
     finally:
         adapter.close()
@@ -351,10 +394,17 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         notes.append(
             f"{confirmed} inferred join(s) match declared tests; kept as declared"
         )
-    if verify and inferred:
+    if verify and inferred and verify_pending is None and verify_warning is None:
         notes.append(
             f"verified {len(inferred)} inferred join(s) with aggregate overlap probes"
         )
+    if verify_pending is not None:
+        notes.append(
+            "relationships saved unverified; verification awaits confirmation "
+            "(see hint)"
+        )
+    if verify_warning:
+        envelope.warnings.append(verify_warning)
     if folded_edges > 0:
         notes.append(
             f"folded {folded_edges} same-lineage duplicate relationship(s); "
@@ -376,7 +426,9 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
             "inferred_count": len(rels) - len(declared),
             "cache_path": str(path),
             "updated_at": now.isoformat(),
-            "notes": notes,
+            # Merge, not overwrite: a verify checkpoint envelope may already
+            # carry notes from the adapter's estimate description.
+            "notes": [*envelope.data.get("notes", []), *notes],
         }
     )
     return envelope
@@ -483,6 +535,8 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
     prior = store.load_cache()
     accumulated: list[Dataset] = []
     over_ceiling = False
+    verify_pending: env.Envelope | None = None
+    verify_warning: str | None = None
     try:
         metas = inventory_mod.inventory(adapter)
         # First-pass rank on cheap signals (no connectivity yet) to choose what to
@@ -497,9 +551,10 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         handshake_notes = None
         if getattr(args, "verify", False):
             handshake_notes = [
-                "--verify overlap probes depend on what inference finds, so "
-                "they are billed within the confirmed budget, not in this "
-                "upfront estimate"
+                "--verify overlap probes depend on what inference finds; they "
+                "are priced after profiling, and if their estimate exceeds "
+                "what remains of this budget a second confirmation checkpoint "
+                "appears before any probe runs"
             ]
         unconfirmed = command_args.billed_handshake(
             "explore map", adapter, estimate, per_table=per_table, notes=handshake_notes
@@ -530,15 +585,37 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
             _annotate_grain(profiled, defs)
             inferred = rel_mod.infer_relationships(profiled)
             if getattr(args, "verify", False):
-                verify_reporter = _reporter(len(inferred), "verified", "joins")
-                rel_mod.verify_relationships(
+                probe_cost, candidates, objects = _verify_estimate(adapter, inferred)
+                verify_pending = command_args.verify_handshake(
+                    "explore map",
                     adapter,
-                    inferred,
-                    timeout_seconds=config.query.timeout_seconds,
-                    progress=verify_reporter,
+                    probe_cost,
+                    candidate_count=candidates,
+                    object_count=objects,
                 )
-                verify_reporter.done()
-        envelope = env.ok({})
+                if verify_pending is None:
+                    verify_reporter = _reporter(len(inferred), "verified", "joins")
+                    try:
+                        rel_mod.verify_relationships(
+                            adapter,
+                            inferred,
+                            timeout_seconds=config.query.timeout_seconds,
+                            progress=verify_reporter,
+                        )
+                        verify_reporter.done()
+                    except OverCeilingError:
+                        # The upfront probe pricing fit, but per-statement
+                        # estimates drifted past the ceiling mid-loop. The map
+                        # itself is complete, so finish with a warning instead
+                        # of the profiling phase's partial-completion error.
+                        done = sum(1 for r in inferred if r.verified)
+                        verify_warning = (
+                            f"budget exhausted after verifying {done} of "
+                            f"{len(inferred)} candidate join(s); verified "
+                            "results are saved; raise --budget and re-run to "
+                            "finish verification"
+                        )
+        envelope = verify_pending or env.ok({})
         command_args.stamp_spend(envelope, adapter)
     finally:
         adapter.close()
@@ -603,6 +680,13 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
             f"{mirrored_objects} object(s) mirror source lineage (a dev/replica "
             "dataset mapped alongside its source)"
         )
+    if verify_pending is not None:
+        notes.append(
+            "relationships saved unverified; verification awaits confirmation "
+            "(see hint)"
+        )
+    if verify_warning:
+        envelope.warnings.append(verify_warning)
 
     pii_columns = sum(1 for d in profiled for c in d.columns if c.pii is not None)
     quality_notes = sum(len(d.data_quality) for d in profiled)
@@ -620,7 +704,9 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
             "top_objects": [
                 {"identifier": d.identifier, "rank_score": d.rank_score} for d in top
             ],
-            "notes": notes,
+            # Merge, not overwrite: a verify checkpoint envelope may already
+            # carry notes from the adapter's estimate description.
+            "notes": [*envelope.data.get("notes", []), *notes],
             "updated_at": now.isoformat(),
         }
     )

--- a/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
@@ -164,6 +164,25 @@ class CostGate:
             )
         return cost
 
+    def preflight_phase(self, estimate: float) -> Cost:
+        """Mid-command gate for a phase whose cost is only knowable after
+        earlier spend (verify probes are priced only after inference finds
+        candidates). Runs on an already-confirmed command, so it asks for
+        confirmation only when the phase would not fit what remains of the
+        ceiling. The raised cost's estimate is the whole-command total the
+        re-run needs (charged so far plus the phase), so the agent can pick a
+        budget directly from it. Raises :class:`ConfirmationRequiredError`
+        rather than :class:`OverCeilingError` because a bigger budget on
+        re-run can cover it; ``needs_confirmation`` is the recovery channel.
+        """
+
+        ceiling = self.effective_ceiling()
+        needed = self._estimated + estimate
+        cost = Cost(paradigm=self.paradigm, estimate=needed, ceiling=ceiling)
+        if ceiling is not None and needed > ceiling:
+            raise ConfirmationRequiredError(cost)
+        return cost
+
     def charge(self, estimate: float) -> None:
         """Gate one statement on the confirmed run. Accumulates estimates so a
         sequence of statements is bounded as a whole, not just individually."""

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -268,3 +268,231 @@ def test_duckdb_explore_stays_confirmation_free(duckdb_file: Path, capsys):
     assert payload["status"] == "ok"
     assert payload["cost"]["paradigm"] == "free_local"
     assert "spend" not in payload["data"]
+
+
+# --- the verify-phase checkpoint -------------------------------------------------
+#
+# Verify probes can only be priced after profiling finds the candidate joins, so
+# the confirm handshake cannot cover them upfront. These tests pin the second,
+# headroom-gated checkpoint: a budget that covers profiling and the probes runs
+# in one pass; one that does not gets needs_confirmation after profiling, with
+# the profiles and unverified relationships already persisted.
+
+
+@pytest.fixture
+def fk_bq_client():
+    """A fake warehouse where inference finds a candidate join: orders carries
+    a customer_id foreign key into customers, whose id the aggregate resolver
+    reports as unique. Local to these tests so the shared fixture's estimate
+    assertions stay untouched."""
+
+    bigquery = pytest.importorskip("google.cloud.bigquery")
+    from fakes.bigquery import FakeBigQueryClient, FakeTable
+
+    tables = [
+        FakeTable(
+            project="test-proj",
+            dataset_id="shop",
+            table_id="customers",
+            schema=[
+                bigquery.SchemaField("id", "INTEGER", mode="REQUIRED"),
+                bigquery.SchemaField("email", "STRING"),
+            ],
+            num_rows=100,
+            num_bytes=5_000,
+        ),
+        FakeTable(
+            project="test-proj",
+            dataset_id="shop",
+            table_id="orders",
+            schema=[
+                bigquery.SchemaField("id", "INTEGER", mode="REQUIRED"),
+                bigquery.SchemaField("customer_id", "INTEGER"),
+                bigquery.SchemaField("total", "NUMERIC"),
+            ],
+            num_rows=100,
+            num_bytes=5_000,
+        ),
+    ]
+    client = FakeBigQueryClient(project="test-proj", tables=tables)
+    client.row_resolver = _aggregate_resolver
+    return client
+
+
+def _probe_executed(client) -> bool:
+    return any(not c.dry_run and "nonnull_fk" in c.sql for c in client.query_calls)
+
+
+def test_verify_within_budget_runs_in_one_pass(fk_bq_client, route_adapter, tmp_path):
+    route_adapter(fk_bq_client)
+    envelope = explore_cmds.cmd_map(
+        _args(
+            tmp_path,
+            subcommand="map",
+            verify=True,
+            confirm=True,
+            budget=float(100 * MB),
+        )
+    )
+    assert envelope.status.value == "ok"
+    assert "phase" not in envelope.data
+    assert _probe_executed(fk_bq_client)
+    cache = DexStore(tmp_path).load_cache()
+    assert cache.relationships and cache.relationships[0].verified
+
+
+def test_verify_beyond_budget_checkpoints_before_any_probe(
+    fk_bq_client, route_adapter, tmp_path
+):
+    # 20 MB covers the profiling handshake exactly (two tables floored to the
+    # per-query minimum each) but leaves no headroom for the two-table probe,
+    # which floors to another 20 MB.
+    route_adapter(fk_bq_client)
+    envelope = explore_cmds.cmd_map(
+        _args(
+            tmp_path,
+            subcommand="map",
+            verify=True,
+            confirm=True,
+            budget=float(20 * MB),
+        )
+    )
+    assert envelope.status.value == "needs_confirmation"
+    assert envelope.data["phase"] == "verify"
+    assert envelope.data["candidate_count"] == 1
+    assert envelope.data["object_count"] == 2
+    assert envelope.data["per_table_bytes"] == {"(join overlap probes)": 20 * MB}
+    assert "--budget" in envelope.data["hint"]
+    # The raised estimate is the whole-command total the re-run needs.
+    assert envelope.cost.estimate > envelope.cost.ceiling
+    assert envelope.cost.ceiling == 20 * MB
+    # No probe was billed; profiling spend is reported on the checkpoint.
+    assert not _probe_executed(fk_bq_client)
+    assert envelope.data["spend"]["bytes_billed"] > 0
+    # The map itself completed and persisted: profiles and the unverified
+    # relationship are in the cache, and the summary rides along.
+    assert envelope.data["relationship_count"] == 1
+    assert Path(envelope.data["cache_path"]).exists()
+    cache = DexStore(tmp_path).load_cache()
+    assert cache.relationships and not cache.relationships[0].verified
+    assert any("unverified" in note for note in envelope.data["notes"])
+
+
+def test_relationships_verify_beyond_budget_checkpoints(
+    fk_bq_client, route_adapter, tmp_path
+):
+    route_adapter(fk_bq_client)
+    envelope = explore_cmds.cmd_relationships(
+        _args(
+            tmp_path,
+            subcommand="relationships",
+            verify=True,
+            confirm=True,
+            budget=float(20 * MB),
+        )
+    )
+    assert envelope.status.value == "needs_confirmation"
+    assert envelope.data["phase"] == "verify"
+    assert envelope.data["command"] == "explore relationships"
+    assert not _probe_executed(fk_bq_client)
+    assert not any(
+        "verified" in note and "overlap" in note for note in envelope.data["notes"]
+    )
+    cache = DexStore(tmp_path).load_cache()
+    assert cache.relationships and not cache.relationships[0].verified
+
+
+def test_verify_with_no_candidates_skips_the_checkpoint(
+    fake_bq_client, route_adapter, tmp_path
+):
+    # The shared fixture's tables share no foreign-key stem, so inference finds
+    # nothing to probe and the confirmed budget alone carries the run.
+    fake_bq_client.row_resolver = _aggregate_resolver
+    route_adapter(fake_bq_client)
+    envelope = explore_cmds.cmd_map(
+        _args(
+            tmp_path,
+            subcommand="map",
+            verify=True,
+            confirm=True,
+            budget=float(20 * MB),
+        )
+    )
+    assert envelope.status.value == "ok"
+    assert "phase" not in envelope.data
+
+
+def test_mid_verify_budget_exhaustion_degrades_to_a_warning(
+    fk_bq_client, route_adapter, tmp_path, monkeypatch
+):
+    # Estimate drift can still trip the per-statement gate after the phase
+    # checkpoint passed; the map is complete, so the run finishes with a
+    # warning instead of the generic error it used to die with.
+    from exmergo_dex_core.guards.cost_guard import OverCeilingError
+
+    def exhaust(adapter, relationships, *, timeout_seconds=None, progress=None):
+        relationships[0].verified = True
+        raise OverCeilingError("drifted past the ceiling")
+
+    monkeypatch.setattr(explore_cmds.rel_mod, "verify_relationships", exhaust)
+    route_adapter(fk_bq_client)
+    envelope = explore_cmds.cmd_map(
+        _args(
+            tmp_path,
+            subcommand="map",
+            verify=True,
+            confirm=True,
+            budget=float(100 * MB),
+        )
+    )
+    assert envelope.status.value == "ok"
+    assert any("1 of 1" in w and "budget exhausted" in w for w in envelope.warnings)
+    cache = DexStore(tmp_path).load_cache()
+    assert cache.relationships
+
+
+def test_verify_handshake_uses_the_adapters_estimate_description():
+    # Connectors that speak credits/seconds describe their own estimate; the
+    # checkpoint payload keeps that shape and overlays the phase fields.
+    gate = CostGate(
+        paradigm=Paradigm.COMPUTE_TIME,
+        ceiling=10.0,
+        session_ceiling=None,
+        session_spent=0.0,
+        confirmed=True,
+        connector="snowflake",
+        command="explore map",
+    )
+    gate.charge(8.0)
+
+    class StubAdapter:
+        cost_gate = gate
+
+        def describe_estimate(self, estimate, per_table):
+            return {
+                "estimated_seconds": estimate,
+                "per_table_seconds": per_table,
+                "notes": ["seconds are a coarse translation"],
+            }
+
+    envelope = command_args.verify_handshake(
+        "explore map", StubAdapter(), 5.0, candidate_count=3, object_count=2
+    )
+    assert envelope.status.value == "needs_confirmation"
+    assert envelope.data["estimated_seconds"] == 5.0
+    assert envelope.data["per_table_seconds"] == {"(join overlap probes)": 5.0}
+    assert envelope.data["candidate_count"] == 3
+    assert envelope.data["object_count"] == 2
+    assert "notes" in envelope.data
+    assert envelope.cost.estimate == 13.0
+
+
+def test_duckdb_map_verify_stays_confirmation_free(duckdb_file: Path, capsys):
+    from exmergo_dex_core.cli import main
+
+    rc = main(["explore", "map", "--verify", "--path", str(duckdb_file)])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["status"] == "ok"
+    assert payload["cost"]["paradigm"] == "free_local"
+    assert "phase" not in payload["data"]

--- a/packages/dex-core/tests/guards/test_cost_guard.py
+++ b/packages/dex-core/tests/guards/test_cost_guard.py
@@ -115,6 +115,39 @@ def test_gate_session_remainder_binds_when_tighter():
         gate.preflight_command(400.0)
 
 
+def test_gate_phase_within_remaining_headroom_passes():
+    gate = _gate()
+    gate.charge(600.0)
+    cost = gate.preflight_phase(300.0)
+    assert cost.estimate == 900.0
+    assert cost.ceiling == 1_000.0
+
+
+def test_gate_phase_beyond_remaining_headroom_asks_for_confirmation():
+    # The raised estimate is the whole-command total (charged so far plus the
+    # phase), so it is directly the budget a re-run needs.
+    gate = _gate()
+    gate.charge(600.0)
+    with pytest.raises(ConfirmationRequiredError) as exc_info:
+        gate.preflight_phase(500.0)
+    assert exc_info.value.cost.estimate == 1_100.0
+    assert exc_info.value.cost.ceiling == 1_000.0
+    assert exc_info.value.cost.paradigm is Paradigm.BYTES_SCANNED
+
+
+def test_gate_phase_session_remainder_binds_when_tighter():
+    gate = _gate(ceiling=1_000.0, session_ceiling=800.0, session_spent=500.0)
+    with pytest.raises(ConfirmationRequiredError) as exc_info:
+        gate.preflight_phase(400.0)
+    assert exc_info.value.cost.ceiling == 300.0
+
+
+def test_gate_phase_zero_estimate_and_no_ceiling_never_raise():
+    assert _gate().preflight_phase(0.0).estimate == 0.0
+    gate = _gate(ceiling=None, session_ceiling=None)
+    assert gate.preflight_phase(500.0).ceiling is None
+
+
 def test_gate_max_bytes_tracks_actual_billing():
     gate = _gate(ceiling=1_000.0)
     assert gate.remaining_for_statement() == 1_000


### PR DESCRIPTION
## Summary

`explore map --full --verify`'s dry-run estimate only covered the profiling pass. Relationship-verify probes ran against the same confirmed budget with no estimate and no checkpoint, so on a large warehouse the run could die mid-verify with a generic error once the budget ran out — with no signal beforehand that verify could cost several times the base estimate.

This adds a second, headroom-gated `needs_confirmation` checkpoint after profiling completes and candidate relationships are known, mirroring the existing preflight shape.

## Changes

- **`guards/cost_guard.py`**: new `CostGate.preflight_phase` — a mid-command gate for costs only knowable after earlier spend. Raises `ConfirmationRequiredError` (recoverable via a bigger budget) only when the phase estimate doesn't fit what remains of the ceiling.
- **`command_args.py`**: new `verify_handshake`, mirroring `billed_handshake`, priced via the existing `probe_statements` + `query_estimate` dry-run hooks (the same pattern `maintain grain` already uses). Payload includes `phase: "verify"`, candidate/object counts, and a hint with the exact `--confirm --budget N` to re-run with. `stamp_spend` now preserves a checkpoint envelope's cost instead of overwriting it.
- **`explore/commands.py`**: new `_verify_estimate` helper; wired into both `cmd_map` and `cmd_relationships`. Verify is now wrapped in `try/except OverCeilingError` for graceful degradation (a warning instead of a crash) when per-probe estimates drift mid-run.

## Related issue
This closes #74 

## Behavior

1. Unconfirmed run → needs_confirmation #1 (profiling estimate), now noting that verify is priced separately and may trigger a second checkpoint.
2. `--confirm --budget B`: profiling and inference run; probes are dry-run priced for free. If they fit the remaining budget, verify runs in the same pass — no change for the common case.
3. If they don't fit → needs_confirmation #2 ("found N candidate relationships across M objects; verifying them all is estimated at ~Y bytes beyond what remains of the budget..."), with the work already paid for **persisted**: cache saved with fresh profiles + unverified relationships, full map summary and spend included, zero probe bytes billed.
4. Re-run with the suggested budget completes in one pass (profiling re-runs at full cost — there's no profile-cache reuse today, which is why the checkpoint is headroom-gated rather than always-fire).
5. Estimate drift mid-verify now degrades to a warning ("verified N of M candidate joins; results saved") instead of an uncaught error.

DuckDB (free) stays fully confirmation-free throughout.

## Test plan

- [x] `pytest tests/guards/test_cost_guard.py` — new `preflight_phase` unit tests (headroom fit, exceeds, session-ceiling binding, zero/no-ceiling edge cases)
- [x] `pytest tests/explore/test_billed_handshake.py` — new coverage: verify within budget (one pass), verify beyond budget (checkpoint shape + persistence), zero candidates (no checkpoint), mid-verify `OverCeilingError` (warning + persisted partial results), credit/seconds `describe_estimate` shape, DuckDB `--verify` regression
- [x] Full suite: `pytest` (969 passed, 68 skipped)
- [x] `ruff check` / `ruff format --check`
- [x] Manual end-to-end: `dex explore map --full --verify --path <duckdb file>` against a two-table FK warehouse — completes in one pass, relationship verified in `.dex/cache.json`
