### PR TITLE
Redshift cold-start race fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Redshift connections survive a Serverless cold start.** An idle Serverless
+  workgroup resumes on first contact, and a slow resume can reset the startup
+  handshake, so the first command to touch a cold workgroup failed hard while
+  everything after it ran warm. The connect is now retried with backoff on the
+  transient connection errors a resume produces (a wrong credential or database
+  still fails immediately), across a window wide enough to cover the wake. A
+  per-attempt connect timeout bounds a stalled handshake and is cleared once the
+  connection is up so it never caps a later billed query's result read.
+
 ## [1.2.1] - 2026-07-17
 
 ### Changed

--- a/packages/dex-core/src/exmergo_dex_core/connect.py
+++ b/packages/dex-core/src/exmergo_dex_core/connect.py
@@ -24,8 +24,10 @@ for.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import re
+import time
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
@@ -1002,6 +1004,67 @@ def _postgres_from_dbt_profiles(repo_root: str | Path) -> dict | None:
     return None
 
 
+# An idle Redshift Serverless workgroup resumes on the first connection: the
+# startup/auth handshake blocks until compute is ready, and a resume slower
+# than the endpoint tolerates is torn down mid-handshake, so the first command
+# to touch a cold workgroup gets a connection error while everything after it
+# runs warm. The bare connect is therefore retried across a window wide enough
+# to cover a cold resume. A per-attempt timeout bounds a stalled handshake so a
+# reset that never arrives cannot block forever, and it is cleared once the
+# connection is up so it never bounds a later billed query's result read. No
+# statement runs here, so the retries add no billed compute; the wake is billed
+# once by the first real statement regardless.
+_CONNECT_ATTEMPT_TIMEOUT_SECONDS = 90
+_CONNECT_BACKOFF_SECONDS = (2.0, 5.0, 10.0)
+
+
+def _connect_redshift(redshift_connector, params: dict):
+    """Open the redshift_connector connection, retrying a cold-start resume.
+
+    Retries only the connection-level failures a resuming Serverless workgroup
+    produces (a reset handshake surfaces as InterfaceError, a stalled one as
+    OperationalError) with backoff, then re-raises as a discovery error that
+    names the resume. A server-side refusal (a bad credential, a missing
+    database, a denied privilege) is a ProgrammingError and surfaces on the
+    first attempt rather than waiting out the backoff.
+    """
+
+    from redshift_connector.error import InterfaceError, OperationalError
+
+    transient = (InterfaceError, OperationalError)
+    attempts = len(_CONNECT_BACKOFF_SECONDS) + 1
+    last_exc: Exception | None = None
+    for attempt in range(attempts):
+        try:
+            connection = redshift_connector.connect(
+                **params,
+                application_name="dex",
+                timeout=_CONNECT_ATTEMPT_TIMEOUT_SECONDS,
+            )
+            connection.autocommit = True
+            # The connect timeout is a socket timeout that would otherwise
+            # persist and cap every later result read; a billed scan on a
+            # just-woken workgroup can legitimately outlast it. Clear it now
+            # that the handshake is done (best-effort: never fail the connect
+            # over a driver internal).
+            usock = getattr(connection, "_usock", None)
+            if usock is not None:
+                with contextlib.suppress(OSError):
+                    usock.settimeout(None)
+            return connection
+        except transient as exc:
+            last_exc = exc
+            if attempt < len(_CONNECT_BACKOFF_SECONDS):
+                time.sleep(_CONNECT_BACKOFF_SECONDS[attempt])
+
+    raise CredentialDiscoveryError(
+        f"could not establish a Redshift connection after {attempts} attempts; "
+        "an idle Serverless workgroup can be slow to resume on first contact. "
+        "Retry the command, or check the workgroup is AVAILABLE and its "
+        "endpoint is reachable"
+    ) from last_exc
+
+
 def _open_redshift(
     config: DexConfig,
     repo_root: str | Path,
@@ -1027,9 +1090,9 @@ def _open_redshift(
     # adapter additionally sets query_group and a best-effort session
     # read-only mode before any statement runs. autocommit keeps session SETs
     # (statement_timeout) outside any transaction the driver would otherwise
-    # open.
-    connection = redshift_connector.connect(**params, application_name="dex")
-    connection.autocommit = True
+    # open. The connect itself is retried: an idle Serverless workgroup resumes
+    # on first contact, and a slow resume can reset the startup handshake.
+    connection = _connect_redshift(redshift_connector, params)
 
     store = DexStore(repo_root)
     utc_midnight = (

--- a/packages/dex-core/tests/adapters/test_connect_redshift.py
+++ b/packages/dex-core/tests/adapters/test_connect_redshift.py
@@ -1142,6 +1142,96 @@ def test_discovery_never_surfaces_a_password(tmp_path: Path):
     assert "supersecret" not in method
 
 
+# --- the cold-start connection retry: a resuming workgroup is not a fatal error ------
+
+
+class _FakeSocket:
+    def __init__(self) -> None:
+        self.timeout: float | None = -1.0  # sentinel: never touched
+
+    def settimeout(self, value) -> None:
+        self.timeout = value
+
+
+class _FakeDriverConnection:
+    def __init__(self) -> None:
+        self.autocommit = False
+        self._usock = _FakeSocket()
+
+
+class _FakeDriver:
+    """Stands in for the redshift_connector module: connect fails with the
+    supplied exceptions in order, then returns a connection."""
+
+    def __init__(self, failures: list[Exception]) -> None:
+        self._failures = list(failures)
+        self.calls = 0
+        self.last_kwargs: dict = {}
+
+    def connect(self, **kwargs):
+        self.calls += 1
+        self.last_kwargs = kwargs
+        if self._failures:
+            raise self._failures.pop(0)
+        return _FakeDriverConnection()
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch):
+    """The retry backoff must not slow the unit suite."""
+
+    from exmergo_dex_core import connect as connect_module
+
+    monkeypatch.setattr(connect_module.time, "sleep", lambda _s: None)
+
+
+def test_connect_retries_a_cold_serverless_resume():
+    from redshift_connector.error import InterfaceError
+
+    from exmergo_dex_core.connect import _connect_redshift
+
+    driver = _FakeDriver(
+        [InterfaceError("communication error"), InterfaceError("network error")]
+    )
+    connection = _connect_redshift(driver, {"iam": True, "host": "wg", "database": "d"})
+    assert driver.calls == 3  # two transient failures, then success
+    assert connection.autocommit is True
+    # The per-attempt connect timeout is applied, then cleared so it never caps
+    # a later billed query's result read.
+    assert driver.last_kwargs["timeout"] is not None
+    assert driver.last_kwargs["application_name"] == "dex"
+    assert connection._usock.timeout is None
+
+
+def test_connect_gives_up_after_retries_and_names_the_resume():
+    from redshift_connector.error import OperationalError
+
+    from exmergo_dex_core.connect import CredentialDiscoveryError, _connect_redshift
+
+    driver = _FakeDriver([OperationalError("connection time out")] * 10)
+    with pytest.raises(CredentialDiscoveryError, match="resume") as excinfo:
+        _connect_redshift(driver, {"iam": True, "host": "wg", "database": "d"})
+    # It tried the full budget (initial attempt + one per backoff step) and
+    # chained the underlying driver error rather than swallowing it.
+    assert driver.calls == 4
+    assert isinstance(excinfo.value.__cause__, OperationalError)
+
+
+def test_connect_does_not_retry_a_credential_refusal():
+    """A server-side refusal (bad credential, missing database, denied grant)
+    is a ProgrammingError: it must surface on the first attempt, not wait out
+    the backoff meant for a resuming workgroup."""
+
+    from redshift_connector.error import ProgrammingError
+
+    from exmergo_dex_core.connect import _connect_redshift
+
+    driver = _FakeDriver([ProgrammingError("password authentication failed")])
+    with pytest.raises(ProgrammingError):
+        _connect_redshift(driver, {"iam": True, "host": "wg", "database": "d"})
+    assert driver.calls == 1
+
+
 # --- scope resolution: an entry that names nothing is refused, not dropped ------------
 
 


### PR DESCRIPTION
# Fix Redshift cold-start connection race

## Summary

CI's live Redshift integration suite intermittently failed on
`test_connect_test_discovers_connection_and_reports_read_only` with a bare
error envelope (`status: error`, `paradigm: free_local`) and no useful
message. The failing run took 135.85s versus a healthy run's ~47s — the tell
that this was a cold-start issue, not a code defect in `connect test` or
`capabilities()`.

**Root cause:** an idle Redshift Serverless workgroup resumes on first
contact. The startup/auth handshake blocks until compute is ready, and a slow
resume gets torn down mid-handshake by the network path. Whichever command
happens to touch the workgroup first pays for that resume; every command
after it finds the workgroup warm and succeeds. `dex` opened the connection
with `redshift_connector.connect(...)` directly — no timeout, no retry — so a
reset handshake surfaced as a raw, unretried exception.

Verified against the driver source (`redshift_connector`) and CI run history:
70 existing adapter unit tests pass against the fake connection, the same
code path passes warm in CI 10/10, and the only server call unique to the
failing test (`version()`) is the same catalog-lookup class as calls the
passing tests already exercise successfully — ruling out a deterministic bug
in the capabilities probe itself.

## Change

`packages/dex-core/src/exmergo_dex_core/connect.py`

- Added `_connect_redshift()`, wrapping the single `redshift_connector.connect`
  call site used by every Redshift auth path (Serverless IAM, cluster IAM,
  environment, config target, dbt profile).
- Retries only the connection-level errors a resuming workgroup produces
  (`InterfaceError`, `OperationalError`) with backoff (2s / 5s / 10s, 4
  attempts total). A `ProgrammingError` (bad credential, missing database,
  denied grant) is **not** retried and surfaces immediately.
- Applies a 90s per-attempt connect timeout so a stalled handshake fails fast
  instead of hanging, then clears the socket timeout once connected so it
  never caps a later billed query's result read.
- On exhaustion, raises `CredentialDiscoveryError` naming the resume instead
  of leaking a raw driver exception into the generic error envelope.

No billed compute is added by the retries — no statement runs during
connect; the Serverless wake minimum is still billed exactly once, by the
first real statement, as before.

## Tests

- 3 new unit tests in `test_connect_redshift.py` against a fake driver:
  - retry-then-succeed on transient errors
  - give-up-and-raise-with-cause after exhausting the retry budget
  - a credential/permission refusal is **not** retried
- Full non-integration suite: 961 passed, 17 skipped, 0 failures.
- `ruff check`: clean.

## Verification caveat

I don't have access to the CI environment's seeded Serverless workgroup, so
I couldn't force a genuinely cold reproduction end-to-end. The fix targets
the exact exception classes and blocking window traced from the
`redshift_connector` source and the historical CI timing; the unit tests
exercise the retry/backoff/give-up logic directly against a fake.

## Changelog

Added an `[Unreleased] / Fixed` entry in `CHANGELOG.md`.
