### PR TITLE
Skip-if-cached profiling for explore map / explore relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Changed
+
+- **`explore map` and `explore relationships` skip re-profiling an object whose
+  cached profile is still fresh.** Before scanning a selected object, each
+  command now checks `.dex/cache.json` for a same-connector profile of that
+  exact object that was profiled within a freshness window and whose column
+  signature (name, type, nullability) still matches the warehouse's free
+  metadata; a match is reused wholesale instead of re-scanned, so it never
+  enters the cost preflight or the billed handshake. Iterative workflows on a
+  metered warehouse (map, tweak, map again) and `--verify` re-runs no longer
+  re-pay the full profiling scan when nothing changed. The freshness check is
+  fail-closed: a missing or unparseable `profiled_at`, a schema change, or a
+  different connector re-profiles. The envelope gains a `cache_hit_count` field
+  (distinct from the existing `carried_forward_count`, which covers
+  below-rank-cutoff objects) and a note when reuse happened.
+- **New `--refresh` flag on `explore map` / `explore relationships`** forces a
+  full re-profile of every selected object even when the cache is fresh, for
+  callers who know the source changed in a way the cheap metadata check cannot
+  see.
+- **New `profile_freshness_hours` config knob** (`DexConfig`, default `24.0`)
+  sets how fresh a cached profile must be to be reused; `0` disables reuse
+  (always re-profile). No cache schema change: `Dataset.profiled_at` and the
+  stored column signatures already carry everything the check needs.
+
 ### Fixed
 
 - **Redshift connections survive a Serverless cold start.** An idle Serverless

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -123,6 +123,14 @@ def _build_parser() -> argparse.ArgumentParser:
                     sp.add_argument(
                         "--verify", action="store_true", default=argparse.SUPPRESS
                     )
+                # Force a full re-profile even when the cache holds a fresh,
+                # schema-matching profile for a selected object (the default is
+                # skip-if-cached; --refresh is the escape hatch when the source
+                # changed in a way the cheap metadata check cannot see).
+                if group == "explore" and name in {"map", "relationships"}:
+                    sp.add_argument(
+                        "--refresh", action="store_true", default=argparse.SUPPRESS
+                    )
                 # Exploration starts bare: warehouse truth, independent of
                 # whatever repo dex runs from. --use-project opts in to folding
                 # the project's declared definitions (joins, grain, metric

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -279,6 +279,9 @@ class DexConfig(BaseModel):
     # How many top-ranked objects `explore map` deep-profiles on a large
     # warehouse; the rest stay inventory-only. Selective by default, overridable.
     profile_top_n: int = 25
+    # How fresh a cached profile must be to skip re-scanning it (`explore map` /
+    # `explore relationships`); 0 disables reuse (always re-profile).
+    profile_freshness_hours: float = 24.0
     # Columns a human has reviewed and cleared as not PII. The only way to
     # durably clear a detector flag; hand-edits to the cache are overwritten by
     # the next profile, this list is re-applied on every profile.

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -14,7 +14,7 @@ import argparse
 import json
 import re
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from .. import command_args, dbt_project
@@ -287,8 +287,20 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         # Relationship inference needs uniqueness signals, so profile every object
         # first (free and local on DuckDB), then infer across the full set.
         metas = inventory_mod.inventory(adapter)
-        identifiers = [m.identifier for m in metas]
-        estimate, per_table = _profile_estimate(adapter, identifiers)
+        connector = adapter.name
+        # Skip re-scanning objects whose cached profile is still fresh (same
+        # connector, schema unchanged, within the freshness window); only the
+        # stale remainder is estimated, confirmed, and profiled below.
+        stale, fresh_reused = _split_fresh_stale(
+            metas,
+            prior,
+            connector,
+            adapter,
+            timedelta(hours=config.profile_freshness_hours),
+            now,
+            refresh=getattr(args, "refresh", False),
+        )
+        estimate, per_table = _profile_estimate(adapter, [m.identifier for m in stale])
         handshake_notes = [
             "relationship inference profiles every object; on a metered "
             "connector `explore map` (top-ranked objects only) is usually the "
@@ -301,37 +313,49 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
                 "what remains of this budget a second confirmation checkpoint "
                 "appears before any probe runs"
             )
-        unconfirmed = command_args.billed_handshake(
-            "explore relationships",
-            adapter,
-            estimate,
-            per_table=per_table,
-            notes=handshake_notes,
-        )
-        if unconfirmed is not None:
-            return unconfirmed
-        connector = adapter.name
-
-        # Billed-connector-gated per-object checkpointing (see cmd_profile).
-        checkpoint = None
-        if command_args.cost_gate(adapter) is not None:
-            checkpoint, accumulated = _profile_checkpointer(
-                store, prior, connector, now
+        if fresh_reused:
+            handshake_notes.append(
+                f"{len(fresh_reused)} object(s) excluded from this estimate as "
+                "fresh-cached (schema unchanged, profiled within the freshness "
+                "window); pass --refresh to re-profile them"
             )
-
-        profile_reporter = _reporter(len(identifiers), "profiled", "objects")
-        try:
-            datasets = profile_mod.profile(
+        profiled: list[Dataset] = []
+        # Nothing stale means nothing to price or confirm: skip the handshake and
+        # the scan entirely, and reuse the cached profiles wholesale.
+        if stale:
+            unconfirmed = command_args.billed_handshake(
+                "explore relationships",
                 adapter,
-                identifiers,
-                progress=profile_reporter,
-                on_complete=checkpoint,
-                pii_overrides=pii_override_paths(config.pii_overrides),
+                estimate,
+                per_table=per_table,
+                notes=handshake_notes,
             )
-            profile_reporter.done()
-        except OverCeilingError:
-            over_ceiling = True
+            if unconfirmed is not None:
+                return unconfirmed
 
+            # Billed-connector-gated per-object checkpointing (see cmd_profile).
+            checkpoint = None
+            if command_args.cost_gate(adapter) is not None:
+                checkpoint, accumulated = _profile_checkpointer(
+                    store, prior, connector, now
+                )
+
+            profile_reporter = _reporter(len(stale), "profiled", "objects")
+            try:
+                profiled = profile_mod.profile(
+                    adapter,
+                    [m.identifier for m in stale],
+                    progress=profile_reporter,
+                    on_complete=checkpoint,
+                    pii_overrides=pii_override_paths(config.pii_overrides),
+                )
+                profile_reporter.done()
+            except OverCeilingError:
+                over_ceiling = True
+
+        # Freshly profiled plus fresh-cached: the full inventory, whether scanned
+        # this run or reused. Inference and merge fold by identifier over the union.
+        datasets = profiled + list(fresh_reused.values())
         if not over_ceiling:
             inferred = rel_mod.infer_relationships(datasets)
             if verify:
@@ -368,12 +392,13 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
     finally:
         adapter.close()
     if over_ceiling:
-        envelope = _over_ceiling_error(store, accumulated, len(identifiers))
+        envelope = _over_ceiling_error(store, accumulated, len(stale))
         command_args.stamp_spend(envelope, adapter)
         return envelope
     # Annotate before persisting so cached datasets carry candidate_keys and
-    # grain, the same shape a `map`-written cache has.
-    _annotate_grain(datasets, defs)
+    # grain, the same shape a `map`-written cache has. Only the freshly profiled
+    # need it; the fresh-cached already carry theirs from the cache write.
+    _annotate_grain(profiled, defs)
 
     # Fold same-lineage duplicates before the merge, as `map` does, so the folded
     # set flows into both the cache and the envelope. Relationships profiles the
@@ -397,6 +422,13 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
     if verify and inferred and verify_pending is None and verify_warning is None:
         notes.append(
             f"verified {len(inferred)} inferred join(s) with aggregate overlap probes"
+        )
+    if fresh_reused:
+        window = config.profile_freshness_hours
+        notes.append(
+            f"reused {len(fresh_reused)} fresh cached profile(s) (schema "
+            f"unchanged, profiled within {window:g}h); pass --refresh to force "
+            "re-profiling"
         )
     if verify_pending is not None:
         notes.append(
@@ -424,6 +456,8 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
             "relationships": [r.model_dump(mode="json") for r in rels],
             "declared_count": len(declared),
             "inferred_count": len(rels) - len(declared),
+            "profiled_count": len(profiled),
+            "cache_hit_count": len(fresh_reused),
             "cache_path": str(path),
             "updated_at": now.isoformat(),
             # Merge, not overwrite: a verify checkpoint envelope may already
@@ -543,47 +577,75 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         # profile; re-ranked with connectivity once relationships are known.
         first_pass = rank_mod.rank(metas, None, hints)
         selected = _select_for_profiling(metas, first_pass, config, full)
+        # Skip re-scanning a selected object whose cached profile is still fresh
+        # (same connector, schema unchanged, within the freshness window); only
+        # the stale remainder is estimated, confirmed, and profiled below.
+        stale, fresh_reused = _split_fresh_stale(
+            selected,
+            prior,
+            adapter.name,
+            adapter,
+            timedelta(hours=config.profile_freshness_hours),
+            now,
+            refresh=getattr(args, "refresh", False),
+        )
         # Inventory and ranking are free, so an unconfirmed billed run repeats
         # them on re-issue; only the profiling scans below need the handshake.
-        estimate, per_table = _profile_estimate(
-            adapter, [m.identifier for m in selected]
-        )
-        handshake_notes = None
+        estimate, per_table = _profile_estimate(adapter, [m.identifier for m in stale])
+        handshake_notes: list[str] = []
         if getattr(args, "verify", False):
-            handshake_notes = [
+            handshake_notes.append(
                 "--verify overlap probes depend on what inference finds; they "
                 "are priced after profiling, and if their estimate exceeds "
                 "what remains of this budget a second confirmation checkpoint "
                 "appears before any probe runs"
-            ]
-        unconfirmed = command_args.billed_handshake(
-            "explore map", adapter, estimate, per_table=per_table, notes=handshake_notes
-        )
-        if unconfirmed is not None:
-            return unconfirmed
-        # Billed-connector-gated per-object checkpointing (see cmd_profile).
-        checkpoint = None
-        if command_args.cost_gate(adapter) is not None:
-            checkpoint, accumulated = _profile_checkpointer(
-                store, prior, adapter.name, now
             )
-
-        profile_reporter = _reporter(len(selected), "profiled", "objects")
-        try:
-            profiled = profile_mod.profile(
+        if fresh_reused:
+            handshake_notes.append(
+                f"{len(fresh_reused)} object(s) excluded from this estimate as "
+                "fresh-cached (schema unchanged, profiled within the freshness "
+                "window); pass --refresh to re-profile them"
+            )
+        profiled: list[Dataset] = []
+        # Nothing stale means nothing to price or confirm: skip the handshake and
+        # the scan entirely, and reuse the cached profiles wholesale.
+        if stale:
+            unconfirmed = command_args.billed_handshake(
+                "explore map",
                 adapter,
-                [m.identifier for m in selected],
-                progress=profile_reporter,
-                on_complete=checkpoint,
-                pii_overrides=pii_override_paths(config.pii_overrides),
+                estimate,
+                per_table=per_table,
+                notes=handshake_notes or None,
             )
-            profile_reporter.done()
-        except OverCeilingError:
-            over_ceiling = True
+            if unconfirmed is not None:
+                return unconfirmed
+            # Billed-connector-gated per-object checkpointing (see cmd_profile).
+            checkpoint = None
+            if command_args.cost_gate(adapter) is not None:
+                checkpoint, accumulated = _profile_checkpointer(
+                    store, prior, adapter.name, now
+                )
 
+            profile_reporter = _reporter(len(stale), "profiled", "objects")
+            try:
+                profiled = profile_mod.profile(
+                    adapter,
+                    [m.identifier for m in stale],
+                    progress=profile_reporter,
+                    on_complete=checkpoint,
+                    pii_overrides=pii_override_paths(config.pii_overrides),
+                )
+                profile_reporter.done()
+            except OverCeilingError:
+                over_ceiling = True
+
+        # Freshly profiled plus fresh-cached: the full selected set, whether
+        # scanned this run or reused. Only the freshly profiled need annotation;
+        # the reused already carry theirs from the cache write that stored them.
+        all_selected = profiled + list(fresh_reused.values())
         if not over_ceiling:
             _annotate_grain(profiled, defs)
-            inferred = rel_mod.infer_relationships(profiled)
+            inferred = rel_mod.infer_relationships(all_selected)
             if getattr(args, "verify", False):
                 probe_cost, candidates, objects = _verify_estimate(adapter, inferred)
                 verify_pending = command_args.verify_handshake(
@@ -620,14 +682,14 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
     finally:
         adapter.close()
     if over_ceiling:
-        envelope = _over_ceiling_error(store, accumulated, len(selected))
+        envelope = _over_ceiling_error(store, accumulated, len(stale))
         command_args.stamp_spend(envelope, adapter)
         return envelope
     # Fold same-lineage duplicates before they reach the cache: a dev/replica
     # dataset mapped alongside its source otherwise inflates one real foreign key
     # into source, replica, and cross-dataset lookalike edges.
     inferred, folded_edges, mirrored_objects = rel_mod.fold_replica_relationships(
-        profiled, inferred, _dev_schemas(config)
+        all_selected, inferred, _dev_schemas(config)
     )
 
     declared, declared_notes = rel_mod.declared_relationships(
@@ -637,7 +699,7 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
     # Prior profiles are only reusable when they came from the same connector.
     reusable = prior if prior and prior.provenance.connector == adapter.name else None
     final_scores = rank_mod.rank(metas, relationships, hints)
-    datasets, carried = _compose_datasets(metas, profiled, final_scores, reusable)
+    datasets, carried = _compose_datasets(metas, all_selected, final_scores, reusable)
 
     cache = DexCache(datasets=datasets, relationships=relationships)
     cache.provenance.connector = adapter.name
@@ -648,7 +710,7 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
     )
     path = store.save_cache(cache, now=now)
 
-    notes = _relationship_notes(profiled, declared, inferred, defs)
+    notes = _relationship_notes(all_selected, declared, inferred, defs)
     notes.extend(declared_notes)
     notes.extend(defs.notes)
     if confirmed:
@@ -661,13 +723,23 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
             f"{metric_hint_count} model(s) back metric definitions; ranking "
             "favors them alongside configured hints"
         )
-    skipped = len(metas) - len(profiled)
+    # Rank-cutoff skip is an axis of its own: objects not selected for profiling.
+    # It is decoupled from len(profiled), which no longer equals len(selected)
+    # once some selected objects are served from cache.
+    skipped = len(metas) - len(selected)
     if skipped > 0:
         notes.append(
-            f"profiled top {len(profiled)} of {len(metas)} objects by rank "
+            f"profiled top {len(selected)} of {len(metas)} objects by rank "
             f"(profile_top_n={config.profile_top_n}; all objects are profiled "
             f"automatically at {_AUTO_PROFILE_ALL} or fewer); pass --full to "
             "profile everything"
+        )
+    if fresh_reused:
+        window = config.profile_freshness_hours
+        notes.append(
+            f"reused {len(fresh_reused)} fresh cached profile(s) for selected "
+            f"object(s) (schema unchanged, profiled within {window:g}h); pass "
+            "--refresh to force re-profiling"
         )
     if carried > 0:
         notes.append(
@@ -688,14 +760,15 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
     if verify_warning:
         envelope.warnings.append(verify_warning)
 
-    pii_columns = sum(1 for d in profiled for c in d.columns if c.pii is not None)
-    quality_notes = sum(len(d.data_quality) for d in profiled)
+    pii_columns = sum(1 for d in all_selected for c in d.columns if c.pii is not None)
+    quality_notes = sum(len(d.data_quality) for d in all_selected)
     top = sorted(datasets, key=lambda d: d.rank_score or 0.0, reverse=True)[:5]
     envelope.data.update(
         {
             "cache_path": str(path),
             "object_count": len(metas),
             "profiled_count": len(profiled),
+            "cache_hit_count": len(fresh_reused),
             "skipped_count": skipped,
             "carried_forward_count": carried,
             "relationship_count": len(relationships),
@@ -1248,6 +1321,68 @@ def _select_for_profiling(
         return metas
     ranked = sorted(metas, key=lambda m: scores.get(m.identifier, 0.0), reverse=True)
     return ranked[: config.profile_top_n]
+
+
+def _column_signature(columns) -> list[tuple[str, str, bool]]:
+    """The (name, data_type, nullable) shape of a column set, sorted so two
+    profiles compare independent of column order. Shared shape as
+    ``maintain/drift.py``'s schema diff, applied here pre-profile against cheap
+    metadata instead of post-profile against two cached snapshots."""
+
+    return sorted((c.name, c.data_type, c.nullable) for c in columns)
+
+
+def _split_fresh_stale(
+    metas: list[ObjectMeta],
+    prior: DexCache | None,
+    connector: str,
+    adapter: Adapter,
+    max_age: timedelta,
+    now: datetime,
+    *,
+    refresh: bool,
+) -> tuple[list[ObjectMeta], dict[str, Dataset]]:
+    """Split selected metas into (still need profiling, reusable-fresh datasets).
+
+    An object is *fresh* (skip the re-scan) only when its cached profile came
+    from this same connector, was actually profiled before (has columns and a
+    ``profiled_at``), was profiled within ``max_age``, and its column signature
+    still matches the warehouse's cheap metadata. Anything else is *stale* and
+    goes back through the billed profiling scan. ``refresh`` forces every object
+    stale (the pre-fix, unconditional-reprofile behavior), and so does a
+    mismatched-connector or absent prior — mirroring ``cmd_map``'s reuse gate.
+
+    Freshness is fail-closed: a missing or unparseable ``profiled_at``, or any
+    doubt, re-profiles rather than trusting a stale scan.
+    """
+
+    if refresh or prior is None or prior.provenance.connector != connector:
+        return list(metas), {}
+
+    prior_by_id = {d.identifier: d for d in prior.datasets if d.columns}
+    stale: list[ObjectMeta] = []
+    fresh: dict[str, Dataset] = {}
+    for meta in metas:
+        prior_ds = prior_by_id.get(meta.identifier)
+        if prior_ds is None or prior_ds.profiled_at is None:
+            stale.append(meta)
+            continue
+        try:
+            profiled_at = datetime.fromisoformat(prior_ds.profiled_at)
+        except ValueError:
+            stale.append(meta)
+            continue
+        if now - profiled_at > max_age:
+            stale.append(meta)
+            continue
+        # The same free, no-scan metadata call profile() makes first: confirms
+        # the schema has not drifted since the cached profile was written.
+        _meta, columns = adapter.table_metadata(meta.identifier)
+        if _column_signature(columns) != _column_signature(prior_ds.columns):
+            stale.append(meta)
+            continue
+        fresh[meta.identifier] = prior_ds.model_copy(deep=True)
+    return stale, fresh
 
 
 def _compose_datasets(

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -142,6 +143,89 @@ def test_unconfirmed_map_estimates_selected_objects(
     # needs a partition filter, so it contributes zero.
     assert envelope.cost.estimate == 2 * 10 * MB
     assert all(c.dry_run for c in fake_bq_client.query_calls)
+
+
+def _fresh_bq_dataset(identifier: str, columns, *, now: str) -> Dataset:
+    """A same-connector prior profile stamped just now, so skip-if-cached treats
+    it as fresh. Column signatures mirror the fake BigQuery schema exactly so the
+    pre-profile metadata check finds no drift."""
+
+    return Dataset(
+        identifier=identifier,
+        row_count=100,
+        columns=columns,
+        candidate_keys=[["id"]],
+        grain=["id"],
+        profiled_at=now,
+    )
+
+
+def _seed_bq_map_cache(tmp_path: Path, *, identifiers: set[str]) -> None:
+    """Seed a bigquery-connector cache holding fresh profiles for the named
+    objects (schema-matching the fake client's tables)."""
+
+    now = datetime.now(UTC).isoformat()
+    catalog = {
+        "test-proj.shop.customers": [
+            ColumnProfile(name="id", data_type="INTEGER", nullable=False),
+            ColumnProfile(name="email", data_type="STRING", nullable=True),
+        ],
+        "test-proj.shop.events": [
+            ColumnProfile(name="id", data_type="INTEGER", nullable=True),
+            ColumnProfile(name="payload", data_type="STRUCT", nullable=True),
+            ColumnProfile(name="labels", data_type="ARRAY<STRING>", nullable=True),
+        ],
+        "test-proj.logs.requests": [
+            ColumnProfile(name="day", data_type="DATE", nullable=True),
+        ],
+    }
+    cache = DexCache(
+        datasets=[
+            _fresh_bq_dataset(identifier, catalog[identifier], now=now)
+            for identifier in identifiers
+        ]
+    )
+    cache.provenance.connector = "bigquery"
+    DexStore(tmp_path).save_cache(cache)
+
+
+def test_unconfirmed_map_excludes_fresh_cached_objects(
+    fake_bq_client, route_adapter, tmp_path
+):
+    """A fresh cached profile for customers is excluded from the preflight
+    estimate and its per-table breakdown; only the stale events is priced."""
+
+    _seed_bq_map_cache(tmp_path, identifiers={"test-proj.shop.customers"})
+    route_adapter(fake_bq_client)
+    envelope = explore_cmds.cmd_map(_args(tmp_path, subcommand="map"))
+    assert envelope.status.value == "needs_confirmation"
+    # Only events is priced now (customers is fresh-cached, requests is
+    # partition-filtered to zero), so the estimate halves versus the no-cache run.
+    assert envelope.cost.estimate == 10 * MB
+    assert "test-proj.shop.customers" not in envelope.data["per_table_bytes"]
+    assert any("fresh-cached" in note for note in envelope.data["notes"])
+    assert all(c.dry_run for c in fake_bq_client.query_calls)
+
+
+def test_fully_fresh_map_needs_no_confirmation(fake_bq_client, route_adapter, tmp_path):
+    """When every object is fresh-cached there is nothing to scan: the billed
+    handshake is skipped entirely and the run completes without confirmation."""
+
+    _seed_bq_map_cache(
+        tmp_path,
+        identifiers={
+            "test-proj.shop.customers",
+            "test-proj.shop.events",
+            "test-proj.logs.requests",
+        },
+    )
+    route_adapter(fake_bq_client)
+    envelope = explore_cmds.cmd_map(_args(tmp_path, subcommand="map"))
+    assert envelope.status.value == "ok"
+    assert envelope.data["profiled_count"] == 0
+    assert envelope.data["cache_hit_count"] == 3
+    # No estimate and no scan: not even a dry-run job was issued.
+    assert fake_bq_client.query_calls == []
 
 
 def test_unconfirmed_relationships_recommends_map(

--- a/packages/dex-core/tests/explore/test_explore.py
+++ b/packages/dex-core/tests/explore/test_explore.py
@@ -166,6 +166,62 @@ def test_relationships_infers_orders_to_customers(duckdb_file: Path, capsys):
     assert fk["confidence"] and fk["confidence"] >= 0.6
 
 
+def test_relationships_reuses_fresh_cached_profiles(
+    duckdb_file: Path, tmp_path: Path, capsys
+):
+    """A second `explore relationships` with nothing changed re-scans nothing,
+    yet still re-infers joins over the reused profiles and can be forced to
+    re-profile with --refresh."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    argv = [
+        "explore",
+        "relationships",
+        "--path",
+        str(duckdb_file),
+        "--repo-root",
+        str(repo),
+    ]
+    _run(argv, capsys)
+    store = DexStore(repo)
+    first_stamps = {d.identifier: d.profiled_at for d in store.load_cache().datasets}
+
+    payload = _run(argv, capsys)
+    assert payload["data"]["profiled_count"] == 0
+    assert payload["data"]["cache_hit_count"] == 2
+    # Inference still runs over the reused profiles, so the join survives.
+    assert payload["data"]["inferred_count"] >= 1
+    assert any("reused 2 fresh cached profile" in n for n in payload["data"]["notes"])
+    assert {
+        d.identifier: d.profiled_at for d in store.load_cache().datasets
+    } == first_stamps
+
+    refreshed = _run([*argv, "--refresh"], capsys)
+    assert refreshed["data"]["profiled_count"] == 2
+    assert refreshed["data"]["cache_hit_count"] == 0
+
+
+def test_relationships_freshness_zero_disables_reuse(
+    duckdb_file: Path, tmp_path: Path, capsys
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    save_config(DexConfig(profile_freshness_hours=0.0), repo)
+    argv = [
+        "explore",
+        "relationships",
+        "--path",
+        str(duckdb_file),
+        "--repo-root",
+        str(repo),
+    ]
+    _run(argv, capsys)
+    payload = _run(argv, capsys)
+    assert payload["data"]["profiled_count"] == 2
+    assert payload["data"]["cache_hit_count"] == 0
+
+
 # --- map ---------------------------------------------------------------------
 
 
@@ -266,8 +322,11 @@ def test_map_carries_forward_prior_profiles(
     first_stamps = {d.identifier: d.profiled_at for d in store.load_cache().datasets}
     assert all(first_stamps.values()), "a full map stamps every profile"
 
-    payload = _run(argv, capsys)
+    # --refresh forces the selected top-25 back through profiling (fresh stamp),
+    # isolating the below-cutoff carry-forward path from skip-if-cached reuse.
+    payload = _run([*argv, "--refresh"], capsys)
     assert payload["data"]["profiled_count"] == 25
+    assert payload["data"]["cache_hit_count"] == 0
     assert payload["data"]["carried_forward_count"] == 35
     assert any("carried forward 35" in n for n in payload["data"]["notes"])
 
@@ -280,6 +339,130 @@ def test_map_carries_forward_prior_profiles(
         if d.profiled_at == first_stamps[d.identifier]
     ]
     assert len(unchanged) == 35, "carried profiles keep their original stamp"
+
+
+def test_map_reuses_fresh_cached_profiles(
+    many_tables_duckdb: Path, tmp_path: Path, capsys
+):
+    """A second `map --full` with nothing changed re-scans nothing: every
+    selected object is served from the fresh cache, stamps untouched."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    argv = [
+        "explore",
+        "map",
+        "--path",
+        str(many_tables_duckdb),
+        "--repo-root",
+        str(repo),
+        "--full",
+    ]
+    _run(argv, capsys)
+    store = DexStore(repo)
+    first_stamps = {d.identifier: d.profiled_at for d in store.load_cache().datasets}
+
+    payload = _run(argv, capsys)
+    assert payload["data"]["profiled_count"] == 0
+    assert payload["data"]["cache_hit_count"] == 60
+    assert payload["data"]["skipped_count"] == 0
+    assert any("reused 60 fresh cached profile" in n for n in payload["data"]["notes"])
+
+    cache = store.load_cache()
+    assert all(d.columns for d in cache.datasets)
+    assert {d.identifier: d.profiled_at for d in cache.datasets} == first_stamps, (
+        "reused profiles keep their original stamp; nothing was re-scanned"
+    )
+
+
+def test_map_reprofiles_only_the_schema_changed_object(
+    many_tables_duckdb: Path, tmp_path: Path, capsys
+):
+    """Altering one table's columns between two `map --full` runs re-profiles
+    only that object; the rest stay fresh cache hits."""
+
+    duckdb = pytest.importorskip("duckdb")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    argv = [
+        "explore",
+        "map",
+        "--path",
+        str(many_tables_duckdb),
+        "--repo-root",
+        str(repo),
+        "--full",
+    ]
+    _run(argv, capsys)
+    store = DexStore(repo)
+    first_stamps = {d.identifier: d.profiled_at for d in store.load_cache().datasets}
+
+    conn = duckdb.connect(str(many_tables_duckdb))
+    conn.execute("ALTER TABLE t_00 ADD COLUMN extra VARCHAR")
+    conn.close()
+
+    payload = _run(argv, capsys)
+    assert payload["data"]["profiled_count"] == 1
+    assert payload["data"]["cache_hit_count"] == 59
+
+    cache = store.load_cache()
+    reprofiled = [
+        d.identifier
+        for d in cache.datasets
+        if d.profiled_at != first_stamps[d.identifier]
+    ]
+    assert len(reprofiled) == 1
+    assert reprofiled[0].endswith(".t_00")
+    altered = next(d for d in cache.datasets if d.identifier.endswith(".t_00"))
+    assert any(c.name == "extra" for c in altered.columns), (
+        "re-profile saw the new column"
+    )
+
+
+def test_map_freshness_zero_disables_reuse(
+    many_tables_duckdb: Path, tmp_path: Path, capsys
+):
+    """profile_freshness_hours: 0 forces a re-profile of every selected object
+    even when the schema is unchanged and the cache was just written."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    save_config(DexConfig(profile_freshness_hours=0.0), repo)
+    argv = [
+        "explore",
+        "map",
+        "--path",
+        str(many_tables_duckdb),
+        "--repo-root",
+        str(repo),
+        "--full",
+    ]
+    _run(argv, capsys)
+    payload = _run(argv, capsys)
+    assert payload["data"]["profiled_count"] == 60
+    assert payload["data"]["cache_hit_count"] == 0
+
+
+def test_map_refresh_forces_full_reprofile(
+    many_tables_duckdb: Path, tmp_path: Path, capsys
+):
+    """`--refresh` re-scans every selected object even when all are fresh."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    argv = [
+        "explore",
+        "map",
+        "--path",
+        str(many_tables_duckdb),
+        "--repo-root",
+        str(repo),
+        "--full",
+    ]
+    _run(argv, capsys)
+    payload = _run([*argv, "--refresh"], capsys)
+    assert payload["data"]["profiled_count"] == 60
+    assert payload["data"]["cache_hit_count"] == 0
 
 
 def test_cache_without_new_fields_still_loads():

--- a/packages/dex-core/tests/maintain/test_volume.py
+++ b/packages/dex-core/tests/maintain/test_volume.py
@@ -58,7 +58,10 @@ def test_axis_results_merge_in_drift_json(maintain_repo):
     # Accepting the new state means re-mapping and re-snapshotting (the
     # documented discipline); that invalidates the report, so axes measured
     # against the old baseline drop rather than lingering as stale findings.
-    _rc, payload = maintain_repo.dex("explore", "map")
+    # --refresh forces a full re-profile: skip-if-cached would otherwise reuse
+    # the still-fresh, schema-unchanged profiles (including orders' pre-DELETE
+    # row count), which is precisely the volume-only change reuse cannot see.
+    _rc, payload = maintain_repo.dex("explore", "map", "--refresh")
     assert payload["status"] == "ok"
     maintain_repo.snapshot()
     _rc, payload = maintain_repo.dex("maintain", "volume")

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -177,7 +177,14 @@ stale manifest (older than the model sources) is noted, not trusted silently.
 `profile_top_n` (default 25) by rank and announces the cutoff in `notes`
 alongside `skipped_count` (`--full` profiles everything). Objects skipped on a
 re-map carry their prior profiles forward (`carried_forward_count`), each
-stamped with its own `profiled_at`.
+stamped with its own `profiled_at`. A selected object whose cached profile is
+still fresh (same connector, schema unchanged, profiled within
+`profile_freshness_hours`, default 24; `0` disables reuse) is reused without a
+re-scan and reported as `cache_hit_count`, so it never enters the cost preflight
+or the billed handshake. `--refresh` forces a full re-profile of every selected
+object even when the cache is fresh, for a source that changed in a way the free
+metadata check cannot see. `explore relationships` reuses fresh profiles the
+same way (`cache_hit_count`); both accept `--refresh`.
 
 Global flags (shared resolution path): `--connector`, `--path` (DuckDB),
 `--scope`, `--project` and `--dataset` (BigQuery only), `--repo-root`,

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -47,7 +47,13 @@ Subcommands, in the usual order:
    rank and says so in `notes` (with `skipped_count`); pass `--full` to profile
    everything. On a re-map, objects skipped this run keep their prior profiles
    (`carried_forward_count`), each stamped with its own `profiled_at` so
-   staleness is visible instead of column detail silently vanishing.
+   staleness is visible instead of column detail silently vanishing. A selected
+   object whose cached profile is still fresh (same connector, schema unchanged,
+   profiled within `profile_freshness_hours`, default 24) is reused without a
+   re-scan (`cache_hit_count`), so re-runs cost nothing to spend; pass
+   `--refresh` to force a full re-profile when the source changed in a way the
+   free metadata check cannot see (e.g. rows changed but the schema did not).
+   `explore relationships` reuses fresh profiles the same way.
 6. `explore query "<SELECT ...>"` answers an ad-hoc question the fixed commands
    don't cover: you write the SQL, the engine's query firewall refuses or bounds
    it. Requires the `.dex/` cache (run `map` first). Results come back columnar


### PR DESCRIPTION
## Summary

`explore map` and `explore relationships` re-profiled every selected object
from scratch on every run, even when `.dex/cache.json` already held a fresh
profile from an earlier run. Iterative workflows (map, tweak, map again) and
`--verify` re-runs paid full profiling cost every time, even when nothing
changed.

Before profiling a selected object, both commands now check the cache for a
same-connector, schema-matching, recently-profiled entry and reuse it wholesale
instead of re-scanning — mirroring the reuse `_compose_datasets` already did
for unselected (below-rank-cutoff) objects, just gated by freshness instead of
by rank.

## Changes

- **`_split_fresh_stale`** (`explore/commands.py`): splits a selected set into
  `stale` (needs profiling) and `fresh_reused` (served from cache). An object
  is fresh only if: `--refresh` was not passed, the prior cache is from the
  same connector, it has a prior profile with columns and a `profiled_at`
  within `profile_freshness_hours`, and its column signature (name, type,
  nullable) still matches the warehouse's free `table_metadata()` call.
  Fail-closed throughout — any doubt re-profiles.
- **`cmd_map` / `cmd_relationships`**: only `stale` objects are estimated,
  enter the billed handshake, and get scanned. When nothing is stale, the
  handshake and scan are skipped entirely. Reused datasets are not
  re-annotated (they already carry their annotations from the run that wrote
  them) and rejoin the freshly-profiled set for inference/compose/merge.
- New envelope field **`cache_hit_count`**, distinct from
  `carried_forward_count` (rank-cutoff carry-forward is a different axis).
  `skipped_count` is now decoupled from `len(profiled)`. New reuse notes on
  both the success envelope and the billed-handshake estimate.
- New **`--refresh` flag** on `map`/`relationships`: forces a full re-profile
  of every selected object, for callers who know the source changed in a way
  the cheap metadata check can't see.
- New **`profile_freshness_hours`** config knob (`DexConfig`, default `24.0`;
  `0` disables reuse). No cache schema change — `Dataset.profiled_at` and
  stored columns already carry everything the check needs.

## Changes
This closes #96 

## Design interaction worth flagging

The freshness check is **schema + time only, not row-count**. `table_metadata()`
returns an *estimated* row count on Postgres and Redshift (planner stats), so
using it in the freshness gate would either produce false staleness noise on
every run there, or require excluding those connectors inconsistently. Schema
signature was the only cheap, exact, cross-connector signal available.

**Consequence:** a volume-only change (rows added/deleted, no schema change)
within the freshness window is invisible to a default re-map — it will be
served from cache. This surfaced in
`tests/maintain/test_volume.py::test_axis_results_merge_in_drift_json`, whose
"accept new state → re-map → re-snapshot" step relied on `explore map` seeing
a post-DELETE row count; that test now passes `--refresh` explicitly, which is
the intended escape hatch for this exact case.

This is a deliberate tradeoff (matches the plan's schema-drift-only design,
paralleling `maintain/drift.py`'s schema axis), but it's worth calling out
explicitly: **`explore map` is no longer sufficient by itself to refresh
volume/row-count in the cache** within the freshness window. Any workflow that
depends on `map` picking up a pure data change (not a schema change) needs
`--refresh` or `profile_freshness_hours: 0`.

## Testing

- `uv run pytest` — 966 passed, 68 skipped (connector-extra tests requiring
  optional deps), 0 failed.
- New tests cover: reuse across identical re-runs, re-profiling only the
  schema-changed object, `profile_freshness_hours: 0`, `--refresh`, the
  `relationships` equivalents, and two BigQuery billed-handshake tests
  (fresh-cached objects excluded from the preflight estimate; a fully-fresh
  re-run needs no confirmation and issues zero jobs).
- `ruff check` / `ruff format --check` clean.