### PR TITLE
SCRUM-934-suppress generic-name relationship collisions before verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   still fails immediately), across a window wide enough to cover the wake. A
   per-attempt connect timeout bounds a stalled handshake and is cleared once the
   connection is up so it never caps a later billed query's result read.
+- **Relationship inference no longer floods `--verify` with generic id-column
+  collisions** ([#77]). On warehouses where many unrelated tables share a
+  generic id-shaped column name (the norm for Firestore/Mongo/DynamoDB-style
+  CDC exports, e.g. every collection has its own `document_id`), name-based
+  inference matched every such pair as a candidate join, spending real verify
+  query cost confirming what was, essentially always, a naming convention
+  rather than a relationship. A same-named-FK match is now withheld when its
+  column name is held as a key by three or more unrelated datasets, and the
+  withheld count and names are surfaced in `explore relationships`/`explore
+  map`'s notes instead of silently inferring less.
 
 ## [1.2.1] - 2026-07-17
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -310,7 +310,8 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
             over_ceiling = True
 
         if not over_ceiling:
-            inferred = rel_mod.infer_relationships(datasets)
+            suppressed: list[rel_mod.SuppressedMatch] = []
+            inferred = rel_mod.infer_relationships(datasets, suppressed=suppressed)
             if verify:
                 verify_reporter = _reporter(len(inferred), "verified", "joins")
                 rel_mod.verify_relationships(
@@ -361,6 +362,7 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
             f"{mirrored_objects} object(s) mirror source lineage (a dev/replica "
             "dataset mapped alongside its source)"
         )
+    notes.extend(_generic_name_notes(suppressed))
 
     # Persist the profiles this run already paid for. Because relationships
     # inventories and profiles the full set and infers across all of it, its
@@ -528,7 +530,8 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
 
         if not over_ceiling:
             _annotate_grain(profiled, defs)
-            inferred = rel_mod.infer_relationships(profiled)
+            suppressed: list[rel_mod.SuppressedMatch] = []
+            inferred = rel_mod.infer_relationships(profiled, suppressed=suppressed)
             if getattr(args, "verify", False):
                 verify_reporter = _reporter(len(inferred), "verified", "joins")
                 rel_mod.verify_relationships(
@@ -603,6 +606,7 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
             f"{mirrored_objects} object(s) mirror source lineage (a dev/replica "
             "dataset mapped alongside its source)"
         )
+    notes.extend(_generic_name_notes(suppressed))
 
     pii_columns = sum(1 for d in profiled for c in d.columns if c.pii is not None)
     quality_notes = sum(len(d.data_quality) for d in profiled)
@@ -1150,6 +1154,30 @@ def _relationship_notes(
     if not fk_columns:
         notes.append("no id-shaped columns found, so there was nothing to infer from")
     return notes
+
+
+def _generic_name_notes(suppressed: list[rel_mod.SuppressedMatch]) -> list[str]:
+    """Explain what a generic shared id-column name cost inference, so the
+    withheld count doesn't read as "nothing more to find" when it's really
+    "found, and declined to trust".
+
+    Empty when nothing was withheld: the common case on warehouses without a
+    CDC-style universal id column.
+    """
+
+    if not suppressed:
+        return []
+    names = sorted({s.shared_name for s in suppressed})
+    max_hosts = max(s.host_count for s in suppressed)
+    shown = ", ".join(names[:5])
+    more = f", +{len(names) - 5} more" if len(names) > 5 else ""
+    return [
+        f"declined to infer {len(suppressed)} candidate join(s) that matched only "
+        f"on a column name shared as a key by {max_hosts} unrelated object(s) "
+        f"({shown}{more}); a name shared this widely (the norm for Firestore/"
+        "Mongo/DynamoDB-style CDC exports) is a naming convention, not evidence "
+        "of a relationship, so these never reached --verify"
+    ]
 
 
 def _select_for_profiling(

--- a/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
@@ -13,6 +13,7 @@ work without a dbt project).
 from __future__ import annotations
 
 import re
+from typing import NamedTuple
 
 from ..adapters.base import Adapter
 from ..cache import (
@@ -42,6 +43,30 @@ _ID_SUFFIXES = ("id", "key")
 # doesn't hide a shared suffix. Bounded to 3 chars so a genuine entity name
 # (`customer_id`) is never mistaken for an alias.
 _COLUMN_ALIAS_PREFIX = re.compile(r"^[a-z]{1,3}_", re.IGNORECASE)
+
+# A single-column key name held, verbatim, by this many or more datasets is a
+# naming convention rather than a specific entity's identifier: CDC exports
+# from Firestore/Mongo/DynamoDB-style sources routinely name every
+# collection's own id column identically (`document_id` in all ~90 of them),
+# and two tables merely sharing that name is not evidence they're related.
+# Below this, a shared name is still a useful same-named-FK signal; at or
+# above it, matching on the bare name alone degenerates into a near-complete
+# cross product on this class of source (issue #77). Only the same-named-FK
+# tier of `_match_parent` needs this guard: the entity-name tier already ties
+# a match to one specific parent by name, and the dealiased tier already
+# refuses a match that collapses to a bare suffix, so neither is vulnerable to
+# a name that's merely popular.
+_GENERIC_NAME_MIN_HOSTS = 3
+
+
+class SuppressedMatch(NamedTuple):
+    """A same-named-FK match withheld because the shared name is too generic
+    to trust (see `_GENERIC_NAME_MIN_HOSTS`). Recorded so a caller can report
+    what inference declined to verify, and why, instead of silently doing
+    less."""
+
+    shared_name: str
+    host_count: int
 
 
 def _fk_stem(column_name: str) -> str | None:
@@ -131,16 +156,41 @@ def detect_grain(dataset: Dataset) -> list[str] | None:
     return by_card[0]
 
 
-def infer_relationships(datasets: list[Dataset]) -> list[Relationship]:
+def _key_host_counts(keyed: dict[str, list[list[str]]]) -> dict[str, int]:
+    """How many distinct datasets hold each single-column key name (lowercased).
+
+    A name held as a key by only one or two datasets is a specific entity's own
+    identifier; held by many, it is a naming convention rather than a reference
+    (see `_GENERIC_NAME_MIN_HOSTS`). Metadata-only: derived entirely from the
+    candidate keys already computed at profile time, no extra queries.
+    """
+
+    counts: dict[str, int] = {}
+    for keys in keyed.values():
+        names = {k[0].lower() for k in keys if len(k) == 1}
+        for name in names:
+            counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+def infer_relationships(
+    datasets: list[Dataset], *, suppressed: list[SuppressedMatch] | None = None
+) -> list[Relationship]:
     """Infer many-to-one joins from column names, type compatibility, and the
     aggregate signals already profiled (uniqueness, distinct counts, min/max).
 
     A parent whose key is not unique still yields a join, at reduced confidence:
     suppressing it entirely would hide a real join behind a data-quality problem
     that :func:`data_quality_notes` reports separately.
+
+    A same-named-FK match withheld as a generic-name collision (see
+    `_GENERIC_NAME_MIN_HOSTS`) is recorded to ``suppressed`` when a caller
+    passes a list, so the withheld count and the names involved can be
+    reported; the default ``None`` costs nothing extra.
     """
 
     keyed = {d.identifier: candidate_keys(d) for d in datasets}
+    host_counts = _key_host_counts(keyed)
     relationships: list[Relationship] = []
 
     for child in datasets:
@@ -151,7 +201,9 @@ def infer_relationships(datasets: list[Dataset]) -> list[Relationship]:
             for parent in datasets:
                 if parent.identifier == child.identifier:
                     continue
-                match = _match_parent(col, stem, parent, keyed[parent.identifier])
+                match = _match_parent(
+                    col, stem, parent, keyed[parent.identifier], host_counts, suppressed
+                )
                 if match is not None:
                     to_columns, confidence = match
                     relationships.append(
@@ -520,6 +572,8 @@ def _match_parent(
     stem: str,
     parent: Dataset,
     parent_keys: list[list[str]],
+    host_counts: dict[str, int],
+    suppressed: list[SuppressedMatch] | None,
 ) -> tuple[list[str], float] | None:
     parent_table = parent.identifier.rsplit(".", 1)[-1]
     stripped = _LAYER_PREFIX.sub("", parent_table)
@@ -550,11 +604,19 @@ def _match_parent(
                 return [pcol.name], _score(base, col, pcol)
 
     # Same-named foreign key shared by both tables (e.g. customer_id in both),
-    # joining to the parent's key of that name.
+    # joining to the parent's key of that name. Trusted only when the name
+    # isn't itself a generic convention shared by many unrelated datasets'
+    # own keys (_GENERIC_NAME_MIN_HOSTS) — otherwise every table sharing the
+    # convention would cross-match every other, as CDC exports do.
     if fk in parent_cols and fk in parent_key_names:
         pcol = parent_cols[fk]
         if _type_compatible(col.data_type, pcol.data_type):
-            return [pcol.name], _score(0.6, col, pcol)
+            host_count = host_counts.get(fk, 0)
+            if host_count >= _GENERIC_NAME_MIN_HOSTS:
+                if suppressed is not None:
+                    suppressed.append(SuppressedMatch(fk, host_count))
+            else:
+                return [pcol.name], _score(0.6, col, pcol)
 
     # Same key suffix once each side's table-alias prefix is stripped: TPC-H
     # names a foreign key after the *child's* alias, not the parent's entity

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -255,6 +255,68 @@ def test_tpch_alias_prefixed_keys_are_inferred():
     assert ("db.tpch.nation", "N_REGIONKEY", "db.tpch.region") in found
 
 
+def _cdc_collections(n: int) -> list[Dataset]:
+    """`n` unrelated tables, each with its own `document_id` unique key, shaped
+    like a Firestore/Mongo/DynamoDB-style CDC export."""
+
+    return [
+        _ds(
+            f"db.main.collection_{i}",
+            [_col("document_id", distinct=5, unique=True)],
+            rows=5,
+        )
+        for i in range(n)
+    ]
+
+
+def test_generic_id_name_shared_across_many_tables_is_not_matched():
+    """A column name that's the norm for every collection in Firestore/Mongo/
+    DynamoDB-style CDC exports (e.g. `document_id`) is a naming convention, not
+    a reference: matching on it alone across many unrelated tables would
+    otherwise generate a near-complete cross product (issue #77)."""
+
+    assert infer_relationships(_cdc_collections(4)) == []
+
+
+def test_generic_id_name_match_is_recorded_as_suppressed():
+    suppressed: list = []
+    assert infer_relationships(_cdc_collections(4), suppressed=suppressed) == []
+    assert len(suppressed) == 4 * 3  # every ordered (child, parent) pair
+    assert all(s.shared_name == "document_id" for s in suppressed)
+    assert all(s.host_count == 4 for s in suppressed)
+
+
+def test_generic_name_threshold_is_three_hosts():
+    """Below the threshold, a shared exact key name is an ordinary same-named
+    FK; at or above it, it's treated as a naming convention."""
+
+    two_hosts = [
+        _ds(f"db.main.t{i}", [_col("thing_id", distinct=2, unique=True)], rows=2)
+        for i in range(2)
+    ]
+    assert len(infer_relationships(two_hosts)) == 2  # each matches the other
+
+    three_hosts = [
+        _ds(f"db.main.t{i}", [_col("thing_id", distinct=2, unique=True)], rows=2)
+        for i in range(3)
+    ]
+    assert infer_relationships(three_hosts) == []
+
+
+def test_shared_key_name_below_generic_threshold_still_matches():
+    """A same-named FK shared by only one other table (accounts.customer_id and
+    orders.customer_id, with no entity-name tie to `orders`) is a real signal,
+    not a naming convention, and must still be inferred."""
+
+    accounts = _ds(
+        "db.main.accounts", [_col("customer_id", distinct=2, unique=True)], rows=2
+    )
+    orders = _ds("db.main.orders", [_col("customer_id", distinct=2)], rows=5)
+    rels = infer_relationships([accounts, orders])
+    assert len(rels) == 1
+    assert rels[0].to_dataset == "db.main.accounts"
+
+
 def test_dealiased_match_skips_when_stripped_to_a_bare_suffix():
     """`x_key` / `y_key` collapse to the bare suffix `key` once dealiased; that's
     too generic to trust, so two unrelated single-letter-prefixed keys must not


### PR DESCRIPTION
## Summary
- On a warehouse where ~90 unrelated tables share a generic per-collection id
  column (the norm for Firestore/Mongo/DynamoDB-style CDC exports, e.g.
  `document_id`), relationship inference's "same-named foreign key" tier
  matched every such pair as a candidate join, purely because they shared a
  column name — no entity-name evidence involved. This generated a
  near-complete cross product (448 candidates in the reported case) that
  `--verify` would then spend real query cost confirming as spurious.
- Added a cheap, metadata-only pre-filter: a same-named-FK match is withheld
  when its column name is held as a single-column key by
  `_GENERIC_NAME_MIN_HOSTS` (3) or more unrelated datasets. Below that, a
  shared name is still a valid same-named-FK signal, so ordinary two-table
  cases are unaffected.
- Withheld matches are recorded and surfaced as a note on `explore
  relationships`/`explore map` (count, shared name(s), host count), so the
  filtering is visible instead of the result silently looking like "nothing
  more to find."
- The other two matching tiers didn't need changes: the entity-name tier
  already ties a match to one specific parent by name, and the dealiased
  tier already refuses a match that collapses to a bare suffix.

tested the issue before : 
<img width="1625" height="427" alt="Screenshot 2026-07-17 110847" src="https://github.com/user-attachments/assets/17f3acc9-7fb9-4302-ba88-aa3fb6110a7c" />

After the fix: 

<img width="1622" height="217" alt="Screenshot 2026-07-17 111511" src="https://github.com/user-attachments/assets/bda8e358-d088-4f58-b88f-e47632f3cc21" />
