### PR TITLE
Issue 73: .dex/config.yml resolution and fixed fault DuckDB default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,13 @@ Install the engine with the connector extra you use: `exmergo-dex-core[duckdb]`
 for the zero-credential on-ramp, or `[snowflake]`, `[bigquery]`, `[databricks]`,
 `[postgres]`, `[redshift]`, or `[all]` for every connector at once. The shipped wrapper pins
 only the engine version and selects that extra for you at runtime from the active
-connector (an explicit `--connector`, then `.dex/config.yml`, then DuckDB), so a
-release is connector-neutral.
+connector (an explicit `--connector`, then the `connector:` in the `.dex/config.yml`
+found by walking up from the run directory to the git root, then DuckDB), so a
+release is connector-neutral. The engine resolves the same way but does not default
+silently: with no `.dex/config.yml` anywhere up the tree and no explicit
+`--connector`/`--path`, it refuses and names the fix rather than reading a phantom
+DuckDB target, so a command run from a subdirectory of your project resolves the
+project's real config instead of a wrong default.
 
 | Subcommand | Returns |
 |---|---|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **`.dex/config.yml` resolves from any subdirectory instead of silently
+  defaulting to DuckDB.** Config was only ever looked for relative to the run
+  directory, so a command issued from a subdirectory of a project (a scaffolded
+  dbt project folder, say) found no config and fell back to a default whose
+  connector is `duckdb`. The failure then surfaced far downstream as a phantom
+  "config and profiles disagree about the connector" error naming a `duckdb` that
+  appears in no file on disk. dex now walks up from the run directory to the
+  enclosing git repository looking for the `.dex/config.yml` that owns the tree,
+  the way git and dbt find their project roots, so the current directory no longer
+  matters. The walk anchors on the config file (a subdirectory holding only a
+  `.dex/` cache never shadows the real config higher up) and stops at the git root
+  (a stray `.dex/config.yml` above the repo can never capture the session). When
+  no config is found anywhere and no `--connector`/`--path` is given, dex refuses
+  and names the fix rather than reading a wrong default. The skill wrapper that
+  picks the install extra walks up the same way, so a subdirectory run installs
+  the project's real connector, not the DuckDB on-ramp.
 - **Redshift connections survive a Serverless cold start.** An idle Serverless
   workgroup resumes on first contact, and a slow resume can reset the startup
   handshake, so the first command to touch a cold workgroup failed hard while

--- a/packages/dex-core/src/exmergo_dex_core/command_args.py
+++ b/packages/dex-core/src/exmergo_dex_core/command_args.py
@@ -16,12 +16,50 @@ from pathlib import Path
 
 from . import envelope as env
 from .adapters.base import Adapter
+from .cache import DEX_DIR
+from .config import CONFIG_FILE
 from .connect import open_adapter
 from .guards.cost_guard import ConfirmationRequiredError, CostGate
 
 
+def _resolve_dex_root(start: Path) -> Path | None:
+    """Nearest ancestor of ``start`` holding a ``.dex/config.yml``, or None.
+
+    dex is used like git or dbt: the config lives at the project root, but
+    commands are run from anywhere inside the tree. So resolution walks up rather
+    than trusting the current directory to be the root. The enclosing git repo is
+    the ceiling, and a project without one does not walk above ``start`` at all,
+    so a stray ``~/.dex/config.yml`` can never capture a session run from inside a
+    real project. Anchoring on the file (not just a ``.dex/`` directory) means a
+    subdirectory that holds only a ``.dex/`` cache never shadows the real config
+    higher up.
+    """
+
+    start = start.resolve()
+    ceiling = start
+    for directory in (start, *start.parents):
+        if (directory / ".git").exists():
+            ceiling = directory
+            break
+    for directory in (start, *start.parents):
+        if (directory / DEX_DIR / CONFIG_FILE).is_file():
+            return directory
+        if directory == ceiling:
+            break
+    return None
+
+
 def repo_root(args: argparse.Namespace) -> str:
-    return getattr(args, "repo_root", ".")
+    """The project root every command-layer path keys off (config load, cache
+    store, dbt discovery, dev-target preflight). Resolved by walking up from the
+    ``--repo-root`` run directory to the ``.dex/config.yml`` that owns it; when
+    none is found the raw value is returned unchanged, so the no-config paths
+    (an explicit ``--connector``/``--path`` read, or the loud refusal in
+    ``open_adapter``) behave as designed."""
+
+    raw = getattr(args, "repo_root", ".")
+    resolved = _resolve_dex_root(Path(raw))
+    return str(resolved) if resolved is not None else raw
 
 
 def open_from_args(args: argparse.Namespace) -> Adapter:

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -261,6 +261,12 @@ class DexConfig(BaseModel):
     """The shape of ``.dex/config.yml``: one optional target per connector plus
     the connector selection, budgets, and engine limits."""
 
+    # The DuckDB on-ramp: a config that omits `connector:` (or a bare `--path`
+    # read with no config) means the free local connector. This default only
+    # applies to a config that actually exists or an explicit `--path`; it is NOT
+    # a fallback for a missing config. `open_adapter` refuses when no config
+    # resolves and nothing explicit is given, rather than fabricating a duckdb
+    # target, so this default can never stand in for a config that was not found.
     connector: str = "duckdb"
     duckdb: DuckDBTarget | None = None
     bigquery: BigQueryTarget | None = None

--- a/packages/dex-core/src/exmergo_dex_core/connect.py
+++ b/packages/dex-core/src/exmergo_dex_core/connect.py
@@ -103,14 +103,37 @@ def open_adapter(
     ignored by free ones; ``command`` labels ledger entries.
     """
 
-    config = load_config(repo_root) or DexConfig()
+    loaded = load_config(repo_root)
+    if loaded is None and connector is None and path is None:
+        # No config resolved anywhere up the tree, and nothing explicit to fall
+        # back on. Refusing here (rather than defaulting to duckdb) is the
+        # connector-selection half of "no silent connector default": a run from a
+        # subdirectory with a real config higher up is fixed by the walk-up in
+        # command_args, so reaching this point means there is genuinely nothing.
+        raise ValueError(
+            f"no .dex/config.yml found searching from '{repo_root}' up to the git "
+            "root: run inside your dex project, pass --repo-root, or pass "
+            "--connector/--path for an ad-hoc read"
+        )
+    config = loaded or DexConfig()
     connector = connector or config.connector
     assert_scope_vocabulary(
         connector, project=project, datasets=datasets, scopes=scopes
     )
 
     if connector == "duckdb":
-        resolved = path or (config.duckdb.path if config.duckdb else None)
+        if path:
+            # A live --path is typed in the user's shell, so it stays relative to
+            # the process cwd.
+            resolved = path
+        elif config.duckdb and config.duckdb.path:
+            # A committed duckdb.path is relative to the config's project root, not
+            # the cwd, so the same target resolves from any subdirectory (config
+            # is now found by walking up). An absolute path is left untouched.
+            target = Path(config.duckdb.path)
+            resolved = str(target if target.is_absolute() else Path(repo_root) / target)
+        else:
+            resolved = None
         if not resolved:
             raise ValueError(
                 "no DuckDB path: pass --path or set duckdb.path in .dex/config.yml"

--- a/packages/dex-core/tests/adapters/test_connect_duckdb.py
+++ b/packages/dex-core/tests/adapters/test_connect_duckdb.py
@@ -75,3 +75,28 @@ def test_distinct_combination_counts_are_exact(duckdb_file: Path):
 def test_open_adapter_requires_a_path():
     with pytest.raises(ValueError):
         open_adapter(connector="duckdb", path=None, repo_root="/nonexistent-root")
+
+
+def test_committed_duckdb_path_resolves_against_repo_root_not_cwd(
+    duckdb_file: Path, tmp_path: Path, monkeypatch
+):
+    # A relative duckdb.path in .dex/config.yml is a committed target, so it must
+    # resolve against the project root the config lives in, not the process cwd.
+    # This is what lets a command run from a subdirectory open the same file.
+    import shutil
+
+    from exmergo_dex_core.config import DexConfig, DuckDBTarget, save_config
+
+    shutil.copy(duckdb_file, tmp_path / "w.duckdb")
+    save_config(
+        DexConfig(connector="duckdb", duckdb=DuckDBTarget(path="w.duckdb")), tmp_path
+    )
+    elsewhere = tmp_path / "sub" / "dir"
+    elsewhere.mkdir(parents=True)
+    monkeypatch.chdir(elsewhere)
+
+    adapter = open_adapter(repo_root=str(tmp_path))
+    try:
+        assert adapter.capabilities()["read_only"] is True
+    finally:
+        adapter.close()

--- a/packages/dex-core/tests/test_cli_contract.py
+++ b/packages/dex-core/tests/test_cli_contract.py
@@ -107,10 +107,11 @@ def test_scope_parses_in_either_position_and_repeats(argv_builder, tmp_path, cap
     """`--scope` is a connection option like `--path`, so it has to work on both
     sides of the subcommand and accumulate."""
 
-    rc = main(["--repo-root", str(tmp_path), *argv_builder()])
+    # An explicit --connector, so this exercises scope parsing rather than the
+    # no-config refusal: DuckDB has no scope, so a parsed --scope is a clean
+    # refusal naming the flag, which proves argparse accepted it in this position.
+    rc = main(["--repo-root", str(tmp_path), "--connector", "duckdb", *argv_builder()])
     payload = json.loads(capsys.readouterr().out)
-    # DuckDB is the default connector and has no scope, so this is a clean refusal
-    # rather than a parse error: the point is that argparse accepted the flag.
     assert rc == 1
     assert payload["status"] == "error"
     assert "--scope" in payload["errors"][0]

--- a/packages/dex-core/tests/test_command_args.py
+++ b/packages/dex-core/tests/test_command_args.py
@@ -1,0 +1,66 @@
+"""Config-root resolution: the walk-up that lets `.dex/config.yml` be referenced
+from anywhere inside a project, and its boundaries (git-root ceiling, config-file
+anchor). The safety-spine tests own the "no silent default" property; these cover
+the resolution edge cases directly."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from exmergo_dex_core import command_args
+from exmergo_dex_core.config import DexConfig, save_config
+
+
+def _root(path: Path | str) -> str:
+    return command_args.repo_root(argparse.Namespace(repo_root=str(path)))
+
+
+def test_walks_up_to_the_owning_config(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    save_config(DexConfig(connector="bigquery"), tmp_path)
+    sub = tmp_path / "a" / "b" / "c"
+    sub.mkdir(parents=True)
+    assert _root(sub) == str(tmp_path.resolve())
+
+
+def test_config_at_the_run_directory_is_found(tmp_path: Path):
+    save_config(DexConfig(connector="bigquery"), tmp_path)
+    assert _root(tmp_path) == str(tmp_path.resolve())
+
+
+def test_cache_only_dex_does_not_shadow_the_real_config(tmp_path: Path):
+    # A subdirectory holding only a .dex/ cache (no config.yml) must not stop the
+    # walk: the real config higher up owns the tree.
+    (tmp_path / ".git").mkdir()
+    save_config(DexConfig(connector="bigquery"), tmp_path)
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / ".dex").mkdir()
+    (sub / ".dex" / "cache.json").write_text("{}", encoding="utf-8")
+    assert _root(sub) == str(tmp_path.resolve())
+
+
+def test_git_root_is_the_ceiling(tmp_path: Path):
+    # config sits ABOVE the git root; the walk must not cross the repo boundary,
+    # so it is not adopted and the raw run directory is returned unchanged.
+    save_config(DexConfig(connector="bigquery"), tmp_path)
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    sub = repo / "models"
+    sub.mkdir()
+    assert _root(sub) == str(sub)
+
+
+def test_no_git_repo_does_not_walk_above_the_run_directory(tmp_path: Path):
+    # Without an enclosing git repo the ceiling is the run directory itself, so a
+    # config in a parent is never silently adopted.
+    save_config(DexConfig(connector="bigquery"), tmp_path)
+    sub = tmp_path / "models"
+    sub.mkdir()
+    assert _root(sub) == str(sub)
+
+
+def test_not_found_returns_the_raw_root_unchanged(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    assert _root(tmp_path) == str(tmp_path)

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -497,6 +497,36 @@ def test_init_never_falls_through_to_a_default_connector(tmp_path: Path, capsys)
     assert not (tmp_path / "analytics").exists()
 
 
+def test_config_resolves_from_a_subdirectory_not_a_silent_default(tmp_path: Path):
+    # The other half of "no silent connector default": a command run from a
+    # subdirectory of a project must resolve the project's own .dex/config.yml
+    # (walked up to the git root), never fall through to the engine-wide DuckDB
+    # default and then surface as a phantom config/profiles connector mismatch.
+    import argparse
+
+    from exmergo_dex_core import command_args
+    from exmergo_dex_core.config import DexConfig, save_config
+
+    (tmp_path / ".git").mkdir()
+    save_config(DexConfig(connector="bigquery"), tmp_path)
+    sub = tmp_path / "analytics" / "models"
+    sub.mkdir(parents=True)
+
+    resolved = command_args.repo_root(argparse.Namespace(repo_root=str(sub)))
+    assert resolved == str(tmp_path.resolve())
+
+
+def test_no_config_anywhere_refuses_rather_than_defaulting_to_duckdb(tmp_path: Path):
+    # With no config resolvable and nothing explicit to fall back on, the engine
+    # refuses instead of reading a phantom DuckDB target. An explicit --connector
+    # or --path still drives the bare ad-hoc read.
+    from exmergo_dex_core.connect import open_adapter
+
+    (tmp_path / ".git").mkdir()
+    with pytest.raises(ValueError, match=r"no \.dex/config\.yml found"):
+        open_adapter(repo_root=str(tmp_path))
+
+
 def test_init_profile_is_dev_only_with_no_secrets(tmp_path: Path):
     # The generated profiles.yml is why bootstrap is engine-owned: a single dev
     # default target, nothing prod-named, and no secret-like keys anywhere.

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -10,7 +10,8 @@ logic.
 - A surface (SKILL.md or AGENTS.md) tells the agent which subcommand to run.
 - A thin PEP 723 wrapper (`skills/<skill>/scripts/run.py`) runs it via `uv run`
   against the pinned engine version, installing the connector extra it resolves at
-  runtime (an explicit `--connector`, then `.dex/config.yml`, then DuckDB), so the
+  runtime (an explicit `--connector`, then the `connector:` in the `.dex/config.yml`
+  found by walking up from the run directory to the git root, then DuckDB), so the
   pin stays connector-neutral.
 - The engine prints **exactly one** sanitized JSON envelope to stdout and nothing
   else. Diagnostics go to stderr.
@@ -98,9 +99,10 @@ deps step in `transform build`) installs them.
   target wired to the warehouse dex already knows (`--path`, or `duckdb.path` in
   `.dex/config.yml`). It is strictly additive (any existing dbt project is a
   refusal, so nothing is ever overwritten), and everything created is reported
-  as `create` diffs. **Init never defaults the connector**: the engine-wide
-  fall-through to DuckDB is safe for read-only commands but wrong here, because
-  init bakes the connector into the generated profile. `--connector` wins, a
+  as `create` diffs. **Init never defaults the connector**: the DuckDB on-ramp a
+  read-only command may take (an explicit `--path`, or a committed config that
+  omits `connector:`) is wrong here, because init bakes the connector into the
+  generated profile. `--connector` wins, a
   `connector:` already committed in `.dex/config.yml` is accepted (the envelope
   names which source was used), and bare init is an error listing the valid
   connectors. On success init writes `connector`, `dbt_project_dir`, and
@@ -189,6 +191,17 @@ same way (`cache_hit_count`); both accept `--refresh`.
 Global flags (shared resolution path): `--connector`, `--path` (DuckDB),
 `--scope`, `--project` and `--dataset` (BigQuery only), `--repo-root`,
 `--confirm`, `--budget`.
+
+`.dex/config.yml` is found by walking up from the `--repo-root` directory (default
+the shell cwd) to the enclosing git root, the way git and dbt locate their project,
+so a command run from a subdirectory resolves the project's config rather than the
+current directory's. The walk anchors on the config file (a subdirectory holding
+only a `.dex/` cache never shadows the real config higher up) and stops at the git
+root (a stray `.dex/config.yml` above the repo cannot capture the session). With no
+config found anywhere and no explicit `--connector`/`--path`, the engine refuses
+and names the fix rather than defaulting to DuckDB. A committed relative
+`duckdb.path` resolves against the project root the config lives in, so the same
+target opens from any subdirectory; a live `--path` stays relative to the shell cwd.
 
 `--scope` is repeatable and narrows the source allowlist for one command. Each
 connector reads it in its own namespace vocabulary: a `dataset` on BigQuery, a

--- a/references/duckdb.md
+++ b/references/duckdb.md
@@ -17,6 +17,11 @@ duckdb:
 
 or pass `--path ./warehouse.duckdb` on any command.
 
+A relative `path:` in `.dex/config.yml` resolves against the project root the
+config lives in, not the shell cwd, so the same file opens whether you run from the
+project root or a subdirectory (config is found by walking up to the git root). A
+live `--path` is typed in your shell, so it stays relative to the current directory.
+
 ## Read-only and resource bounds
 
 DuckDB is always opened **read-only** (`read_only=True`). A read-only open of a

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -19,10 +19,14 @@ The engine version is pinned; the connector *extra* is chosen at runtime from th
 active connector, so one published release serves every warehouse. This wrapper is
 stdlib-only and runs before the engine is installed, so it resolves the connector
 itself (it cannot import the engine) with the same precedence the engine uses:
-an explicit --connector flag, then the top-level `connector:` in
-<repo-root>/.dex/config.yml, then DuckDB. The guess only picks which extra to
-install; the full argv is still forwarded, so the engine stays authoritative for
-the actual connection and a wrong guess surfaces as a clean error envelope.
+an explicit --connector flag, then the top-level `connector:` in the
+`.dex/config.yml` found by walking up from the run directory to the git root (the
+way git and dbt find their project), then DuckDB. The walk-up must mirror the
+engine's: if it did not, a run from a subdirectory would install the DuckDB extra
+while the engine resolves the project's real connector and then fails for want of
+that connector's deps. The guess only picks which extra to install; the full argv
+is still forwarded, so the engine stays authoritative for the actual connection
+and a wrong guess surfaces as a clean error envelope.
 
 `DEX_CORE_VERSION` is the single line bumped at release time, by
 scripts/prepare_release.sh before the tag; nothing else here changes per release.
@@ -76,9 +80,30 @@ def _connector_from_config(config_path: Path) -> str | None:
     return None
 
 
+def _find_config(start: Path) -> Path | None:
+    """Nearest ancestor `.dex/config.yml` at or above `start`, mirroring the
+    engine's resolution: walk up to the enclosing git repo (the ceiling), and
+    without one do not walk above `start`. Anchors on the file so a subdirectory
+    holding only a `.dex/` cache never shadows the real config higher up."""
+
+    start = start.resolve()
+    ceiling = start
+    for directory in (start, *start.parents):
+        if (directory / ".git").exists():
+            ceiling = directory
+            break
+    for directory in (start, *start.parents):
+        candidate = directory / ".dex" / "config.yml"
+        if candidate.is_file():
+            return candidate
+        if directory == ceiling:
+            break
+    return None
+
+
 def _resolve_connector(argv: list[str], cwd: Path) -> str:
     """Pick the connector whose extra we install, mirroring the engine's order:
-    explicit --connector, then .dex/config.yml, then DuckDB."""
+    explicit --connector, then the walked-up .dex/config.yml, then DuckDB."""
 
     # allow_abbrev=False and parse_known_args so we only peek at these two flags
     # and never consume or reorder the argv that is forwarded to the engine.
@@ -87,9 +112,11 @@ def _resolve_connector(argv: list[str], cwd: Path) -> str:
     parser.add_argument("--repo-root", default=".")
     known, _ = parser.parse_known_args(argv)
 
-    connector = known.connector or _connector_from_config(
-        cwd / known.repo_root / ".dex" / "config.yml"
-    )
+    connector = known.connector
+    if connector is None:
+        config_path = _find_config(cwd / known.repo_root)
+        if config_path is not None:
+            connector = _connector_from_config(config_path)
     return connector if connector in _KNOWN_CONNECTORS else _DEFAULT_CONNECTOR
 
 

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -19,10 +19,14 @@ The engine version is pinned; the connector *extra* is chosen at runtime from th
 active connector, so one published release serves every warehouse. This wrapper is
 stdlib-only and runs before the engine is installed, so it resolves the connector
 itself (it cannot import the engine) with the same precedence the engine uses:
-an explicit --connector flag, then the top-level `connector:` in
-<repo-root>/.dex/config.yml, then DuckDB. The guess only picks which extra to
-install; the full argv is still forwarded, so the engine stays authoritative for
-the actual connection and a wrong guess surfaces as a clean error envelope.
+an explicit --connector flag, then the top-level `connector:` in the
+`.dex/config.yml` found by walking up from the run directory to the git root (the
+way git and dbt find their project), then DuckDB. The walk-up must mirror the
+engine's: if it did not, a run from a subdirectory would install the DuckDB extra
+while the engine resolves the project's real connector and then fails for want of
+that connector's deps. The guess only picks which extra to install; the full argv
+is still forwarded, so the engine stays authoritative for the actual connection
+and a wrong guess surfaces as a clean error envelope.
 
 `DEX_CORE_VERSION` is the single line bumped at release time, by
 scripts/prepare_release.sh before the tag; nothing else here changes per release.
@@ -76,9 +80,30 @@ def _connector_from_config(config_path: Path) -> str | None:
     return None
 
 
+def _find_config(start: Path) -> Path | None:
+    """Nearest ancestor `.dex/config.yml` at or above `start`, mirroring the
+    engine's resolution: walk up to the enclosing git repo (the ceiling), and
+    without one do not walk above `start`. Anchors on the file so a subdirectory
+    holding only a `.dex/` cache never shadows the real config higher up."""
+
+    start = start.resolve()
+    ceiling = start
+    for directory in (start, *start.parents):
+        if (directory / ".git").exists():
+            ceiling = directory
+            break
+    for directory in (start, *start.parents):
+        candidate = directory / ".dex" / "config.yml"
+        if candidate.is_file():
+            return candidate
+        if directory == ceiling:
+            break
+    return None
+
+
 def _resolve_connector(argv: list[str], cwd: Path) -> str:
     """Pick the connector whose extra we install, mirroring the engine's order:
-    explicit --connector, then .dex/config.yml, then DuckDB."""
+    explicit --connector, then the walked-up .dex/config.yml, then DuckDB."""
 
     # allow_abbrev=False and parse_known_args so we only peek at these two flags
     # and never consume or reorder the argv that is forwarded to the engine.
@@ -87,9 +112,11 @@ def _resolve_connector(argv: list[str], cwd: Path) -> str:
     parser.add_argument("--repo-root", default=".")
     known, _ = parser.parse_known_args(argv)
 
-    connector = known.connector or _connector_from_config(
-        cwd / known.repo_root / ".dex" / "config.yml"
-    )
+    connector = known.connector
+    if connector is None:
+        config_path = _find_config(cwd / known.repo_root)
+        if config_path is not None:
+            connector = _connector_from_config(config_path)
     return connector if connector in _KNOWN_CONNECTORS else _DEFAULT_CONNECTOR
 
 

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -19,10 +19,14 @@ The engine version is pinned; the connector *extra* is chosen at runtime from th
 active connector, so one published release serves every warehouse. This wrapper is
 stdlib-only and runs before the engine is installed, so it resolves the connector
 itself (it cannot import the engine) with the same precedence the engine uses:
-an explicit --connector flag, then the top-level `connector:` in
-<repo-root>/.dex/config.yml, then DuckDB. The guess only picks which extra to
-install; the full argv is still forwarded, so the engine stays authoritative for
-the actual connection and a wrong guess surfaces as a clean error envelope.
+an explicit --connector flag, then the top-level `connector:` in the
+`.dex/config.yml` found by walking up from the run directory to the git root (the
+way git and dbt find their project), then DuckDB. The walk-up must mirror the
+engine's: if it did not, a run from a subdirectory would install the DuckDB extra
+while the engine resolves the project's real connector and then fails for want of
+that connector's deps. The guess only picks which extra to install; the full argv
+is still forwarded, so the engine stays authoritative for the actual connection
+and a wrong guess surfaces as a clean error envelope.
 
 `DEX_CORE_VERSION` is the single line bumped at release time, by
 scripts/prepare_release.sh before the tag; nothing else here changes per release.
@@ -76,9 +80,30 @@ def _connector_from_config(config_path: Path) -> str | None:
     return None
 
 
+def _find_config(start: Path) -> Path | None:
+    """Nearest ancestor `.dex/config.yml` at or above `start`, mirroring the
+    engine's resolution: walk up to the enclosing git repo (the ceiling), and
+    without one do not walk above `start`. Anchors on the file so a subdirectory
+    holding only a `.dex/` cache never shadows the real config higher up."""
+
+    start = start.resolve()
+    ceiling = start
+    for directory in (start, *start.parents):
+        if (directory / ".git").exists():
+            ceiling = directory
+            break
+    for directory in (start, *start.parents):
+        candidate = directory / ".dex" / "config.yml"
+        if candidate.is_file():
+            return candidate
+        if directory == ceiling:
+            break
+    return None
+
+
 def _resolve_connector(argv: list[str], cwd: Path) -> str:
     """Pick the connector whose extra we install, mirroring the engine's order:
-    explicit --connector, then .dex/config.yml, then DuckDB."""
+    explicit --connector, then the walked-up .dex/config.yml, then DuckDB."""
 
     # allow_abbrev=False and parse_known_args so we only peek at these two flags
     # and never consume or reorder the argv that is forwarded to the engine.
@@ -87,9 +112,11 @@ def _resolve_connector(argv: list[str], cwd: Path) -> str:
     parser.add_argument("--repo-root", default=".")
     known, _ = parser.parse_known_args(argv)
 
-    connector = known.connector or _connector_from_config(
-        cwd / known.repo_root / ".dex" / "config.yml"
-    )
+    connector = known.connector
+    if connector is None:
+        config_path = _find_config(cwd / known.repo_root)
+        if config_path is not None:
+            connector = _connector_from_config(config_path)
     return connector if connector in _KNOWN_CONNECTORS else _DEFAULT_CONNECTOR
 
 


### PR DESCRIPTION
## What this changes

We enhance the .dex/config.yml resolution - so that any command can be run even in subdirectories.
We also fix the issue of DuckDB being assigned as the default value when config.yml isn't found

## Related issues

Closes #73