### PR TITLE
Issue 83 (Partial and Closing)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,10 +81,13 @@ engine does not care which skill fronts a subcommand.
 
 Authored content reaches the engine through `--edits-file <path>` (or `-` for
 stdin): a JSON payload of `{"edits": [{"path", "kind", "content"}, ...]}` with
-`kind` one of `model_sql`, `schema_yml`, `semantic_yml`, or `packages_yml` (the
+`kind` one of `model_sql`, `schema_yml`, `semantic_yml`, `packages_yml` (the
 guarded way to author the project-root `packages.yml`/`dependencies.yml`, so
-declaring a dbt package is a reviewable diff too). The engine validates, diffs,
-and stores the plan under `.dex/plans/`; nothing touches the dbt project until
+declaring a dbt package is a reviewable diff too), `macro_sql`, `project_yml`
+(the project-root `dbt_project.yml`), or `profiles_yml` (the project-root
+`profiles.yml`, secret-guarded so a credential never enters the diff: reference
+secrets via `{{ env_var('NAME') }}`). The engine validates, diffs, and stores
+the plan under `.dex/plans/`; nothing touches the dbt project until
 `transform apply`. See `references/command-contract.md`.
 
 ### The envelope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,22 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **`transform plan` can author the two project-root config files** (#83). New
+  edit kinds `project_yml` (`dbt_project.yml`) and `profiles_yml`
+  (`profiles.yml`) bring project settings and connection targets into the same
+  plan -> diff -> apply flow as models, schema, semantic, macro, and packages
+  edits, so a project-wide config change is a reviewable, hash-pinned diff
+  rather than a raw file write outside the guardrail. Each kind is pinned by
+  name to the one root file it may target (and no other kind may reach those
+  files), a `project_yml` edit must keep a `name` (and warns when it drops a
+  `model-paths`/`macro-paths` entry that would orphan files), and both are
+  gated by dbt's own parser at plan time. `profiles_yml` is secret-guarded: an
+  edit is refused when it, or the file it would replace, inlines a literal
+  credential, so no secret ever reaches the diff or agent context; reference
+  secrets via `{{ env_var('NAME') }}`. As a side effect, the loader now carries
+  root config files into its view, so edits to an existing `packages.yml` /
+  `dependencies.yml` pin the real content hash instead of mis-registering as a
+  create.
 - **`explore query` can unnest JSON and array columns** (#78). The firewall's
   FROM clause now admits each connector's native unnest idiom (BigQuery
   `UNNEST`, Snowflake `LATERAL FLATTEN`, Databricks `LATERAL VIEW EXPLODE`,

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -45,10 +45,15 @@ REF_PATTERN = re.compile(r"ref\(\s*['\"]([^'\"]+)['\"]")
 SOURCE_PATTERN = re.compile(r"source\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]")
 BARE_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
-# dbt project-root manifests dex may author outside the model paths. They declare
-# package dependencies (not model content), so the editing surface widens by
-# exactly these two known files, never to arbitrary root files.
-_ALLOWED_ROOT_FILES = frozenset({"packages.yml", "dependencies.yml"})
+# dbt project-root files dex may author outside the model paths: the package
+# manifests (dependency declarations), the project config, and the connection
+# profiles. Each governs the whole project, not one model, which is why the
+# editing surface widens by exactly these known names and never to arbitrary
+# root files. Kinds are pinned to the specific file each one may target in
+# ``transform.plans``; here we only gate containment.
+_ALLOWED_ROOT_FILES = frozenset(
+    {"packages.yml", "dependencies.yml", PROJECT_FILE, PROFILES_FILE}
+)
 
 
 class DbtProjectError(Exception):
@@ -187,6 +192,18 @@ def load(project_dir: Path | str = ".") -> DbtProjectView:
             content = path.read_text(encoding="utf-8")
             files[rel] = SourceFile(
                 path=rel, content=content, sha256=content_hash(content)
+            )
+
+    # Root-level config files dex may author (project settings, connection
+    # targets, package manifests). Included so an edit to an existing one pins
+    # the real content hash instead of mis-registering as a create, which would
+    # otherwise surface at apply as a spurious conflict.
+    for root_file in _ALLOWED_ROOT_FILES:
+        path = root / root_file
+        if path.is_file():
+            content = path.read_text(encoding="utf-8")
+            files[root_file] = SourceFile(
+                path=root_file, content=content, sha256=content_hash(content)
             )
 
     manifest: dict[str, Any] | None = None

--- a/packages/dex-core/src/exmergo_dex_core/transform/build.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/build.py
@@ -26,7 +26,13 @@ from typing import Any
 
 import yaml
 
-from ..dbt_project import DbtProjectError, Edit, contained_path, profiles_dir
+from ..dbt_project import (
+    PROFILES_FILE,
+    DbtProjectError,
+    Edit,
+    contained_path,
+    profiles_dir,
+)
 from ..dbt_project import load as load_project
 from ..envelope import Cost, Paradigm, redact
 from ..guards.cost_guard import preflight
@@ -238,13 +244,24 @@ def shadow_parse(
             edit_path.parent.mkdir(parents=True, exist_ok=True)
             edit_path.write_text(edit.new_content, encoding="utf-8")
 
+        # A profiles.yml edit only takes effect if dbt reads the shadowed copy;
+        # pointing --profiles-dir at the real project would parse the edit
+        # against the unedited profile. Redirect to the shadow when the
+        # project-local profiles is the one being edited (the copytree already
+        # placed it there and the overlay above wrote the new content).
+        profiles_arg = profiles.resolve()
+        if profiles_arg == project and any(
+            Path(edit.path).name == PROFILES_FILE and Path(edit.path).parent == Path()
+            for edit in edits
+        ):
+            profiles_arg = shadow.resolve()
         argv = [
             executable,
             "parse",
             "--project-dir",
             str(shadow),
             "--profiles-dir",
-            str(profiles.resolve()),
+            str(profiles_arg),
             "--log-format",
             "json",
         ]

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -101,7 +101,38 @@ def cmd_plan(args: argparse.Namespace) -> env.Envelope:
             "transform plan needs content: pass --edits-file <path|-> with the "
             "authored edits, or --scaffold <table> for a staging skeleton"
         )
-    return _make_plan(args, intent, edits)
+
+    parse_notes: list[str] = []
+    if any(e.kind in (EditKind.PROJECT_YML, EditKind.PROFILES_YML) for e in edits):
+        # A broken dbt_project.yml or profiles.yml breaks the whole project, so
+        # config edits are gated by dbt's own parser at plan time (the same
+        # authoritative gate semantic and macro plans use), not left to surface
+        # for the first time at build. The secret-guard runs first, so an
+        # inlined credential is never handed to the dbt subprocess.
+        from ..config import DexConfig, load_config
+        from ..dbt_project import load as load_project
+        from .build import shadow_parse
+        from .validate import assert_profiles_safe
+
+        project = command_args.project_dir(args)
+        view = load_project(project)
+        assert_profiles_safe(view, edits)
+        config = load_config(command_args.repo_root(args)) or DexConfig()
+        parse_result = shadow_parse(project, edits, target=config.dbt_target)
+        if not parse_result["available"]:
+            parse_notes.append(parse_result["reason"])
+        elif not parse_result["success"]:
+            return env.error(
+                _failure_message("dbt parse failed", parse_result["messages"]),
+                warnings=parse_result["messages"][1:],
+            )
+        elif parse_result["messages"]:
+            parse_notes = [f"dbt: {m}" for m in parse_result["messages"]]
+
+    envelope = _make_plan(args, intent, edits)
+    if parse_notes and envelope.status is env.Status.OK:
+        envelope.warnings.extend(parse_notes)
+    return envelope
 
 
 def cmd_macro(args: argparse.Namespace) -> env.Envelope:

--- a/packages/dex-core/src/exmergo_dex_core/transform/plans.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/plans.py
@@ -19,6 +19,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+import yaml
 from pydantic import BaseModel
 
 from ..cache import DEX_DIR
@@ -34,7 +35,7 @@ from ..dbt_project import (
     load as load_project,
 )
 from ..diffs import file_diff
-from .validate import validate_edit
+from .validate import find_inlined_secret, validate_edit
 
 PLANS_DIR = "plans"
 
@@ -57,6 +58,12 @@ class EditKind(str, Enum):
     # A macro definition under the project's macro paths, the surface widened
     # for scaffolded and hand-repaired macros alike.
     MACRO_SQL = "macro_sql"
+    # dbt project-root config: the project settings and the connection profiles.
+    # Each governs the whole project (a wider blast radius than a single model),
+    # so each is pinned by name to the one root file it may target, and
+    # profiles carries a secret-guard so no credential enters the plan diff.
+    PROJECT_YML = "project_yml"
+    PROFILES_YML = "profiles_yml"
 
 
 class PlanEdit(Edit):
@@ -153,6 +160,14 @@ def plan(
     diffs: list[dict[str, Any]] = []
     project_resolved = project.resolve()
     macro_bases = [(project_resolved / mp).resolve() for mp in view.macro_paths]
+    # The one root file each config kind may target, resolved once. Both the
+    # kind and the path must agree: a config kind aimed elsewhere, or one of
+    # these files reached by any other kind, is refused.
+    root_config = {
+        EditKind.PROJECT_YML: (project_resolved / "dbt_project.yml").resolve(),
+        EditKind.PROFILES_YML: (project_resolved / "profiles.yml").resolve(),
+    }
+    config_targets = {target: kind for kind, target in root_config.items()}
     for edit in edits:
         # Containment is checked at plan time as well as at write time, so a bad
         # path is refused before it ever becomes a stored proposal.
@@ -175,8 +190,45 @@ def plan(
                 f"'{edit.path}' is under a macro path but the edit kind is "
                 f"{edit.kind.value}; use macro_sql for macro files"
             )
+        if edit.kind in root_config and resolved != root_config[edit.kind]:
+            raise PlanError(
+                f"a {edit.kind.value} edit must target the project's "
+                f"{root_config[edit.kind].name}, got '{edit.path}'"
+            )
+        target_kind = config_targets.get(resolved)
+        if target_kind is not None and edit.kind is not target_kind:
+            raise PlanError(
+                f"'{edit.path}' is a project config file but the edit kind is "
+                f"{edit.kind.value}; use {target_kind.value} for it"
+            )
         warnings.extend(validate_edit(edit))
         current = view.files.get(edit.path)
+        # The profiles secret-guard, current side: validate_edit covers the
+        # proposed content, but the diff also surfaces the removed (on-disk)
+        # content, so a pre-existing inlined credential is refused before any
+        # diff is built, never reaching agent context.
+        if edit.kind is EditKind.PROFILES_YML and current is not None:
+            secret_key = find_inlined_secret(current.content)
+            if secret_key is not None:
+                raise PlanError(
+                    f"{edit.path}: the current profiles.yml inlines a literal "
+                    f"credential in '{secret_key}'; move it to "
+                    "{{ env_var('NAME') }} before editing so no credential "
+                    "enters the plan diff"
+                )
+        # A dbt_project.yml that drops model or macro paths silently orphans the
+        # files under them; warn rather than refuse, since a deliberate
+        # restructure is a legitimate reason to change them.
+        if edit.kind is EditKind.PROJECT_YML and current is not None:
+            old = yaml.safe_load(current.content) or {}
+            new = yaml.safe_load(edit.new_content) or {}
+            for key in ("model-paths", "macro-paths"):
+                dropped = set(old.get(key) or []) - set(new.get(key) or [])
+                if dropped:
+                    warnings.append(
+                        f"{edit.path}: {key} drops {sorted(dropped)}; files under "
+                        "those paths would no longer be part of the project"
+                    )
         pinned.append(
             edit.model_copy(
                 update={"old_content_hash": current.sha256 if current else None}

--- a/packages/dex-core/src/exmergo_dex_core/transform/validate.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/validate.py
@@ -16,11 +16,101 @@ import yaml
 from ..guards.sql_guard import assert_select_only
 
 if TYPE_CHECKING:
+    from ..dbt_project import DbtProjectView
     from .plans import PlanEdit
 
 
 class EditValidationError(Exception):
     pass
+
+
+# profiles.yml keys whose value dbt reads from the environment, never a literal
+# in a committed file. A path-typed key (``private_key_path``) holds no secret,
+# and method-based auth (externalbrowser/iam/oauth) carries none either, so both
+# are exempt by not being listed. This mirrors init's "no persisted secret" rule
+# and, at author time, keeps a credential out of the plan diff and thus out of
+# agent context.
+_SECRET_KEYS = frozenset(
+    {
+        "password",
+        "pass",
+        "token",
+        "access_token",
+        "refresh_token",
+        "client_secret",
+        "secret",
+        "private_key",
+        "private_key_passphrase",
+    }
+)
+# The one safe form for a sensitive value: a dbt env_var() reference, resolved at
+# runtime. Any other value for a sensitive key is a literal and is refused.
+_ENV_VAR_REF = re.compile(r"\{\{\s*env_var\s*\(")
+
+
+def find_inlined_secret(content: str) -> str | None:
+    """The first profiles.yml key that inlines a literal secret, or ``None``.
+
+    Walks the parsed mapping; a sensitive key is safe only when its value is an
+    ``env_var()`` reference. A parse failure returns ``None`` here (the mapping
+    check reports malformed YAML), so this never masks a structural error.
+    """
+
+    try:
+        parsed = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return None
+    return _scan_for_secret(parsed)
+
+
+def _scan_for_secret(node: object) -> str | None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            sensitive = isinstance(key, str) and key.lower() in _SECRET_KEYS
+            if sensitive and not (
+                isinstance(value, str) and _ENV_VAR_REF.search(value)
+            ):
+                return key
+            hit = _scan_for_secret(value)
+            if hit is not None:
+                return hit
+    elif isinstance(node, list):
+        for item in node:
+            hit = _scan_for_secret(item)
+            if hit is not None:
+                return hit
+    return None
+
+
+def assert_profiles_safe(view: DbtProjectView, edits: list[PlanEdit]) -> None:
+    """Refuse a profiles.yml edit that inlines a literal credential, on either the
+    current file (the diff's removed side) or the proposed content.
+
+    Runs before the content reaches a diff or a dbt subprocess, so a credential
+    never leaves the file. The message names the offending key, never its value.
+    """
+
+    from .plans import EditKind
+
+    for edit in edits:
+        if edit.kind is not EditKind.PROFILES_YML:
+            continue
+        current = view.files.get(edit.path)
+        sides = (
+            ("current", current.content if current is not None else None),
+            ("proposed", edit.new_content),
+        )
+        for label, content in sides:
+            if content is None:
+                continue
+            key = find_inlined_secret(content)
+            if key is not None:
+                raise EditValidationError(
+                    f"{edit.path}: the {label} profiles.yml inlines a literal "
+                    f"credential in '{key}'; reference it via "
+                    "{{ env_var('NAME') }} so no credential enters the plan "
+                    "diff or agent context"
+                )
 
 
 # Jinja expression / statement / comment blocks, non-greedy so adjacent blocks
@@ -123,4 +213,18 @@ def validate_edit(edit: PlanEdit) -> list[str]:
                 f"{edit.path}: a packages manifest needs a 'packages:' (or "
                 "'dependencies:') list"
             )
+        elif edit.kind is EditKind.PROJECT_YML and not parsed.get("name"):
+            # dbt keys the project on 'name'; without it dbt cannot load the
+            # project at all. Structural gate before the authoritative dbt parse.
+            raise EditValidationError(
+                f"{edit.path}: dbt_project.yml must declare a 'name'"
+            )
+        elif edit.kind is EditKind.PROFILES_YML:
+            secret_key = find_inlined_secret(edit.new_content)
+            if secret_key is not None:
+                raise EditValidationError(
+                    f"{edit.path}: '{secret_key}' inlines a literal credential; a "
+                    "profiles.yml edit must reference secrets via "
+                    "{{ env_var('NAME') }} so no credential enters the plan diff"
+                )
     return warnings

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -368,6 +368,57 @@ def test_changes_are_diffs_not_silent_writes(dbt_project_dir: Path):
     assert not new_model.exists()
 
 
+def test_profiles_edit_never_carries_a_credential_into_a_diff(dbt_project_dir: Path):
+    # profiles.yml is an editable surface, but a credential must never reach the
+    # plan diff (and thus agent context). An inlined literal is refused whether
+    # it is in the proposed content or already on disk (the diff's removed side).
+    from exmergo_dex_core import transform
+
+    (dbt_project_dir / "profiles.yml").write_text(
+        "dex_test:\n  target: dev\n  outputs:\n    dev:\n      type: postgres\n"
+        "      host: localhost\n      user: u\n      password: s3cr3t-on-disk\n"
+        "      dbname: d\n      schema: public\n",
+        encoding="utf-8",
+    )
+    proposed_secret = transform.PlanEdit(
+        path="profiles.yml",
+        kind=transform.EditKind.PROFILES_YML,
+        new_content=(
+            "dex_test:\n  outputs:\n    dev:\n      type: postgres\n"
+            "      password: s3cr3t-proposed\n"
+        ),
+    )
+    with pytest.raises(Exception) as proposed_exc:
+        transform.plan(
+            "inline a secret",
+            [proposed_secret],
+            dbt_project_dir,
+            repo_root=dbt_project_dir.parent,
+        )
+    assert "s3cr3t-proposed" not in str(proposed_exc.value)
+
+    # Even a clean (env_var) proposal is refused while the on-disk file still
+    # inlines a secret, since diffing it would surface the removed literal.
+    clean_proposal = transform.PlanEdit(
+        path="profiles.yml",
+        kind=transform.EditKind.PROFILES_YML,
+        new_content=(
+            "dex_test:\n  target: dev\n  outputs:\n    dev:\n      type: postgres\n"
+            "      host: localhost\n      user: u\n"
+            "      password: \"{{ env_var('PGPASSWORD') }}\"\n"
+            "      dbname: d\n      schema: public\n"
+        ),
+    )
+    with pytest.raises(Exception) as current_exc:
+        transform.plan(
+            "env-var the password",
+            [clean_proposal],
+            dbt_project_dir,
+            repo_root=dbt_project_dir.parent,
+        )
+    assert "s3cr3t-on-disk" not in str(current_exc.value)
+
+
 def test_apply_refuses_to_overwrite_a_human_edit(dbt_project_dir: Path):
     from exmergo_dex_core import transform
 

--- a/packages/dex-core/tests/transform/test_dbt_project.py
+++ b/packages/dex-core/tests/transform/test_dbt_project.py
@@ -180,7 +180,6 @@ def test_write_edits_all_or_nothing(dbt_project_dir: Path):
     [
         "../outside.sql",
         "models/../../escape.sql",
-        "dbt_project.yml",
         "seeds/data.yml",
     ],
 )
@@ -200,26 +199,31 @@ def test_write_edits_refuses_absolute_paths(dbt_project_dir: Path, tmp_path: Pat
         write_edits([edit], dbt_project_dir)
 
 
-@pytest.mark.parametrize("manifest", ["packages.yml", "dependencies.yml"])
-def test_write_edits_allows_dbt_package_manifests_at_root(
-    dbt_project_dir: Path, manifest: str
-):
+@pytest.mark.parametrize(
+    "root_file", ["packages.yml", "dependencies.yml", "dbt_project.yml", "profiles.yml"]
+)
+def test_write_edits_allows_root_config_files(dbt_project_dir: Path, root_file: str):
+    # Containment now admits the project config and profiles alongside the
+    # package manifests. Pin the current hash so an existing fixture file is a
+    # clean apply, not a conflict, and a not-yet-present one is a create.
+    existing = dbt_project_dir / root_file
+    old_hash = content_hash(existing.read_text()) if existing.is_file() else None
     edit = Edit(
-        path=manifest,
-        new_content="packages:\n  - package: dbt-labs/dbt_utils\n    version: 1.1.1\n",
-        old_content_hash=None,
+        path=root_file,
+        new_content="name: dex_test\nprofile: dex_test\n# authored\n",
+        old_content_hash=old_hash,
     )
     result = write_edits([edit], dbt_project_dir)
-    assert result.written == [manifest]
-    assert (dbt_project_dir / manifest).is_file()
+    assert result.written == [root_file]
+    assert existing.is_file()
 
 
-@pytest.mark.parametrize("root_file", ["profiles.yml", "dbt_project.yml", "random.yml"])
+@pytest.mark.parametrize("root_file", ["random.yml", "Makefile", "secrets.env"])
 def test_write_edits_still_refuses_other_root_files(
     dbt_project_dir: Path, root_file: str
 ):
-    # The carve-out is exactly the two package manifests, not project-root files
-    # in general.
+    # The carve-out is exactly the known dbt files (package manifests, project
+    # config, profiles), not project-root files in general.
     edit = Edit(path=root_file, new_content="x: 1\n", old_content_hash=None)
     with pytest.raises(DbtProjectError):
         write_edits([edit], dbt_project_dir)

--- a/packages/dex-core/tests/transform/test_plan.py
+++ b/packages/dex-core/tests/transform/test_plan.py
@@ -293,3 +293,161 @@ def test_plan_without_content_is_a_clean_error(
     assert rc == 1
     assert envelope["status"] == "error"
     assert "edits-file" in envelope["errors"][0]
+
+
+# --- project config kinds (project_yml / profiles_yml) ------------------------
+#
+# These exercise the engine directly (`transform.plan`), which does not run dbt
+# parse, so containment, the profiles secret-guard, and the path drop-check are
+# deterministic without a dbt subprocess. The CLI tests below cover the
+# parse-gated path.
+
+from exmergo_dex_core import transform  # noqa: E402
+
+
+def _cfg_edit(path: str, content: str, kind) -> transform.PlanEdit:
+    return transform.PlanEdit(path=path, new_content=content, kind=kind)
+
+
+def test_project_yml_edit_pins_the_existing_file(dbt_project_dir: Path):
+    # load() now carries root config into the view, so an edit to the existing
+    # dbt_project.yml diffs as an update against a real pinned hash, not a create.
+    edit = _cfg_edit(
+        "dbt_project.yml",
+        'name: dex_test\nversion: "1.0.0"\nprofile: dex_test\n'
+        'model-paths: ["models"]\n# tuned\n',
+        transform.EditKind.PROJECT_YML,
+    )
+    plan, diffs, _warnings = transform.plan(
+        "tune project", [edit], dbt_project_dir, repo_root=dbt_project_dir.parent
+    )
+    assert diffs[0]["op"] == "update"
+    assert plan.edits[0].old_content_hash is not None
+
+
+def test_project_yml_kind_must_target_dbt_project(dbt_project_dir: Path):
+    edit = _cfg_edit(
+        "models/staging/x.yml", "name: x\n", transform.EditKind.PROJECT_YML
+    )
+    with pytest.raises(transform.PlanError):
+        transform.plan(
+            "misaimed", [edit], dbt_project_dir, repo_root=dbt_project_dir.parent
+        )
+
+
+def test_config_file_reached_by_the_wrong_kind_is_refused(dbt_project_dir: Path):
+    edit = _cfg_edit("dbt_project.yml", "select 1\n", transform.EditKind.MODEL_SQL)
+    with pytest.raises(transform.PlanError):
+        transform.plan(
+            "wrong kind", [edit], dbt_project_dir, repo_root=dbt_project_dir.parent
+        )
+
+
+def test_profiles_yml_refuses_a_secret_already_on_disk(dbt_project_dir: Path):
+    # The diff's removed side would leak a pre-existing inlined credential even
+    # when the proposed content is clean, so the current file is guarded too.
+    (dbt_project_dir / "profiles.yml").write_text(
+        "dex_test:\n  target: dev\n  outputs:\n    dev:\n      type: postgres\n"
+        "      host: localhost\n      user: u\n      password: hunter2\n"
+        "      dbname: d\n      schema: public\n",
+        encoding="utf-8",
+    )
+    safe = (
+        "dex_test:\n  target: dev\n  outputs:\n    dev:\n      type: postgres\n"
+        "      host: localhost\n      user: u\n"
+        "      password: \"{{ env_var('PGPASSWORD') }}\"\n"
+        "      dbname: d\n      schema: public\n"
+    )
+    edit = _cfg_edit("profiles.yml", safe, transform.EditKind.PROFILES_YML)
+    with pytest.raises(transform.PlanError) as exc:
+        transform.plan(
+            "env-var the password",
+            [edit],
+            dbt_project_dir,
+            repo_root=dbt_project_dir.parent,
+        )
+    assert "hunter2" not in str(exc.value)
+    assert "password" in str(exc.value)
+
+
+def test_project_yml_dropping_a_model_path_warns(dbt_project_dir: Path):
+    edit = _cfg_edit(
+        "dbt_project.yml",
+        'name: dex_test\nprofile: dex_test\nmodel-paths: ["staging"]\n',
+        transform.EditKind.PROJECT_YML,
+    )
+    _plan, _diffs, warnings = transform.plan(
+        "restructure", [edit], dbt_project_dir, repo_root=dbt_project_dir.parent
+    )
+    assert any("model-paths drops" in w and "models" in w for w in warnings)
+
+
+def test_plan_cli_refuses_an_inlined_profiles_secret(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    payload = _write_payload(
+        tmp_path,
+        [
+            {
+                "path": "profiles.yml",
+                "kind": "profiles_yml",
+                "content": (
+                    "dex_test:\n  target: dev\n  outputs:\n    dev:\n"
+                    "      type: postgres\n      host: h\n      user: u\n"
+                    "      password: hunter2\n      dbname: d\n      schema: public\n"
+                ),
+            }
+        ],
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "set profile",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert envelope["status"] == "error"
+    blob = json.dumps(envelope)
+    assert "hunter2" not in blob
+    assert "env_var" in blob or "credential" in blob
+    plans_dir = tmp_path / ".dex" / "plans"
+    assert not plans_dir.exists() or not list(plans_dir.glob("*.json"))
+
+
+def test_plan_cli_project_yml_pins_an_update(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    payload = _write_payload(
+        tmp_path,
+        [
+            {
+                "path": "dbt_project.yml",
+                "kind": "project_yml",
+                "content": (
+                    'name: dex_test\nversion: "1.0.0"\nprofile: dex_test\n'
+                    'model-paths: ["models"]\n# tuned by dex\n'
+                ),
+            }
+        ],
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "tune project",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 0
+    assert envelope["status"] == "ok"
+    assert envelope["diffs"][0]["op"] == "update"

--- a/packages/dex-core/tests/transform/test_validate.py
+++ b/packages/dex-core/tests/transform/test_validate.py
@@ -1,0 +1,79 @@
+"""Per-kind edit validation, including the profiles.yml secret-guard."""
+
+from __future__ import annotations
+
+import pytest
+
+from exmergo_dex_core.transform.plans import EditKind, PlanEdit
+from exmergo_dex_core.transform.validate import (
+    EditValidationError,
+    find_inlined_secret,
+    validate_edit,
+)
+
+
+def test_find_inlined_secret_flags_a_literal_value():
+    assert find_inlined_secret("o:\n  password: hunter2\n") == "password"
+
+
+def test_find_inlined_secret_allows_an_env_var_reference():
+    assert (
+        find_inlined_secret("o:\n  password: \"{{ env_var('PGPASSWORD') }}\"\n") is None
+    )
+
+
+def test_find_inlined_secret_allows_a_key_path_and_method():
+    # A path is not a secret, and a substring match must not misfire on it.
+    assert find_inlined_secret("o:\n  private_key_path: /keys/rsa.p8\n") is None
+    assert find_inlined_secret("o:\n  method: externalbrowser\n") is None
+
+
+def test_find_inlined_secret_walks_nested_outputs():
+    content = (
+        "profile:\n  outputs:\n    dev:\n      type: snowflake\n"
+        "      token: raw-token-value\n"
+    )
+    assert find_inlined_secret(content) == "token"
+
+
+def test_validate_project_yml_requires_a_name():
+    edit = PlanEdit(
+        path="dbt_project.yml",
+        new_content='version: "1.0.0"\nprofile: p\n',
+        kind=EditKind.PROJECT_YML,
+    )
+    with pytest.raises(EditValidationError):
+        validate_edit(edit)
+
+
+def test_validate_project_yml_with_a_name_passes():
+    edit = PlanEdit(
+        path="dbt_project.yml",
+        new_content="name: analytics\nprofile: analytics\n",
+        kind=EditKind.PROJECT_YML,
+    )
+    assert validate_edit(edit) == []
+
+
+def test_validate_profiles_yml_refuses_a_literal_secret():
+    edit = PlanEdit(
+        path="profiles.yml",
+        new_content="p:\n  outputs:\n    dev:\n      password: s3cr3t-value\n",
+        kind=EditKind.PROFILES_YML,
+    )
+    with pytest.raises(EditValidationError) as exc:
+        validate_edit(edit)
+    assert "s3cr3t-value" not in str(exc.value)  # names the key, never the value
+    assert "password" in str(exc.value)
+
+
+def test_validate_profiles_yml_accepts_env_var_indirection():
+    edit = PlanEdit(
+        path="profiles.yml",
+        new_content=(
+            "p:\n  outputs:\n    dev:\n      type: postgres\n"
+            "      password: \"{{ env_var('PGPASSWORD') }}\"\n"
+        ),
+        kind=EditKind.PROFILES_YML,
+    )
+    assert validate_edit(edit) == []

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -84,20 +84,28 @@ hands it over via `--edits-file <path>` (or `-` for stdin), a JSON payload:
 ```
 
 `kind` is one of `model_sql`, `schema_yml`, `semantic_yml` (optional on
-`semantic define|update`, which imply `semantic_yml`), `packages_yml`, or
-`macro_sql`. The engine validates each edit (model SQL must be a single
-read-only SELECT once jinja is stripped; YAML must parse; semantic YAML must
-satisfy MetricFlow's schemas; a `packages_yml` edit must carry a `packages:`
-or `dependencies:` list and targets the project-root `packages.yml` or
-`dependencies.yml`; a `macro_sql` edit must hold only macro definitions and
-jinja comments and must target the project's macro paths, where no other kind
-may go), pins it to the sha256 of the file it would change, computes the
-diffs, and stores the plan under `.dex/plans/<plan-id>.json`. Nothing touches
-the dbt project until an apply. `packages_yml` is the guarded way to declare
-dbt package dependencies: a reviewable diff like any other edit, then
-`transform deps` (or the automatic deps step in `transform build`) installs
-them. `macro_sql` is how a macro is repaired or customized by hand;
-`transform macro <name>` is the scaffolding path for the macros dex ships.
+`semantic define|update`, which imply `semantic_yml`), `packages_yml`,
+`macro_sql`, `project_yml`, or `profiles_yml`. The engine validates each edit
+(model SQL must be a single read-only SELECT once jinja is stripped; YAML must
+parse; semantic YAML must satisfy MetricFlow's schemas; a `packages_yml` edit
+must carry a `packages:` or `dependencies:` list and targets the project-root
+`packages.yml` or `dependencies.yml`; a `macro_sql` edit must hold only macro
+definitions and jinja comments and must target the project's macro paths, where
+no other kind may go; a `project_yml` edit targets the project-root
+`dbt_project.yml` and must keep a `name`; a `profiles_yml` edit targets the
+project-root `profiles.yml` and must reference every secret via
+`{{ env_var('NAME') }}`, never a literal), pins it to the sha256 of the file it
+would change, computes the diffs, and stores the plan under
+`.dex/plans/<plan-id>.json`. Nothing touches the dbt project until an apply.
+`packages_yml` is the guarded way to declare dbt package dependencies: a
+reviewable diff like any other edit, then `transform deps` (or the automatic
+deps step in `transform build`) installs them. `macro_sql` is how a macro is
+repaired or customized by hand; `transform macro <name>` is the scaffolding path
+for the macros dex ships. `project_yml` and `profiles_yml` bring the two
+project-root config files into the same plan/diff/apply flow; because they carry
+project-wide settings and connection targets, they are gated by dbt's own parser
+at plan time, and a `profiles_yml` edit is refused if it (or the file it would
+replace) inlines a literal credential, so no secret ever reaches the diff.
 
 - `transform init "<name>" --connector <duckdb|snowflake|bigquery|databricks|postgres>`
   bootstraps a dbt project when none exists: `dbt_project.yml`, `models/staging/`

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.2.1"
+DEX_CORE_VERSION = "1.2.2"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.2.1"
+DEX_CORE_VERSION = "1.2.2"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/SKILL.md
+++ b/skills/transform/SKILL.md
@@ -29,12 +29,16 @@ and stores the proposal as a plan. Hand content over with `--edits-file <path>`
 ```
 
 `kind` is `model_sql`, `schema_yml`, `semantic_yml` (optional on
-`semantic define|update|plan`, which imply it), or `macro_sql` (a macro file
-under the project's macro paths). Model SQL must be a single read-only SELECT
-once its jinja is stripped; semantic YAML is validated against MetricFlow's
-schemas, cross-reference-checked, and (when dbt is available) parsed by dbt
-itself before the plan is accepted; a macro file must hold only macro
-definitions and jinja comments.
+`semantic define|update|plan`, which imply it), `macro_sql` (a macro file under
+the project's macro paths), `packages_yml`, `project_yml` (the project-root
+`dbt_project.yml`), or `profiles_yml` (the project-root `profiles.yml`). Model
+SQL must be a single read-only SELECT once its jinja is stripped; semantic YAML
+is validated against MetricFlow's schemas, cross-reference-checked, and (when
+dbt is available) parsed by dbt itself before the plan is accepted; a macro file
+must hold only macro definitions and jinja comments. `project_yml` must keep a
+`name`; `profiles_yml` must reference every secret via `{{ env_var('NAME') }}`
+(a literal credential is refused so none reaches the diff), and both config
+kinds are parsed by dbt at plan time.
 
 ### Bootstrapping a project
 

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.2.1"
+DEX_CORE_VERSION = "1.2.2"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
## What this changes

PR #100 solved the main requirement in issue #83 : adding macros to transform's functionalities.

This PR solves the second part: `dbt_project.yml` and `profiles.yml` are editable in `transform`.
Bonus: secret/credentials validation within these files is added.

## Related issues

Closes: #83 (Internally: SCRUM-939)
