### PR TITLE
SCRUM-942-Fix transform build swallowing dbt's real error on every connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,27 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   still fails immediately), across a window wide enough to cover the wake. A
   per-attempt connect timeout bounds a stalled handshake and is cleared once the
   connection is up so it never caps a later billed query's result read.
+- **`transform build` names dbt's real error on every connector, not just
+  Snowflake** ([#76], a connector-parity follow-up to [#50]/[#55]). dbt wraps
+  a failure's actual cause behind one or more generic, information-free
+  headers -- a per-node failure as "<Type> Error in <node> (<path>)", a
+  whole-invocation fatal again in "Encountered an error:", a nested exception
+  chain once more per level -- and, for a per-node failure specifically, logs
+  a bare progress line and a bare "Failure in <node> (<path>)" header before
+  the message that actually names the cause. This shape is identical on every
+  adapter (it comes from dbt_common, not a connector), but keeping only the
+  first captured line let whichever of these uninformative lines happened to
+  log first silently win the envelope's `errors[0]` slot, on Snowflake as much
+  as BigQuery -- #50/#55's own repro just never happened to hit it. The real
+  cause line now rides alongside its header instead of being dropped, and
+  dbt's own per-node/per-run "this is what actually failed" events are
+  promoted ahead of a progress line or bare header the same way the #50 fix
+  already promoted them ahead of a deprecation notice. Also fixed in the same
+  pass: a stale `target/run_results.json` left over from a prior successful
+  build, which a whole-invocation fatal never rewrites, is now cleared before
+  each build so it can never be misreported as this invocation's node
+  results; and ANSI color codes dbt bakes into its messages even under
+  `--log-format json` no longer leak into the envelope.
 
 ## [1.2.1] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,15 +22,15 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 - **`transform build` names dbt's real error on every connector, not just
   Snowflake** ([#76], a connector-parity follow-up to [#50]/[#55]). dbt wraps
   a failure's actual cause behind one or more generic, information-free
-  headers -- a per-node failure as "<Type> Error in <node> (<path>)", a
+  headers: a per-node failure as "<Type> Error in <node> (<path>)", a
   whole-invocation fatal again in "Encountered an error:", a nested exception
-  chain once more per level -- and, for a per-node failure specifically, logs
+  chain once more per level. For a per-node failure specifically, it also logs
   a bare progress line and a bare "Failure in <node> (<path>)" header before
   the message that actually names the cause. This shape is identical on every
   adapter (it comes from dbt_common, not a connector), but keeping only the
   first captured line let whichever of these uninformative lines happened to
   log first silently win the envelope's `errors[0]` slot, on Snowflake as much
-  as BigQuery -- #50/#55's own repro just never happened to hit it. The real
+  as BigQuery; #50/#55's own repro just never happened to hit it. The real
   cause line now rides alongside its header instead of being dropped, and
   dbt's own per-node/per-run "this is what actually failed" events are
   promoted ahead of a progress line or bare header the same way the #50 fix

--- a/packages/dex-core/src/exmergo_dex_core/transform/build.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/build.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -153,6 +154,16 @@ def build(
     ]
     if select:
         argv += ["--select", select]
+
+    # A hard compile-time/parse-time failure (a Jinja context error, for
+    # instance) dies before dbt ever reaches node execution, so it never
+    # (re)writes target/run_results.json -- a stale one left over from a prior
+    # successful build would otherwise still be sitting there, and _summarize
+    # would report its node results as if they belonged to this invocation
+    # (issue #76). Clearing it first means "file absent" always means "this
+    # invocation wrote nothing", never "an old invocation's results carried
+    # over".
+    (project / "target" / "run_results.json").unlink(missing_ok=True)
 
     # cwd is pinned to the project dir so relative paths in profiles.yml (for
     # example a DuckDB `path: ./dev.duckdb`) resolve against the project, never
@@ -386,9 +397,47 @@ def _default_runner(
 # message text regardless of `info.level`. Left undistinguished from a real
 # failure, one of these reliably wins the errors[0] slot merely by logging
 # before the actual cause does. `MainEncounteredError` is dbt's own summary of
-# what actually killed the run and always leads when present.
+# what actually killed a *run-level* fatal (a connection or parse failure,
+# before any node executes) and always leads when present.
+#
+# A per-node failure has no MainEncounteredError at all; instead dbt fires, in
+# order, a bare progress line (`LogModelResult`, e.g. "1 of 1 ERROR creating
+# sql view model x .... [ERROR in 0.1s]"), a bare `RunResultFailure` header
+# ("Failure in model x (models/x.sql)"), and only then `RunResultError`, whose
+# `msg` is the actual dbt exception text (`result.message`) -- the one event
+# that names *why* the node failed. None of the first two are deprecation-
+# tagged, so without also promoting `RunResultError`, whichever of them
+# logged first silently wins errors[0] ahead of the real cause -- verified
+# against a real `dbt build --log-format json` failure (issue #76).
 _DEPRECATION_MARKER = "[WARNING]"
 _MAIN_ENCOUNTERED_ERROR = "MainEncounteredError"
+_RUN_RESULT_ERROR = "RunResultError"
+
+# dbt wraps a failure's actual cause behind one or more generic headers with no
+# information of their own. dbt_common's DbtRuntimeError (and its Database/
+# Compilation/Validation/Runtime subclasses) render a per-node failure as
+# "<Type> Error in <node> (<path>)", with the cause on the next line (e.g.
+# "Database Error in model x (models/x.sql)\n  Argument 2 to JSON_VALUE must
+# be a constant expression\n  compiled code at ..."). A whole-invocation fatal
+# caught by dbt's own top-level handler is wrapped again in "Encountered an
+# error:", and a chained/nested exception repeats a bare "<Type> Error" once
+# per level before the innermost, actual message (verified against a real
+# `dbt build --log-format json` run: "Encountered an error:\nRuntime Error\n
+# Compilation Error\n    Could not render {{ 1/0 }}: division by zero"). This
+# shape comes from dbt_common, not from any connector, so it is identical on
+# Snowflake, BigQuery, or any other adapter. Keeping only the first line (a
+# bare "first line of msg" truncation) silently dropped the cause behind
+# whichever of these wrappers led; the #50 deprecation fix never caught it
+# because #50's own repro didn't spell one out in its test message (#76).
+_GENERIC_HEADER = re.compile(
+    r"^(?:Encountered an error:|"
+    r"(?:Database|Runtime|Compilation|Validation|Internal) Error(?: in .+)?)$"
+)
+
+# dbt colors its console messages (red failures, yellow warnings) even under
+# --log-format json, baking raw ANSI escapes into info.msg; harmless on a
+# terminal, but unreadable noise once that text crosses into a JSON envelope.
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 def _collect_messages(
@@ -397,11 +446,16 @@ def _collect_messages(
     """Reduce dbt's output to actionable one-liners for the envelope.
 
     Keeps the first line of each error/warn message (redacted, length-capped,
-    deduplicated); deprecation notices sink below real errors so they cannot
-    poison the errors[0] slot, and dbt's own MainEncounteredError event (the
-    structured summary of the actual failure) always leads when present. When
-    anything was cut, the last entry points at the full log instead of letting
-    a raw traceback cross the envelope boundary.
+    deduplicated) -- except a generic header (see _GENERIC_HEADER), which says
+    nothing about why the node or run failed on its own, so the nearest
+    following line that isn't itself another generic header rides along with
+    it. Deprecation notices sink below real errors so they cannot poison the
+    errors[0] slot, and dbt's own structured summaries of what actually
+    failed -- MainEncounteredError for a run-level fatal, RunResultError for a
+    per-node one -- always lead over an uninformative progress line or bare
+    failure header that merely logged first. When anything was cut, the last
+    entry points at the full log
+    instead of letting a raw traceback cross the envelope boundary.
     """
 
     entries: list[tuple[str, str]] = []
@@ -415,8 +469,22 @@ def _collect_messages(
         info = event.get("info", {})
         if info.get("level") not in {"error", "warn"} or not info.get("msg"):
             continue
-        msg = redact(str(info["msg"]))
-        first_line = msg.splitlines()[0] if msg else msg
+        msg = redact(_ANSI_ESCAPE.sub("", str(info["msg"])))
+        msg_lines = msg.splitlines()
+        first_line = msg_lines[0].strip() if msg_lines else msg.strip()
+        if _GENERIC_HEADER.match(first_line):
+            cause = next(
+                (
+                    stripped
+                    for line in msg_lines[1:]
+                    if (stripped := line.strip())
+                    and not _GENERIC_HEADER.match(stripped)
+                ),
+                None,
+            )
+            if cause:
+                sep = "" if first_line.endswith(":") else ":"
+                first_line = f"{first_line}{sep} {cause}"
         if len(first_line) > _MESSAGE_MAX_CHARS:
             first_line = first_line[:_MESSAGE_MAX_CHARS] + "..."
             trimmed = True
@@ -433,8 +501,15 @@ def _collect_messages(
     main_error = next(
         (m for name, m in entries if name == _MAIN_ENCOUNTERED_ERROR), None
     )
-    if main_error is not None:
-        primary = [main_error] + [m for m in primary if m != main_error]
+    # Per-node cause(s), in case a build fails several models at once; a
+    # run-level MainEncounteredError (when present) still leads them, since it
+    # is the reason none of them, or nothing after them, ran at all.
+    node_causes = [
+        m for name, m in entries if name == _RUN_RESULT_ERROR and m != main_error
+    ]
+    promoted = ([main_error] if main_error is not None else []) + node_causes
+    if promoted:
+        primary = promoted + [m for m in primary if m not in promoted]
     messages = primary + deprecations
 
     if not messages and completed.stderr:

--- a/packages/dex-core/tests/transform/test_build.py
+++ b/packages/dex-core/tests/transform/test_build.py
@@ -133,9 +133,21 @@ def test_non_dev_target_is_refused(
 
 
 def _fake_runner_factory(
-    monkeypatch, *, returncode: int, stdout: str = "", stderr: str = ""
+    monkeypatch,
+    *,
+    returncode: int,
+    stdout: str = "",
+    stderr: str = "",
+    run_results_json: tuple[Path, str] | None = None,
 ):
-    """Replace _default_runner with a recorder returning a canned dbt result."""
+    """Replace _default_runner with a recorder returning a canned dbt result.
+
+    ``run_results_json``, when given, is written only once the fake ``run()``
+    is actually invoked -- matching real dbt, which writes the artifact as
+    part of running rather than beforehand (`build()` clears any stale one
+    right before invocation, so pre-seeding it ahead of the call would just
+    have it deleted unread).
+    """
 
     import subprocess
 
@@ -145,6 +157,10 @@ def _fake_runner_factory(
     def fake(timeout: float, cwd, env=None):
         def run(argv: list[str]):
             calls.append({"argv": argv, "cwd": cwd, "env": env})
+            if run_results_json is not None:
+                path, content = run_results_json
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
             return subprocess.CompletedProcess(
                 args=argv, returncode=returncode, stdout=stdout, stderr=stderr
             )
@@ -263,6 +279,196 @@ def test_build_failure_error_skips_deprecation_warnings_for_the_real_cause(
         '"NOPE_MISSING_DB"'
     )
     assert any("PropertyMovedToConfigDeprecation" in w for w in envelope["warnings"])
+
+
+def test_build_failure_names_the_cause_behind_a_per_node_database_error(
+    dbt_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """Regression for #76: a per-node `Database/Runtime/Compilation Error in
+    <node> (<path>)` header (dbt_common's DbtRuntimeError.__str__ shape, the
+    same on every adapter) carries no cause of its own -- the real one is the
+    next line. Shape confirmed against a real `dbt build --log-format json`
+    failure, not hand-guessed."""
+
+    real_error = (
+        "Runtime Error in model my_model (models/staging/my_model.sql)\n"
+        "  Argument 2 to JSON_VALUE must be a constant expression\n"
+        "  compiled code at target/run/dex_test/models/staging/my_model.sql"
+    )
+    lines = [
+        json.dumps(
+            {
+                "info": {
+                    "level": "error",
+                    "name": "LogModelResult",
+                    "msg": "1 of 1 ERROR creating sql view model my_model ... "
+                    "[ERROR in 0.12s]",
+                }
+            }
+        ),
+        json.dumps(
+            {
+                "info": {
+                    "level": "error",
+                    "name": "RunResultFailure",
+                    "msg": "Failure in model my_model (models/staging/my_model.sql)",
+                }
+            }
+        ),
+        json.dumps(
+            {"info": {"level": "error", "name": "RunResultError", "msg": real_error}}
+        ),
+    ]
+    _fake_runner_factory(monkeypatch, returncode=1, stdout="\n".join(lines))
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert envelope["errors"][0] == (
+        "dbt build failed: Runtime Error in model my_model "
+        "(models/staging/my_model.sql): Argument 2 to JSON_VALUE must be a "
+        "constant expression"
+    )
+    # The uninformative progress line and bare failure header are demoted to
+    # warnings, not lost, and not mistaken for the cause.
+    assert any("Failure in model my_model" in w for w in envelope["warnings"])
+    assert any("ERROR creating" in w for w in envelope["warnings"])
+
+
+def test_build_failure_names_the_cause_behind_a_whole_run_fatal(
+    dbt_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """A whole-invocation fatal (no node ever ran) is wrapped by dbt's own
+    top-level handler in "Encountered an error:", then by each nested
+    exception level in a bare "<Type> Error" -- confirmed against a real `dbt
+    build` failure (a division-by-zero in a profile Jinja expression)."""
+
+    real_error = (
+        "Encountered an error:\n"
+        "Runtime Error\n"
+        "  Compilation Error\n"
+        "    Could not render {{ 1/0 }}: division by zero"
+    )
+    lines = [
+        json.dumps(
+            {
+                "info": {
+                    "level": "error",
+                    "name": "MainEncounteredError",
+                    "msg": real_error,
+                }
+            }
+        ),
+    ]
+    _fake_runner_factory(monkeypatch, returncode=2, stdout="\n".join(lines))
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert envelope["errors"][0] == (
+        "dbt build failed: Encountered an error: Could not render {{ 1/0 }}: "
+        "division by zero"
+    )
+
+
+def test_build_failure_message_strips_ansi_color_codes(
+    dbt_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """dbt colors console messages even under --log-format json; the escapes
+    are noise once that text crosses into the JSON envelope."""
+
+    lines = [
+        json.dumps(
+            {
+                "info": {
+                    "level": "error",
+                    "name": "RunResultFailure",
+                    "msg": "\x1b[31mFailure in model x (models/x.sql)\x1b[0m",
+                }
+            }
+        ),
+    ]
+    _fake_runner_factory(monkeypatch, returncode=1, stdout="\n".join(lines))
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert envelope["errors"][0] == (
+        "dbt build failed: Failure in model x (models/x.sql)"
+    )
+    assert "\x1b" not in envelope["errors"][0]
+
+
+def test_build_ignores_a_stale_run_results_json_from_a_prior_invocation(
+    dbt_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """Regression for #76: a whole-invocation fatal (e.g. a Jinja context
+    error) dies before dbt ever reaches node execution, so it never rewrites
+    target/run_results.json. A stale one left over from a prior successful
+    build must not be reported as this invocation's node results -- verified
+    against real dbt behavior (its mtime is untouched by such a failure)."""
+
+    target_dir = dbt_project_dir / "target"
+    target_dir.mkdir(exist_ok=True)
+    (target_dir / "run_results.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "unique_id": "model.dex_test.stg_customers",
+                        "status": "success",
+                        "execution_time": 1.23,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    # A fatal that never touches run_results.json: empty stdout, no node ever
+    # ran, matching a real whole-invocation compile/parse-time crash.
+    _fake_runner_factory(monkeypatch, returncode=2, stdout="")
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+        ],
+        capsys,
+    )
+    assert rc == 1
+    assert envelope["data"]["nodes"] == []
+    assert envelope["data"]["counts"] == {}
 
 
 def test_missing_dev_db_with_sources_is_an_actionable_error(
@@ -527,29 +733,29 @@ def test_billed_build_sums_bytes_billed_into_the_ledger(
 ):
     import json as json_mod
 
-    _fake_runner_factory(monkeypatch, returncode=0)
     target_dir = bigquery_project_dir / "target"
-    target_dir.mkdir(exist_ok=True)
-    (target_dir / "run_results.json").write_text(
-        json_mod.dumps(
-            {
-                "results": [
-                    {
-                        "unique_id": "model.dex_test.stg_customers",
-                        "status": "success",
-                        "execution_time": 1.0,
-                        "adapter_response": {"bytes_billed": 1000},
-                    },
-                    {
-                        "unique_id": "model.dex_test.mart_customers",
-                        "status": "success",
-                        "execution_time": 1.0,
-                        "adapter_response": {"bytes_billed": 2000},
-                    },
-                ]
-            }
-        ),
-        encoding="utf-8",
+    run_results = json_mod.dumps(
+        {
+            "results": [
+                {
+                    "unique_id": "model.dex_test.stg_customers",
+                    "status": "success",
+                    "execution_time": 1.0,
+                    "adapter_response": {"bytes_billed": 1000},
+                },
+                {
+                    "unique_id": "model.dex_test.mart_customers",
+                    "status": "success",
+                    "execution_time": 1.0,
+                    "adapter_response": {"bytes_billed": 2000},
+                },
+            ]
+        }
+    )
+    _fake_runner_factory(
+        monkeypatch,
+        returncode=0,
+        run_results_json=(target_dir / "run_results.json", run_results),
     )
     rc, envelope = _run(
         [


### PR DESCRIPTION
- #50/#55 fixed transform build's errors[0] getting poisoned by a dbt
  deprecation-warning line instead of the real failure, but were verified
  against Snowflake only. Reproducing the identical symptom on BigQuery
  showed the actual bug is broader than a missing connector-specific port —
  it's connector-agnostic and was never fully fixed for *any* adapter.
- Root cause, confirmed against real `dbt build --log-format json` output
  (not hand-written test fixtures): dbt wraps a failure's real cause behind
  one or more generic, information-free headers, identical on every
  connector since the shape comes from dbt_common:
  - A per-node failure has no `MainEncounteredError` at all. Instead dbt
    fires, in order, a bare progress line (`LogModelResult`), a bare
    `"Failure in model x (path)"` header (`RunResultFailure`), and only
    then `RunResultError`, whose `msg` is the actual exception text. Nothing
    marks the first two as deprecations, so whichever logs first — usually
    the useless one — won `errors[0]`.
  - Even the right message could lose its cause: `"<Type> Error in <node>
    (<path>)"` puts the real cause on the *next* line; a whole-invocation
    fatal wraps again in `"Encountered an error:"`; a nested exception chain
    repeats a bare `"<Type> Error"` once per level. The old code kept only
    `msg.splitlines()[0]`.
- Fix (`transform/build.py`):
  - `RunResultError` (the per-node cause event) is now promoted the same
    way `MainEncounteredError` (the run-level cause event) already was.
  - A new `_GENERIC_HEADER` walks past chained wrapper lines to find the
    first real content line and appends it to the header instead of
    dropping it.
  - ANSI color codes dbt bakes into messages even under `--log-format json`
    are stripped before they reach the envelope.
  - `build()` now clears any stale `target/run_results.json` before
    invoking dbt: a whole-invocation fatal never rewrites that file, so a
    prior successful build's node results could otherwise be misreported as
    belonging to the current (failed, near-instant) invocation — confirmed
    by comparing real file mtimes before/after such a failure.
Before the fix: 
<img width="1631" height="167" alt="Screenshot 2026-07-19 121651" src="https://github.com/user-attachments/assets/0c5a4996-115e-4961-954f-5a36baeb6eee" />
After fix:
<img width="1627" height="187" alt="Screenshot 2026-07-19 121301" src="https://github.com/user-attachments/assets/68b92dfc-5e7c-4e41-ac97-4924f2a7568b" />
