### PR TITLE
Issue-108: Blob-column pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,20 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   its only batched filtered-count spelling, and it was the one form the
   firewall still refused. The refusal message's example list and the probe
   playbook now name `COUNTIF` alongside `COUNT` (#105).
+- **`explore profile` no longer scans blob-type columns by default.**
+  `BYTES`/`BLOB`/`bytea`/`BINARY` columns, scalar or repeated, are excluded
+  from the aggregate scan across every connector (DuckDB, BigQuery,
+  Snowflake, Databricks, Postgres, Redshift): their profile can only ever be
+  a null fraction and a distinct estimate, yet a columnar engine bills for a
+  column's full stored bytes once it is referenced at all, so blob-heavy
+  tables had these columns dominating scan cost for negligible signal.
+  Excluded columns are named in the dataset's `data_quality` notes, the same
+  convention `explore cluster` already uses for excluded keys. A new
+  `blob_overrides` list in `.dex/config.yml` (mirroring `pii_overrides`)
+  restores real stats for a specific column when they matter. Every
+  connector's `profile_estimate` reflects the same exclusion, so the
+  pre-execution cost estimate matches what the pruned scan actually runs
+  (#108).
 - **`explore query` now resolves CTE aliases across set operations.** `WITH`
   clause relations attached to `UNION`, `INTERSECT`, or `EXCEPT` roots are
   registered before either branch is inspected, including later CTEs that

--- a/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
@@ -43,6 +43,7 @@ from .base import (
     QueryResult,
     blame,
     distinct_combination_sql,
+    is_blob_type,
     json_safe,
     name_list,
     shape_stat_expressions,
@@ -677,18 +678,31 @@ class DatabricksAdapter:
     # --- estimation (free; feeds the confirm handshake) -------------------------
 
     def profile_estimate(
-        self, identifiers: list[str]
+        self, identifiers: list[str], *, include_blobs: set[str] | None = None
     ) -> tuple[float, dict[str, float]]:
         """The floor estimate for profiling: per table, its aggregate-batch
         count times the per-statement floor (sharpened by any size already
         learned this command), plus one DESCRIBE DETAIL per table, plus the
         startup floor when the warehouse is not running. Free: everything
-        comes from REST metadata."""
+        comes from REST metadata.
 
+        Blob-type columns are excluded from the batch count the same way
+        ``explore.profile.profile`` excludes them from the scan itself
+        (``include_blobs`` names the ``identifier.column`` paths a human
+        opted back in), so this estimate's batch count matches what the run
+        will actually issue."""
+
+        blob_paths = include_blobs or set()
         per_table: dict[str, float] = {}
         for identifier in identifiers:
             meta, columns = self.table_metadata(identifier)
-            batches = max((len(columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
+            scan_columns = [
+                c
+                for c in columns
+                if not is_blob_type(c.data_type)
+                or f"{identifier}.{c.name}".lower() in blob_paths
+            ]
+            batches = max((len(scan_columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
             per_table[identifier] = (
                 batches * self._statement_seconds(meta.byte_size) + _DETAIL_SECONDS
             )

--- a/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
@@ -49,6 +49,7 @@ from .base import (
     QueryResult,
     blame,
     distinct_combination_sql,
+    is_blob_type,
     json_safe,
     name_list,
     shape_stat_expressions,
@@ -475,16 +476,29 @@ class PostgresAdapter:
     # --- estimation (free; feeds the confirm handshake) -------------------------
 
     def profile_estimate(
-        self, identifiers: list[str]
+        self, identifiers: list[str], *, include_blobs: set[str] | None = None
     ) -> tuple[float, dict[str, float]]:
         """The heuristic database-seconds estimate for profiling: per table,
         its bytes over a conservative scan rate times the number of aggregate
-        batches. Free: everything comes from catalog metadata."""
+        batches. Free: everything comes from catalog metadata.
 
+        Blob-type columns are excluded from the batch count the same way
+        ``explore.profile.profile`` excludes them from the scan itself
+        (``include_blobs`` names the ``identifier.column`` paths a human
+        opted back in), so this estimate's batch count matches what the run
+        will actually issue."""
+
+        blob_paths = include_blobs or set()
         per_table: dict[str, float] = {}
         for identifier in identifiers:
             meta, columns = self.table_metadata(identifier)
-            batches = max((len(columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
+            scan_columns = [
+                c
+                for c in columns
+                if not is_blob_type(c.data_type)
+                or f"{identifier}.{c.name}".lower() in blob_paths
+            ]
+            batches = max((len(scan_columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
             per_table[identifier] = batches * self._scan_seconds(meta.byte_size)
         return sum(per_table.values()), per_table
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
@@ -54,6 +54,7 @@ from .base import (
     QueryResult,
     blame,
     distinct_combination_sql,
+    is_blob_type,
     json_safe,
     name_list,
     shape_stat_expressions,
@@ -641,17 +642,30 @@ class RedshiftAdapter:
     # --- estimation (feeds the confirm handshake; no scans) -----------------------
 
     def profile_estimate(
-        self, identifiers: list[str]
+        self, identifiers: list[str], *, include_blobs: set[str] | None = None
     ) -> tuple[float, dict[str, float]]:
         """The heuristic compute-seconds estimate for profiling: per table,
         its bytes over the capacity-scaled scan rate times the number of
         aggregate batches; plus the 60-second wake minimum once on
-        Serverless. Everything comes from catalog metadata."""
+        Serverless. Everything comes from catalog metadata.
 
+        Blob-type columns are excluded from the batch count the same way
+        ``explore.profile.profile`` excludes them from the scan itself
+        (``include_blobs`` names the ``identifier.column`` paths a human
+        opted back in), so this estimate's batch count matches what the run
+        will actually issue."""
+
+        blob_paths = include_blobs or set()
         per_table: dict[str, float] = {}
         for identifier in identifiers:
             meta, columns = self.table_metadata(identifier)
-            batches = max((len(columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
+            scan_columns = [
+                c
+                for c in columns
+                if not is_blob_type(c.data_type)
+                or f"{identifier}.{c.name}".lower() in blob_paths
+            ]
+            batches = max((len(scan_columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
             per_table[identifier] = batches * self._scan_seconds(meta.byte_size)
         return sum(per_table.values()) + self._estimate_floor(), per_table
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
@@ -41,6 +41,7 @@ from .base import (
     QueryResult,
     blame,
     distinct_combination_sql,
+    is_blob_type,
     json_safe,
     name_list,
     scope_within,
@@ -627,17 +628,30 @@ class SnowflakeAdapter:
     # --- estimation (free; feeds the confirm handshake) -------------------------
 
     def profile_estimate(
-        self, identifiers: list[str]
+        self, identifiers: list[str], *, include_blobs: set[str] | None = None
     ) -> tuple[float, dict[str, float]]:
         """The heuristic warehouse-seconds estimate for profiling: per table,
         its bytes over the size-scaled scan rate times the number of aggregate
         batches; plus the 60-second resume minimum once when the warehouse is
-        currently suspended. Free: everything comes from SHOW metadata."""
+        currently suspended. Free: everything comes from SHOW metadata.
 
+        Blob-type columns are excluded from the batch count the same way
+        ``explore.profile.profile`` excludes them from the scan itself
+        (``include_blobs`` names the ``identifier.column`` paths a human
+        opted back in), so this estimate's batch count matches what the run
+        will actually issue."""
+
+        blob_paths = include_blobs or set()
         per_table: dict[str, float] = {}
         for identifier in identifiers:
             meta, columns = self.table_metadata(identifier)
-            batches = max((len(columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
+            scan_columns = [
+                c
+                for c in columns
+                if not is_blob_type(c.data_type)
+                or f"{identifier}.{c.name}".lower() in blob_paths
+            ]
+            batches = max((len(scan_columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
             per_table[identifier] = batches * self._scan_seconds(meta.byte_size)
         total = sum(per_table.values()) + self._resume_floor()
         return total, per_table

--- a/packages/dex-core/tests/adapters/test_connect_databricks.py
+++ b/packages/dex-core/tests/adapters/test_connect_databricks.py
@@ -180,6 +180,44 @@ def test_no_startup_floor_on_a_running_warehouse(fake_databricks):
     assert total == pytest.approx(per_table["shop.core.customers"])
 
 
+def _wide_blob_table():
+    from fakes.databricks import FakeDatabricksTable
+
+    # 50 plain columns plus one binary column: without exclusion this is 2
+    # batches (51 columns), with exclusion (the default) it's 1 (50 columns).
+    # bytes=0 keeps _statement_seconds at the floor regardless of warehouse info.
+    columns = [(f"c_{i}", "bigint", True) for i in range(50)]
+    columns.append(("payload", "binary", True))
+    return FakeDatabricksTable(
+        catalog="shop", schema="core", name="sessions", columns=columns, rows=100
+    )
+
+
+def test_profile_estimate_accepts_include_blobs_without_crashing(fake_databricks):
+    # Regression test: explore/commands.py::_profile_estimate always calls
+    # adapter.profile_estimate(identifiers, include_blobs=...), so every
+    # adapter with a profile_estimate must accept that kwarg.
+    warm(fake_databricks)
+    adapter = make_adapter(fake_databricks)
+    adapter.profile_estimate(["shop.core.customers"], include_blobs=set())
+
+
+def test_profile_estimate_excludes_blob_columns_from_batch_count(fake_databricks):
+    warm(fake_databricks)
+    fake_databricks.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_databricks)
+    _total, per_table = adapter.profile_estimate(["shop.core.sessions"])
+    assert per_table["shop.core.sessions"] == pytest.approx(
+        1 * _MIN_STATEMENT_SECONDS + _DETAIL_SECONDS
+    )
+    _total, per_table = adapter.profile_estimate(
+        ["shop.core.sessions"], include_blobs={"shop.core.sessions.payload"}
+    )
+    assert per_table["shop.core.sessions"] == pytest.approx(
+        2 * _MIN_STATEMENT_SECONDS + _DETAIL_SECONDS
+    )
+
+
 def test_query_estimate_is_the_floor_until_a_size_is_known(fake_databricks):
     warm(fake_databricks)
     adapter = make_adapter(fake_databricks)

--- a/packages/dex-core/tests/adapters/test_connect_postgres.py
+++ b/packages/dex-core/tests/adapters/test_connect_postgres.py
@@ -174,6 +174,47 @@ def test_profile_estimate_scales_with_bytes_and_batches(fake_pg_connection):
     assert fake_pg_connection.data_statements == []
 
 
+def _wide_blob_table() -> FakePostgresTable:
+    # 50 plain columns plus one bytea column: without exclusion this is 2
+    # batches (51 columns), with exclusion (the default) it's 1 (50 columns).
+    columns = [(f"c_{i}", "integer", True) for i in range(50)]
+    columns.append(("payload", "bytea", True))
+    return FakePostgresTable(
+        schema="raw",
+        name="sessions",
+        columns=columns,
+        reltuples=100.0,
+        total_bytes=5_000_000_000,
+    )
+
+
+def test_profile_estimate_accepts_include_blobs_without_crashing(fake_pg_connection):
+    # Regression test: explore/commands.py::_profile_estimate always calls
+    # adapter.profile_estimate(identifiers, include_blobs=...), so every
+    # adapter with a profile_estimate must accept that kwarg.
+    adapter = make_adapter(fake_pg_connection)
+    adapter.profile_estimate(["dexdb.shop.customers"], include_blobs=set())
+
+
+def test_profile_estimate_excludes_blob_columns_from_batch_count(fake_pg_connection):
+    fake_pg_connection.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_pg_connection)
+    total, per_table = adapter.profile_estimate(["dexdb.raw.sessions"])
+    expected = 1 * (5_000_000_000 / _SCAN_BYTES_PER_SECOND)  # 1 batch, blob excluded
+    assert per_table["dexdb.raw.sessions"] == pytest.approx(expected)
+    assert total == pytest.approx(expected)
+
+
+def test_profile_estimate_include_blobs_override_adds_a_batch(fake_pg_connection):
+    fake_pg_connection.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_pg_connection)
+    total, _per_table = adapter.profile_estimate(
+        ["dexdb.raw.sessions"], include_blobs={"dexdb.raw.sessions.payload"}
+    )
+    expected = 2 * (5_000_000_000 / _SCAN_BYTES_PER_SECOND)  # 2 batches, 51 columns
+    assert total == pytest.approx(expected)
+
+
 def test_query_estimate_uses_the_free_planner(fake_pg_connection):
     fake_pg_connection.plan_costs = lambda sql: 640_000.0  # planner cost units
     adapter = make_adapter(fake_pg_connection)

--- a/packages/dex-core/tests/adapters/test_connect_redshift.py
+++ b/packages/dex-core/tests/adapters/test_connect_redshift.py
@@ -284,6 +284,47 @@ def test_estimate_scales_with_base_capacity(fake_redshift_connection):
     )
 
 
+def _wide_blob_table() -> FakeRedshiftTable:
+    # 50 plain columns plus one binary column: without exclusion this is 2
+    # batches (51 columns), with exclusion (the default) it's 1 (50 columns).
+    # size_mb matches `customers` so CUSTOMERS_SCAN_SECONDS is the per-batch rate.
+    columns = [(f"c_{i}", "bigint", True) for i in range(50)]
+    columns.append(("payload", "binary", True))
+    return FakeRedshiftTable(
+        schema="raw", name="sessions", columns=columns, size_mb=5_000, tbl_rows=100.0
+    )
+
+
+def test_profile_estimate_accepts_include_blobs_without_crashing(
+    fake_redshift_connection,
+):
+    # Regression test: explore/commands.py::_profile_estimate always calls
+    # adapter.profile_estimate(identifiers, include_blobs=...), so every
+    # adapter with a profile_estimate must accept that kwarg.
+    adapter = make_adapter(fake_redshift_connection)
+    adapter.profile_estimate(["dexdb.shop.customers"], include_blobs=set())
+
+
+def test_profile_estimate_excludes_blob_columns_from_batch_count(
+    fake_redshift_connection,
+):
+    fake_redshift_connection.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_redshift_connection)
+    _total, per_table = adapter.profile_estimate(["dexdb.raw.sessions"])
+    assert per_table["dexdb.raw.sessions"] == pytest.approx(CUSTOMERS_SCAN_SECONDS)
+
+
+def test_profile_estimate_include_blobs_override_adds_a_batch(
+    fake_redshift_connection,
+):
+    fake_redshift_connection.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_redshift_connection)
+    _total, per_table = adapter.profile_estimate(
+        ["dexdb.raw.sessions"], include_blobs={"dexdb.raw.sessions.payload"}
+    )
+    assert per_table["dexdb.raw.sessions"] == pytest.approx(2 * CUSTOMERS_SCAN_SECONDS)
+
+
 def test_query_estimate_sums_referenced_tables(fake_redshift_connection):
     adapter = make_adapter(fake_redshift_connection)
     estimate = adapter.query_estimate("SELECT count(*) FROM dexdb.shop.customers")

--- a/packages/dex-core/tests/adapters/test_connect_snowflake.py
+++ b/packages/dex-core/tests/adapters/test_connect_snowflake.py
@@ -158,6 +158,44 @@ def test_no_resume_floor_on_a_running_warehouse(fake_sf_connection):
     assert total == pytest.approx(per_table["SHOP.PUBLIC.CUSTOMERS"])
 
 
+def _wide_blob_table():
+    from fakes.snowflake import FakeSnowflakeTable
+
+    # 50 plain columns plus one BINARY column: without exclusion this is 2
+    # batches (51 columns), with exclusion (the default) it's 1 (50 columns).
+    columns = [(f"C_{i}", "FIXED", True) for i in range(50)]
+    columns.append(("PAYLOAD", "BINARY", True))
+    return FakeSnowflakeTable(
+        database="SHOP",
+        schema="PUBLIC",
+        name="SESSIONS",
+        columns=columns,
+        rows=100,
+        bytes=5_000_000_000,
+    )
+
+
+def test_profile_estimate_accepts_include_blobs_without_crashing(fake_sf_connection):
+    # Regression test: explore/commands.py::_profile_estimate always calls
+    # adapter.profile_estimate(identifiers, include_blobs=...), so every
+    # adapter with a profile_estimate must accept that kwarg.
+    adapter = make_adapter(fake_sf_connection)
+    adapter.profile_estimate(["SHOP.PUBLIC.CUSTOMERS"], include_blobs=set())
+
+
+def test_profile_estimate_excludes_blob_columns_from_batch_count(fake_sf_connection):
+    fake_sf_connection.warehouses[0].state = "STARTED"
+    fake_sf_connection.warehouse_resumes_pending = False
+    fake_sf_connection.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_sf_connection)
+    total_excluded, _per_table = adapter.profile_estimate(["SHOP.PUBLIC.SESSIONS"])
+    total_included, _per_table = adapter.profile_estimate(
+        ["SHOP.PUBLIC.SESSIONS"], include_blobs={"shop.public.sessions.payload"}
+    )
+    # 1 batch (50 cols) vs 2 batches (51 cols), no resume floor to muddy the ratio.
+    assert total_included == pytest.approx(2 * total_excluded)
+
+
 def test_query_estimate_sums_referenced_tables(fake_sf_connection):
     fake_sf_connection.warehouses[0].state = "STARTED"
     fake_sf_connection.warehouse_resumes_pending = False


### PR DESCRIPTION
## Summary

- `explore profile` scanned every column of a table, including `BYTES`/`BLOB`-shaped columns (and `ARRAY<BYTES>`/`BLOB[]`) whose profile can only ever be a null fraction and a distinct estimate. On a columnar warehouse, referencing such a column at all bills for its full stored bytes, so on blob-heavy tables these columns dominated scan cost for almost no decision-relevant signal (one reported case: ~93% of estimated scan bytes from 7 of 35 columns).
- Blob-type columns are now excluded from the profiling scan by default. The exclusion is type-based (classified from the already-fetched catalog type string — no adapter exposes a free per-column byte size, so a size threshold isn't possible) and applies uniformly across connectors because the filtering happens once in `explore/profile.py`, upstream of every adapter's SQL builder.
- Excluded columns are named in the dataset's `data_quality` notes, the same "excluded columns are named, check the notes" convention `explore cluster` already uses.
- A durable per-column opt-in (`blob_overrides` in `.dex/config.yml`) restores real stats for a specific column, mirroring the existing `pii_overrides` mechanism exactly.
- Every connector's `profile_estimate` (the pre-execution cost estimate shown at the billed handshake) applies the same exclusion, so the estimate the user confirms against matches what actually runs. This required each of Postgres, Snowflake, Databricks, and Redshift to accept a new `include_blobs` parameter too — without it, `explore profile`/`relationships`/`map` crashed with a `TypeError` against all four, since `explore/commands.py` calls `profile_estimate(identifiers, include_blobs=...)` unconditionally on any adapter that exposes it.

## Related Issues
Closes #108, closes #122

## Changes

- `adapters/base.py`: `is_blob_type()` classifier (BYTES/BLOB/BYTEA/BINARY, substring-matched like `is_numeric_type`).
- `config.py`: `BlobOverride`, `blob_override_paths()`, `DexConfig.blob_overrides`.
- `explore/profile.py`: `profile()` filters blob columns out of the scan (unless overridden) and adds a `data_quality` note naming what was skipped.
- `explore/commands.py`: threads the override set through `cmd_profile`, `cmd_relationships`, and `cmd_map`.
- `adapters/bigquery.py`, `adapters/postgres.py`, `adapters/snowflake.py`, `adapters/databricks.py`, `adapters/redshift.py`: `profile_estimate` on each accepts `include_blobs` and filters the same way, so every connector's cost estimate reflects the pruned scan.
- No changes needed to any adapter's actual scan-building SQL (`column_aggregates`) — the exclusion happens once, upstream, in `explore/profile.py`, before that's ever called.

## Test plan

- [x] `tests/test_config.py` — `BlobOverride`/`blob_override_paths` round-trip, case-insensitivity, clean-when-unset
- [x] `tests/explore/test_profile.py` — default exclusion + `data_quality` note, override restores stats
- [x] `tests/adapters/test_connect_bigquery.py` — `profile_estimate` excludes a `BYTES` column's bytes by default, restores it under `include_blobs`
- [x] `tests/adapters/test_connect_postgres.py`, `test_connect_snowflake.py`, `test_connect_databricks.py`, `test_connect_redshift.py` — regression test reproducing the exact crash (`profile_estimate(identifiers, include_blobs=set())`), plus batch-count accuracy tests
- [x] Full suite: 1121 passed, 78 skipped
- [x] `ruff check` clean on all touched files