### PR TITLE
Issue 106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **`pii_overrides` gains an opt-in pattern form** (#106). Alongside the
+  existing exact `column` entry, a `column_name` + `scope` entry clears a
+  named column on every table whose fully-qualified identifier matches the
+  `scope` glob, so one reviewed decision (for example, "this CDC export's
+  `document_name` is a resource path, not a person name") no longer costs one
+  config entry per table per environment on Firestore/Mongo/DynamoDB-style
+  sources, where the same column exists by construction on every entity's
+  table in every environment mirror. `column` and `column_name`/`scope` are
+  mutually exclusive on one entry (enforced at load). The profile-time typo
+  guard now covers pattern entries too: it warns when a `scope` matches
+  profiled tables but none carries the named column, and stays silent when
+  the scope matches no table yet, since new entities landing later under the
+  same scope is the point of the pattern form. `blob_overrides` keeps its
+  exact-only shape for now.
 - **`transform init --layered-schemas`: per-layer schema routing out of the
   box.** The flag additionally scaffolds `models/intermediate/`, a
   `generate_schema_name` macro override, and a `dbt_project.yml` `models:`

--- a/packages/dex-core/src/exmergo_dex_core/adapters/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/base.py
@@ -170,6 +170,25 @@ def json_safe(value: object | None) -> object | None:
     return str(value)
 
 
+# Substring hints for arbitrary binary-blob column types across dialects
+# (BigQuery BYTES, DuckDB BLOB, Postgres bytea, Snowflake/Databricks
+# BINARY/VARBINARY). Matched the same way as profile.is_numeric_type, so a
+# repeated spelling (ARRAY<BYTES>, BLOB[]) is caught by the same substring
+# search without a separate case.
+_BLOB_HINTS = ("BYTES", "BLOB", "BYTEA", "BINARY")
+
+
+def is_blob_type(data_type: str) -> bool:
+    """Whether a connector's raw column type is an arbitrary binary blob, scalar
+    or repeated. A blob column's profile can only ever be a null fraction and a
+    distinct estimate, yet a columnar engine bills for the whole column once it
+    is referenced by any aggregate at all -- so ``explore profile`` excludes
+    these columns from its scan by default (see ``explore.profile.profile``)."""
+
+    upper = data_type.upper()
+    return any(h in upper for h in _BLOB_HINTS)
+
+
 def distinct_combination_sql(
     table_sql: str,
     combinations: list[list[str]],

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -29,6 +29,7 @@ from .base import (
     QueryResult,
     blame,
     distinct_combination_sql,
+    is_blob_type,
     json_safe,
     name_list,
     shape_stat_expressions,
@@ -580,7 +581,7 @@ class BigQueryAdapter:
     # --- estimation (free dry-runs; feeds the confirm handshake) --------------
 
     def profile_estimate(
-        self, identifiers: list[str]
+        self, identifiers: list[str], *, include_blobs: set[str] | None = None
     ) -> tuple[float, dict[str, float]]:
         """Dry-run every aggregate batch profiling would issue and sum the
         bytes, per table and in total. Free: metadata GETs and dry-run jobs
@@ -590,24 +591,36 @@ class BigQueryAdapter:
         Each batch is one billed query over one table, so its cost is floored
         to the per-query minimum: on small tables the raw scan is a fraction of
         what BigQuery actually bills, and an unfloored estimate would send the
-        agent into a ladder of budget rejections."""
+        agent into a ladder of budget rejections.
 
+        Blob-type columns are excluded from the batches the same way
+        ``explore.profile.profile`` excludes them from the scan itself
+        (``include_blobs`` names the ``identifier.column`` paths a human opted
+        back in), so this estimate matches what the run will actually bill."""
+
+        blob_paths = include_blobs or set()
         per_table: dict[str, float] = {}
         for identifier in identifiers:
             _meta, columns = self.table_metadata(identifier)
             if self._unqueryable(identifier):
                 per_table[identifier] = 0.0
                 continue
+            scan_columns = [
+                c
+                for c in columns
+                if not is_blob_type(c.data_type)
+                or f"{identifier}.{c.name}".lower() in blob_paths
+            ]
             # min/max and shape fractions add no scanned bytes: columnar
             # billing already charges the whole column.
             safe: set[str] = set()
             shape: set[str] = set()
             sample_percent = self._sample_percent(identifier)
             total = 0.0
-            for start in range(0, len(columns), _COLUMN_BATCH):
+            for start in range(0, len(scan_columns), _COLUMN_BATCH):
                 sql, _plan = self._build_aggregate_sql(
                     identifier,
-                    columns[start : start + _COLUMN_BATCH],
+                    scan_columns[start : start + _COLUMN_BATCH],
                     safe,
                     shape,
                     sample_percent=sample_percent,

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -278,8 +278,7 @@ class PIIOverride(BaseModel):
             )
         if is_pattern and (self.column_name is None or self.scope is None):
             raise ValueError(
-                "pattern-form pii_overrides entry needs both 'column_name' "
-                "and 'scope'"
+                "pattern-form pii_overrides entry needs both 'column_name' and 'scope'"
             )
         return self
 

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -8,10 +8,11 @@ Secrets (passwords, keys, tokens) are read at runtime from their own stores by
 
 from __future__ import annotations
 
+import fnmatch
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from .cache import DEX_DIR
 from .envelope import Paradigm
@@ -235,26 +236,94 @@ class ClusterLimits(BaseModel):
 
 
 class PIIOverride(BaseModel):
-    """One reviewed column the team has decided is not PII.
+    """One reviewed column, or a reviewed *class* of structurally identical
+    columns, the team has decided is not PII.
 
-    ``column`` is fully qualified (the cache's connector-normalized identifier
-    plus the column name, e.g. ``MY_DB.PUBLIC.REGION.R_NAME``) so an override
-    can never silently widen to a same-named column elsewhere. No wildcards: an
-    override records a per-column human decision, and living in the committed
-    config makes that decision reviewable in git and durable across re-profiles.
+    Two mutually exclusive shapes:
+
+    - Exact (default): ``column`` is fully qualified (the cache's
+      connector-normalized identifier plus the column name, e.g.
+      ``MY_DB.PUBLIC.REGION.R_NAME``) so the override can never silently widen
+      to a same-named column elsewhere. This is a per-column human decision.
+    - Pattern (opt-in): ``column_name`` + ``scope`` clears every column named
+      ``column_name`` on any table whose fully-qualified identifier matches
+      the ``scope`` glob (``*`` wildcards, case-insensitive). For the
+      Firestore/Mongo/DynamoDB-export case, where the same structurally
+      identical column exists by construction on every entity's table in
+      every environment mirror, so the exact form would otherwise cost one
+      entry per table per environment for a single human decision.
+
+    Either shape lives in the committed config, so the decision stays
+    reviewable in git and durable across re-profiles.
     """
 
-    column: str
+    column: str | None = None
+    column_name: str | None = None
+    scope: str | None = None
     reason: str | None = None
 
+    @model_validator(mode="after")
+    def _check_shape(self) -> PIIOverride:
+        is_exact = self.column is not None
+        is_pattern = self.column_name is not None or self.scope is not None
+        if is_exact and is_pattern:
+            raise ValueError(
+                "pii_overrides entry must be either 'column' (exact) or "
+                "'column_name' + 'scope' (pattern), not both"
+            )
+        if not is_exact and not is_pattern:
+            raise ValueError(
+                "pii_overrides entry needs either 'column' (exact) or "
+                "'column_name' + 'scope' (pattern)"
+            )
+        if is_pattern and (self.column_name is None or self.scope is None):
+            raise ValueError(
+                "pattern-form pii_overrides entry needs both 'column_name' "
+                "and 'scope'"
+            )
+        return self
 
-def pii_override_paths(overrides: list[PIIOverride]) -> set[str]:
-    """Lowered fully-qualified column paths, the form the engine matches columns
-    against. Case-insensitive because the connectors disagree about identifier
-    case (same rationale as ``scope_within``), and a case mismatch must never
-    re-block a reviewed column."""
 
-    return {entry.column.strip().lower() for entry in overrides}
+class PIIOverrideMatcher:
+    """Resolves ``pii_overrides`` against a fully-qualified ``identifier.column``
+    path. Exact entries match verbatim; pattern entries (``column_name`` +
+    ``scope``) match any column of that name in any dataset whose identifier
+    matches the ``scope`` glob. Duck-types the exact-match set every call site
+    already used (``path in matcher``, ``if not matcher``), so pattern support
+    needs no change at the match sites in ``explore/profile.py`` or
+    ``maintain/reconcile.py``."""
+
+    def __init__(self, overrides: list[PIIOverride]):
+        self._exact = {
+            entry.column.strip().lower() for entry in overrides if entry.column
+        }
+        self._patterns = [
+            (entry.column_name.strip().lower(), entry.scope.strip().lower())
+            for entry in overrides
+            if entry.column_name
+        ]
+
+    def __contains__(self, path: str) -> bool:
+        path = path.strip().lower()
+        if path in self._exact:
+            return True
+        table, _, column = path.rpartition(".")
+        return any(
+            column == name and fnmatch.fnmatchcase(table, scope)
+            for name, scope in self._patterns
+        )
+
+    def __bool__(self) -> bool:
+        return bool(self._exact or self._patterns)
+
+
+def pii_override_paths(overrides: list[PIIOverride]) -> PIIOverrideMatcher:
+    """The form the engine matches columns against: lowered exact paths plus
+    any pattern entries, case-insensitive because the connectors disagree
+    about identifier case (same rationale as ``scope_within``), and a case
+    mismatch must never re-block a reviewed column."""
+
+    return PIIOverrideMatcher(overrides)
 
 
 class BlobOverride(BaseModel):

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -257,6 +257,24 @@ def pii_override_paths(overrides: list[PIIOverride]) -> set[str]:
     return {entry.column.strip().lower() for entry in overrides}
 
 
+class BlobOverride(BaseModel):
+    """One reviewed blob-type column a human wants profiled despite the default
+    exclusion (see ``adapters.base.is_blob_type``). ``column`` is fully
+    qualified, same shape and rationale as :class:`PIIOverride`: a per-column
+    human decision, durable and reviewable in git, never a wildcard."""
+
+    column: str
+    reason: str | None = None
+
+
+def blob_override_paths(overrides: list[BlobOverride]) -> set[str]:
+    """Lowered fully-qualified column paths a human has opted back into
+    profiling despite being blob-typed. Same matching rules as
+    ``pii_override_paths``."""
+
+    return {entry.column.strip().lower() for entry in overrides}
+
+
 class DexConfig(BaseModel):
     """The shape of ``.dex/config.yml``: one optional target per connector plus
     the connector selection, budgets, and engine limits."""
@@ -292,6 +310,10 @@ class DexConfig(BaseModel):
     # durably clear a detector flag; hand-edits to the cache are overwritten by
     # the next profile, this list is re-applied on every profile.
     pii_overrides: list[PIIOverride] = Field(default_factory=list)
+    # Blob-type columns (BYTES/BLOB/bytea/BINARY, scalar or repeated) a human has
+    # reviewed and wants profiled despite the default exclusion. Re-applied on
+    # every profile, same durability rationale as pii_overrides.
+    blob_overrides: list[BlobOverride] = Field(default_factory=list)
 
 
 def load_config(repo_root: Path | str = ".") -> DexConfig | None:

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -30,7 +30,13 @@ from ..cache import (
     RelationshipKind,
     match_identifier,
 )
-from ..config import DexConfig, QueryLimits, load_config, pii_override_paths
+from ..config import (
+    DexConfig,
+    QueryLimits,
+    blob_override_paths,
+    load_config,
+    pii_override_paths,
+)
 from ..guards.cost_guard import OverCeilingError
 from ..guards.query_firewall import (
     InspectedQuery,
@@ -100,12 +106,12 @@ def _mask_overridden(cache: DexCache, override_paths: set[str]) -> DexCache:
 
 
 def _profile_estimate(
-    adapter: Adapter, identifiers: list[str]
+    adapter: Adapter, identifiers: list[str], *, include_blobs: set[str] | None = None
 ) -> tuple[float, dict[str, float]]:
     estimate = getattr(adapter, "profile_estimate", None)
     if estimate is None:
         return 0.0, {}
-    return estimate(identifiers)
+    return estimate(identifiers, include_blobs=include_blobs or set())
 
 
 def _verify_estimate(
@@ -198,6 +204,7 @@ def cmd_profile(args: argparse.Namespace) -> env.Envelope:
     config = load_config(repo_root) or DexConfig()
     defs = _project_definitions(args, config)
     override_paths = pii_override_paths(config.pii_overrides)
+    blob_paths = blob_override_paths(config.blob_overrides)
     adapter = command_args.open_from_args(args)
     # Capture pre-run cache state before any checkpoint write, so the success-path
     # compose reads the pre-run cache rather than a checkpoint this run wrote.
@@ -208,7 +215,9 @@ def cmd_profile(args: argparse.Namespace) -> env.Envelope:
     over_ceiling = False
     try:
         identifiers = _resolve_identifiers(adapter, args.objects)
-        estimate, per_table = _profile_estimate(adapter, identifiers)
+        estimate, per_table = _profile_estimate(
+            adapter, identifiers, include_blobs=blob_paths
+        )
         unconfirmed = command_args.billed_handshake(
             "explore profile", adapter, estimate, per_table=per_table
         )
@@ -232,6 +241,7 @@ def cmd_profile(args: argparse.Namespace) -> env.Envelope:
                 progress=profile_reporter,
                 on_complete=checkpoint,
                 pii_overrides=override_paths,
+                include_blobs=blob_paths,
             )
             profile_reporter.done()
         except OverCeilingError:
@@ -300,7 +310,10 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
             now,
             refresh=getattr(args, "refresh", False),
         )
-        estimate, per_table = _profile_estimate(adapter, [m.identifier for m in stale])
+        blob_paths = blob_override_paths(config.blob_overrides)
+        estimate, per_table = _profile_estimate(
+            adapter, [m.identifier for m in stale], include_blobs=blob_paths
+        )
         handshake_notes = [
             "relationship inference profiles every object; on a metered "
             "connector `explore map` (top-ranked objects only) is usually the "
@@ -348,6 +361,7 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
                     progress=profile_reporter,
                     on_complete=checkpoint,
                     pii_overrides=pii_override_paths(config.pii_overrides),
+                    include_blobs=blob_paths,
                 )
                 profile_reporter.done()
             except OverCeilingError:
@@ -593,7 +607,10 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         )
         # Inventory and ranking are free, so an unconfirmed billed run repeats
         # them on re-issue; only the profiling scans below need the handshake.
-        estimate, per_table = _profile_estimate(adapter, [m.identifier for m in stale])
+        blob_paths = blob_override_paths(config.blob_overrides)
+        estimate, per_table = _profile_estimate(
+            adapter, [m.identifier for m in stale], include_blobs=blob_paths
+        )
         handshake_notes: list[str] = []
         if getattr(args, "verify", False):
             handshake_notes.append(
@@ -636,6 +653,7 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
                     progress=profile_reporter,
                     on_complete=checkpoint,
                     pii_overrides=pii_override_paths(config.pii_overrides),
+                    include_blobs=blob_paths,
                 )
                 profile_reporter.done()
             except OverCeilingError:

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -11,6 +11,7 @@ and only to the ``.dex/`` cache, so a scan is never paid for twice.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import re
 from collections.abc import Callable
@@ -32,6 +33,7 @@ from ..cache import (
 )
 from ..config import (
     DexConfig,
+    PIIOverride,
     QueryLimits,
     blob_override_paths,
     load_config,
@@ -66,23 +68,45 @@ def _override_notes(datasets: list[Dataset]) -> list[str]:
 
 
 def _override_mismatches(
-    datasets: list[Dataset], override_paths: set[str]
+    datasets: list[Dataset], overrides: list[PIIOverride]
 ) -> list[str]:
-    """Warn when an override entry names a profiled table but no column of it:
-    almost certainly a typo, and silence would read as the override working."""
+    """Warn when an override entry can't possibly do anything: an exact entry
+    names a profiled table but no column of it, or a pattern entry's scope
+    matches profiled tables but none carries the named column. Almost
+    certainly a typo, and silence would read as the override working.
+
+    A pattern matching zero tables stays silent, same escape hatch as an exact
+    entry on a not-yet-profiled table: new entities landing later under the
+    same scope are the whole point of the pattern form."""
 
     warnings = []
-    for path in sorted(override_paths):
-        table, _, column = path.rpartition(".")
-        for dataset in datasets:
-            if dataset.identifier.lower() != table:
-                continue
-            if not any(c.name.lower() == column for c in dataset.columns):
+    for entry in overrides:
+        if entry.column:
+            path = entry.column.strip().lower()
+            table, _, column = path.rpartition(".")
+            for dataset in datasets:
+                if dataset.identifier.lower() != table:
+                    continue
+                if not any(c.name.lower() == column for c in dataset.columns):
+                    warnings.append(
+                        f"pii_overrides entry '{path}' matches no column of "
+                        f"{dataset.identifier}"
+                    )
+                break
+        else:
+            column_name = entry.column_name.strip().lower()  # type: ignore[union-attr]
+            scope = entry.scope.strip().lower()  # type: ignore[union-attr]
+            matched = [
+                d for d in datasets if fnmatch.fnmatchcase(d.identifier.lower(), scope)
+            ]
+            if matched and not any(
+                c.name.lower() == column_name for d in matched for c in d.columns
+            ):
                 warnings.append(
-                    f"pii_overrides entry '{path}' matches no column of "
-                    f"{dataset.identifier}"
+                    f"pii_overrides pattern entry (column_name='{entry.column_name}', "
+                    f"scope='{entry.scope}') matches no column named "
+                    f"'{entry.column_name}' in {len(matched)} matched dataset(s)"
                 )
-            break
     return warnings
 
 
@@ -273,7 +297,7 @@ def cmd_profile(args: argparse.Namespace) -> env.Envelope:
             "notes": notes,
         }
     )
-    envelope.warnings.extend(_override_mismatches(datasets, override_paths))
+    envelope.warnings.extend(_override_mismatches(datasets, config.pii_overrides))
     return envelope
 
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 from dataclasses import replace
 from datetime import UTC, datetime
 
-from ..adapters.base import Adapter, ColumnAggregate, json_safe
+from ..adapters.base import Adapter, ColumnAggregate, is_blob_type, json_safe
 from ..cache import ColumnProfile, Dataset, PIICategory, PIIFlag
 from ..progress import ProgressReporter
 
@@ -238,6 +238,7 @@ def profile(
     progress: ProgressReporter | None = None,
     on_complete: Callable[[Dataset], None] | None = None,
     pii_overrides: set[str] | None = None,
+    include_blobs: set[str] | None = None,
 ) -> list[Dataset]:
     """Profile each object into a Dataset of aggregate-derived ColumnProfiles.
 
@@ -255,9 +256,18 @@ def profile(
     are decided, and the suppressed category is recorded on the profile as the
     audit trail. Re-applied on every profile, which is what makes the override
     durable: the cache is overwritten wholesale by re-profiling.
+
+    ``include_blobs`` holds lowered ``identifier.column`` paths a human has opted
+    back into profiling despite being blob-typed (from `.dex/config.yml`). Blob
+    columns (BYTES/BLOB/bytea/BINARY, scalar or repeated) are excluded from the
+    aggregate scan by default: their profile can only ever be a null fraction
+    and a distinct estimate, yet a columnar engine bills for the whole column
+    once it is referenced at all, so scanning them by default trades most of a
+    table's scan cost for stats that rarely inform a decision.
     """
 
     override_paths = pii_overrides or set()
+    blob_paths = include_blobs or set()
     datasets: list[Dataset] = []
     for identifier in identifiers:
         meta, columns = adapter.table_metadata(identifier)
@@ -284,10 +294,22 @@ def profile(
             if generic and prelim_pii[name] is not None
         }
 
+        # Blob-type columns can only ever yield a null fraction and a distinct
+        # estimate, yet a columnar engine bills for the whole column once it is
+        # referenced at all, so they are dropped from the scan before it is
+        # built (unless a human opted a specific one back in via config).
+        blob_excluded = [
+            c.name
+            for c in columns
+            if is_blob_type(c.data_type)
+            and f"{identifier}.{c.name}".lower() not in blob_paths
+        ]
+        scan_columns = [c for c in columns if c.name not in blob_excluded]
+
         aggregates = {
             a.name: a
             for a in adapter.column_aggregates(
-                identifier, columns, safe_min_max=safe, shape_stats=shape
+                identifier, scan_columns, safe_min_max=safe, shape_stats=shape
             )
         }
         # Re-read the metadata after the aggregate scan: adapters whose
@@ -307,6 +329,15 @@ def profile(
         data_quality: list[str] = []
         if meta.row_count == 0:
             data_quality.append("empty table (no rows)")
+        if blob_excluded:
+            data_quality.append(
+                f"excluded {len(blob_excluded)} blob-type column(s) from "
+                f"profiling scan ({', '.join(sorted(blob_excluded))}): "
+                "BYTES/BLOB-shaped columns only ever yield a null fraction and "
+                "a distinct estimate, and a columnar engine bills for the whole "
+                "column once referenced; add a blob_overrides entry in "
+                ".dex/config.yml to include one"
+            )
 
         # Adapters that degrade a profile (partition-filter tables, block
         # sampling, skipped escalations) explain themselves through this

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime
 
 from ..adapters.base import Adapter, ColumnAggregate, is_blob_type, json_safe
 from ..cache import ColumnProfile, Dataset, PIICategory, PIIFlag
+from ..config import PIIOverrideMatcher
 from ..progress import ProgressReporter
 
 # approx_count_distinct error observed in practice reaches ~14% in both
@@ -237,7 +238,7 @@ def profile(
     *,
     progress: ProgressReporter | None = None,
     on_complete: Callable[[Dataset], None] | None = None,
-    pii_overrides: set[str] | None = None,
+    pii_overrides: PIIOverrideMatcher | None = None,
     include_blobs: set[str] | None = None,
 ) -> list[Dataset]:
     """Profile each object into a Dataset of aggregate-derived ColumnProfiles.

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 from .. import command_args
 from .. import envelope as env
 from ..cache import DexStore
-from ..config import DexConfig, load_config
+from ..config import DexConfig, load_config, pii_override_paths
 from ..dbt_project import DbtProjectError
 from ..dbt_project import load as load_project
 from . import drift as drift_mod
@@ -431,7 +431,7 @@ def cmd_reconcile(args: argparse.Namespace) -> env.Envelope:
         snap,
         store.load_cache(),
         view,
-        pii_overrides={e.column.strip().lower() for e in config.pii_overrides},
+        pii_overrides=pii_override_paths(config.pii_overrides),
     )
     warnings.extend(build_warnings)
 

--- a/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
@@ -23,6 +23,7 @@ import yaml
 from pydantic import BaseModel, Field
 
 from ..cache import ColumnProfile, Dataset, DexCache
+from ..config import PIIOverrideMatcher
 from ..dbt_project import DbtProjectView
 from ..explore.profile import detect_pii
 from ..transform.plans import EditKind, PlanEdit
@@ -58,7 +59,7 @@ def build(
     cache: DexCache | None,
     view: DbtProjectView,
     *,
-    pii_overrides: set[str] | None = None,
+    pii_overrides: PIIOverrideMatcher | None = None,
 ) -> tuple[list[Proposal], list[PlanEdit], list[str]]:
     """Map findings to proposals and plan edits. Pure: writes nothing.
 
@@ -209,7 +210,9 @@ def _base_dataset(
 
 
 def _patched_dataset(
-    base: Dataset, findings: list[DriftFinding], pii_overrides: set[str]
+    base: Dataset,
+    findings: list[DriftFinding],
+    pii_overrides: PIIOverrideMatcher | set[str],
 ) -> Dataset:
     """Apply the detected column drift to the baseline profile, so the
     re-scaffold reflects the warehouse as it is now without re-profiling.

--- a/packages/dex-core/tests/adapters/test_connect_bigquery.py
+++ b/packages/dex-core/tests/adapters/test_connect_bigquery.py
@@ -430,6 +430,44 @@ def test_profile_estimate_sums_free_dry_runs(fake_bq_client):
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
 
+def _blob_fake_client():
+    from fakes.bigquery import FakeBigQueryClient, FakeTable
+
+    tables = [
+        FakeTable(
+            project="test-proj",
+            dataset_id="raw",
+            table_id="sessions",
+            schema=[
+                bigquery.SchemaField("id", "INTEGER"),
+                bigquery.SchemaField("payload", "BYTES"),
+            ],
+            num_rows=100,
+            num_bytes=5_000,
+        ),
+    ]
+    return FakeBigQueryClient(project="test-proj", tables=tables)
+
+
+def test_profile_estimate_excludes_blob_columns_by_default():
+    client = _blob_fake_client()
+    adapter = make_adapter(client)
+    adapter.profile_estimate(["test-proj.raw.sessions"])
+    dry_run_sql = next(c.sql for c in client.query_calls if c.dry_run)
+    assert "`payload`" not in dry_run_sql
+
+
+def test_profile_estimate_include_blobs_override_restores_the_column():
+    client = _blob_fake_client()
+    adapter = make_adapter(client)
+    adapter.profile_estimate(
+        ["test-proj.raw.sessions"],
+        include_blobs={"test-proj.raw.sessions.payload"},
+    )
+    dry_run_sql = next(c.sql for c in client.query_calls if c.dry_run)
+    assert "`payload`" in dry_run_sql
+
+
 def test_exact_distinct_counts_degrade_when_budget_cannot_cover(fake_bq_client):
     fake_bq_client.row_resolver = lambda sql: [{"d_0": 100}]
     adapter = make_adapter(fake_bq_client, ceiling=100 * MB)

--- a/packages/dex-core/tests/explore/conftest.py
+++ b/packages/dex-core/tests/explore/conftest.py
@@ -105,6 +105,23 @@ def tpch_names_duckdb(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def blob_duckdb(tmp_path: Path) -> Path:
+    """A table with an informative numeric column next to a `BLOB` column
+    (serialized-state shape): the profile scan-pruning gap the blob-column
+    exclusion targets."""
+
+    duckdb = pytest.importorskip("duckdb")
+    path = tmp_path / "blob.duckdb"
+    conn = duckdb.connect(str(path))
+    conn.execute("CREATE TABLE sessions (id INTEGER, payload BLOB)")
+    conn.execute(
+        "INSERT INTO sessions VALUES (1, 'abc'::BLOB), (2, 'defgh'::BLOB), (3, NULL)"
+    )
+    conn.close()
+    return path
+
+
+@pytest.fixture
 def near_unique_duckdb(tmp_path: Path) -> Path:
     """Tables big enough for approx_count_distinct to genuinely err: a 50k-row
     table with an exactly-unique key (the field failure: HLL noise made every

--- a/packages/dex-core/tests/explore/test_profile.py
+++ b/packages/dex-core/tests/explore/test_profile.py
@@ -355,6 +355,60 @@ def test_pii_override_matching_no_column_warns(tpch_names_duckdb: Path, capsys):
     assert person["pii"] is not None, "a typo must not clear anything"
 
 
+# --- blob-type column exclusion -------------------------------------------------
+
+
+def test_blob_column_excluded_by_default_with_note(blob_duckdb: Path, capsys):
+    payload = _run(
+        ["explore", "profile", "sessions", "--path", str(blob_duckdb)], capsys
+    )
+    (dataset,) = payload["data"]["datasets"]
+    columns = {c["name"]: c for c in dataset["columns"]}
+    payload_col = columns["payload"]
+    assert payload_col["null_fraction"] is None
+    assert payload_col["distinct_count"] is None
+    # The informative sibling column is untouched by the exclusion.
+    assert columns["id"]["distinct_count"] == 3
+    note = next(n for n in dataset["data_quality"] if "blob-type column" in n)
+    assert "payload" in note
+    assert "blob_overrides" in note
+
+
+def _write_blob_overrides(entries: list[str]) -> None:
+    from exmergo_dex_core.config import BlobOverride, DexConfig, save_config
+
+    save_config(DexConfig(blob_overrides=[BlobOverride(column=e) for e in entries]))
+
+
+def test_blob_override_restores_stats(blob_duckdb: Path, capsys):
+    _write_blob_overrides(["blob.main.sessions.payload"])
+    payload = _run(
+        ["explore", "profile", "sessions", "--path", str(blob_duckdb)], capsys
+    )
+    (dataset,) = payload["data"]["datasets"]
+    payload_col = {c["name"]: c for c in dataset["columns"]}["payload"]
+    assert payload_col["null_fraction"] == pytest.approx(1 / 3)
+    assert payload_col["distinct_count"] == 2
+    assert not any("blob-type column" in n for n in dataset["data_quality"])
+
+
+def test_profile_include_blobs_param_matches_by_identifier_column(blob_duckdb: Path):
+    from exmergo_dex_core.adapters.duckdb import DuckDBAdapter
+
+    adapter = DuckDBAdapter(blob_duckdb)
+    try:
+        (dataset,) = profile(
+            adapter,
+            ["blob.main.sessions"],
+            include_blobs={"blob.main.sessions.payload"},
+        )
+    finally:
+        adapter.close()
+    payload_col = {c.name: c for c in dataset.columns}["payload"]
+    assert payload_col.null_fraction is not None
+    assert payload_col.distinct_count is not None
+
+
 def test_non_unique_id_gets_fan_out_warning(airbnb_duckdb: Path, capsys):
     payload = _run(
         ["explore", "profile", "RAW_HOSTS", "--path", str(airbnb_duckdb)], capsys

--- a/packages/dex-core/tests/explore/test_profile.py
+++ b/packages/dex-core/tests/explore/test_profile.py
@@ -355,6 +355,117 @@ def test_pii_override_matching_no_column_warns(tpch_names_duckdb: Path, capsys):
     assert person["pii"] is not None, "a typo must not clear anything"
 
 
+# --- pii_overrides pattern form (column_name + scope): issue #106 --------------
+
+
+def _write_pattern_override(column_name: str, scope: str) -> None:
+    from exmergo_dex_core.config import DexConfig, PIIOverride, save_config
+
+    save_config(
+        DexConfig(pii_overrides=[PIIOverride(column_name=column_name, scope=scope)]),
+    )
+
+
+def test_pii_override_pattern_clears_flag_with_audit(tpch_names_duckdb: Path, capsys):
+    _write_pattern_override("name", "tpch_names.main.*")
+    payload = _run(
+        ["explore", "profile", "hosts", "--path", str(tpch_names_duckdb)], capsys
+    )
+    (dataset,) = payload["data"]["datasets"]
+    person = {c["name"]: c for c in dataset["columns"]}["name"]
+    assert person["pii"] is None
+    assert person["pii_overridden"] == "name", "the audit trail"
+    assert any("pii_overrides" in n for n in payload["data"]["notes"])
+
+
+def test_pii_override_pattern_scope_excludes_non_matching_dataset(
+    tpch_names_duckdb: Path, capsys
+):
+    _write_pattern_override("name", "tpch_names.main.other_*")
+    payload = _run(
+        ["explore", "profile", "hosts", "--path", str(tpch_names_duckdb)], capsys
+    )
+    (dataset,) = payload["data"]["datasets"]
+    person = {c["name"]: c for c in dataset["columns"]}["name"]
+    assert person["pii"] is not None, "a non-matching scope must not clear anything"
+
+
+def test_pii_override_pattern_matching_no_column_warns(tpch_names_duckdb: Path, capsys):
+    _write_pattern_override("nmae", "tpch_names.main.*")
+    rc = main(["explore", "profile", "hosts", "--path", str(tpch_names_duckdb)])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert any("matches no column" in w for w in payload["warnings"])
+
+
+def test_pii_override_pattern_matching_zero_tables_stays_silent(
+    tpch_names_duckdb: Path, capsys
+):
+    # A scope naming an entity that hasn't landed yet must not warn: that's
+    # the whole point of the pattern form (new tables land under scope later).
+    _write_pattern_override("name", "no_such_db.*")
+    payload = _run(
+        ["explore", "profile", "hosts", "--path", str(tpch_names_duckdb)], capsys
+    )
+    assert payload["warnings"] == []
+
+
+def test_pii_override_pattern_clears_across_multiple_tables():
+    """The point of the pattern form: one config entry clears the same
+    structurally identical column on every table its scope glob matches, and
+    leaves it alone outside that scope."""
+
+    from exmergo_dex_core.adapters.base import ColumnAggregate, ColumnMeta, ObjectMeta
+    from exmergo_dex_core.config import PIIOverride, pii_override_paths
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    class _Recorder:
+        name = "stub"
+        dialect = "duckdb"
+
+        def __init__(self):
+            self.shape_requests: list[set[str]] = []
+
+        def table_metadata(self, identifier):
+            columns = [ColumnMeta("document_name", "VARCHAR", True, 0)]
+            meta = ObjectMeta(
+                identifier=identifier,
+                object_type="table",
+                schema="s",
+                name=identifier,
+                row_count=1,
+                byte_size=None,
+                column_count=len(columns),
+            )
+            return meta, columns
+
+        def column_aggregates(
+            self, identifier, columns, *, safe_min_max=None, shape_stats=None
+        ):
+            self.shape_requests.append(set(shape_stats or set()))
+            return [ColumnAggregate(c.name, 0.0, 1, False, None, None) for c in columns]
+
+    adapter = _Recorder()
+    matcher = pii_override_paths(
+        [PIIOverride(column_name="document_name", scope="db.raw_*")]
+    )
+    datasets = profile_mod.profile(
+        adapter,
+        ["db.raw_orders_dev", "db.raw_users_qa", "db.other_table"],
+        pii_overrides=matcher,
+    )
+    by_id = {d.identifier: d for d in datasets}
+    assert by_id["db.raw_orders_dev"].columns[0].pii is None
+    assert by_id["db.raw_orders_dev"].columns[0].pii_overridden is not None
+    assert by_id["db.raw_users_qa"].columns[0].pii is None
+    assert by_id["db.raw_users_qa"].columns[0].pii_overridden is not None
+    # Outside the scope glob, the same-named column is untouched.
+    assert by_id["db.other_table"].columns[0].pii is not None
+    assert by_id["db.other_table"].columns[0].pii_overridden is None
+    # No shape SQL spent on the two overridden columns; only the unmatched one.
+    assert adapter.shape_requests == [set(), set(), {"document_name"}]
+
+
 # --- blob-type column exclusion -------------------------------------------------
 
 

--- a/packages/dex-core/tests/maintain/test_reconcile.py
+++ b/packages/dex-core/tests/maintain/test_reconcile.py
@@ -43,6 +43,38 @@ def test_drift_added_column_honors_pii_override():
     assert added.pii_overridden is not None
 
 
+def test_drift_added_column_honors_pattern_pii_override():
+    """A pattern-form override (column_name + scope) reaches drift-added
+    columns the same way an exact override does: this is the path
+    `maintain/commands.py` feeds through `pii_override_paths()`."""
+
+    from exmergo_dex_core.cache import ColumnProfile, Dataset
+    from exmergo_dex_core.config import PIIOverride, pii_override_paths
+    from exmergo_dex_core.maintain.drift import DriftFinding
+    from exmergo_dex_core.maintain.reconcile import _patched_dataset
+
+    base = Dataset(
+        identifier="db.raw_orders_qa",
+        columns=[ColumnProfile(name="id", data_type="INTEGER")],
+    )
+    finding = DriftFinding(
+        axis="schema",
+        code="column_added",
+        identifier="db.raw_orders_qa",
+        column="customer_name",
+        detail="column customer_name added",
+        data={"data_type": "VARCHAR"},
+    )
+    matcher = pii_override_paths(
+        [PIIOverride(column_name="customer_name", scope="db.raw_*")]
+    )
+
+    cleared = _patched_dataset(base, [finding], matcher)
+    added = next(c for c in cleared.columns if c.name == "customer_name")
+    assert added.pii is None
+    assert added.pii_overridden is not None
+
+
 def test_reconcile_needs_a_drift_report(maintain_repo):
     maintain_repo.snapshot()
     rc, payload = maintain_repo.dex("maintain", "reconcile")

--- a/packages/dex-core/tests/test_config.py
+++ b/packages/dex-core/tests/test_config.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from exmergo_dex_core.config import (
+    BlobOverride,
     DexConfig,
     PIIOverride,
+    blob_override_paths,
     load_config,
     pii_override_paths,
     save_config,
@@ -45,3 +47,37 @@ def test_config_without_overrides_stays_clean(tmp_path: Path):
     text = (tmp_path / ".dex" / "config.yml").read_text()
     assert "pii_overrides" not in text
     assert load_config(tmp_path).pii_overrides == []
+
+
+def test_blob_overrides_round_trip(tmp_path: Path):
+    config = DexConfig(
+        blob_overrides=[
+            BlobOverride(
+                column="MY_DB.PUBLIC.SESSIONS.PAYLOAD",
+                reason="small serialized state; worth profiling",
+            ),
+            BlobOverride(column="my_db.public.events.raw_blob"),
+        ]
+    )
+    save_config(config, tmp_path)
+    loaded = load_config(tmp_path)
+    assert [e.column for e in loaded.blob_overrides] == [
+        "MY_DB.PUBLIC.SESSIONS.PAYLOAD",
+        "my_db.public.events.raw_blob",
+    ]
+    assert loaded.blob_overrides[0].reason == "small serialized state; worth profiling"
+    assert loaded.blob_overrides[1].reason is None
+
+
+def test_blob_override_paths_are_case_insensitive():
+    paths = blob_override_paths(
+        [BlobOverride(column="  MY_DB.PUBLIC.SESSIONS.PAYLOAD ")]
+    )
+    assert paths == {"my_db.public.sessions.payload"}
+
+
+def test_config_without_blob_overrides_stays_clean(tmp_path: Path):
+    save_config(DexConfig(connector="duckdb"), tmp_path)
+    text = (tmp_path / ".dex" / "config.yml").read_text()
+    assert "blob_overrides" not in text
+    assert load_config(tmp_path).blob_overrides == []

--- a/packages/dex-core/tests/test_config.py
+++ b/packages/dex-core/tests/test_config.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from exmergo_dex_core.config import (
     BlobOverride,
     DexConfig,
@@ -37,7 +39,62 @@ def test_pii_overrides_round_trip(tmp_path: Path):
 
 def test_override_paths_are_case_insensitive():
     paths = pii_override_paths([PIIOverride(column="  MY_DB.PUBLIC.REGION.R_NAME ")])
-    assert paths == {"my_db.public.region.r_name"}
+    assert "my_db.public.region.r_name" in paths
+
+
+def test_pii_override_pattern_round_trip(tmp_path: Path):
+    config = DexConfig(
+        pii_overrides=[
+            PIIOverride(
+                column_name="document_name",
+                scope="proj.raw_*",
+                reason="Firestore resource path, not a person name",
+            ),
+        ]
+    )
+    save_config(config, tmp_path)
+    loaded = load_config(tmp_path)
+    (entry,) = loaded.pii_overrides
+    assert entry.column is None
+    assert entry.column_name == "document_name"
+    assert entry.scope == "proj.raw_*"
+    text = (tmp_path / ".dex" / "config.yml").read_text()
+    assert "column:" not in text
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # both shapes at once
+        {"column": "db.t.c", "column_name": "c", "scope": "db.*"},
+        # neither shape
+        {},
+        # pattern half-given
+        {"column_name": "c"},
+        {"scope": "db.*"},
+    ],
+)
+def test_pii_override_rejects_invalid_shapes(kwargs):
+    with pytest.raises(ValueError):
+        PIIOverride(**kwargs)
+
+
+def test_pii_override_pattern_matches_across_scope():
+    paths = pii_override_paths(
+        [PIIOverride(column_name="document_name", scope="db.raw_*")]
+    )
+    assert "db.raw_dev.t1.document_name" in paths
+    assert "db.raw_qa.t2.document_name" in paths
+    assert "db.other.t1.document_name" not in paths
+    # a different column name on a matching table is untouched
+    assert "db.raw_dev.t1.other_column" not in paths
+
+
+def test_pii_override_pattern_matching_is_case_insensitive():
+    paths = pii_override_paths(
+        [PIIOverride(column_name="Document_Name", scope="DB.RAW_*")]
+    )
+    assert "db.raw_dev.t1.document_name" in paths
 
 
 def test_config_without_overrides_stays_clean(tmp_path: Path):


### PR DESCRIPTION
## What this changes

`pii_overrides` entries were exact fully-qualified columns only. On CDC-shaped
sources (Firestore/Mongo/DynamoDB-style exports) the same structurally
identical column, for example `document_name`, exists on every entity's
changelog table in every environment mirror. Clearing one false positive cost
one config entry per table per environment, forever growing with the schema
for a single human decision.

This adds an opt-in pattern form alongside the existing exact form:

```yaml
pii_overrides:
  - column: MY_DB.PUBLIC.REGION.R_NAME       # exact, unchanged
    reason: TPC-H region labels; reviewed
  - column_name: document_name                # new: pattern
    scope: "<project>.raw_*"
    reason: Firestore resource path, not a person name
```

- `PIIOverride` now accepts either `column` (exact) or `column_name` + `scope`
  (pattern, a dataset-identifier glob), enforced by a validator so a config
  entry cannot mix the two shapes or supply half of the pattern pair.
- `pii_override_paths()` returns a `PIIOverrideMatcher` that duck-types the
  exact-match set every call site already used (`path in matcher`), so the
  profiling and drift-reconciliation match sites needed no changes.
- The profile-time typo guard (`_override_mismatches`) now understands
  pattern entries: it warns when a scope matches profiled tables but none
  carries the named column, and stays silent when a scope matches nothing yet
  (new entities landing later under the same scope is the point of the
  pattern form).
- Fixed a latent bug in `maintain/commands.py`, which built its override set
  inline instead of calling `pii_override_paths()`. That inline code would
  have raised on a pattern entry, since it assumed every entry had a `column`.

`blob_overrides` has the identical exact-match-only shape and could hit the
same per-table, per-environment growth problem. It is left untouched here
since #106 only asked about `pii_overrides`; worth its own follow-up issue if
it comes up in practice.

## Related issues

Closes #106.


## Notes

Merge #118 first