### PR TITLE
/dex:explore on MetricFlow - `local` and `api ` (on dbt Cloud)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,9 +139,9 @@ them.
    ceiling. The source allowlist in `.dex/config.yml` is a committed cost
    boundary: `--scope` narrows it for one command and can never widen it, and a
    scope that names nothing is refused rather than dropped. The one place dex
-   cannot enforce a ceiling is the hosted dbt Cloud Semantic Layer (`explore
-   semantic query --api`): dbt Cloud owns the warehouse connection and executes
-   the query server-side, so no dry-run estimate and no `maximum_bytes_billed`
+   cannot enforce a ceiling is the hosted dbt Cloud Semantic Layer
+   (`explore semantic query --api`): dbt Cloud owns the warehouse connection and
+   executes the query server-side, so no dry-run estimate and no `maximum_bytes_billed`
    are possible from dex. That backend therefore runs without a `--confirm`
    handshake and instead states, explicitly and on every result, that the cost
    guard is unavailable and spend is governed by the dbt Cloud environment, not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ project's real config instead of a wrong default.
 | `explore map [--verify] [--use-project]` | writes/updates the `.dex/` map; prints a summary; `--use-project` additionally applies declared grain and ranks metric-backing models higher |
 | `explore query "<SELECT ...>"` | runs one agent-authored SELECT through the query firewall: columnar, capped result; values only from profiled columns whose PII flag is absent or below the 0.5 blocking threshold (sub-threshold projections warn in the envelope); the FROM clause may unnest JSON/array columns in the connector's native idiom (UNNEST, LATERAL FLATTEN, LATERAL VIEW EXPLODE, set-returning functions, PartiQL) when the unnested value derives from a queried table's column, with the outputs inheriting that column's flags; requires the `.dex/` cache (`explore map` first) |
 | `explore cluster <object> [--features a,b] [-k N]` | k-means over a bounded, column-pruned, dialect-sampled scan of numeric columns; returns cluster sizes + centroids (feature means) + silhouette, never rows; auto-selects non-PII, non-key numeric features (or takes `--features`; a named PII column is opt-in, mean only); requires the `.dex/` cache and the `[cluster]` extra; billed connectors take the cost handshake |
+| `explore semantic list [--local\|--api]` | discover the dbt semantic layer in one shape from either backend: metrics (name, type, label, description, queryable dimensions), dimensions, and entities. Local reads the compiled `target/semantic_manifest.json` (no extra); hosted introspects the dbt Cloud GraphQL API. Distinct from the top-level `semantic` group, which *authors* the layer; `explore semantic` *queries* it |
+| `explore semantic query --metric <m> [--group-by <entity__dim>...] [--where "<jinja>"] [--order-by <c>] [--grain <g>] [--limit N] [--local\|--api]` | run a governed metric query. Local (`[semantic]` extra): MetricFlow `explain()` renders the SQL and dex executes it through its own connector, PII request-gate, SELECT-only assertion, and cost handshake, so cost is surfaced before spend. Hosted (`[semantic-api]` extra): dbt Cloud executes server-side, so the cost guard cannot apply and every result warns so (see guardrail 4); PII is screened from the layer's metadata plus a name heuristic before the query is sent, and the service token never crosses the envelope. Backend is ambient (`.dex/config.yml` `semantic.backend`), overridable with `--local` / `--api` |
 | `transform init "<name>" --connector <c>` | bootstrap a dbt project skeleton (`dbt_project.yml`, `models/staging/` + `models/marts/`, a dev-only `profiles.yml`), reported as create diffs; refuses if any dbt project exists; the connector never defaults, so bare init errors (an explicit flag or a committed `connector:` in `.dex/config.yml` is required); `--layered-schemas` additionally scaffolds `models/intermediate/`, a `generate_schema_name` override, and per-folder `+schema:` config so each layer builds into its own `<layer>_<target name>` schema; init also runs a free, metadata-only content check on every namespace the project would build into and warns (never refuses) when one already holds tables or views, degrading to a note when no connection opens |
 | `transform plan "<intent>" --edits-file <f>` | proposed dbt edits as diffs (nothing applied); `--scaffold <table>` adds a staging skeleton from the cache |
 | `transform apply [plan-id]` | writes diffs into the dbt project (a reviewable git diff); a human edit since planning returns `needs_confirmation`, never an overwrite; no id applies the latest unapplied plan of any kind |
@@ -133,10 +135,18 @@ them.
 3. Read-only against data; writes confined to the repo. DuckDB opens read-only;
    generated SQL is SELECT-only; agent-authored SQL runs only through the query
    firewall; builds run against a dev target only, never prod.
-4. Cost-aware by connector. Nothing runs without a ceiling. The source allowlist
-   in `.dex/config.yml` is a committed cost boundary: `--scope` narrows it for one
-   command and can never widen it, and a scope that names nothing is refused
-   rather than dropped.
+4. Cost-aware by connector. Nothing dex runs touches the warehouse without a
+   ceiling. The source allowlist in `.dex/config.yml` is a committed cost
+   boundary: `--scope` narrows it for one command and can never widen it, and a
+   scope that names nothing is refused rather than dropped. The one place dex
+   cannot enforce a ceiling is the hosted dbt Cloud Semantic Layer (`explore
+   semantic query --api`): dbt Cloud owns the warehouse connection and executes
+   the query server-side, so no dry-run estimate and no `maximum_bytes_billed`
+   are possible from dex. That backend therefore runs without a `--confirm`
+   handshake and instead states, explicitly and on every result, that the cost
+   guard is unavailable and spend is governed by the dbt Cloud environment, not
+   by dex. The local backend (`--local`) executes through dex's own connector and
+   keeps the full cost-before-spend handshake.
 5. Nothing reaches agent context except through the sanitized envelope.
    Credentials never; data values only from profiled, PII-cleared columns,
    bounded and capped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 - **`explore semantic`: query the dbt semantic layer, locally or against dbt
   Cloud, behind one abstraction.** `explore semantic list` discovers metrics,
-  dimensions, and entities; `explore semantic query --metric <m> --group-by
-  <entity__dim>` runs a governed metric query and returns a capped, columnar
+  dimensions, and entities; `explore semantic query` with a `--metric` and a
+  `--group-by` runs a governed metric query and returns a capped, columnar
   result. Two backends answer the same commands, chosen ambiently by
   `.dex/config.yml` `semantic.backend` and overridable per command with `--local`
   / `--api`. `--local` renders the SQL with MetricFlow's `explain()` through a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-21
+
 ### Added
 
 - **`explore semantic`: query the dbt semantic layer, locally or against dbt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **`explore semantic`: query the dbt semantic layer, locally or against dbt
+  Cloud, behind one abstraction.** `explore semantic list` discovers metrics,
+  dimensions, and entities; `explore semantic query --metric <m> --group-by
+  <entity__dim>` runs a governed metric query and returns a capped, columnar
+  result. Two backends answer the same commands, chosen ambiently by
+  `.dex/config.yml` `semantic.backend` and overridable per command with `--local`
+  / `--api`. `--local` renders the SQL with MetricFlow's `explain()` through a
+  renderer-only client (MetricFlow never opens a connection or sees a credential)
+  and executes it through dex's own connector, PII request-gate, SELECT-only
+  assertion, and cost-before-spend handshake; it needs a dbt project and the
+  `[semantic]` extra, while `list` is a pure `semantic_manifest.json` read-view
+  that needs neither. `--api` queries a hosted dbt Cloud Semantic Layer over
+  GraphQL with no local project required (the `[semantic-api]` extra plus a
+  `DBT_SL_TOKEN`); because dbt Cloud owns the warehouse connection and executes
+  server-side, dex's cost guard is structurally unavailable there, so every hosted
+  result warns, explicitly, that spend is governed by the dbt Cloud environment,
+  not by dex. No credential ever crosses the envelope on either backend.
+  PII is gated before any query runs: locally, each grouped or filtered dimension
+  resolves through the manifest to its physical column and that column's `.dex/`
+  cache flag decides (honoring `pii_overrides`), so a dimension whose name reads
+  clean is still refused when its column is flagged, and a profiled, cleared column
+  is not re-blocked by a PII-shaped name; where the cache cannot speak, a name
+  heuristic is the fail-closed floor. The local backend also pre-checks the
+  rendered SQL's relations against the cached inventory and refuses, before the
+  cost handshake, when the project was compiled against a namespace this
+  connection does not have.
 - **`transform init --layered-schemas`: per-layer schema routing out of the
   box.** The flag additionally scaffolds `models/intermediate/`, a
   `generate_schema_name` macro override, and a `dbt_project.yml` `models:`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ time. `dex` owns exactly that loop.
 
 - **Explore** an unfamiliar warehouse: rank what matters, profile selectively,
   infer and verify joins, answer ad-hoc questions with guarded SQL probes behind
-  a PII-aware query firewall, persist a draft map. Fully read-only.
+  a PII-aware query firewall, and query the semantic layer's metrics (locally via
+  MetricFlow or against a hosted dbt Cloud deployment). Persist a draft map.
+  Fully read-only.
 
 <img width="522" height="343" alt="image" src="https://github.com/user-attachments/assets/7f16b370-66ed-4596-ae01-041cf3db3525" />
 

--- a/packages/dex-core/README.md
+++ b/packages/dex-core/README.md
@@ -61,7 +61,11 @@ read-only. It starts bare by default; with `--use-project` it reads an existing
 dbt project, promoting declared `relationships` joins, honoring declared grain
 and `unique` tests, and letting metric-backing models surface first in the
 ranking. A repeatable `--scope` narrows the source scope per command without
-writing back to `.dex/config.yml`.
+writing back to `.dex/config.yml`. It also queries the dbt semantic layer
+(`explore semantic list` / `query`): metric queries run either locally through
+MetricFlow and dex's own cost handshake (`--local`), or against a hosted dbt Cloud
+deployment (`--api`), where dbt Cloud executes server-side and every result warns
+that dex's cost guard does not apply there.
 
 `transform`: bootstraps a dbt project where none exists (`transform init`, with an
 explicit connector, never a default), turns agent-authored edits and

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -62,6 +62,19 @@ postgres = ["psycopg[binary]>=3", "sqlglot>=25", "dbt-postgres>=1.9"]
 # capacity) come from the control plane, and the driver mints IAM temporary
 # database credentials through the same chain.
 redshift = ["redshift-connector>=2.1", "boto3>=1.34", "sqlglot>=25", "dbt-redshift>=1.9"]
+# The local semantic-layer query backend (`explore semantic query --local`):
+# MetricFlow renders metric SQL via explain(), and dex executes it through its own
+# connector and cost guard. Just the metricflow library (not dbt-metricflow, whose
+# CLI bundle pulls a dbt adapter the active connector extra already provides). 0.211
+# is the floor that resolves against a released dbt-semantic-interfaces (0.209 pins
+# a prerelease). `explore semantic list --local` is a pure manifest read-view and
+# needs none of this.
+semantic = ["metricflow>=0.211,<0.212", "sqlglot>=25"]
+# The hosted dbt Cloud Semantic Layer backend (`explore semantic --api`): a thin
+# GraphQL client over httpx, nothing else. No warehouse client and no dbt-core:
+# dbt Cloud owns the warehouse connection and executes server-side, so a
+# pure-remote user (no local dbt project) installs only this.
+semantic-api = ["httpx>=0.27"]
 # k-means clustering (`explore cluster`). scikit-learn pulls numpy and scipy, so
 # it is deliberately NOT a base dependency: the light default and the [duckdb]
 # on-ramp stay lean, and this extra is installed only when clustering is actually

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -22,7 +22,15 @@ from . import envelope as env
 # The full command surface. Group -> its subcommands.
 COMMAND_SURFACE: dict[str, list[str]] = {
     "connect": ["test"],
-    "explore": ["inventory", "profile", "relationships", "map", "query", "cluster"],
+    "explore": [
+        "inventory",
+        "profile",
+        "relationships",
+        "map",
+        "query",
+        "cluster",
+        "semantic",
+    ],
     "transform": ["init", "plan", "apply", "build", "deps", "plans", "macro"],
     "semantic": ["define", "update", "plan"],
     # maintain: keep the dbt project correct as the world drifts. `snapshot`
@@ -115,6 +123,25 @@ def _build_parser() -> argparse.ArgumentParser:
                         type=int,
                         default=argparse.SUPPRESS,
                     )
+                # `explore semantic list|query` queries the dbt semantic layer
+                # (distinct from the top-level `semantic` group, which authors it).
+                # The backend (local MetricFlow vs a hosted dbt Cloud deployment) is
+                # ambient: the .dex config `semantic.backend`, overridable here with
+                # --local / --api.
+                if group == "explore" and name == "semantic":
+                    # Bare `explore semantic` lists (discovery is first-class);
+                    # `explore semantic query` runs a metric query.
+                    sp.add_argument(
+                        "mode", nargs="?", choices=["list", "query"], default="list"
+                    )
+                    sp.add_argument("--metric", action="append", default=None)
+                    sp.add_argument("--group-by", action="append", default=None)
+                    sp.add_argument("--where", action="append", default=None)
+                    sp.add_argument("--order-by", action="append", default=None)
+                    sp.add_argument("--grain", default=None)
+                    sp.add_argument("--limit", type=int, default=None)
+                    sp.add_argument("--local", action="store_true", default=False)
+                    sp.add_argument("--api", action="store_true", default=False)
                 if group == "explore" and name == "map":
                     sp.add_argument(
                         "--full", action="store_true", default=argparse.SUPPRESS
@@ -211,6 +238,7 @@ def dispatch(args: argparse.Namespace) -> env.Envelope:
             "map": explore_cmds.cmd_map,
             "query": explore_cmds.cmd_query,
             "cluster": explore_cmds.cmd_cluster,
+            "semantic": explore_cmds.cmd_semantic,
         }
         return handlers[args.subcommand](args)
 

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -257,6 +257,30 @@ def pii_override_paths(overrides: list[PIIOverride]) -> set[str]:
     return {entry.column.strip().lower() for entry in overrides}
 
 
+class SemanticConfig(BaseModel):
+    """How ``explore semantic`` reaches the semantic layer.
+
+    Two backends, selected by ``backend`` and overridable per command with
+    ``--local`` / ``--api``. ``local`` renders metric queries with MetricFlow and
+    executes them through dex's own connector and cost guard, so a dbt project
+    must be present (like DuckDB needs a local file). ``dbt_cloud`` sends the
+    query to a hosted dbt Cloud Semantic Layer over GraphQL and needs no local
+    project (like BigQuery needs no local DuckDB); dbt Cloud owns the warehouse
+    connection and executes server-side, so **dex's cost guard does not apply on
+    that path** (the dbt Cloud environment governs spend, and every hosted result
+    says so).
+
+    ``host`` and ``environment_id`` are the non-secret hosted coordinates, copied
+    from the dbt Cloud Semantic Layer panel (or ``DBT_SL_HOST`` / ``DBT_SL_ENV_ID``
+    at runtime). The service token is a secret and is never here: connect.py reads
+    it from ``DBT_SL_TOKEN`` (then ``~/.dbt/dbt_cloud.yml``) at runtime.
+    """
+
+    backend: str = "local"
+    host: str | None = None
+    environment_id: str | None = None
+
+
 class DexConfig(BaseModel):
     """The shape of ``.dex/config.yml``: one optional target per connector plus
     the connector selection, budgets, and engine limits."""
@@ -278,6 +302,10 @@ class DexConfig(BaseModel):
     # Pins the dbt project directory (relative to the repo root) when discovery
     # would be ambiguous; by default the project is located automatically.
     dbt_project_dir: str | None = None
+    # How `explore semantic` reaches the semantic layer (local MetricFlow vs a
+    # hosted dbt Cloud deployment). Defaults to local; a bare project queries the
+    # dbt project it lives in.
+    semantic: SemanticConfig = Field(default_factory=SemanticConfig)
     budget: Budget = Field(default_factory=Budget)
     ranking_hints: list[str] = Field(default_factory=list)
     query: QueryLimits = Field(default_factory=QueryLimits)

--- a/packages/dex-core/src/exmergo_dex_core/connect.py
+++ b/packages/dex-core/src/exmergo_dex_core/connect.py
@@ -1544,3 +1544,62 @@ def _project_from_dbt_profiles(repo_root: str | Path) -> str | None:
             ):
                 return str(output["project"])
     return None
+
+
+def resolve_semantic_layer_connection(
+    semantic: object | None,
+    env: dict | os._Environ,
+) -> tuple[str, str, str, str]:
+    """Resolve the hosted dbt Cloud Semantic Layer coordinates and token.
+
+    Discover, don't ask, same as every connector. Non-secret coordinates come
+    from the environment first (``DBT_SL_HOST`` / ``DBT_SL_ENV_ID``), then the
+    ``.dex/config.yml`` ``semantic`` block. The token is a secret and is never in
+    config: ``DBT_SL_TOKEN`` first, then a ``token-value`` in
+    ``~/.dbt/dbt_cloud.yml``. Returns ``(host, environment_id, token,
+    credential_kind)``; the token value is never logged and ``credential_kind``
+    (``"service_token"``) is the only class safe to surface. Every failure names
+    the fix, never a value.
+    """
+
+    host = env.get("DBT_SL_HOST") or getattr(semantic, "host", None)
+    env_id = env.get("DBT_SL_ENV_ID") or getattr(semantic, "environment_id", None)
+    if not host or not env_id:
+        raise CredentialDiscoveryError(
+            "the hosted semantic layer needs a host and environment id; set them "
+            "under `semantic:` in .dex/config.yml (host, environment_id) or export "
+            "DBT_SL_HOST and DBT_SL_ENV_ID (both are shown in the dbt Cloud "
+            "Semantic Layer panel and are not secret)"
+        )
+    token = env.get("DBT_SL_TOKEN") or _dbt_cloud_service_token(env)
+    if not token:
+        raise CredentialDiscoveryError(
+            "no dbt Cloud Semantic Layer token found; export DBT_SL_TOKEN (a "
+            "'Semantic Layer Only' service token) or add one to ~/.dbt/dbt_cloud.yml"
+        )
+    return str(host), str(env_id), str(token), "service_token"
+
+
+def _dbt_cloud_service_token(env: dict | os._Environ) -> str | None:
+    """A ``token-value`` from ``~/.dbt/dbt_cloud.yml`` (the dbt Cloud CLI config),
+    the active project's first. It may be a dbt Cloud API token rather than a
+    Semantic Layer service token; if so the API rejects it with a clear message,
+    which is why ``DBT_SL_TOKEN`` is the documented primary source."""
+
+    directory = env.get("DBT_CLOUD_CONFIG_DIR")
+    path = (Path(directory) if directory else Path.home() / ".dbt") / "dbt_cloud.yml"
+    if not path.is_file():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+    projects = data.get("projects") or []
+    active = (data.get("context") or {}).get("active-project")
+    for project in projects:
+        if str(project.get("project-id")) == str(active) and project.get("token-value"):
+            return str(project["token-value"])
+    for project in projects:
+        if project.get("token-value"):
+            return str(project["token-value"])
+    return None

--- a/packages/dex-core/src/exmergo_dex_core/envelope.py
+++ b/packages/dex-core/src/exmergo_dex_core/envelope.py
@@ -37,6 +37,11 @@ class Paradigm(str, Enum):
     BYTES_SCANNED = "bytes_scanned"
     COMPUTE_TIME = "compute_time"
     DB_LOAD = "db_load"
+    # The hosted dbt Cloud Semantic Layer executes queries server-side under its
+    # own warehouse connection, so dex's cost guard is structurally unavailable:
+    # no dry-run estimate and no ceiling. `estimate` and `ceiling` stay None and
+    # the command warns that dbt Cloud, not dex, governs spend.
+    HOSTED = "hosted"
 
 
 class Cost(BaseModel):

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -556,6 +556,42 @@ def cmd_query(args: argparse.Namespace) -> env.Envelope:
     return envelope
 
 
+def cmd_semantic(args: argparse.Namespace) -> env.Envelope:
+    """`explore semantic list|query`: discover and query the dbt semantic layer.
+
+    Backend resolution and the two guard postures (local: dex renders and executes
+    under its own cost guard; hosted: dbt Cloud executes and dex only warns) live in
+    the ``explore.semantic`` package; this orchestrator just resolves the backend
+    and hands it the intent, turning any backend refusal into a clean envelope.
+    """
+
+    from .semantic import SemanticBackendError, SemanticQuery, resolve_backend
+
+    root = command_args.repo_root(args)
+    config = load_config(root) or DexConfig()
+    try:
+        backend = resolve_backend(args, config, root)
+        if getattr(args, "mode", None) == "list":
+            return env.ok(backend.list_definitions().to_data())
+        metrics = getattr(args, "metric", None) or []
+        if not metrics:
+            return env.error(
+                "`explore semantic query` needs at least one --metric "
+                "(discover them with `explore semantic list`)"
+            )
+        query = SemanticQuery(
+            metrics=metrics,
+            group_by=getattr(args, "group_by", None) or [],
+            where=getattr(args, "where", None) or [],
+            order_by=getattr(args, "order_by", None) or [],
+            grain=getattr(args, "grain", None),
+            limit=getattr(args, "limit", None),
+        )
+        return backend.query(query)
+    except SemanticBackendError as exc:
+        return env.error(str(exc))
+
+
 def cmd_map(args: argparse.Namespace) -> env.Envelope:
     repo_root = command_args.repo_root(args)
     config = load_config(repo_root) or DexConfig()

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/__init__.py
@@ -1,0 +1,298 @@
+"""The semantic-layer query surface: one intent, one envelope, two backends.
+
+``explore semantic`` lets an agent discover metrics and dimensions and run
+governed metric queries against the dbt semantic layer. Two backends share the
+intent grammar and the columnar envelope but differ in who executes and how spend
+and PII are governed:
+
+- ``local`` (:mod:`.local`): MetricFlow renders the metric SQL with ``explain()``
+  and dex executes it through its own connector, cost guard, and PII request-gate.
+  A dbt project must be present, the way DuckDB needs a local file.
+- ``dbt_cloud`` (:mod:`.hosted`): the query is sent to a hosted dbt Cloud Semantic
+  Layer over GraphQL and needs no local project, the way BigQuery needs no local
+  DuckDB. dbt Cloud owns the warehouse connection and executes server-side, so
+  dex's cost guard is structurally unavailable on that path (every hosted result
+  says so) and PII is gated from the layer's own metadata plus a name heuristic.
+
+Backend selection is ambient, mirroring how the warehouse connector resolves: the
+``.dex/config.yml`` ``semantic.backend`` default, overridable per command with
+``--local`` / ``--api``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from typing import Any, Protocol
+
+# The confidence at or above which a name-detected PII category refuses a query,
+# shared with the query firewall so the two surfaces block at the same threshold.
+from ...guards.query_firewall import PII_BLOCK_CONFIDENCE
+from ..profile import detect_pii
+
+
+@dataclass
+class SemanticQuery:
+    """A backend-neutral metric query: the grammar shared by MetricFlow, the dbt
+    Cloud GraphQL API, and the JDBC macro.
+
+    ``group_by`` tokens are entity-qualified dimension names (``user__pricing_tier``,
+    ``metric_time``). ``grain`` applies to ``metric_time`` when the caller wants a
+    time bucket without spelling it into the token; ``where`` clauses use the Jinja
+    filter dialect (``{{ Dimension('session__is_deleted') }} = false``) verbatim on
+    both backends.
+    """
+
+    metrics: list[str]
+    group_by: list[str] = field(default_factory=list)
+    where: list[str] = field(default_factory=list)
+    order_by: list[str] = field(default_factory=list)
+    grain: str | None = None
+    limit: int | None = None
+
+
+@dataclass
+class MetricInfo:
+    name: str
+    type: str
+    label: str | None = None
+    description: str | None = None
+    # The dimensions this metric can be grouped by, entity-qualified. Precise on
+    # the hosted backend (the API resolves the join graph); on the local read-view
+    # it is the per-semantic-model listing, noted as such.
+    dimensions: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DimensionInfo:
+    name: str
+    type: str
+
+
+@dataclass
+class EntityInfo:
+    name: str
+    type: str
+
+
+@dataclass
+class SemanticCatalog:
+    """What ``explore semantic list`` returns: enough for an agent to discover what
+    it can query, in the same shape from either backend."""
+
+    backend: str
+    metrics: list[MetricInfo] = field(default_factory=list)
+    dimensions: list[DimensionInfo] = field(default_factory=list)
+    entities: list[EntityInfo] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def to_data(self) -> dict[str, Any]:
+        return {
+            "backend": self.backend,
+            "metrics": [asdict(m) for m in self.metrics],
+            "dimensions": [asdict(d) for d in self.dimensions],
+            "entities": [asdict(e) for e in self.entities],
+            "notes": self.notes,
+        }
+
+
+class SemanticBackendError(Exception):
+    """A backend cannot be constructed or reached: a missing extra, missing hosted
+    coordinates, missing credentials, or a missing local project. The message names
+    the fix; the command turns it into a clean ``env.error`` (never a stack trace)."""
+
+
+class SemanticBackend(Protocol):
+    """The seam both backends satisfy. ``query`` returns a full envelope rather
+    than raw rows because the two paths differ in cost surfacing and warnings, and
+    each owns its own posture."""
+
+    name: str
+
+    def list_definitions(self) -> SemanticCatalog: ...
+
+    def query(self, q: SemanticQuery): ...
+
+
+# ---- shared PII screening --------------------------------------------------
+#
+# A metric query touches dimensions two ways: the group_by tokens, and the
+# Dimension()/TimeDimension()/Entity() refs inside a where filter. Both are
+# screened, because grouping by an email is as much a disclosure as filtering by
+# one and then projecting it.
+
+_DIMENSION_REF = re.compile(r"(?:Time)?Dimension\(\s*['\"]([^'\"]+)['\"]")
+_ENTITY_REF = re.compile(r"Entity\(\s*['\"]([^'\"]+)['\"]")
+# Meta keys, on a dimension's dbt `config.meta`, that authoritatively mark it PII.
+_PII_META_KEYS = ("pii", "contains_pii", "is_pii", "pii_category")
+
+
+def requested_dimension_refs(q: SemanticQuery) -> list[str]:
+    """Every dimension/entity token a query would touch, de-duplicated in order."""
+
+    refs: list[str] = [*q.group_by]
+    for clause in q.where:
+        refs.extend(_DIMENSION_REF.findall(clause))
+        refs.extend(_ENTITY_REF.findall(clause))
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for ref in refs:
+        if ref not in seen:
+            seen.add(ref)
+            ordered.append(ref)
+    return ordered
+
+
+def _meta_says_pii(meta: Any) -> bool:
+    return isinstance(meta, dict) and any(bool(meta.get(key)) for key in _PII_META_KEYS)
+
+
+def _meta_clears(meta: Any) -> bool:
+    """Whether a lookup positively adjudicated the ref as not PII.
+
+    Only an explicit ``{"pii": False}`` clears: a lookup that knows nothing returns
+    None and leaves the name heuristic in charge. This is what lets a profiled,
+    value-evidence-cleared column (or a human ``pii_overrides`` entry) stop being
+    re-blocked by its name, without that silence ever being mistaken for consent.
+    """
+
+    return isinstance(meta, dict) and meta.get("pii") is False
+
+
+def screen_dimension_refs(
+    refs: list[str],
+    *,
+    meta_lookup: Callable[[str], Any] | None = None,
+) -> list[tuple[str, str]]:
+    """Refuse verdicts for the refs that must not be queried, as ``(ref, reason)``.
+
+    Evidence beats names, and silence never clears. A lookup that positively knows
+    the ref (the ``.dex/`` cache's value-evidence flags on the resolved physical
+    column, or a dimension's dbt ``config.meta``) decides in both directions; a
+    lookup that returns nothing falls through to the name heuristic, which is the
+    fail-closed floor because a false positive is the wanted error direction on PII.
+    Runs on the entity-qualified token (``user__email``), whose bounded ``_email``
+    suffix still matches the email pattern, so no join-graph resolution is needed
+    when nothing authoritative is available.
+    """
+
+    blocked: list[tuple[str, str]] = []
+    for ref in refs:
+        meta = meta_lookup(ref) if meta_lookup is not None else None
+        if _meta_says_pii(meta):
+            category = meta.get("category") if isinstance(meta, dict) else None
+            reason = (
+                f"{category} (profiled and flagged)"
+                if category
+                else "declared PII in the semantic-layer metadata"
+            )
+            blocked.append((ref, reason))
+            continue
+        if _meta_clears(meta):
+            continue
+        flag = detect_pii(ref, "string")
+        if flag is not None and flag.confidence >= PII_BLOCK_CONFIDENCE:
+            blocked.append(
+                (ref, f"{flag.category.value} (name heuristic, {flag.confidence:.2f})")
+            )
+    return blocked
+
+
+def cap_columnar(
+    columns: list[str],
+    types: list[str],
+    cells: list[list[Any]],
+    *,
+    max_rows: int,
+    max_cell_chars: int,
+    max_payload_bytes: int,
+    truncated_by_source: bool = False,
+    extra_notes: list[str] | None = None,
+) -> dict[str, Any]:
+    """Cap a columnar result for agent context, matching ``explore query`` shaping:
+    per-cell width truncation, a hard row cap, and a total payload byte cap, each
+    cut announced in ``notes`` so a trimmed result is never mistaken for complete.
+    Shared by both backends so their envelopes are identical in shape."""
+
+    import json
+
+    notes: list[str] = list(extra_notes or [])
+    truncated = truncated_by_source
+
+    if len(cells) > max_rows:
+        cells = cells[:max_rows]
+        truncated = True
+        notes.append(
+            f"result truncated to {max_rows} rows (engine cap); refine the query "
+            "or raise query.max_rows in .dex/config.yml"
+        )
+
+    clipped = 0
+    shaped_cells: list[list[Any]] = []
+    for row in cells:
+        shaped: list[Any] = []
+        for value in row:
+            if isinstance(value, str) and len(value) > max_cell_chars:
+                shaped.append(value[:max_cell_chars] + "...")
+                clipped += 1
+            else:
+                shaped.append(value)
+        shaped_cells.append(shaped)
+    if clipped:
+        notes.append(f"{clipped} cell(s) truncated to {max_cell_chars} chars")
+
+    dropped = 0
+    while shaped_cells and (
+        len(json.dumps(shaped_cells, default=str)) > max_payload_bytes
+    ):
+        shaped_cells.pop()
+        dropped += 1
+    if dropped:
+        truncated = True
+        notes.append(
+            f"dropped {dropped} row(s) to fit the {max_payload_bytes}-byte payload "
+            "cap; aggregate further or select fewer columns"
+        )
+
+    return {
+        "columns": columns,
+        "types": types,
+        "cells": shaped_cells,
+        "row_count": len(shaped_cells),
+        "truncated": truncated,
+        "notes": notes,
+    }
+
+
+def resolve_backend(args, config, repo_root: str) -> SemanticBackend:
+    """The ambient backend resolution: ``--api``/``--local`` override the
+    ``.dex/config.yml`` ``semantic.backend`` default. Raises
+    :class:`SemanticBackendError` (never a bare import error) when the chosen
+    backend's extra, config, or credentials are missing."""
+
+    want_api = bool(getattr(args, "api", False))
+    want_local = bool(getattr(args, "local", False))
+    if want_api and want_local:
+        raise SemanticBackendError("choose one of --local or --api, not both")
+
+    if want_api:
+        backend = "dbt_cloud"
+    elif want_local:
+        backend = "local"
+    else:
+        configured = getattr(getattr(config, "semantic", None), "backend", None)
+        backend = (configured or "local").strip().lower()
+
+    if backend in {"dbt_cloud", "api", "cloud"}:
+        from .hosted import HostedDbtCloudBackend
+
+        return HostedDbtCloudBackend.from_config(args, config)
+    if backend == "local":
+        from .local import LocalMetricFlowBackend
+
+        return LocalMetricFlowBackend.from_args(args, config, repo_root)
+    raise SemanticBackendError(
+        f"unknown semantic backend '{backend}'; use 'local' or 'dbt_cloud' "
+        "(or pass --local / --api)"
+    )

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/hosted.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/hosted.py
@@ -1,0 +1,338 @@
+"""The hosted dbt Cloud Semantic Layer backend: a thin GraphQL client over httpx.
+
+dbt Cloud owns the warehouse connection and executes the query server-side, so
+this backend does not open a warehouse adapter, does not estimate cost, and cannot
+set a ceiling: the cost guard is structurally unavailable here and every result
+says so. What dex still owns is the request and the returned aggregates, so PII is
+screened before the query is sent (the layer's own dimension metadata when it
+carries a PII flag, a name heuristic otherwise), the service token never leaves
+this process, and the result is capped for agent context like ``explore query``.
+
+Transport is single-transport GraphQL: ``createQuery`` (mutation) returns a
+``queryId``, then ``query(queryId)`` is polled until ``SUCCESSFUL`` and its
+``jsonResult`` (pandas ``orient='table'``) is reshaped into the columnar envelope.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from collections.abc import Callable
+from typing import Any
+
+from ... import envelope as env
+from ...config import QueryLimits
+from . import (
+    DimensionInfo,
+    EntityInfo,
+    MetricInfo,
+    SemanticBackendError,
+    SemanticCatalog,
+    SemanticQuery,
+    cap_columnar,
+    requested_dimension_refs,
+    screen_dimension_refs,
+)
+
+# The very explicit line the founder asked for: wherever a reader or agent might
+# expect the cost guard, say plainly that it does not apply on the hosted path.
+_HOSTED_COST_WARNING = (
+    "cost guard unavailable on the hosted semantic layer: dbt Cloud owns the "
+    "warehouse connection and executes this query server-side, so dex applies no "
+    "cost estimate or ceiling here. Spend is governed by the dbt Cloud "
+    "environment's own limits, not by dex."
+)
+
+_MISSING_EXTRA = (
+    "the hosted semantic-layer backend needs the [semantic-api] extra: "
+    "pip install 'exmergo-dex-core[semantic-api]'"
+)
+
+# MetricFlow standard time grains, the only values the API's grain enum accepts.
+_GRAINS = ("day", "week", "month", "quarter", "year")
+# Metric/dimension/entity names are identifiers; validating them keeps
+# caller-supplied values out of the GraphQL query as anything but a quoted name or
+# a known enum, so a name can never smuggle in extra query structure.
+_IDENT = re.compile(r"[A-Za-z0-9_]+")
+
+
+def _ident(name: str) -> str:
+    if not isinstance(name, str) or not _IDENT.fullmatch(name):
+        raise SemanticBackendError(f"invalid semantic-layer name: {name!r}")
+    return name
+
+
+def _split_grain(token: str, default_grain: str | None) -> tuple[str, str | None]:
+    """A group-by/order-by token to ``(name, grain)``. A trailing ``__<grain>`` is
+    a grain (``metric_time__month``); an ordinary ``entity__dimension`` is not.
+    ``metric_time`` picks up the query's ``--grain`` when the token carries none."""
+
+    name, grain = token, None
+    if "__" in token:
+        head, tail = token.rsplit("__", 1)
+        if tail.lower() in _GRAINS:
+            name, grain = head, tail.lower()
+    if name == "metric_time" and grain is None and default_grain:
+        grain = default_grain.lower()
+    if grain is not None and grain not in _GRAINS:
+        raise SemanticBackendError(
+            f"unknown time grain '{grain}'; use one of {', '.join(_GRAINS)}"
+        )
+    return _ident(name), grain
+
+
+class HostedDbtCloudBackend:
+    name = "dbt_cloud"
+
+    _POLL_ATTEMPTS = 90
+    _POLL_INTERVAL = 1.0
+
+    def __init__(
+        self,
+        host: str,
+        environment_id: str,
+        token: str,
+        limits: QueryLimits,
+        *,
+        timeout: float = 60.0,
+    ) -> None:
+        self._url = f"https://{host}/api/graphql"
+        self._env = str(environment_id)
+        # Secret: held only for the Authorization header, never logged, never put
+        # in an envelope (the sanitizer would hard-fail on it anyway).
+        self._token = token
+        self._limits = limits
+        self._timeout = timeout
+
+    @classmethod
+    def from_config(cls, args, config) -> HostedDbtCloudBackend:
+        try:
+            import httpx  # noqa: F401
+        except ImportError as exc:
+            raise SemanticBackendError(_MISSING_EXTRA) from exc
+        from ...connect import (
+            CredentialDiscoveryError,
+            resolve_semantic_layer_connection,
+        )
+
+        semantic = getattr(config, "semantic", None)
+        try:
+            host, env_id, token, _kind = resolve_semantic_layer_connection(
+                semantic, os.environ
+            )
+        except CredentialDiscoveryError as exc:
+            raise SemanticBackendError(str(exc)) from exc
+        limits = getattr(config, "query", None) or QueryLimits()
+        return cls(host, env_id, token, limits)
+
+    # ---- transport ---------------------------------------------------------
+
+    def _post(self, query: str) -> dict[str, Any]:
+        import httpx
+
+        try:
+            with httpx.Client(timeout=self._timeout) as client:
+                resp = client.post(
+                    self._url,
+                    headers={
+                        "Authorization": f"Bearer {self._token}",
+                        "Content-Type": "application/json",
+                    },
+                    json={"query": query},
+                )
+        except httpx.HTTPError as exc:
+            raise SemanticBackendError(
+                f"could not reach the dbt Cloud Semantic Layer: {env.redact(str(exc))}"
+            ) from exc
+        if resp.status_code == 401 or resp.status_code == 403:
+            raise SemanticBackendError(
+                "dbt Cloud Semantic Layer rejected the token (HTTP "
+                f"{resp.status_code}); check DBT_SL_TOKEN is a current "
+                "'Semantic Layer Only' service token for this environment"
+            )
+        if resp.status_code != 200:
+            raise SemanticBackendError(
+                f"dbt Cloud Semantic Layer returned HTTP {resp.status_code}"
+            )
+        body = resp.json()
+        if body.get("errors"):
+            joined = "; ".join(str(e.get("message", e)) for e in body["errors"])
+            raise SemanticBackendError(f"semantic layer error: {env.redact(joined)}")
+        return body.get("data") or {}
+
+    # ---- discovery ---------------------------------------------------------
+
+    def list_definitions(self) -> SemanticCatalog:
+        query = (
+            "{ metrics(environmentId: " + self._env + ") "
+            "{ name type label description "
+            "dimensions { name type } entities { name type } } }"
+        )
+        data = self._post(query)
+        metrics: list[MetricInfo] = []
+        dim_types: dict[str, str] = {}
+        ent_types: dict[str, str] = {}
+        for m in data.get("metrics") or []:
+            dims = [d.get("name") for d in (m.get("dimensions") or [])]
+            for d in m.get("dimensions") or []:
+                dim_types.setdefault(d.get("name"), (d.get("type") or "").lower())
+            for e in m.get("entities") or []:
+                ent_types.setdefault(e.get("name"), (e.get("type") or "").lower())
+            metrics.append(
+                MetricInfo(
+                    name=m.get("name"),
+                    type=(m.get("type") or "").lower(),
+                    label=m.get("label"),
+                    description=m.get("description"),
+                    dimensions=dims,
+                )
+            )
+        return SemanticCatalog(
+            backend=self.name,
+            metrics=metrics,
+            dimensions=[
+                DimensionInfo(name=n, type=t) for n, t in sorted(dim_types.items())
+            ],
+            entities=[EntityInfo(name=n, type=t) for n, t in sorted(ent_types.items())],
+        )
+
+    # ---- query -------------------------------------------------------------
+
+    def query(self, q: SemanticQuery) -> env.Envelope:
+        refs = requested_dimension_refs(q)
+        blocked = screen_dimension_refs(refs, meta_lookup=self._meta_lookup(q.metrics))
+        if blocked:
+            named = ", ".join(f"{ref} ({reason})" for ref, reason in blocked)
+            return env.error(
+                f"refused: grouping or filtering by {named} would surface PII from "
+                "the semantic layer. PII is flagged, never surfaced; query a "
+                "non-PII dimension instead."
+            )
+
+        try:
+            query_id = self._create_query(q)
+            json_result = self._await_result(query_id)
+        except SemanticBackendError as exc:
+            return env.error(str(exc))
+        data = self._shape(json_result)
+        data["backend"] = self.name
+        data["query_id"] = query_id
+        return env.ok(
+            data,
+            cost=env.Cost(paradigm=env.Paradigm.HOSTED),
+            warnings=[_HOSTED_COST_WARNING],
+        )
+
+    def _meta_lookup(self, metrics: list[str]) -> Callable[[str], Any]:
+        """A ``ref -> dbt config.meta`` lookup for the PII gate. Best-effort: if the
+        dimension-metadata call fails, the name heuristic still screens every ref."""
+
+        try:
+            metric_inputs = ", ".join(f'{{name: "{_ident(m)}"}}' for m in metrics)
+            query = (
+                f"{{ dimensions(environmentId: {self._env}, metrics: "
+                f"[{metric_inputs}]) {{ name config {{ meta }} }} }}"
+            )
+            data = self._post(query)
+        except SemanticBackendError:
+            return lambda _ref: None
+        meta: dict[str, Any] = {}
+        for d in data.get("dimensions") or []:
+            cfg = d.get("config")
+            meta[d.get("name")] = cfg.get("meta") if isinstance(cfg, dict) else None
+        return lambda ref: meta.get(ref)
+
+    def _create_query(self, q: SemanticQuery) -> str:
+        if not q.metrics:
+            raise SemanticBackendError("a metric query needs at least one --metric")
+        metrics = ", ".join(f'{{name: "{_ident(m)}"}}' for m in q.metrics)
+        parts = [f"environmentId: {self._env}", f"metrics: [{metrics}]"]
+        if q.group_by:
+            parts.append(f"groupBy: {self._group_by(q)}")
+        if q.where:
+            clauses = ", ".join("{sql: " + json.dumps(c) + "}" for c in q.where)
+            parts.append(f"where: [{clauses}]")
+        if q.order_by:
+            parts.append(f"orderBy: {self._order_by(q)}")
+        if q.limit:
+            parts.append(f"limit: {int(q.limit)}")
+        mutation = "mutation { createQuery(" + ", ".join(parts) + ") { queryId } }"
+        data = self._post(mutation)
+        query_id = (data.get("createQuery") or {}).get("queryId")
+        if not query_id:
+            raise SemanticBackendError("the semantic layer returned no queryId")
+        return query_id
+
+    def _group_by(self, q: SemanticQuery) -> str:
+        entries = []
+        for token in q.group_by:
+            name, grain = _split_grain(token, q.grain)
+            if grain:
+                entries.append(f'{{name: "{name}", grain: {grain.upper()}}}')
+            else:
+                entries.append(f'{{name: "{name}"}}')
+        return "[" + ", ".join(entries) + "]"
+
+    def _order_by(self, q: SemanticQuery) -> str:
+        entries = []
+        for token in q.order_by:
+            descending = token.startswith("-")
+            name, grain = _split_grain(token[1:] if descending else token, q.grain)
+            if name in q.metrics:
+                inner = f'metric: {{name: "{name}"}}'
+            elif grain:
+                inner = f'groupBy: {{name: "{name}", grain: {grain.upper()}}}'
+            else:
+                inner = f'groupBy: {{name: "{name}"}}'
+            entries.append(
+                f"{{{inner}, descending: {'true' if descending else 'false'}}}"
+            )
+        return "[" + ", ".join(entries) + "]"
+
+    def _await_result(self, query_id: str) -> Any:
+        for _ in range(self._POLL_ATTEMPTS):
+            query = (
+                f"{{ query(environmentId: {self._env}, queryId: "
+                f"{json.dumps(query_id)}) {{ status error "
+                f"jsonResult(encoded: false) }} }}"
+            )
+            data = self._post(query)
+            result = data.get("query") or {}
+            status = result.get("status")
+            if status == "SUCCESSFUL":
+                return result.get("jsonResult")
+            if status == "FAILED":
+                raise SemanticBackendError(
+                    "semantic layer query failed: "
+                    f"{env.redact(str(result.get('error')))}"
+                )
+            time.sleep(self._POLL_INTERVAL)
+        raise SemanticBackendError(
+            f"timed out waiting for semantic layer query {query_id}"
+        )
+
+    def _shape(self, json_result: Any) -> dict[str, Any]:
+        payload = (
+            json.loads(json_result) if isinstance(json_result, str) else json_result
+        ) or {}
+        fields = (payload.get("schema") or {}).get("fields") or []
+        columns: list[str] = []
+        types: list[str] = []
+        for f in fields:
+            # `index` is the pandas row index, an artifact of orient='table'.
+            if f.get("name") == "index":
+                continue
+            columns.append(f.get("name"))
+            types.append(f.get("type"))
+        rows = payload.get("data") or []
+        cells = [[row.get(c) for c in columns] for row in rows]
+        return cap_columnar(
+            columns,
+            types,
+            cells,
+            max_rows=self._limits.max_rows,
+            max_cell_chars=self._limits.max_cell_chars,
+            max_payload_bytes=self._limits.max_payload_bytes,
+        )

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/local.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/local.py
@@ -1,0 +1,495 @@
+"""The local MetricFlow backend: query the dbt project's own semantic layer.
+
+``list`` is a pure read-view over the compiled ``target/semantic_manifest.json``,
+so it needs no extra and no warehouse connection: it is the discovery surface an
+agent uses to find what it can query.
+
+``query`` renders the metric SQL with MetricFlow's ``explain()`` through a
+renderer-only ``SqlClient`` (MetricFlow never opens a connection or sees a
+credential), then runs the rendered SQL through dex's own spine, in order: a PII
+request-gate on the grouped and filtered dimensions (resolved to physical columns
+and checked against the ``.dex/`` cache, with a name heuristic as the floor), a
+relation pre-check against the cached inventory, a SELECT-only assertion, the
+cost-before-spend handshake, and the connector. dex owns execution here, so the
+full cost guard applies, unlike the hosted backend.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+
+from ... import command_args
+from ... import envelope as env
+from ...adapters import get_dialect
+from ...cache import DexStore, match_identifier
+from ...config import QueryLimits, pii_override_paths
+from . import (
+    PII_BLOCK_CONFIDENCE,
+    DimensionInfo,
+    EntityInfo,
+    MetricInfo,
+    SemanticBackendError,
+    SemanticCatalog,
+    SemanticQuery,
+    cap_columnar,
+    requested_dimension_refs,
+    screen_dimension_refs,
+)
+
+_MISSING_EXTRA = (
+    "local metric queries need the [semantic] extra: "
+    "pip install 'exmergo-dex-core[semantic]'"
+)
+
+# dex connector -> (renderer submodule under _RENDER_ROOT, class, SqlEngine name).
+# MetricFlow ships a renderer per dialect; the shim hands the engine the one
+# matching the active connector so the SQL it renders is in that connector's dialect.
+_RENDER_ROOT = "metricflow.sql.render"
+_RENDERERS: dict[str, tuple[str, str, str]] = {
+    "duckdb": ("duckdb_renderer", "DuckDbSqlPlanRenderer", "DUCKDB"),
+    "bigquery": ("big_query", "BigQuerySqlPlanRenderer", "BIGQUERY"),
+    "snowflake": ("snowflake", "SnowflakeSqlPlanRenderer", "SNOWFLAKE"),
+    "databricks": ("databricks", "DatabricksSqlPlanRenderer", "DATABRICKS"),
+    "postgres": ("postgres", "PostgresSqlPlanRenderer", "POSTGRES"),
+    "redshift": ("redshift", "RedshiftSqlPlanRenderer", "REDSHIFT"),
+}
+
+
+class _RendererOnlySqlClient:
+    """A MetricFlow ``SqlClient`` that can render but never execute. If MetricFlow
+    calls anything execution-shaped, it raises: the mechanical form of "MetricFlow
+    never reaches the warehouse". Only ``explain()`` (pure rendering) uses it."""
+
+    def __init__(self, renderer, engine) -> None:
+        self._renderer = renderer
+        self._engine = engine
+
+    @property
+    def sql_plan_renderer(self):
+        return self._renderer
+
+    @property
+    def sql_engine_type(self):
+        return self._engine
+
+    def render_bind_parameter_key(self, bind_parameter_key: str) -> str:
+        return f":{bind_parameter_key}"
+
+    def query(self, *args, **kwargs):
+        raise RuntimeError("renderer-only SqlClient: execution is not permitted")
+
+    def execute(self, *args, **kwargs):
+        raise RuntimeError("renderer-only SqlClient: execution is not permitted")
+
+    def dry_run(self, *args, **kwargs):
+        raise RuntimeError("renderer-only SqlClient: execution is not permitted")
+
+    def close(self) -> None:
+        pass
+
+
+class LocalMetricFlowBackend:
+    name = "local"
+
+    def __init__(
+        self,
+        project: Path,
+        config,
+        args,
+        connector: str,
+        limits: QueryLimits,
+        repo_root: str | Path = ".",
+    ) -> None:
+        self._project = project
+        self._config = config
+        self._args = args
+        self._connector = connector
+        self._limits = limits
+        self._repo_root = repo_root
+        self._mf_engine = None
+        self._dim_columns: dict[str, tuple[str, str]] | None = None
+
+    @classmethod
+    def from_args(cls, args, config, repo_root: str) -> LocalMetricFlowBackend:
+        connector = getattr(args, "connector", None) or getattr(
+            config, "connector", "duckdb"
+        )
+        limits = getattr(config, "query", None) or QueryLimits()
+        return cls(
+            command_args.project_dir(args),
+            config,
+            args,
+            connector,
+            limits,
+            repo_root,
+        )
+
+    # ---- discovery ---------------------------------------------------------
+
+    def list_definitions(self) -> SemanticCatalog:
+        from ... import dbt_project
+
+        manifest = dbt_project._read_semantic_manifest(self._project)
+        if manifest is None:
+            raise SemanticBackendError(
+                "no compiled semantic manifest at target/semantic_manifest.json; "
+                "run `dbt parse` in the project so `explore semantic` can read it "
+                "(or query a hosted deployment with --api)"
+            )
+
+        entities: dict[str, str] = {}
+        dimensions: dict[str, str] = {}
+        model_dims: dict[str, list[str]] = {}
+        measure_model: dict[str, str] = {}
+        for model in manifest.get("semantic_models") or []:
+            model_name = model.get("name")
+            primary = None
+            for entity in model.get("entities") or []:
+                entities.setdefault(
+                    entity.get("name"), (entity.get("type") or "").lower()
+                )
+                if str(entity.get("type", "")).lower() == "primary":
+                    primary = entity.get("name")
+            qualified: list[str] = []
+            for dim in model.get("dimensions") or []:
+                # Entity-qualified name, the form a metric query groups by
+                # (session__created_at). Cross-model joined dimensions resolve
+                # only at query time, hence the catalog note below.
+                name = f"{primary}__{dim.get('name')}" if primary else dim.get("name")
+                qualified.append(name)
+                dimensions.setdefault(name, (dim.get("type") or "").lower())
+            model_dims[model_name] = qualified
+            for measure in model.get("measures") or []:
+                measure_model[measure.get("name")] = model_name
+        dimensions.setdefault("metric_time", "time")
+
+        metrics: list[MetricInfo] = []
+        for metric in manifest.get("metrics") or []:
+            params = metric.get("type_params") or {}
+            owners: set[str] = set()
+            for input_measure in params.get("input_measures") or []:
+                measure_name = (
+                    input_measure.get("name")
+                    if isinstance(input_measure, dict)
+                    else input_measure
+                )
+                owner = measure_model.get(measure_name)
+                if owner:
+                    owners.add(owner)
+            metric_dims = {"metric_time"}
+            for owner in owners:
+                metric_dims.update(model_dims.get(owner, []))
+            metrics.append(
+                MetricInfo(
+                    name=metric.get("name"),
+                    type=(metric.get("type") or "").lower(),
+                    label=metric.get("label"),
+                    description=metric.get("description"),
+                    dimensions=sorted(metric_dims),
+                )
+            )
+
+        return SemanticCatalog(
+            backend=self.name,
+            metrics=metrics,
+            dimensions=[
+                DimensionInfo(name=n, type=t) for n, t in sorted(dimensions.items())
+            ],
+            entities=[EntityInfo(name=n, type=t) for n, t in sorted(entities.items())],
+            notes=[
+                "local list: a metric's dimensions are those of its owning "
+                "semantic model(s), entity-qualified; dimensions reachable only "
+                "through a join resolve at query time (or list with --api)"
+            ],
+        )
+
+    # ---- query -------------------------------------------------------------
+
+    def query(self, q: SemanticQuery) -> env.Envelope:
+        if not q.metrics:
+            return env.error("a metric query needs at least one --metric")
+
+        cache = self._load_cache()
+
+        # PII request-gate, before rendering. Catching a flagged dimension at the
+        # request is cheaper and more precise than parsing rendered SQL.
+        blocked = screen_dimension_refs(
+            requested_dimension_refs(q), meta_lookup=self._cache_pii_lookup(cache)
+        )
+        if blocked:
+            named = ", ".join(f"{ref} ({reason})" for ref, reason in blocked)
+            return env.error(
+                f"refused: grouping or filtering by {named} would surface PII. "
+                "PII is flagged, never surfaced; query a non-PII dimension instead."
+            )
+
+        try:
+            sql = self._render(q)
+        except SemanticBackendError as exc:  # missing extra or uncompiled manifest
+            return env.error(str(exc))
+        except Exception as exc:  # a MetricFlow resolution error (unknown metric,
+            # unresolvable dimension) is the query's fault, not a crash: surface it.
+            return env.error(
+                f"could not resolve the metric query: {env.redact(str(exc))}"
+            )
+
+        from ...guards.sql_guard import NotSelectOnlyError, assert_select_only
+
+        dialect = get_dialect(self._connector)
+        # The rendered SQL bakes in the relation names the project was compiled
+        # against, which routinely disagree with the connection when a manifest
+        # was built elsewhere. Catch that here, with a precise message, instead of
+        # letting the warehouse answer with a table-not-found after a billed job.
+        mismatch = self._namespace_mismatch(sql, cache, dialect)
+        if mismatch is not None:
+            return env.error(mismatch)
+
+        try:
+            assert_select_only(sql, dialect=dialect)
+        except NotSelectOnlyError as exc:
+            return env.error(f"rendered metric SQL was not read-only: {exc}")
+
+        adapter = command_args.open_from_args(self._args)
+        try:
+            estimate_fn = getattr(adapter, "query_estimate", None)
+            estimate = estimate_fn(sql) if estimate_fn else 0.0
+            unconfirmed = command_args.billed_handshake(
+                "explore semantic query", adapter, estimate
+            )
+            if unconfirmed is not None:
+                return unconfirmed
+            result = adapter.run_query(
+                sql,
+                max_rows=self._limits.max_rows,
+                timeout_seconds=self._limits.timeout_seconds,
+            )
+            data = cap_columnar(
+                result.columns,
+                result.types,
+                result.cells,
+                max_rows=self._limits.max_rows,
+                max_cell_chars=self._limits.max_cell_chars,
+                max_payload_bytes=self._limits.max_payload_bytes,
+                truncated_by_source=result.truncated,
+            )
+            data["backend"] = self.name
+            envelope = env.ok(data)
+            command_args.stamp_spend(envelope, adapter)
+            return envelope
+        finally:
+            adapter.close()
+
+    def _load_cache(self):
+        """The ``.dex/`` cache with config PII overrides applied in memory, or None.
+
+        Absence is not fatal here (unlike ``explore query``, whose whole policy is
+        the cache): the metric query still has the name heuristic and the semantic
+        layer's own metadata, and the relation pre-check simply has no inventory to
+        check against. A repo that never ran ``explore map`` can still query metrics.
+        """
+
+        try:
+            cache = DexStore(self._repo_root).load_cache()
+        except Exception:
+            return None
+        if cache is None:
+            return None
+        overrides = pii_override_paths(getattr(self._config, "pii_overrides", []) or [])
+        if not overrides:
+            return cache
+        from ..commands import _mask_overridden
+
+        return _mask_overridden(cache, overrides)
+
+    def _cache_pii_lookup(self, cache):
+        """A ``dimension token -> {"pii": True}`` lookup backed by the cache.
+
+        A semantic dimension (``session__is_deleted``) maps to a physical column on
+        its owning model, so the token is resolved through the manifest to
+        (relation, column) and that column's cached PII flag decides. This is the
+        value-evidence-backed adjudication the profiler produced; the name
+        heuristic in ``screen_dimension_refs`` remains the floor underneath it, so
+        an unprofiled column is still caught by its name. Returns None for a token
+        the cache cannot speak to, which leaves the heuristic in charge.
+        """
+
+        if cache is None:
+            return None
+        columns = self._dimension_columns()
+        if not columns:
+            return None
+        known = [dataset.identifier for dataset in cache.datasets]
+
+        def lookup(ref: str):
+            target = columns.get(ref)
+            if target is None:
+                return None
+            relation, column_name = target
+            matches = match_identifier(relation, known)
+            for dataset in cache.datasets:
+                if dataset.identifier not in matches:
+                    continue
+                for column in dataset.columns:
+                    if column.name.lower() != column_name.lower():
+                        continue
+                    flag = column.pii
+                    if flag is not None and flag.confidence >= PII_BLOCK_CONFIDENCE:
+                        return {"pii": True, "category": flag.category.value}
+                    # Profiled and cleared (or a human override): authoritative,
+                    # so say so rather than leaving it to the name heuristic.
+                    return {"pii": False}
+            return None
+
+        return lookup
+
+    def _dimension_columns(self) -> dict[str, tuple[str, str]]:
+        """``entity-qualified dimension -> (relation, physical column)`` from the
+        compiled manifest. Computed dimensions (an expression rather than a bare
+        column) map to nothing: guessing a column out of an expression would make
+        the gate over-claim, and the name heuristic still covers them."""
+
+        from ... import dbt_project
+
+        if self._dim_columns is not None:
+            return self._dim_columns
+        mapping: dict[str, tuple[str, str]] = {}
+        manifest = dbt_project._read_semantic_manifest(self._project)
+        for model in (manifest or {}).get("semantic_models") or []:
+            node_relation = model.get("node_relation") or {}
+            relation = node_relation.get("relation_name") or node_relation.get("alias")
+            if not relation:
+                continue
+            relation = dbt_project._strip_relation_quoting(str(relation))
+            primary = None
+            for entity in model.get("entities") or []:
+                if str(entity.get("type", "")).lower() == "primary":
+                    primary = entity.get("name")
+            for element in (model.get("dimensions") or []) + (
+                model.get("entities") or []
+            ):
+                column = dbt_project.physical_column(element)
+                if not column:
+                    continue
+                name = element.get("name")
+                for token in {name, f"{primary}__{name}" if primary else name}:
+                    if token:
+                        mapping.setdefault(token, (relation, column))
+        self._dim_columns = mapping
+        return mapping
+
+    def _namespace_mismatch(self, sql: str, cache, dialect: str) -> str | None:
+        """A refusal message when the rendered SQL reads relations this connection
+        does not have, else None.
+
+        MetricFlow bakes ``node_relation.relation_name`` from the compiled manifest
+        straight into the SQL, so a project compiled against another database (or a
+        different dev target) renders relations that do not exist here. Without an
+        inventory there is nothing to check against, and a relation that resolves by
+        suffix is accepted: the cache is normalized per connector, so an exact
+        string match would reject legitimate namespace spellings.
+        """
+
+        if cache is None or not cache.datasets:
+            return None
+        try:
+            import sqlglot
+
+            parsed = sqlglot.parse_one(sql, read=dialect)
+        except Exception:
+            return None  # unparseable SQL is the SELECT-only guard's problem
+        from sqlglot import exp
+
+        known = [dataset.identifier for dataset in cache.datasets]
+        unknown: list[str] = []
+        for table in parsed.find_all(exp.Table):
+            parts = (table.args.get("catalog"), table.args.get("db"), table.this)
+            name = ".".join(part.name for part in parts if part)
+            if not name or not table.name:
+                continue
+            # Resolve the qualified name as written. Deliberately no bare-name
+            # fallback: `match_identifier` matches any identifier ending in
+            # `.orders`, so falling back would let a relation from another
+            # database pass purely because a same-named table exists here, which
+            # is exactly the mismatch this check exists to catch.
+            if not match_identifier(name, known):
+                unknown.append(name)
+        if not unknown:
+            return None
+        named = ", ".join(sorted(set(unknown)))
+        return (
+            f"refused: the metric query reads {named}, which this connection does "
+            "not have. The project was compiled against a different namespace than "
+            "the one dex is connected to; re-run `dbt parse` against the target "
+            "you are querying, or point dex at the connection the project was "
+            "built for."
+        )
+
+    def _render(self, q: SemanticQuery) -> str:
+        from metricflow.engine.metricflow_engine import MetricFlowQueryRequest
+
+        request = MetricFlowQueryRequest.create(
+            metric_names=q.metrics,
+            group_by_names=self._group_by_names(q) or None,
+            where_constraints=q.where or None,
+            order_by_names=q.order_by or None,
+            limit=q.limit,
+        )
+        return self._engine().explain(request).sql_statement.sql
+
+    def _group_by_names(self, q: SemanticQuery) -> list[str]:
+        # MetricFlow spells a time grain into the token (metric_time__month); a
+        # bare metric_time with --grain becomes that form. Other tokens pass through.
+        names: list[str] = []
+        for tok in q.group_by:
+            if tok == "metric_time" and q.grain:
+                names.append(f"metric_time__{q.grain.lower()}")
+            else:
+                names.append(tok)
+        return names
+
+    def _engine(self):
+        if self._mf_engine is not None:
+            return self._mf_engine
+        try:
+            from metricflow.engine.metricflow_engine import MetricFlowEngine
+            from metricflow_semantics.model.dbt_manifest_parser import (
+                parse_manifest_from_dbt_generated_manifest,
+            )
+            from metricflow_semantics.model.semantic_manifest_lookup import (
+                SemanticManifestLookup,
+            )
+        except ImportError as exc:
+            raise SemanticBackendError(_MISSING_EXTRA) from exc
+
+        from ... import dbt_project
+
+        manifest_path = self._project / dbt_project.SEMANTIC_MANIFEST_PATH
+        if not manifest_path.is_file():
+            raise SemanticBackendError(
+                "no compiled semantic manifest at target/semantic_manifest.json; "
+                "run `dbt parse` in the project first"
+            )
+        manifest = parse_manifest_from_dbt_generated_manifest(
+            manifest_path.read_text(encoding="utf-8")
+        )
+        lookup = SemanticManifestLookup(manifest)
+        self._mf_engine = MetricFlowEngine(
+            semantic_manifest_lookup=lookup, sql_client=self._sql_client()
+        )
+        return self._mf_engine
+
+    def _sql_client(self) -> _RendererOnlySqlClient:
+        spec = _RENDERERS.get(self._connector)
+        if spec is None:
+            raise SemanticBackendError(
+                f"no MetricFlow renderer for connector '{self._connector}'; local "
+                "metric queries support duckdb, bigquery, snowflake, databricks, "
+                "postgres, and redshift"
+            )
+        module_name, class_name, engine_name = spec
+        from metricflow.protocols.sql_client import SqlEngine
+
+        module = import_module(f"{_RENDER_ROOT}.{module_name}")
+        renderer = getattr(module, class_name)()
+        return _RendererOnlySqlClient(renderer, SqlEngine[engine_name])

--- a/packages/dex-core/tests/explore/test_semantic.py
+++ b/packages/dex-core/tests/explore/test_semantic.py
@@ -1,0 +1,388 @@
+"""Tests for `explore semantic`: the backend-neutral abstraction, the hosted dbt
+Cloud backend (against the fake GraphQL transport), and the local read-view.
+
+The hosted query path and the local execution path are also live-verified against
+real targets during development; these tests lock the offline-checkable behavior:
+intent parsing, PII screening, payload capping, backend selection, envelope shape,
+and the honest hosted cost posture.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fakes.semantic import SECRET_TOKEN, FakeHostedBackend, table_json_result
+
+from exmergo_dex_core import envelope as env
+from exmergo_dex_core.cache import (
+    ColumnProfile,
+    Dataset,
+    DexCache,
+    PIICategory,
+    PIIFlag,
+)
+from exmergo_dex_core.config import DexConfig, QueryLimits
+from exmergo_dex_core.explore import semantic as sem
+from exmergo_dex_core.explore.semantic import (
+    SemanticQuery,
+    cap_columnar,
+    requested_dimension_refs,
+    screen_dimension_refs,
+)
+from exmergo_dex_core.explore.semantic.local import LocalMetricFlowBackend
+
+
+class _Args:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+# ---- the shared abstraction -------------------------------------------------
+
+
+def test_requested_dimension_refs_from_group_by_and_where():
+    q = SemanticQuery(
+        metrics=["m"],
+        group_by=["user__pricing_tier", "metric_time"],
+        where=[
+            "{{ Dimension('session__is_deleted') }} = false",
+            "{{ TimeDimension('metric_time', 'month') }} > '2020-01-01'",
+            "{{ Entity('user') }} is not null",
+        ],
+    )
+    refs = requested_dimension_refs(q)
+    assert "user__pricing_tier" in refs
+    assert "session__is_deleted" in refs
+    assert "user" in refs
+    assert len(refs) == len(set(refs))  # de-duplicated
+
+
+def test_screen_blocks_pii_name_allows_clean():
+    blocked = dict(screen_dimension_refs(["user__email", "user__pricing_tier"]))
+    assert "user__email" in blocked
+    assert "user__pricing_tier" not in blocked
+
+
+def test_screen_meta_lookup_is_authoritative():
+    blocked = dict(
+        screen_dimension_refs(
+            ["order__region"],
+            meta_lookup=lambda ref: {"pii": True} if ref == "order__region" else None,
+        )
+    )
+    assert "order__region" in blocked
+
+
+def test_screen_evidence_clears_a_name_flagged_ref():
+    # A column the profiler examined and cleared (or a human pii_overrides entry)
+    # must stop being re-blocked by its name: evidence beats the heuristic.
+    blocked = dict(
+        screen_dimension_refs(["user__email"], meta_lookup=lambda _ref: {"pii": False})
+    )
+    assert blocked == {}
+
+
+def test_screen_silence_never_clears():
+    # A lookup that knows nothing must leave the fail-closed heuristic in charge.
+    blocked = dict(screen_dimension_refs(["user__email"], meta_lookup=lambda _r: None))
+    assert "user__email" in blocked
+
+
+def test_cap_columnar_row_and_payload_caps():
+    cells = [[i, "x"] for i in range(100)]
+    data = cap_columnar(
+        ["a", "b"],
+        ["int", "str"],
+        cells,
+        max_rows=10,
+        max_cell_chars=5,
+        max_payload_bytes=100_000,
+    )
+    assert data["row_count"] == 10
+    assert data["truncated"] is True
+    assert any("truncated to 10 rows" in note for note in data["notes"])
+
+
+def test_cap_columnar_cell_truncation():
+    data = cap_columnar(
+        ["a"],
+        ["str"],
+        [["abcdefghij"]],
+        max_rows=50,
+        max_cell_chars=3,
+        max_payload_bytes=100_000,
+    )
+    assert data["cells"][0][0] == "abc..."
+
+
+def test_resolve_backend_selection(monkeypatch):
+    import exmergo_dex_core.explore.semantic.hosted as hosted_mod
+    import exmergo_dex_core.explore.semantic.local as local_mod
+
+    monkeypatch.setattr(
+        hosted_mod.HostedDbtCloudBackend,
+        "from_config",
+        classmethod(lambda cls, args, config: "HOSTED"),
+    )
+    monkeypatch.setattr(
+        local_mod.LocalMetricFlowBackend,
+        "from_args",
+        classmethod(lambda cls, args, config, root: "LOCAL"),
+    )
+    cfg = DexConfig()
+    assert sem.resolve_backend(_Args(api=True, local=False), cfg, ".") == "HOSTED"
+    assert sem.resolve_backend(_Args(api=False, local=True), cfg, ".") == "LOCAL"
+    # default (no flag) follows config; a bare project defaults to local
+    assert sem.resolve_backend(_Args(api=False, local=False), cfg, ".") == "LOCAL"
+    cfg_cloud = DexConfig(semantic={"backend": "dbt_cloud"})
+    hosted = sem.resolve_backend(_Args(api=False, local=False), cfg_cloud, ".")
+    assert hosted == "HOSTED"
+    with pytest.raises(sem.SemanticBackendError):
+        sem.resolve_backend(_Args(api=True, local=True), cfg, ".")
+
+
+# ---- hosted backend (fake transport) ----------------------------------------
+
+
+def _viz_like_metrics():
+    return [
+        {
+            "name": "sessions",
+            "type": "SIMPLE",
+            "label": "Sessions",
+            "description": "Total sessions.",
+            "dimensions": [
+                {"name": "metric_time", "type": "TIME"},
+                {"name": "user__pricing_tier", "type": "CATEGORICAL"},
+            ],
+            "entities": [{"name": "user", "type": "PRIMARY"}],
+        }
+    ]
+
+
+def test_hosted_list_definitions():
+    backend = FakeHostedBackend(metrics=_viz_like_metrics())
+    catalog = backend.list_definitions()
+    assert catalog.backend == "dbt_cloud"
+    assert catalog.metrics[0].name == "sessions"
+    assert catalog.metrics[0].type == "simple"  # normalized from SIMPLE
+    assert "user__pricing_tier" in catalog.metrics[0].dimensions
+    assert any(d.name == "user__pricing_tier" for d in catalog.dimensions)
+    assert any(e.name == "user" for e in catalog.entities)
+
+
+def test_hosted_query_is_warn_only_and_shaped():
+    result = table_json_result(
+        ["metric_time__month", "sessions"],
+        ["datetime", "string"],
+        [["2025-01-01", 5.0], ["2025-02-01", 9.0]],
+    )
+    backend = FakeHostedBackend(result=result)
+    envelope = backend.query(
+        SemanticQuery(metrics=["sessions"], group_by=["metric_time__month"], limit=5)
+    )
+    assert envelope.status == env.Status.OK
+    # honest posture: paradigm hosted, no estimate/ceiling, explicit warning
+    assert envelope.cost.paradigm == env.Paradigm.HOSTED
+    assert envelope.cost.estimate is None and envelope.cost.ceiling is None
+    assert any("cost guard unavailable" in w for w in envelope.warnings)
+    # the pandas index column is dropped; shape matches explore query
+    assert envelope.data["columns"] == ["metric_time__month", "sessions"]
+    assert envelope.data["row_count"] == 2
+    assert envelope.data["query_id"] == "FAKE_QID"
+
+
+def test_hosted_pii_gate_blocks_before_execution():
+    backend = FakeHostedBackend()
+    envelope = backend.query(
+        SemanticQuery(metrics=["sessions"], group_by=["user__email"])
+    )
+    assert envelope.status == env.Status.ERROR
+    assert "PII" in envelope.errors[0]
+    # the refusal happens before the query is submitted for execution
+    assert not any("createQuery" in posted for posted in backend.posted)
+
+
+def test_hosted_failed_query_surfaces_error():
+    backend = FakeHostedBackend(status="FAILED", error="bad grain")
+    envelope = backend.query(SemanticQuery(metrics=["sessions"]))
+    assert envelope.status == env.Status.ERROR
+    assert "bad grain" in envelope.errors[0]
+
+
+# ---- local backend read-view ------------------------------------------------
+
+
+def _write_manifest(tmp_path: Path) -> Path:
+    project = tmp_path / "proj"
+    (project / "target").mkdir(parents=True)
+    manifest = {
+        "semantic_models": [
+            {
+                "name": "orders",
+                "entities": [{"name": "order", "type": "primary"}],
+                "dimensions": [{"name": "status", "type": "categorical"}],
+                "measures": [{"name": "order_count", "agg": "count"}],
+            }
+        ],
+        "metrics": [
+            {
+                "name": "orders",
+                "type": "simple",
+                "label": "Orders",
+                "type_params": {"input_measures": [{"name": "order_count"}]},
+            }
+        ],
+    }
+    (project / "target" / "semantic_manifest.json").write_text(json.dumps(manifest))
+    return project
+
+
+def test_local_list_reads_manifest(tmp_path: Path):
+    backend = LocalMetricFlowBackend(
+        _write_manifest(tmp_path), None, None, "duckdb", QueryLimits()
+    )
+    catalog = backend.list_definitions()
+    assert catalog.backend == "local"
+    orders = next(m for m in catalog.metrics if m.name == "orders")
+    assert "order__status" in orders.dimensions
+    assert "metric_time" in orders.dimensions
+    assert any(e.name == "order" for e in catalog.entities)
+
+
+def test_local_list_missing_manifest_errors(tmp_path: Path):
+    backend = LocalMetricFlowBackend(tmp_path, None, None, "duckdb", QueryLimits())
+    with pytest.raises(sem.SemanticBackendError):
+        backend.list_definitions()
+
+
+def test_local_query_pii_gate_blocks_before_render(tmp_path: Path):
+    # No manifest and no metricflow needed: the PII gate runs before rendering.
+    backend = LocalMetricFlowBackend(tmp_path, None, None, "duckdb", QueryLimits())
+    envelope = backend.query(
+        SemanticQuery(metrics=["orders"], group_by=["customer__email"])
+    )
+    assert envelope.status == env.Status.ERROR
+    assert "PII" in envelope.errors[0]
+
+
+# ---- local guards: cache-backed PII + namespace pre-check -------------------
+
+
+def _cache_with(columns: list[ColumnProfile], identifier: str = "wh.main.orders"):
+    return DexCache(datasets=[Dataset(identifier=identifier, columns=columns)])
+
+
+def _relation_manifest(tmp_path: Path, relation: str = "`wh`.`main`.`orders`") -> Path:
+    """A manifest whose semantic model resolves to a physical relation, so the
+    dimension-to-column mapping and the relation pre-check have something real."""
+
+    project = tmp_path / "proj"
+    (project / "target").mkdir(parents=True)
+    manifest = {
+        "semantic_models": [
+            {
+                "name": "orders",
+                "node_relation": {"alias": "orders", "relation_name": relation},
+                "entities": [{"name": "order", "type": "primary", "expr": "order_id"}],
+                "dimensions": [
+                    {"name": "contact", "type": "categorical", "expr": "contact_col"},
+                    {"name": "status", "type": "categorical"},
+                ],
+                "measures": [{"name": "order_count", "agg": "count"}],
+            }
+        ],
+        "metrics": [
+            {
+                "name": "orders",
+                "type": "simple",
+                "type_params": {"input_measures": [{"name": "order_count"}]},
+            }
+        ],
+    }
+    (project / "target" / "semantic_manifest.json").write_text(json.dumps(manifest))
+    return project
+
+
+def test_local_cache_pii_flag_blocks_a_clean_named_dimension(tmp_path: Path):
+    # `order__contact` reads innocuous by name; the cache says its physical column
+    # is flagged email. Evidence must block what the heuristic would have allowed.
+    backend = LocalMetricFlowBackend(
+        _relation_manifest(tmp_path), None, None, "duckdb", QueryLimits()
+    )
+    cache = _cache_with(
+        [
+            ColumnProfile(
+                name="contact_col",
+                data_type="VARCHAR",
+                pii=PIIFlag(category=PIICategory.EMAIL, confidence=0.9),
+            )
+        ]
+    )
+    lookup = backend._cache_pii_lookup(cache)
+    assert lookup("order__contact") == {"pii": True, "category": "email"}
+    blocked = dict(screen_dimension_refs(["order__contact"], meta_lookup=lookup))
+    assert "order__contact" in blocked
+
+
+def test_local_cache_clears_a_profiled_unflagged_column(tmp_path: Path):
+    backend = LocalMetricFlowBackend(
+        _relation_manifest(tmp_path), None, None, "duckdb", QueryLimits()
+    )
+    cache = _cache_with([ColumnProfile(name="contact_col", data_type="VARCHAR")])
+    assert backend._cache_pii_lookup(cache)("order__contact") == {"pii": False}
+
+
+def test_local_cache_lookup_is_silent_on_unknown_dimensions(tmp_path: Path):
+    backend = LocalMetricFlowBackend(
+        _relation_manifest(tmp_path), None, None, "duckdb", QueryLimits()
+    )
+    lookup = backend._cache_pii_lookup(_cache_with([]))
+    # Not in the manifest at all, and a column the cache never profiled: both must
+    # return None so the name heuristic stays in charge.
+    assert lookup("nowhere__thing") is None
+    assert lookup("order__status") is None
+
+
+def test_namespace_precheck_refuses_a_foreign_relation(tmp_path: Path):
+    backend = LocalMetricFlowBackend(
+        _relation_manifest(tmp_path), None, None, "duckdb", QueryLimits()
+    )
+    cache = _cache_with([ColumnProfile(name="status", data_type="VARCHAR")])
+    sql = "SELECT status FROM other_db.main.orders"
+    message = backend._namespace_mismatch(sql, cache, "duckdb")
+    assert message is not None
+    assert "different namespace" in message
+
+
+def test_namespace_precheck_accepts_a_suffix_match(tmp_path: Path):
+    # The cache is connector-normalized, so a legitimate spelling that resolves by
+    # suffix must pass rather than being rejected on an exact string compare.
+    backend = LocalMetricFlowBackend(
+        _relation_manifest(tmp_path), None, None, "duckdb", QueryLimits()
+    )
+    cache = _cache_with([ColumnProfile(name="status", data_type="VARCHAR")])
+    for sql in ("SELECT status FROM main.orders", "SELECT status FROM orders"):
+        assert backend._namespace_mismatch(sql, cache, "duckdb") is None
+
+
+def test_namespace_precheck_noops_without_an_inventory(tmp_path: Path):
+    # No `explore map` yet: nothing to check against, so metric queries still run.
+    backend = LocalMetricFlowBackend(
+        _relation_manifest(tmp_path), None, None, "duckdb", QueryLimits()
+    )
+    sql = "SELECT status FROM anything.at.all"
+    assert backend._namespace_mismatch(sql, None, "duckdb") is None
+    assert backend._namespace_mismatch(sql, DexCache(datasets=[]), "duckdb") is None
+
+
+def test_token_never_reaches_the_envelope():
+    result = table_json_result(["sessions"], ["string"], [[5.0]])
+    backend = FakeHostedBackend(result=result)
+    envelope = backend.query(SemanticQuery(metrics=["sessions"]))
+    # the sanitizer must accept it (no secret-like keys), and the token value must
+    # appear nowhere in the serialized envelope
+    env.sanitize(envelope)
+    assert SECRET_TOKEN not in json.dumps(envelope.model_dump(mode="json"))

--- a/packages/dex-core/tests/fakes/semantic.py
+++ b/packages/dex-core/tests/fakes/semantic.py
@@ -1,0 +1,75 @@
+"""A behavioral fake of the dbt Cloud Semantic Layer GraphQL transport.
+
+Not a mock: the backend under test is the real ``HostedDbtCloudBackend``; only the
+``_post`` transport is replaced. It answers real GraphQL query strings
+(introspection, ``createQuery``, poll) from a canned catalog and result, records
+every posted query in order (so a test can assert what the backend did and did NOT
+call, e.g. that a PII-refused query never reached ``createQuery``), and carries a
+recognizable secret token so the no-leak assertions have something to catch.
+"""
+
+from __future__ import annotations
+
+import json
+
+from exmergo_dex_core.config import QueryLimits
+from exmergo_dex_core.explore.semantic.hosted import HostedDbtCloudBackend
+
+# A token shaped like a real dbt Cloud Semantic Layer service token; the no-leak
+# tests assert this exact string never appears in an emitted envelope.
+SECRET_TOKEN = "dbts_FAKE_secret_token_must_not_leak"  # noqa: S105 (test fixture)
+
+
+def table_json_result(columns: list[str], types: list[str], rows: list[list]) -> str:
+    """A pandas ``orient='table'`` ``jsonResult`` string, including the leading
+    pandas ``index`` column the real API returns (which the backend must drop)."""
+
+    fields = [{"name": "index", "type": "integer"}] + [
+        {"name": c, "type": t} for c, t in zip(columns, types, strict=False)
+    ]
+    data = []
+    for i, row in enumerate(rows):
+        record = {"index": i}
+        record.update(dict(zip(columns, row, strict=False)))
+        data.append(record)
+    return json.dumps(
+        {"schema": {"fields": fields, "primaryKey": ["index"]}, "data": data}
+    )
+
+
+class FakeHostedBackend(HostedDbtCloudBackend):
+    def __init__(
+        self,
+        *,
+        metrics: list | None = None,
+        dimensions_meta: list | None = None,
+        result: str | None = None,
+        status: str = "SUCCESSFUL",
+        error: str | None = None,
+        limits: QueryLimits | None = None,
+    ) -> None:
+        super().__init__("fake.host", "42", SECRET_TOKEN, limits or QueryLimits())
+        self._metrics = metrics or []
+        self._dimensions_meta = dimensions_meta or []
+        self._result = result
+        self._status = status
+        self._error = error
+        self.posted: list[str] = []
+
+    def _post(self, query: str) -> dict:
+        self.posted.append(query)
+        if "createQuery" in query:
+            return {"createQuery": {"queryId": "FAKE_QID"}}
+        if "query(environmentId" in query:
+            return {
+                "query": {
+                    "status": self._status,
+                    "error": self._error,
+                    "jsonResult": self._result,
+                }
+            }
+        if "dimensions(environmentId" in query:
+            return {"dimensions": self._dimensions_meta}
+        if "metrics(environmentId" in query:
+            return {"metrics": self._metrics}
+        raise AssertionError(f"unexpected GraphQL query: {query}")

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -2280,3 +2280,147 @@ def test_maintain_envelopes_pass_the_sanitizer(tmp_path: Path, capsys):
     ):
         payload = _run(["--repo-root", str(root), *argv], capsys)
         assert payload["status"] in {"ok", "needs_confirmation"}
+
+
+# --- Family 5 + cost honesty: the hosted semantic-layer backend --------------
+#
+# The hosted dbt Cloud Semantic Layer executes server-side under its own warehouse
+# credential, so dex's cost guard is structurally unavailable there. Two invariants
+# guard that seam: the service token never crosses the stdout boundary, and the
+# backend is honest about the missing guard rather than faking one.
+
+
+def test_hosted_semantic_token_never_crosses_the_boundary():
+    import json
+
+    from fakes.semantic import SECRET_TOKEN, FakeHostedBackend, table_json_result
+
+    from exmergo_dex_core.explore.semantic import SemanticQuery
+
+    backend = FakeHostedBackend(
+        result=table_json_result(["sessions"], ["string"], [[5.0]])
+    )
+    envelope = backend.query(SemanticQuery(metrics=["sessions"]))
+    env.sanitize(envelope)  # a secret-like key would hard-fail here
+    assert SECRET_TOKEN not in json.dumps(envelope.model_dump(mode="json"))
+
+
+def test_hosted_semantic_is_warn_only_never_silently_priced():
+    from fakes.semantic import FakeHostedBackend, table_json_result
+
+    from exmergo_dex_core.explore.semantic import SemanticQuery
+
+    backend = FakeHostedBackend(
+        result=table_json_result(["sessions"], ["string"], [[5.0]])
+    )
+    envelope = backend.query(SemanticQuery(metrics=["sessions"]))
+    # ok WITHOUT any --confirm (dex governs nothing on this path)...
+    assert envelope.status == env.Status.OK
+    # ...but it never pretends to have priced or bounded the spend...
+    assert envelope.cost.paradigm == env.Paradigm.HOSTED
+    assert envelope.cost.estimate is None and envelope.cost.ceiling is None
+    # ...and it says so, loudly, on every result.
+    assert any("cost guard unavailable" in w for w in envelope.warnings)
+
+
+def test_local_semantic_pii_evidence_blocks_an_innocent_looking_dimension(
+    tmp_path: Path,
+):
+    # Family 3: on the local backend the .dex cache's value-evidence flags decide,
+    # so a dimension whose NAME reads clean is still refused when the physical
+    # column it resolves to is flagged. The name heuristic alone would allow it.
+    import json as _json
+
+    from exmergo_dex_core.cache import (
+        ColumnProfile,
+        Dataset,
+        DexCache,
+        PIICategory,
+        PIIFlag,
+    )
+    from exmergo_dex_core.config import QueryLimits
+    from exmergo_dex_core.explore.semantic import screen_dimension_refs
+    from exmergo_dex_core.explore.semantic.local import LocalMetricFlowBackend
+
+    project = tmp_path / "proj"
+    (project / "target").mkdir(parents=True)
+    (project / "target" / "semantic_manifest.json").write_text(
+        _json.dumps(
+            {
+                "semantic_models": [
+                    {
+                        "name": "orders",
+                        "node_relation": {
+                            "alias": "orders",
+                            "relation_name": "wh.main.orders",
+                        },
+                        "entities": [{"name": "order", "type": "primary"}],
+                        "dimensions": [
+                            {
+                                "name": "contact",
+                                "type": "categorical",
+                                "expr": "contact_col",
+                            }
+                        ],
+                        "measures": [{"name": "order_count", "agg": "count"}],
+                    }
+                ],
+                "metrics": [],
+            }
+        )
+    )
+    cache = DexCache(
+        datasets=[
+            Dataset(
+                identifier="wh.main.orders",
+                columns=[
+                    ColumnProfile(
+                        name="contact_col",
+                        data_type="VARCHAR",
+                        pii=PIIFlag(category=PIICategory.EMAIL, confidence=0.9),
+                    )
+                ],
+            )
+        ]
+    )
+    backend = LocalMetricFlowBackend(project, None, None, "duckdb", QueryLimits())
+    lookup = backend._cache_pii_lookup(cache)
+    assert dict(screen_dimension_refs(["order__contact"], meta_lookup=lookup))
+
+
+def test_local_semantic_refuses_a_foreign_namespace_before_spending(tmp_path: Path):
+    # Family 2 + 1: rendered metric SQL bakes in the relations the project was
+    # compiled against. Reading a namespace this connection does not have is
+    # refused BEFORE the cost handshake, so a mismatch never bills a failed job.
+    from exmergo_dex_core.cache import ColumnProfile, Dataset, DexCache
+    from exmergo_dex_core.config import QueryLimits
+    from exmergo_dex_core.explore.semantic.local import LocalMetricFlowBackend
+
+    backend = LocalMetricFlowBackend(tmp_path, None, None, "duckdb", QueryLimits())
+    cache = DexCache(
+        datasets=[
+            Dataset(
+                identifier="wh.main.orders",
+                columns=[ColumnProfile(name="status", data_type="VARCHAR")],
+            )
+        ]
+    )
+    verdict = backend._namespace_mismatch(
+        "SELECT status FROM other_db.main.orders", cache, "duckdb"
+    )
+    assert verdict is not None and "different namespace" in verdict
+
+
+def test_hosted_semantic_pii_dimension_refused_not_surfaced():
+    from fakes.semantic import FakeHostedBackend
+
+    from exmergo_dex_core.explore.semantic import SemanticQuery
+
+    backend = FakeHostedBackend()
+    envelope = backend.query(
+        SemanticQuery(metrics=["sessions"], group_by=["user__email"])
+    )
+    assert envelope.status == env.Status.ERROR
+    assert "PII" in envelope.errors[0]
+    # refused before the query was ever submitted for execution
+    assert not any("createQuery" in posted for posted in backend.posted)

--- a/packages/dex-core/uv.lock
+++ b/packages/dex-core/uv.lock
@@ -833,6 +833,13 @@ redshift = [
     { name = "redshift-connector" },
     { name = "sqlglot" },
 ]
+semantic = [
+    { name = "metricflow" },
+    { name = "sqlglot" },
+]
+semantic-api = [
+    { name = "httpx" },
+]
 snowflake = [
     { name = "dbt-snowflake" },
     { name = "snowflake-connector-python" },
@@ -863,6 +870,8 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=1" },
     { name = "google-cloud-bigquery", marker = "extra == 'all'", specifier = ">=3" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3" },
+    { name = "httpx", marker = "extra == 'semantic-api'", specifier = ">=0.27" },
+    { name = "metricflow", marker = "extra == 'semantic'", specifier = ">=0.211,<0.212" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'all'", specifier = ">=3" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3" },
     { name = "pydantic", specifier = ">=2" },
@@ -881,9 +890,10 @@ requires-dist = [
     { name = "sqlglot", marker = "extra == 'duckdb'", specifier = ">=25" },
     { name = "sqlglot", marker = "extra == 'postgres'", specifier = ">=25" },
     { name = "sqlglot", marker = "extra == 'redshift'", specifier = ">=25" },
+    { name = "sqlglot", marker = "extra == 'semantic'", specifier = ">=25" },
     { name = "sqlglot", marker = "extra == 'snowflake'", specifier = ">=25" },
 ]
-provides-extras = ["all", "bigquery", "cluster", "databricks", "dev", "duckdb", "postgres", "redshift", "snowflake"]
+provides-extras = ["all", "bigquery", "cluster", "databricks", "dev", "duckdb", "postgres", "redshift", "semantic", "semantic-api", "snowflake"]
 
 [[package]]
 name = "fastjsonschema"
@@ -1689,6 +1699,29 @@ wheels = [
 [package.optional-dependencies]
 msgpack = [
     { name = "msgpack" },
+]
+
+[[package]]
+name = "metricflow"
+version = "0.211.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "more-itertools" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "rapidfuzz" },
+    { name = "referencing" },
+    { name = "sqlglot" },
+    { name = "tabulate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/1c/2303b109a1e02216615d5c01cccf61a12d133f326388b9c881d32d00d182/metricflow-0.211.0.tar.gz", hash = "sha256:e15d0c24647f4498fa0926e87c61dd23b15205c9577566bcf848460d58f48bec", size = 1549648, upload-time = "2026-05-11T21:53:51.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/b7/de51d5d04ac43aeecbfea7741bf29da84fd5a04995e25a2b85abaa6ee807/metricflow-0.211.0-py3-none-any.whl", hash = "sha256:9cb83ccaa0c47363482fcc5cb57944a3f1af17ca948d90805524161f4e03d600", size = 1914356, upload-time = "2026-05-11T21:53:49.225Z" },
 ]
 
 [[package]]
@@ -2641,6 +2674,85 @@ wheels = [
 ]
 
 [[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/f9/3c41a7be8855803f4f6c713b472226a98d31d41869d98f64f4ca790510d6/rapidfuzz-3.14.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e251126d48615e1f02b4a178f2cd0cd4f0332b8a019c01a2e10480f7552554b4", size = 1952372, upload-time = "2026-04-07T11:13:58.32Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/89/c2557e37531d03465193bff0ab9de70b468420a807d71a26a65100635459/rapidfuzz-3.14.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ab449c9abd0d4e1f8145dce0798a4c822a1a1933d613c764a641bea88b8bdab", size = 1159782, upload-time = "2026-04-07T11:14:00.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b2/ffeeb7eca1a897d51b998f4c0ef0281696c3b06abcca4f88f9def708ffe1/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb2829fedd672dd7107267189dabe2bbe07972801d636014417c6861eb89e358", size = 1383677, upload-time = "2026-04-07T11:14:01.696Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d0/4539e42a2d596e068f7738f279638a4a74edd1fbb6f8594e2458058979c6/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d50e5861872935fece391351cbb5ba21d1bced277cf5e1143d207a0a35f1925", size = 3168906, upload-time = "2026-04-07T11:14:03.29Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1c/3ec897eb9d8b05308aa8ef6ae4ed64b088ad521a3f9d8ff469e7e97bc2b0/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:7092a216728f80c960bd6b3807275d1ee318b168986bd5dc523349581d4890b8", size = 1478176, upload-time = "2026-04-07T11:14:04.94Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ba/970c03a12ce20a5399e22afe9f8932fd4cd1265b8a8461d0e63b00eb4eae/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9669753caef7fdc6529f6adcc5883ed98d65976445d9322e7dbdb6b697feee13", size = 2402441, upload-time = "2026-04-07T11:14:07.228Z" },
+    { url = "https://files.pythonhosted.org/packages/81/93/61d351cae60c1d0e21ba5ff1a1015ad045539ed215da9d6e302204ed887a/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:823b1b9d9230809d8edcc18872770764bfe8ef4357995e16744047c8ccf0e489", size = 2511628, upload-time = "2026-04-07T11:14:09.234Z" },
+    { url = "https://files.pythonhosted.org/packages/87/52/374d2d4f60fd98155142a869323aa221e30868cfa1f15171a0f64070c247/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f0b2af76b7e7060c09e1a0dfa9410eb19369cbe6164509bff2ef94094b54d2b6", size = 4275480, upload-time = "2026-04-07T11:14:11.332Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/04/82e7989bc9ec20a15b720a335c5cb6b0724bf6582013898f90a3280cfccd/rapidfuzz-3.14.5-cp311-cp311-win32.whl", hash = "sha256:c5801a89604c65ab4cc9e91b23bc4076d0ca80efd8c976fb63843d7879a85d7f", size = 1725627, upload-time = "2026-04-07T11:14:13.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b5/eca8ac5609bc9bcb02bb6ff87fa5983cc92b8772d66a431556ab8a8c178f/rapidfuzz-3.14.5-cp311-cp311-win_amd64.whl", hash = "sha256:d7ca16637c0ede8243f84074044bd0b2335a0341421f8227c85756de2d18c819", size = 1545977, upload-time = "2026-04-07T11:14:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/e1/dbf318de28f65fa2cdd0a9dfbdee380f8199eb83b19259bc4f8592551b4e/rapidfuzz-3.14.5-cp311-cp311-win_arm64.whl", hash = "sha256:8c90cdf8516d9057e502aa6003cea71cf5ec27cc44699ca52412b502a04761bb", size = 816827, upload-time = "2026-04-07T11:14:16.788Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/e3/574435c6aafb80254c191ef40d7aca2cb2bb97a095ec9395e9fa59ac307a/rapidfuzz-3.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d3378f471ef440473a396ce2f8e97ee12f89a78b495540e0a5617bbfe895638", size = 1944601, upload-time = "2026-04-07T11:14:18.771Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1f/fbad3102a255ecc112ce9a7e779bacab7fd14398217be8868dc9082ba363/rapidfuzz-3.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e910eebca9fd0eba245c0555e764597e8a0cccb673a92da2dc2397050725f48", size = 1164293, upload-time = "2026-04-07T11:14:20.534Z" },
+    { url = "https://files.pythonhosted.org/packages/88/37/a3eb7ff6121ed3a5f199a8c38cc86c8e481816f879cb0e0b738b078c9a7e/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01550fe5f60fd176aa66b7611289d46dc4aa4b1b904874c7b6d1d54e581c5ec1", size = 1371999, upload-time = "2026-04-07T11:14:22.63Z" },
+    { url = "https://files.pythonhosted.org/packages/79/72/97a9728c711c7c1b06e107d3f0623880fb4ef90e147ed13c551a1730e7cc/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48bee0b91bebfaec41e1081e351000659ab7570cc4598d617aa04d5bf827f9e6", size = 3145715, upload-time = "2026-04-07T11:14:24.508Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/d5caabbea233ac90c286c87c260e49d7641467e87438a18d858e41c82e91/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:7e580cb04ad849ae9b786fa21383c6b994b6e6c1444ad1cb9f22392759d72741", size = 1456304, upload-time = "2026-04-07T11:14:26.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a7/2d1a81250ac8c01a0100c026018e76f0e7a097ff63e4c553e02a6938c6fb/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:09d6c9ba091854f07817055d795d604179c12a8f308ba4c7d56f3719dfea1646", size = 2389089, upload-time = "2026-04-07T11:14:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0d/c47c3872203ae88e6506997c0b576ad731f5261daa25d559be09c9756658/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1e989f86113be66574113b9c7bdf4793f3f863d248e47d911b355e05ca6b6b10", size = 2493404, upload-time = "2026-04-07T11:14:30.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/71e0a5a3130792146c8a200a2dd1e52aa16f7c1074012e17f2601eea9a90/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ebd1a18e2e47bc0b292a07e6ed9c3642f8aaa672d12253885f599b50807a4f9", size = 4251709, upload-time = "2026-04-07T11:14:32.451Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/d39874901abacef325adb5b34ae416817c8486dfb4fb87c7a9b74ec5b072/rapidfuzz-3.14.5-cp312-cp312-win32.whl", hash = "sha256:9981d38a703b86f0e315a3cd229fd1906fe1d91c989ed121fb975b3c849f89f5", size = 1710069, upload-time = "2026-04-07T11:14:34.37Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0b/f65572c53de8a1c704bda707f63a447b67bdbe95d7cdc70d18885e191df5/rapidfuzz-3.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:d8375e3da319593389727c3187ccaf3e0e84199accc530866b8e0f2b79af05e9", size = 1540630, upload-time = "2026-04-07T11:14:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c3/143be3a578f989758cae516f3270d5cbb49783a7bfdf57cc27a670e00456/rapidfuzz-3.14.5-cp312-cp312-win_arm64.whl", hash = "sha256:478b59bb018a6780d73f33e38d0b3ec5e968a6c1ed42876b993dd456b7aa20e8", size = 813137, upload-time = "2026-04-07T11:14:38.289Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/252803f2010ba699618cdc048b6e1f7cc1f433c08b4a9a17579b92ab0142/rapidfuzz-3.14.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebd8fd343bf8492a1e60bcb6dc99f90f74f65d98d8241a6b3e1fed225b76ecd6", size = 1940205, upload-time = "2026-04-07T11:14:40.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/59/b2afd98e41af9cd54554a4c1c423d84cdd60e6b1c0a09496f033b55f60ec/rapidfuzz-3.14.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6737b35d5af7479c5bf9710f7b17edd9d2c43128d974d25fb4ea653e42c64609", size = 1159639, upload-time = "2026-04-07T11:14:42.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/7aa7e62c4c516a7af322ed0c4f0774208b72d457d0cfec808bad0df12f4a/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b002c7994cc9f2bc9d9856f0fbaee6e8072c983873846c92f25cefba5b2a925f", size = 1367194, upload-time = "2026-04-07T11:14:44.25Z" },
+    { url = "https://files.pythonhosted.org/packages/90/79/2fc252a63bc91d3c3b234d0a3a6ad4ebc460037a23cdcdaf9285f986e6c9/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17a34330cd2a538c1ce5d400b61ba358c5b72c654b928ff87b362e88f8b864c7", size = 3151805, upload-time = "2026-04-07T11:14:46.21Z" },
+    { url = "https://files.pythonhosted.org/packages/17/54/0c83508f2683ea70e2d05f8527eb07328acf7bb1e9d97a3bece5702378e7/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:95d937e74c1a7a1287dfb03b62a827be08ede10a155cf1af73bbf47f2b73ee6e", size = 1455667, upload-time = "2026-04-07T11:14:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1b/070175e873177814d58850a01ebe80e20ae11e93eb4da894d563988660fa/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:46b92a9970dcc34f0096901c792644094cab49554ac3547f35e3aebbdf0a3610", size = 2388246, upload-time = "2026-04-07T11:14:50.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/77caf7aaf9c2be050ad1f128d7c24ff0f59079aa62c5f62f9df41c0af45e/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e012177c8e8a8a0754ae0d6027d63042aa5ff036d9f40f07cb3466a6082e21b8", size = 2494333, upload-time = "2026-04-07T11:14:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/dd7e1f2aa31a8fbbfc16b0610af1d770ffaf1287490f3c8c5b1c52da264f/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ae6f53f99c9a0eca7a0afc5b4e45fc73bc1dd4ac74c00509031d76df80ed98", size = 4258579, upload-time = "2026-04-07T11:14:54.538Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0a/ac99e1ba347ba0e85e0bb60b74231d55fb93c0eff43f2920ccb413d0be08/rapidfuzz-3.14.5-cp313-cp313-win32.whl", hash = "sha256:4a60f0057231188e3bd30216f7b4e0f279b11fa4ec818bb6c1d9f014d1562fbc", size = 1709231, upload-time = "2026-04-07T11:14:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cb/0e251d731b3166378644238e8f0cf9e89858c024e19f75ca9f7e3ae83fd5/rapidfuzz-3.14.5-cp313-cp313-win_amd64.whl", hash = "sha256:11bfc2ed8fbe4ab86bd516fadefab126f90e6dcadffa761739fcb304707dfd35", size = 1538519, upload-time = "2026-04-07T11:14:58.635Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/4548132acc947db6d5346a248e44a8b3a22d608ef30e770fb578caaf2d00/rapidfuzz-3.14.5-cp313-cp313-win_arm64.whl", hash = "sha256:b486b5218808f6f4dc471b114b1054e63553db69705c97da0271f47bd706aedd", size = 812628, upload-time = "2026-04-07T11:15:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/00/60/69b177577290c5eab892c6f75fe89c3aff3f9ae80298a78d9372b1cecb9a/rapidfuzz-3.14.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:39ef8658aaf67d51667e7bdaf7096f432333377d8302ac43c70b5df8a4cf89b8", size = 1970231, upload-time = "2026-04-07T11:15:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/48/38/2fd790052659cc4e2907b63c25433f0987864b445c1aeec1a302ef5ad948/rapidfuzz-3.14.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ad37a0be705b544af6296da8edddc260d10a8ae5462530fc9991f66498bb1f9", size = 1194394, upload-time = "2026-04-07T11:15:04.572Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f4/28430ad8472fc3536e8ebd51a864a226e979cfe924c6e3f83d111373aa74/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d45e06f60729e07d9b20c205f7e5cff90b6ef2584e852eecf46e045aea69627d", size = 1377051, upload-time = "2026-04-07T11:15:06.728Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7e/9aeacabcfd1e77397968362e5b98fe14248b8307011136b17daf99752a8e/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e52da10236aa6212de71b9e170bace65b64b129c0dea7fc243d6c9ce976f5074", size = 3160565, upload-time = "2026-04-07T11:15:08.667Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f4/db4dd7be0cd2f2022117ac5407d905f435d60e48baaea313a567ad27e865/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:440d30faaf682ca496170a7f0cc5453ec942e3e079f0fd802c9a7f938dfb50a3", size = 1442113, upload-time = "2026-04-07T11:15:11.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/99/0e9f6aa57f3e32a767216f797e56dc96b720fcecfb9d8ee907ecc82f8d66/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:56227a61fd3d17b0cd9793132431f3a3d07c8654be96794ba9f89fe0fc8b2d09", size = 2396618, upload-time = "2026-04-07T11:15:13.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/44a78e39ffce17cbdd3e2b53b696acc751d5d153be0f499d052b07a4d904/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2e83cd2e25bb4edd97b689d9979d9c3acccdaaf26ceac08212ceece202febcfa", size = 2478220, upload-time = "2026-04-07T11:15:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/df/454311469a09a507e9d784a35796742bec22e4cebe75551e2da4e0e290fd/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:af3b859726cd3374287e405e14b9634563c078c5531a4f62375508addebddad1", size = 4265027, upload-time = "2026-04-07T11:15:17.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/01/175465a9ab3e3b70ba669058372f009d1d49c1746e2dcd56b69df188d3a5/rapidfuzz-3.14.5-cp313-cp313t-win32.whl", hash = "sha256:8ce1d850b3c0178440efde9e884d98421b5e87ff925f364d6d79e23910d7593f", size = 1766814, upload-time = "2026-04-07T11:15:19.687Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/a9b84a47af06ebed94a1439eb2f02adebfb8628bcd30af1fe3e02f5ef56c/rapidfuzz-3.14.5-cp313-cp313t-win_amd64.whl", hash = "sha256:c84af70bcf34e99aee894e46a0f1ac77f17d0ef828179c387407642e2466d28a", size = 1582448, upload-time = "2026-04-07T11:15:21.98Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/5937800238b3f8248e70860d79f69ba8f73e764fff47e36bc9e2f26dbcc6/rapidfuzz-3.14.5-cp313-cp313t-win_arm64.whl", hash = "sha256:aac0ad28c686a5e72b81668b906c030ee28050b244544b8af68e12fb32543895", size = 832932, upload-time = "2026-04-07T11:15:24.358Z" },
+    { url = "https://files.pythonhosted.org/packages/81/41/aa3ffb3355e62e1bf91f6599b3092e866bc88487a07c524004943c7676df/rapidfuzz-3.14.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1a31cc6d7d03e7318a0974c038959c59e19c752b81115f2e9138b3331cd64d45", size = 1943327, upload-time = "2026-04-07T11:15:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e1/c2141f1840a41e07ad2db6f724945f8f8ff3065463899a22939152dd6e09/rapidfuzz-3.14.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0298d357e2bc59d572da4db0bc631009b6f8f6c9bc8c11e99a12b833f16b6575", size = 1161755, upload-time = "2026-04-07T11:15:28.659Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/07/66e753eeaa353161d1d331b7dd517bb349b0bacfebe8496d7b26be26f81f/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59b3dba758661a318995655435c6ab20a04ade79fa51e75bc8dc107cac8df280", size = 1376571, upload-time = "2026-04-07T11:15:31.225Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/85/9535df0b78ba51f478c9ce7eb6d1f85535cc31fe356773b48fd9d3e563ca/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4900143d82071bdda533b00300c40b14b963ff826b3642cc463b6dd0f036585e", size = 3156468, upload-time = "2026-04-07T11:15:33.428Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ee/b667eb93bba6dc4e0de658edd778e1619dc4d6aab68fa5e5c7f075152735/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:feedf219672eef83ea6be6f3bb093bba396a8560fc75be85ba225f082903df0a", size = 1458311, upload-time = "2026-04-07T11:15:35.557Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ce/479074f5624364a48df3403c538797ef22d3ac49c19dc76c3f79fcdcc70c/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:419e4397a36e2665ec992d8d64c20ba4b2a42500c76ecadeca78a4f19cb9cc32", size = 2398228, upload-time = "2026-04-07T11:15:37.669Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/a8982f649150fffbdcd6f17565974501f6ab33b2795267bffbd4a7ba905b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:97131ab2be39043054ee28d99e09efe316e6d53449b7e962dfcf3c2de8b2b246", size = 2497226, upload-time = "2026-04-07T11:15:39.857Z" },
+    { url = "https://files.pythonhosted.org/packages/19/52/5267c03ef6759831b7d4625a0c9c06e87baa2fae084b61ac9c388858317b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:593c00dac4e30231c35bf3b4f1da8ec0998762e9e94425586a5d636fcd57f9d0", size = 4262283, upload-time = "2026-04-07T11:15:42.279Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c0/2579f343a97f5254c43bb5853baccc01488357dcb64a27bcb869b7888a4a/rapidfuzz-3.14.5-cp314-cp314-win32.whl", hash = "sha256:0084b687b02b4e569b46d8d6d4ad25659528e6081cd6d067ca453a69035f07e4", size = 1744614, upload-time = "2026-04-07T11:15:44.498Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/8edfed1e80119dc9c35b11df4bc701eea85622ad681fff0263b6961d3224/rapidfuzz-3.14.5-cp314-cp314-win_amd64.whl", hash = "sha256:5dfa89d78f22cd773054caff44827b846161a29f2dcf7e78b8f90d086621e502", size = 1588971, upload-time = "2026-04-07T11:15:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/04/5676df93c85cfa57a3045d8047318df9f3cd58c7b8a99340dd95f874795e/rapidfuzz-3.14.5-cp314-cp314-win_arm64.whl", hash = "sha256:67f3f9d2b444268ab53e47d31bab89954888d23c04c6789f2c727e51fe4b1d13", size = 834985, upload-time = "2026-04-07T11:15:49.411Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0d/4a8988cea658fe335048ddef8c876addff1b6daa3c9ca8ad65a5a2196e69/rapidfuzz-3.14.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:77eac0526899b3c3ad1454bb2b03cdb491d67358ec8ef0c9c48bd61b632b431d", size = 1972517, upload-time = "2026-04-07T11:15:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a3/f5cfd9965a9d9a9e32249159797c47b5d6299ea6d1629f9126b25f1c10a3/rapidfuzz-3.14.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b9c6bd754d11f6e78ac54e3d86b4b11dc1ba2f13e5fc958899574532897f5a99", size = 1196056, upload-time = "2026-04-07T11:15:54.292Z" },
+    { url = "https://files.pythonhosted.org/packages/64/07/561c2e40cfd10e6630a7b0ac5a2a813aef50d944bcd1f3d260319d659d5b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:738c96944d076deeaff70e92b65696ab4f7ecb8081d7791c5403a3257dfaf8ff", size = 1374732, upload-time = "2026-04-07T11:15:56.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/39/123bb94fee40e2fb3b7c49b80827c7ef42d838e18def3fc2fef5a3cf817a/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4c1bca487a17fe4226b4ffb2d30e799d2b274d692cffa76bd0746f56235fca3", size = 3166902, upload-time = "2026-04-07T11:15:58.768Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0a/45716fafc9fd2e028cf20b5ac5bc704887081cd312f84edb0e325599414b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:af6a90a4ed2a48fa1a2d17e9d824e6c7c950bea5bad0b707c77fd55751e6bfef", size = 1452130, upload-time = "2026-04-07T11:16:01.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/49/4e96c413114398481c0a5b0086af32c364a18613c9a2ea578d17c4bea4ee/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bf5018938208d4597b2e679a4f8cff9fd252f1df53583130ae56281a21801b64", size = 2396308, upload-time = "2026-04-07T11:16:03.588Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b7/49fea9fc6878d59bd259d01dd1972d9b86117992b1c66d9b16f0a65273c3/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c0919d1f89ddf91129906705723118ea09754171e4116f5a5dbc667c7bc9b261", size = 2488210, upload-time = "2026-04-07T11:16:05.871Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/44/a1f732b93ffacbdad077b7c801149549b2938e1bece6addb5ad85ed74df8/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:93d8da883a35116d6813432177f35e570db5b0a5e30ecb0cbd7cb39c815735df", size = 4270621, upload-time = "2026-04-07T11:16:08.483Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ce/ff942d19fce5385054650bb71a58495ddda299d94661ccc4e6e7fa44868b/rapidfuzz-3.14.5-cp314-cp314t-win32.whl", hash = "sha256:0f23e37019ec07712d58976b1ab2b889f8649a7f7c2f626a2f34ea9139e79279", size = 1803950, upload-time = "2026-04-07T11:16:10.873Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0f/9aafc63f9661222b819b391c187eed29fc90ad5935f9690e5ecc2d2047a4/rapidfuzz-3.14.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7d5ca9c7832e6879a707296d1463685f7c243a27846227044504741640caec66", size = 1632357, upload-time = "2026-04-07T11:16:13.1Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a6/51fc1b0e61e3326e1c68a61cfd0c6b3c34c843681c4b1eefbf0596f59162/rapidfuzz-3.14.5-cp314-cp314t-win_arm64.whl", hash = "sha256:3e91dcd2549b8f8d843f98ba03a17e01f3d8b72ce942adbbb6761bc58ffce813", size = 855409, upload-time = "2026-04-07T11:16:15.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ee/e71853bf82846c5c2174b924b71d8e8099fb05ff87c958a720380b434ba3/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:578e6051f6d5e6200c259b47a103cf06bb875ab5814d17333fc0b5c290b22f4c", size = 1888603, upload-time = "2026-04-07T11:16:18.223Z" },
+    { url = "https://files.pythonhosted.org/packages/36/82/40f67b730f32be2ebad9f62add1571c754f52249254b2e88af094b907eee/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fbf1b8bb2695415b347f3727da1addca2acb82c9b97ac86bebf8b1bead1eb12d", size = 1120599, upload-time = "2026-04-07T11:16:20.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/9f/a3635cc4ec8fc6e14b46e7db1f7f8763d8c4bef33dcc124eea2e6cb2c8f3/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f4a8f5cc84c7ad6bffa0e9947b33eb343ad66e6b53e94fe54378a5508c5ed53", size = 1348524, upload-time = "2026-04-07T11:16:23.451Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1b/2b229520f0b48464cfcd7aa758f74551d12c9bc4ab544022a60210aab064/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97c6d85283629646fa87acc22c66b30ea9d4de7f6fdf887daa2e30fa041829b5", size = 3099302, upload-time = "2026-04-07T11:16:25.858Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b5/363906b1064fc6fe611783a61764927bbd91919aaaabe8cba82151ca93ef/rapidfuzz-3.14.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:dfef96543ced67d9513a422755db422ae1dc34dade0a1485e0b43e7342ed3ebf", size = 1509889, upload-time = "2026-04-07T11:16:28.487Z" },
+]
+
+[[package]]
 name = "redshift-connector"
 version = "2.1.15"
 source = { registry = "https://pypi.org/simple" }
@@ -3220,6 +3332,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]

--- a/references/semantic-layer.md
+++ b/references/semantic-layer.md
@@ -1,0 +1,110 @@
+# Querying the semantic layer (`explore semantic`)
+
+dex can author the dbt semantic layer (`transform` / `semantic define|update`) and
+detect drift in it (`maintain semantic`). `explore semantic` is the third piece:
+it *queries* the layer, so an agent can discover metrics and run governed metric
+queries. Two backends answer the same commands through one abstraction, and the
+difference between them is load-bearing, so it is spelled out here.
+
+## The two commands
+
+- `explore semantic list` returns the catalog in one shape from either backend:
+  metrics (name, type, label, description, and the dimensions each can be grouped
+  by), dimensions, and entities. This is the discovery surface an agent reads to
+  decide what to query.
+- `explore semantic query --metric <m> [--group-by <entity__dim>...]
+  [--where "<jinja>"] [--order-by <c>] [--grain <g>] [--limit N]` runs a metric
+  query and returns a capped, columnar result, the same envelope shape as
+  `explore query`.
+
+The query grammar is identical across backends: entity-qualified group-by tokens
+(`user__pricing_tier`, `metric_time`), the Jinja filter dialect in `--where`
+(`{{ Dimension('session__is_deleted') }} = false`), and a `--grain` that applies
+to `metric_time`.
+
+## Choosing a backend (ambient, like a connector)
+
+The backend is not a per-command mode you must remember; it resolves the way the
+warehouse connector does. The default is `.dex/config.yml`:
+
+```yaml
+semantic:
+  backend: local          # or dbt_cloud
+  host: <account>.semantic-layer.<region>.dbt.com   # hosted only, not secret
+  environment_id: "70506183145969"                  # hosted only, not secret
+```
+
+`--local` and `--api` override the default for one command, which is what lets you
+run the same metric both ways and compare (a local build against the deployed
+production layer, for instance).
+
+## Local backend (`--local`)
+
+A dbt project must be present, the way DuckDB needs a local file. MetricFlow's
+`explain()` renders the metric SQL through a renderer-only client that can never
+open a connection or see a credential, and dex then runs that SQL through its own
+spine, in order:
+
+1. **PII request-gate.** Each grouped or filtered dimension is resolved through the
+   manifest to its physical column, and that column's `.dex/` cache flag decides
+   (with `pii_overrides` from `.dex/config.yml` applied). Evidence rules in both
+   directions: a dimension whose name reads innocuous is refused when its column is
+   flagged, and a profiled, cleared column is not re-blocked by a PII-shaped name.
+   When the cache cannot speak to a dimension (never profiled, or a computed
+   expression rather than a bare column), the name heuristic is the fail-closed
+   floor, so silence never clears.
+2. **Relation pre-check.** The rendered SQL bakes in `relation_name` from the
+   compiled manifest, which routinely disagrees with the connection when the
+   project was compiled elsewhere. Each relation is resolved against the cached
+   inventory, and a relation this connection does not have is refused with a
+   precise message before the cost handshake, so a namespace mismatch never bills
+   a failed job. A same-named table in another database does not satisfy the
+   check. Without a cached inventory there is nothing to check against, and the
+   query proceeds.
+3. **SELECT-only assertion**, then the **cost-before-spend handshake**, then the
+   active connector.
+
+**dex owns execution here, so the full cost guard applies** exactly as it does for
+`explore query`. `list` is a pure read-view over `target/semantic_manifest.json`
+and needs no extra; `query` needs the `[semantic]` extra (MetricFlow) and a
+compiled manifest (`dbt parse`).
+
+## Hosted backend (`--api`, dbt Cloud Semantic Layer)
+
+Needs no local dbt project, the way BigQuery needs no local DuckDB: only a host,
+an environment id, and a service token. dex talks to the dbt Cloud Semantic Layer
+GraphQL API (`createQuery` then poll then read the result). The token is
+discovered from `DBT_SL_TOKEN` (then `~/.dbt/dbt_cloud.yml`), held only for the
+`Authorization` header, and never written to config or an envelope. Needs the
+`[semantic-api]` extra (an httpx client, nothing heavier).
+
+**The cost guard is unavailable on this backend, and dex says so on every
+result.** dbt Cloud owns the warehouse connection and executes the query
+server-side under its own credential, so dex cannot dry-run to estimate cost and
+cannot set a byte or credit ceiling. The hosted backend therefore does not ask for
+a `--confirm` (a confirmation dex could not back with a ceiling would be
+dishonest); it runs, and it attaches a warning to every result stating that dbt
+Cloud, not dex, governs the spend, with the cost paradigm reported as `hosted` and
+no estimate or ceiling. Spend is bounded only by the dbt Cloud environment's own
+limits.
+
+PII is still screened before the query is sent: a dimension the layer's own
+metadata marks as PII is refused, and a name heuristic (the same detector the
+profiler uses) is the fail-closed floor for a layer that carries no such metadata.
+Grouping or filtering by a PII-shaped dimension (`user__email`) is refused with a
+recovery hint before anything reaches dbt Cloud.
+
+## The asymmetry at a glance
+
+| | Local (`--local`) | Hosted (`--api`) |
+|---|---|---|
+| Renders the SQL | dex, via MetricFlow `explain()` | dbt Cloud |
+| Executes the SQL | dex, through the active connector | dbt Cloud, server-side |
+| Needs a local dbt project | yes | no |
+| Cost surfaced before spend | yes, the full handshake | no: cost guard unavailable, warns on every result |
+| Ceiling enforced by dex | yes (`maximum_bytes_billed` / timeout) | no: the dbt Cloud environment's own limits |
+| `--confirm` required | yes, on billed connectors | no (nothing dex can gate) |
+| PII gate | `.dex/` cache flags on the resolved physical column, name heuristic as the floor | layer metadata plus a name heuristic |
+| Namespace mismatch | refused before spend, against the cached inventory | dbt Cloud resolves its own relations |
+| Credentials | the connector's, never in context | a dbt Cloud service token, never in context |
+| Extra | `[semantic]` (query); none for `list` | `[semantic-api]` |

--- a/references/semantic-layer.md
+++ b/references/semantic-layer.md
@@ -12,10 +12,10 @@ difference between them is load-bearing, so it is spelled out here.
   metrics (name, type, label, description, and the dimensions each can be grouped
   by), dimensions, and entities. This is the discovery surface an agent reads to
   decide what to query.
-- `explore semantic query --metric <m> [--group-by <entity__dim>...]
-  [--where "<jinja>"] [--order-by <c>] [--grain <g>] [--limit N]` runs a metric
-  query and returns a capped, columnar result, the same envelope shape as
-  `explore query`.
+- `explore semantic query` runs a metric query and returns a capped, columnar
+  result, the same envelope shape as `explore query`. It takes `--metric <m>`
+  (repeatable), and optionally `--group-by <entity__dim>` (repeatable),
+  `--where "<jinja>"`, `--order-by <c>`, `--grain <g>`, and `--limit N`.
 
 The query grammar is identical across backends: entity-qualified group-by tokens
 (`user__pricing_tier`, `metric_time`), the Jinja filter dialect in `--where`

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -89,6 +89,23 @@ Subcommands, in the usual order:
    sample clause reads a fraction), so surface the estimate and get a budget
    first. Needs the `[cluster]` extra (scikit-learn); the wrapper installs it
    automatically for this subcommand.
+8. `explore semantic list` and `explore semantic query` reach the dbt semantic
+   layer (metrics, dimensions, entities). `list` is discovery: which metrics
+   exist and which dimensions each can be grouped by. `query --metric <m>
+   --group-by <entity__dim> [--where "<jinja>"] [--grain <g>] [--limit N]`
+   returns a metric's values as a capped, columnar result. Two backends answer
+   these, chosen by `.dex/config.yml` `semantic.backend` and overridable with
+   `--local` / `--api`. `--local` renders the SQL with MetricFlow and executes it
+   through dex's own connector and cost handshake, so cost is surfaced before
+   spend (needs a dbt project and, for `query`, the `[semantic]` extra; `list` is
+   a manifest read-view that needs neither). `--api` sends the query to a hosted
+   dbt Cloud deployment (needs only a host, an environment id, and a
+   `DBT_SL_TOKEN`, plus the `[semantic-api]` extra, no local project). The hosted
+   backend is the one place the cost guard cannot apply: dbt Cloud executes
+   server-side, so the result carries an explicit warning that spend is governed
+   there, not by dex, and no `--confirm` is asked. Either way a PII-shaped grouped
+   or filtered dimension (e.g. `user__email`) is refused before the query runs.
+   This queries the layer; authoring it is `transform`'s job.
 
 Rules of engagement for `query`: prefer the fixed commands when they answer the
 question; one probe answers one question; batch related measures into a single

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -91,9 +91,9 @@ Subcommands, in the usual order:
    automatically for this subcommand.
 8. `explore semantic list` and `explore semantic query` reach the dbt semantic
    layer (metrics, dimensions, entities). `list` is discovery: which metrics
-   exist and which dimensions each can be grouped by. `query --metric <m>
-   --group-by <entity__dim> [--where "<jinja>"] [--grain <g>] [--limit N]`
-   returns a metric's values as a capped, columnar result. Two backends answer
+   exist and which dimensions each can be grouped by. `query` takes a `--metric`
+   and a `--group-by <entity__dim>` (plus optional `--where`, `--grain`, and
+   `--limit`) and returns a metric's values as a capped, columnar result. Two backends answer
    these, chosen by `.dex/config.yml` `semantic.backend` and overridable with
    `--local` / `--api`. `--local` renders the SQL with MetricFlow and executes it
    through dex's own connector and cost handshake, so cost is surfaced before

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.2.2"
+DEX_CORE_VERSION = "1.3.0"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.2.2"
+DEX_CORE_VERSION = "1.3.0"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.2.2"
+DEX_CORE_VERSION = "1.3.0"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
## What this changes

Here we set up semantic layer exploration for `exmergo-dex-core`.

New command `dex explore semantic`
- key flags: 
  - `local` - dex queries the semantic model defined within a local dbt project
  - `api` - dex queries a hosted semantic layer on `dbt Cloud`
Subcommands
- `dex explore semantic list`: lists all available metrics
- `dex explore semantic query`: runs a query against a metric (requires at least one --metric)

## Related issues

Closes #56
Closes #114
