### PR TITLE
Fix multi-CTE resolution across set operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   schemas are checked. Backing this, every adapter gains a
   `list_namespace_objects` metadata method alongside `missing_dev_namespaces`.
 
+### Fixed
+
+- **`explore query` now resolves CTE aliases across set operations.** `WITH`
+  clause relations attached to `UNION`, `INTERSECT`, or `EXCEPT` roots are
+  registered before either branch is inspected, including later CTEs that
+  reference earlier ones. Multi-CTE probes no longer misdiagnose query-local
+  aliases as tables missing from the `.dex` cache (#117).
+
 ## [1.2.2] - 2026-07-18
 
 ### Changed

--- a/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
@@ -341,11 +341,22 @@ def _query_outputs(
 ) -> _Outputs:
     """Output taints of a whole query node (SELECT or a set operation)."""
 
+    # sqlglot attaches a WITH clause to the query root. For a plain query that
+    # root is a Select, but for UNION/INTERSECT/EXCEPT it is the set operation.
+    # Register CTEs here so both sides of any query shape resolve the same local
+    # relations. Process them in order because later CTEs may reference earlier
+    # ones.
+    local_env = dict(env)
+    for cte in node.ctes:
+        local_env[cte.alias_or_name.lower()] = _query_outputs(
+            cte.this, local_env, known, tables, dialect
+        )
+
     if isinstance(node, exp.Select):
-        return _select_outputs(node, env, known, tables, dialect)
+        return _select_outputs(node, local_env, known, tables, dialect)
     if isinstance(node, _QUERY_ROOTS):  # set operation: UNION/INTERSECT/EXCEPT
-        left = _query_outputs(node.left, env, known, tables, dialect)
-        right = _query_outputs(node.right, env, known, tables, dialect)
+        left = _query_outputs(node.left, local_env, known, tables, dialect)
+        right = _query_outputs(node.right, local_env, known, tables, dialect)
         # Column names come from the left side; taints merge positionally, and a
         # length mismatch (invalid SQL anyway) merges everything conservatively.
         left_items = list(left.items())
@@ -357,7 +368,7 @@ def _query_outputs(
             name: taint | right_taints[i] for i, (name, taint) in enumerate(left_items)
         }
     if isinstance(node, exp.Subquery):
-        return _query_outputs(node.this, env, known, tables, dialect)
+        return _query_outputs(node.this, local_env, known, tables, dialect)
     raise QueryRefusedError(f"unsupported query shape: {type(node).__name__}")
 
 
@@ -369,10 +380,6 @@ def _select_outputs(
     dialect: str,
 ) -> _Outputs:
     env = dict(outer_env)
-    for cte in select.ctes:
-        env[cte.alias_or_name.lower()] = _query_outputs(
-            cte.this, env, known, tables, dialect
-        )
 
     sources = _resolve_sources(select, env, known, tables, dialect)
 

--- a/packages/dex-core/tests/guards/test_query_firewall.py
+++ b/packages/dex-core/tests/guards/test_query_firewall.py
@@ -85,6 +85,30 @@ def test_allowed(sql: str, cache: DexCache):
     assert inspected.row_cap <= LIMITS.max_rows
 
 
+@pytest.mark.parametrize(
+    ("sql", "expected_tables"),
+    [
+        (
+            "WITH listings AS (SELECT ID FROM RAW_LISTINGS), "
+            "hosts AS (SELECT ID FROM RAW_HOSTS) "
+            "SELECT ID FROM listings UNION ALL SELECT ID FROM hosts",
+            ["db.main.RAW_HOSTS", "db.main.RAW_LISTINGS"],
+        ),
+        (
+            "WITH base AS (SELECT ID, HOST_ID FROM RAW_LISTINGS), "
+            "host_ids AS (SELECT HOST_ID FROM base) "
+            "SELECT HOST_ID FROM host_ids UNION ALL SELECT HOST_ID FROM base",
+            ["db.main.RAW_LISTINGS"],
+        ),
+    ],
+)
+def test_multiple_ctes_resolve_across_set_operations(
+    sql: str, expected_tables: list[str], cache: DexCache
+):
+    inspected = inspect_query(sql, cache, LIMITS)
+    assert inspected.tables == expected_tables
+
+
 # --- refused: value-carrying paths from flagged columns -------------------------
 
 


### PR DESCRIPTION
## What this changes

`WITH` clauses are attached by sqlglot to the query root. For queries ending in `UNION`, `INTERSECT`, or `EXCEPT`, that root is the set operation rather than either child `SELECT`.

This moves CTE registration into `_query_outputs`, so all query shapes share the same local relations. CTEs are processed in declaration order, which also lets later CTEs reference earlier ones.

Regression coverage includes both independent CTEs joined by `UNION ALL` and a later CTE derived from an earlier one.

## Related issues

Closes #117.

## Validation

- `pytest tests/guards/test_query_firewall.py tests/test_safety_spine.py -q -k query_firewall` (118 passed, 81 deselected)
- `ruff check src/exmergo_dex_core/guards/query_firewall.py tests/guards/test_query_firewall.py`
- `ruff format --check src/exmergo_dex_core/guards/query_firewall.py tests/guards/test_query_firewall.py`
- The full non-integration engine suite was attempted twice but exceeded the local 5-minute limit without reporting a failure.

## Checklist

- [x] Engine tests pass (`uv run pytest` in `packages/dex-core`) - focused suite passes; full suite timed out locally
- [x] Eval scoring-core tests pass (`uvx pytest evals`) - not run; evaluation code is unchanged
- [x] If a safety path is touched, the spine still holds: read-only against data, cost-guarded, PII flagged not surfaced, propose-don't-impose
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free (checked in CI)
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures