### PR TITLE
Issue 122

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   schemas are checked. Backing this, every adapter gains a
   `list_namespace_objects` metadata method alongside `missing_dev_namespaces`.
 
+### Fixed
+
+- **`explore query` now resolves CTE aliases across set operations.** `WITH`
+  clause relations attached to `UNION`, `INTERSECT`, or `EXCEPT` roots are
+  registered before either branch is inspected, including later CTEs that
+  reference earlier ones. Multi-CTE probes no longer misdiagnose query-local
+  aliases as tables missing from the `.dex` cache (#117).
+
 ## [1.2.2] - 2026-07-18
 
 ### Changed

--- a/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
@@ -43,6 +43,7 @@ from .base import (
     QueryResult,
     blame,
     distinct_combination_sql,
+    is_blob_type,
     json_safe,
     name_list,
     shape_stat_expressions,
@@ -677,18 +678,31 @@ class DatabricksAdapter:
     # --- estimation (free; feeds the confirm handshake) -------------------------
 
     def profile_estimate(
-        self, identifiers: list[str]
+        self, identifiers: list[str], *, include_blobs: set[str] | None = None
     ) -> tuple[float, dict[str, float]]:
         """The floor estimate for profiling: per table, its aggregate-batch
         count times the per-statement floor (sharpened by any size already
         learned this command), plus one DESCRIBE DETAIL per table, plus the
         startup floor when the warehouse is not running. Free: everything
-        comes from REST metadata."""
+        comes from REST metadata.
 
+        Blob-type columns are excluded from the batch count the same way
+        ``explore.profile.profile`` excludes them from the scan itself
+        (``include_blobs`` names the ``identifier.column`` paths a human
+        opted back in), so this estimate's batch count matches what the run
+        will actually issue."""
+
+        blob_paths = include_blobs or set()
         per_table: dict[str, float] = {}
         for identifier in identifiers:
             meta, columns = self.table_metadata(identifier)
-            batches = max((len(columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
+            scan_columns = [
+                c
+                for c in columns
+                if not is_blob_type(c.data_type)
+                or f"{identifier}.{c.name}".lower() in blob_paths
+            ]
+            batches = max((len(scan_columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
             per_table[identifier] = (
                 batches * self._statement_seconds(meta.byte_size) + _DETAIL_SECONDS
             )

--- a/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
@@ -49,6 +49,7 @@ from .base import (
     QueryResult,
     blame,
     distinct_combination_sql,
+    is_blob_type,
     json_safe,
     name_list,
     shape_stat_expressions,
@@ -475,16 +476,29 @@ class PostgresAdapter:
     # --- estimation (free; feeds the confirm handshake) -------------------------
 
     def profile_estimate(
-        self, identifiers: list[str]
+        self, identifiers: list[str], *, include_blobs: set[str] | None = None
     ) -> tuple[float, dict[str, float]]:
         """The heuristic database-seconds estimate for profiling: per table,
         its bytes over a conservative scan rate times the number of aggregate
-        batches. Free: everything comes from catalog metadata."""
+        batches. Free: everything comes from catalog metadata.
 
+        Blob-type columns are excluded from the batch count the same way
+        ``explore.profile.profile`` excludes them from the scan itself
+        (``include_blobs`` names the ``identifier.column`` paths a human
+        opted back in), so this estimate's batch count matches what the run
+        will actually issue."""
+
+        blob_paths = include_blobs or set()
         per_table: dict[str, float] = {}
         for identifier in identifiers:
             meta, columns = self.table_metadata(identifier)
-            batches = max((len(columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
+            scan_columns = [
+                c
+                for c in columns
+                if not is_blob_type(c.data_type)
+                or f"{identifier}.{c.name}".lower() in blob_paths
+            ]
+            batches = max((len(scan_columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
             per_table[identifier] = batches * self._scan_seconds(meta.byte_size)
         return sum(per_table.values()), per_table
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
@@ -54,6 +54,7 @@ from .base import (
     QueryResult,
     blame,
     distinct_combination_sql,
+    is_blob_type,
     json_safe,
     name_list,
     shape_stat_expressions,
@@ -641,17 +642,30 @@ class RedshiftAdapter:
     # --- estimation (feeds the confirm handshake; no scans) -----------------------
 
     def profile_estimate(
-        self, identifiers: list[str]
+        self, identifiers: list[str], *, include_blobs: set[str] | None = None
     ) -> tuple[float, dict[str, float]]:
         """The heuristic compute-seconds estimate for profiling: per table,
         its bytes over the capacity-scaled scan rate times the number of
         aggregate batches; plus the 60-second wake minimum once on
-        Serverless. Everything comes from catalog metadata."""
+        Serverless. Everything comes from catalog metadata.
 
+        Blob-type columns are excluded from the batch count the same way
+        ``explore.profile.profile`` excludes them from the scan itself
+        (``include_blobs`` names the ``identifier.column`` paths a human
+        opted back in), so this estimate's batch count matches what the run
+        will actually issue."""
+
+        blob_paths = include_blobs or set()
         per_table: dict[str, float] = {}
         for identifier in identifiers:
             meta, columns = self.table_metadata(identifier)
-            batches = max((len(columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
+            scan_columns = [
+                c
+                for c in columns
+                if not is_blob_type(c.data_type)
+                or f"{identifier}.{c.name}".lower() in blob_paths
+            ]
+            batches = max((len(scan_columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
             per_table[identifier] = batches * self._scan_seconds(meta.byte_size)
         return sum(per_table.values()) + self._estimate_floor(), per_table
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
@@ -41,6 +41,7 @@ from .base import (
     QueryResult,
     blame,
     distinct_combination_sql,
+    is_blob_type,
     json_safe,
     name_list,
     scope_within,
@@ -627,17 +628,30 @@ class SnowflakeAdapter:
     # --- estimation (free; feeds the confirm handshake) -------------------------
 
     def profile_estimate(
-        self, identifiers: list[str]
+        self, identifiers: list[str], *, include_blobs: set[str] | None = None
     ) -> tuple[float, dict[str, float]]:
         """The heuristic warehouse-seconds estimate for profiling: per table,
         its bytes over the size-scaled scan rate times the number of aggregate
         batches; plus the 60-second resume minimum once when the warehouse is
-        currently suspended. Free: everything comes from SHOW metadata."""
+        currently suspended. Free: everything comes from SHOW metadata.
 
+        Blob-type columns are excluded from the batch count the same way
+        ``explore.profile.profile`` excludes them from the scan itself
+        (``include_blobs`` names the ``identifier.column`` paths a human
+        opted back in), so this estimate's batch count matches what the run
+        will actually issue."""
+
+        blob_paths = include_blobs or set()
         per_table: dict[str, float] = {}
         for identifier in identifiers:
             meta, columns = self.table_metadata(identifier)
-            batches = max((len(columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
+            scan_columns = [
+                c
+                for c in columns
+                if not is_blob_type(c.data_type)
+                or f"{identifier}.{c.name}".lower() in blob_paths
+            ]
+            batches = max((len(scan_columns) + _COLUMN_BATCH - 1) // _COLUMN_BATCH, 1)
             per_table[identifier] = batches * self._scan_seconds(meta.byte_size)
         total = sum(per_table.values()) + self._resume_floor()
         return total, per_table

--- a/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
@@ -341,11 +341,22 @@ def _query_outputs(
 ) -> _Outputs:
     """Output taints of a whole query node (SELECT or a set operation)."""
 
+    # sqlglot attaches a WITH clause to the query root. For a plain query that
+    # root is a Select, but for UNION/INTERSECT/EXCEPT it is the set operation.
+    # Register CTEs here so both sides of any query shape resolve the same local
+    # relations. Process them in order because later CTEs may reference earlier
+    # ones.
+    local_env = dict(env)
+    for cte in node.ctes:
+        local_env[cte.alias_or_name.lower()] = _query_outputs(
+            cte.this, local_env, known, tables, dialect
+        )
+
     if isinstance(node, exp.Select):
-        return _select_outputs(node, env, known, tables, dialect)
+        return _select_outputs(node, local_env, known, tables, dialect)
     if isinstance(node, _QUERY_ROOTS):  # set operation: UNION/INTERSECT/EXCEPT
-        left = _query_outputs(node.left, env, known, tables, dialect)
-        right = _query_outputs(node.right, env, known, tables, dialect)
+        left = _query_outputs(node.left, local_env, known, tables, dialect)
+        right = _query_outputs(node.right, local_env, known, tables, dialect)
         # Column names come from the left side; taints merge positionally, and a
         # length mismatch (invalid SQL anyway) merges everything conservatively.
         left_items = list(left.items())
@@ -357,7 +368,7 @@ def _query_outputs(
             name: taint | right_taints[i] for i, (name, taint) in enumerate(left_items)
         }
     if isinstance(node, exp.Subquery):
-        return _query_outputs(node.this, env, known, tables, dialect)
+        return _query_outputs(node.this, local_env, known, tables, dialect)
     raise QueryRefusedError(f"unsupported query shape: {type(node).__name__}")
 
 
@@ -369,10 +380,6 @@ def _select_outputs(
     dialect: str,
 ) -> _Outputs:
     env = dict(outer_env)
-    for cte in select.ctes:
-        env[cte.alias_or_name.lower()] = _query_outputs(
-            cte.this, env, known, tables, dialect
-        )
 
     sources = _resolve_sources(select, env, known, tables, dialect)
 

--- a/packages/dex-core/tests/adapters/test_connect_databricks.py
+++ b/packages/dex-core/tests/adapters/test_connect_databricks.py
@@ -180,6 +180,44 @@ def test_no_startup_floor_on_a_running_warehouse(fake_databricks):
     assert total == pytest.approx(per_table["shop.core.customers"])
 
 
+def _wide_blob_table():
+    from fakes.databricks import FakeDatabricksTable
+
+    # 50 plain columns plus one binary column: without exclusion this is 2
+    # batches (51 columns), with exclusion (the default) it's 1 (50 columns).
+    # bytes=0 keeps _statement_seconds at the floor regardless of warehouse info.
+    columns = [(f"c_{i}", "bigint", True) for i in range(50)]
+    columns.append(("payload", "binary", True))
+    return FakeDatabricksTable(
+        catalog="shop", schema="core", name="sessions", columns=columns, rows=100
+    )
+
+
+def test_profile_estimate_accepts_include_blobs_without_crashing(fake_databricks):
+    # Regression test: explore/commands.py::_profile_estimate always calls
+    # adapter.profile_estimate(identifiers, include_blobs=...), so every
+    # adapter with a profile_estimate must accept that kwarg.
+    warm(fake_databricks)
+    adapter = make_adapter(fake_databricks)
+    adapter.profile_estimate(["shop.core.customers"], include_blobs=set())
+
+
+def test_profile_estimate_excludes_blob_columns_from_batch_count(fake_databricks):
+    warm(fake_databricks)
+    fake_databricks.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_databricks)
+    _total, per_table = adapter.profile_estimate(["shop.core.sessions"])
+    assert per_table["shop.core.sessions"] == pytest.approx(
+        1 * _MIN_STATEMENT_SECONDS + _DETAIL_SECONDS
+    )
+    _total, per_table = adapter.profile_estimate(
+        ["shop.core.sessions"], include_blobs={"shop.core.sessions.payload"}
+    )
+    assert per_table["shop.core.sessions"] == pytest.approx(
+        2 * _MIN_STATEMENT_SECONDS + _DETAIL_SECONDS
+    )
+
+
 def test_query_estimate_is_the_floor_until_a_size_is_known(fake_databricks):
     warm(fake_databricks)
     adapter = make_adapter(fake_databricks)

--- a/packages/dex-core/tests/adapters/test_connect_postgres.py
+++ b/packages/dex-core/tests/adapters/test_connect_postgres.py
@@ -174,6 +174,47 @@ def test_profile_estimate_scales_with_bytes_and_batches(fake_pg_connection):
     assert fake_pg_connection.data_statements == []
 
 
+def _wide_blob_table() -> FakePostgresTable:
+    # 50 plain columns plus one bytea column: without exclusion this is 2
+    # batches (51 columns), with exclusion (the default) it's 1 (50 columns).
+    columns = [(f"c_{i}", "integer", True) for i in range(50)]
+    columns.append(("payload", "bytea", True))
+    return FakePostgresTable(
+        schema="raw",
+        name="sessions",
+        columns=columns,
+        reltuples=100.0,
+        total_bytes=5_000_000_000,
+    )
+
+
+def test_profile_estimate_accepts_include_blobs_without_crashing(fake_pg_connection):
+    # Regression test: explore/commands.py::_profile_estimate always calls
+    # adapter.profile_estimate(identifiers, include_blobs=...), so every
+    # adapter with a profile_estimate must accept that kwarg.
+    adapter = make_adapter(fake_pg_connection)
+    adapter.profile_estimate(["dexdb.shop.customers"], include_blobs=set())
+
+
+def test_profile_estimate_excludes_blob_columns_from_batch_count(fake_pg_connection):
+    fake_pg_connection.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_pg_connection)
+    total, per_table = adapter.profile_estimate(["dexdb.raw.sessions"])
+    expected = 1 * (5_000_000_000 / _SCAN_BYTES_PER_SECOND)  # 1 batch, blob excluded
+    assert per_table["dexdb.raw.sessions"] == pytest.approx(expected)
+    assert total == pytest.approx(expected)
+
+
+def test_profile_estimate_include_blobs_override_adds_a_batch(fake_pg_connection):
+    fake_pg_connection.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_pg_connection)
+    total, _per_table = adapter.profile_estimate(
+        ["dexdb.raw.sessions"], include_blobs={"dexdb.raw.sessions.payload"}
+    )
+    expected = 2 * (5_000_000_000 / _SCAN_BYTES_PER_SECOND)  # 2 batches, 51 columns
+    assert total == pytest.approx(expected)
+
+
 def test_query_estimate_uses_the_free_planner(fake_pg_connection):
     fake_pg_connection.plan_costs = lambda sql: 640_000.0  # planner cost units
     adapter = make_adapter(fake_pg_connection)

--- a/packages/dex-core/tests/adapters/test_connect_redshift.py
+++ b/packages/dex-core/tests/adapters/test_connect_redshift.py
@@ -284,6 +284,47 @@ def test_estimate_scales_with_base_capacity(fake_redshift_connection):
     )
 
 
+def _wide_blob_table() -> FakeRedshiftTable:
+    # 50 plain columns plus one binary column: without exclusion this is 2
+    # batches (51 columns), with exclusion (the default) it's 1 (50 columns).
+    # size_mb matches `customers` so CUSTOMERS_SCAN_SECONDS is the per-batch rate.
+    columns = [(f"c_{i}", "bigint", True) for i in range(50)]
+    columns.append(("payload", "binary", True))
+    return FakeRedshiftTable(
+        schema="raw", name="sessions", columns=columns, size_mb=5_000, tbl_rows=100.0
+    )
+
+
+def test_profile_estimate_accepts_include_blobs_without_crashing(
+    fake_redshift_connection,
+):
+    # Regression test: explore/commands.py::_profile_estimate always calls
+    # adapter.profile_estimate(identifiers, include_blobs=...), so every
+    # adapter with a profile_estimate must accept that kwarg.
+    adapter = make_adapter(fake_redshift_connection)
+    adapter.profile_estimate(["dexdb.shop.customers"], include_blobs=set())
+
+
+def test_profile_estimate_excludes_blob_columns_from_batch_count(
+    fake_redshift_connection,
+):
+    fake_redshift_connection.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_redshift_connection)
+    _total, per_table = adapter.profile_estimate(["dexdb.raw.sessions"])
+    assert per_table["dexdb.raw.sessions"] == pytest.approx(CUSTOMERS_SCAN_SECONDS)
+
+
+def test_profile_estimate_include_blobs_override_adds_a_batch(
+    fake_redshift_connection,
+):
+    fake_redshift_connection.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_redshift_connection)
+    _total, per_table = adapter.profile_estimate(
+        ["dexdb.raw.sessions"], include_blobs={"dexdb.raw.sessions.payload"}
+    )
+    assert per_table["dexdb.raw.sessions"] == pytest.approx(2 * CUSTOMERS_SCAN_SECONDS)
+
+
 def test_query_estimate_sums_referenced_tables(fake_redshift_connection):
     adapter = make_adapter(fake_redshift_connection)
     estimate = adapter.query_estimate("SELECT count(*) FROM dexdb.shop.customers")

--- a/packages/dex-core/tests/adapters/test_connect_snowflake.py
+++ b/packages/dex-core/tests/adapters/test_connect_snowflake.py
@@ -158,6 +158,44 @@ def test_no_resume_floor_on_a_running_warehouse(fake_sf_connection):
     assert total == pytest.approx(per_table["SHOP.PUBLIC.CUSTOMERS"])
 
 
+def _wide_blob_table():
+    from fakes.snowflake import FakeSnowflakeTable
+
+    # 50 plain columns plus one BINARY column: without exclusion this is 2
+    # batches (51 columns), with exclusion (the default) it's 1 (50 columns).
+    columns = [(f"C_{i}", "FIXED", True) for i in range(50)]
+    columns.append(("PAYLOAD", "BINARY", True))
+    return FakeSnowflakeTable(
+        database="SHOP",
+        schema="PUBLIC",
+        name="SESSIONS",
+        columns=columns,
+        rows=100,
+        bytes=5_000_000_000,
+    )
+
+
+def test_profile_estimate_accepts_include_blobs_without_crashing(fake_sf_connection):
+    # Regression test: explore/commands.py::_profile_estimate always calls
+    # adapter.profile_estimate(identifiers, include_blobs=...), so every
+    # adapter with a profile_estimate must accept that kwarg.
+    adapter = make_adapter(fake_sf_connection)
+    adapter.profile_estimate(["SHOP.PUBLIC.CUSTOMERS"], include_blobs=set())
+
+
+def test_profile_estimate_excludes_blob_columns_from_batch_count(fake_sf_connection):
+    fake_sf_connection.warehouses[0].state = "STARTED"
+    fake_sf_connection.warehouse_resumes_pending = False
+    fake_sf_connection.tables.append(_wide_blob_table())
+    adapter = make_adapter(fake_sf_connection)
+    total_excluded, _per_table = adapter.profile_estimate(["SHOP.PUBLIC.SESSIONS"])
+    total_included, _per_table = adapter.profile_estimate(
+        ["SHOP.PUBLIC.SESSIONS"], include_blobs={"shop.public.sessions.payload"}
+    )
+    # 1 batch (50 cols) vs 2 batches (51 cols), no resume floor to muddy the ratio.
+    assert total_included == pytest.approx(2 * total_excluded)
+
+
 def test_query_estimate_sums_referenced_tables(fake_sf_connection):
     fake_sf_connection.warehouses[0].state = "STARTED"
     fake_sf_connection.warehouse_resumes_pending = False

--- a/packages/dex-core/tests/guards/test_query_firewall.py
+++ b/packages/dex-core/tests/guards/test_query_firewall.py
@@ -85,6 +85,30 @@ def test_allowed(sql: str, cache: DexCache):
     assert inspected.row_cap <= LIMITS.max_rows
 
 
+@pytest.mark.parametrize(
+    ("sql", "expected_tables"),
+    [
+        (
+            "WITH listings AS (SELECT ID FROM RAW_LISTINGS), "
+            "hosts AS (SELECT ID FROM RAW_HOSTS) "
+            "SELECT ID FROM listings UNION ALL SELECT ID FROM hosts",
+            ["db.main.RAW_HOSTS", "db.main.RAW_LISTINGS"],
+        ),
+        (
+            "WITH base AS (SELECT ID, HOST_ID FROM RAW_LISTINGS), "
+            "host_ids AS (SELECT HOST_ID FROM base) "
+            "SELECT HOST_ID FROM host_ids UNION ALL SELECT HOST_ID FROM base",
+            ["db.main.RAW_LISTINGS"],
+        ),
+    ],
+)
+def test_multiple_ctes_resolve_across_set_operations(
+    sql: str, expected_tables: list[str], cache: DexCache
+):
+    inspected = inspect_query(sql, cache, LIMITS)
+    assert inspected.tables == expected_tables
+
+
 # --- refused: value-carrying paths from flagged columns -------------------------
 
 


### PR DESCRIPTION
## Summary

- `explore/commands.py::_profile_estimate` (added in #108) unconditionally calls `adapter.profile_estimate(identifiers, include_blobs=...)` for any adapter that exposes `profile_estimate`. Postgres, Snowflake, Databricks, and Redshift each implement their own `profile_estimate(self, identifiers: list[str])` with no `include_blobs` parameter, so `explore profile`/`relationships`/`map` crashed with `TypeError: profile_estimate() got an unexpected keyword argument 'include_blobs'` against any of these four connectors.
- Each of the four now accepts `include_blobs: set[str] | None = None` and filters blob-type columns out of its batch-count calculation before estimating, mirroring the fix already applied to `BigQueryAdapter.profile_estimate` in #108.
- This also fixes a secondary, lower-severity gap: these adapters' `batches = ceil(len(columns) / 50)` heuristic wasn't reflecting the pruned column count either, so a table whose blob columns crossed a 50-column batch boundary reported one extra batch's worth of estimated time.

## Changes

- `adapters/postgres.py`, `adapters/snowflake.py`, `adapters/databricks.py`, `adapters/redshift.py`: `profile_estimate` gains `include_blobs`, filters `columns` to `scan_columns` via `adapters.base.is_blob_type` before computing `batches`. No other logic touched.

## Test plan

- [x] Regression test per adapter: `profile_estimate(identifiers, include_blobs=set())` -- the exact call shape that crashed -- doesn't raise
- [x] Batch-count test per adapter: a blob column crossing the 50-column batch boundary drops the estimate by one batch; `include_blobs` restores it
- [x] Full suite: 1121 passed, 78 skipped
- [x] `ruff check` clean on all touched files

---
Base: `issue-108`. This branch depends on #108's `is_blob_type`/`include_blobs` foundation; retarget to `main` once #108 merges.