### PR TITLE
Issue-105: Allow COUNTIF over a PII-flagged column in the query firewall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 - **`explore query` now allows `COUNTIF(cond)` over a PII-flagged column.**
   `COUNTIF`/`COUNT_IF` (BigQuery, Snowflake, DuckDB) releases exactly what
-  `COUNT(*) FILTER (WHERE cond)` already released -- a row count, with the
-  condition never crossing the envelope -- so the firewall now treats it as a
+  `COUNT(*) FILTER (WHERE cond)` already released a row count, with the
+  condition never crossing the envelope so the firewall now treats it as a
   measuring aggregate instead of refusing it as value-carrying. This closes a
   dialect gap: BigQuery has no `FILTER (WHERE ...)` clause, so `COUNTIF` was
   its only batched filtered-count spelling, and it was the one form the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **`explore query` now allows `COUNTIF(cond)` over a PII-flagged column.**
+  `COUNTIF`/`COUNT_IF` (BigQuery, Snowflake, DuckDB) releases exactly what
+  `COUNT(*) FILTER (WHERE cond)` already released -- a row count, with the
+  condition never crossing the envelope -- so the firewall now treats it as a
+  measuring aggregate instead of refusing it as value-carrying. This closes a
+  dialect gap: BigQuery has no `FILTER (WHERE ...)` clause, so `COUNTIF` was
+  its only batched filtered-count spelling, and it was the one form the
+  firewall still refused. The refusal message's example list and the probe
+  playbook now name `COUNTIF` alongside `COUNT` (#105).
 - **`explore query` now resolves CTE aliases across set operations.** `WITH`
   clause relations attached to `UNION`, `INTERSECT`, or `EXCEPT` roots are
   registered before either branch is inspected, including later CTEs that

--- a/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
@@ -16,7 +16,12 @@ cache does not know, refuses with the fix ("profile it first"). Filters, join
 conditions, GROUP BY and ORDER BY are unrestricted: values flow into them, not
 out of them. Row-level projections of a flagged column (including comparisons
 like ``name LIKE 'A%'``) are refused; per-row predicates over PII are still
-row-level PII-derived data.
+row-level PII-derived data. The same reasoning cuts the path through
+``FILTER (WHERE ...)`` and ``COUNTIF``/``COUNT_IF``: their condition argument is
+a filter, not a projected value, so it is never walked for taint -- only the
+aggregate's own (measuring) output crosses the envelope. This is what lets
+BigQuery, which has no ``FILTER (WHERE ...)`` clause, express a batched
+filtered count as ``COUNTIF(cond)`` instead.
 
 A FROM clause may unnest, in each dialect's native idiom (UNNEST, LATERAL
 FLATTEN, LATERAL VIEW EXPLODE, set-returning functions, PartiQL navigation and
@@ -79,9 +84,19 @@ class InspectedQuery:
 # from a flagged column to the projection. MIN/MAX/ANY_VALUE/MODE/percentiles
 # and the collecting aggregates (STRING_AGG, ARRAY_AGG, LIST, HISTOGRAM) all
 # return actual values, so they are deliberately absent.
+#
+# count_if: sqlglot parses COUNTIF/COUNT_IF (BigQuery, Snowflake, DuckDB) into
+# its own exp.CountIf node, normalized to "count_if" by sql_name() regardless
+# of dialect. Its sole argument is grammatically always a boolean condition,
+# never a value-carrying expression -- structurally the same as a
+# FILTER (WHERE ...) clause, which already passes via the exp.Filter carve-out
+# in _expr_taint. Listing it here (rather than a separate carve-out) skips its
+# condition entirely, exactly as intended: the condition is a filter, not a
+# projection.
 _MEASURING = frozenset(
     {
         "count",
+        "count_if",
         "approx_distinct",
         "approx_count_distinct",
         "avg",
@@ -287,7 +302,7 @@ def inspect_query(
         message = (
             "the projection would carry values from PII-flagged column(s): "
             + "; ".join(offending)
-            + ". Use a measuring aggregate over them (COUNT, "
+            + ". Use a measuring aggregate over them (COUNT, COUNTIF, "
             "APPROX_COUNT_DISTINCT, AVG(LENGTH(...))), or drop them from the "
             "output. PII values never cross the envelope."
         )

--- a/packages/dex-core/tests/guards/test_query_firewall.py
+++ b/packages/dex-core/tests/guards/test_query_firewall.py
@@ -71,6 +71,7 @@ def _refusal(sql: str, cache: DexCache) -> str:
         "SELECT COUNT(*) FROM RAW_HOSTS WHERE NAME = 'Ada'",  # values flow in
         "SELECT COUNT(*) FROM RAW_HOSTS GROUP BY NAME",  # group key not projected
         "SELECT COUNT(*) FILTER (WHERE NAME LIKE 'A%') FROM RAW_HOSTS",
+        "SELECT COUNTIF(NAME LIKE 'A%') FROM RAW_HOSTS",
         "WITH x AS (SELECT NAME FROM RAW_HOSTS) SELECT COUNT(NAME) FROM x",
         "SELECT ID FROM (SELECT ID, NAME FROM RAW_HOSTS) t",
         "SELECT l.HOST_ID FROM RAW_LISTINGS l JOIN RAW_HOSTS h ON l.HOST_ID = h.ID",
@@ -83,6 +84,20 @@ def test_allowed(sql: str, cache: DexCache):
     inspected = inspect_query(sql, cache, LIMITS)
     assert inspected.sql
     assert inspected.row_cap <= LIMITS.max_rows
+
+
+def test_countif_allowed_on_bigquery(cache: DexCache):
+    """BigQuery has no FILTER (WHERE ...) clause, so COUNTIF(cond) is its only
+    batched filtered-count spelling; it must pass exactly like FILTER already
+    does on engines that support it."""
+
+    inspected = inspect_query(
+        "select countif(name like 'A%') as names_starting_a from RAW_HOSTS",
+        cache,
+        LIMITS,
+        dialect="bigquery",
+    )
+    assert inspected.sql
 
 
 @pytest.mark.parametrize(

--- a/skills/explore/references/probe-playbook.md
+++ b/skills/explore/references/probe-playbook.md
@@ -115,7 +115,7 @@ FROM users
 ```
 
 Recipes 4, 6, and 8 above use `FILTER (WHERE ...)`, which is not available on
-BigQuery -- BigQuery's engine will reject that clause outright, and the firewall
+BigQuery BigQuery's engine will reject that clause outright, and the firewall
 will not catch it first (it parses fine). On BigQuery, spell the same batched
 filtered count as `COUNTIF(cond)` instead, e.g. recipe 4's blank/sentinel
 breakdown becomes:

--- a/skills/explore/references/probe-playbook.md
+++ b/skills/explore/references/probe-playbook.md
@@ -16,10 +16,11 @@ Two habits pay for everything else:
 
 Firewall rules that shape your SQL: values may be projected only from profiled,
 PII-cleared columns; over a flagged column use a measuring aggregate (COUNT,
-COUNT(DISTINCT ...), APPROX_COUNT_DISTINCT, AVG, SUM, STDDEV), never a
-value-carrying one (MIN, MAX, ANY_VALUE, STRING_AGG, ARRAY_AGG). Filters and join
-conditions may reference anything. Results are capped (rows, cell width, bytes),
-and every cut is announced in `notes`, so aggregate first rather than paging.
+COUNT(DISTINCT ...), COUNTIF/COUNT_IF, APPROX_COUNT_DISTINCT, AVG, SUM, STDDEV),
+never a value-carrying one (MIN, MAX, ANY_VALUE, STRING_AGG, ARRAY_AGG). Filters and
+join conditions may reference anything. Results are capped (rows, cell width,
+bytes), and every cut is announced in `notes`, so aggregate first rather than
+paging.
 
 ## The recipes
 
@@ -112,6 +113,22 @@ SELECT COUNT(email)                    AS present,
        COUNT(*) FILTER (WHERE email NOT LIKE '%@%') AS shape_violations
 FROM users
 ```
+
+Recipes 4, 6, and 8 above use `FILTER (WHERE ...)`, which is not available on
+BigQuery -- BigQuery's engine will reject that clause outright, and the firewall
+will not catch it first (it parses fine). On BigQuery, spell the same batched
+filtered count as `COUNTIF(cond)` instead, e.g. recipe 4's blank/sentinel
+breakdown becomes:
+
+```sql
+SELECT COUNT(*)                            AS rows,
+       COUNTIF(TRIM(col) = '')             AS blank,
+       COUNTIF(col IN ('N/A', 'none'))     AS sentinel
+FROM t
+```
+
+`COUNTIF(cond)` is equivalent to `COUNT(*) FILTER (WHERE cond)` and passes the
+firewall the same way: the condition is a filter, not a projected value.
 
 ## When a probe is refused
 


### PR DESCRIPTION
## Summary

- Allow `COUNTIF(cond)` over a PII-flagged column in the query firewall. `COUNTIF`/`COUNT_IF` (BigQuery, Snowflake, DuckDB) releases exactly what `COUNT(*) FILTER (WHERE cond)` already releases — a row count, with the condition never crossing the envelope — so it's now treated as a measuring aggregate instead of refused as value-carrying.
- Closes a BigQuery-specific gap: BigQuery has no `FILTER (WHERE ...)` clause, so `COUNTIF` was its only batched filtered-count spelling, and the one form the firewall still blocked.
- Updated the refusal message's example list and the probe playbook to name `COUNTIF`, and added a playbook callout that BigQuery rejects `FILTER (WHERE ...)` at the engine (recipes 4/6/8 need the `COUNTIF` spelling there).

Fixes #105.

## Test plan

- [x] `pytest tests/guards/test_query_firewall.py` — new `COUNTIF` cases (default dialect + BigQuery) pass, no existing refusals flip.
- [x] Full `dex-core` suite (`pytest -q`) — 1105 passed, 78 skipped, no regressions.
