### PR TITLE
Issue-112: Type-aware PII de-rating: stop flagging non-string columns as EMAIL/N…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,32 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **`explore profile` no longer flags non-string columns as EMAIL/NAME/PHONE,
+  nor aggregate-count columns as PII.** PII classification is now type-aware: a
+  category that cannot structurally live on a column's type is suppressed at
+  classification time rather than flagged and then worked around. An integer
+  `<x>_email_count` (the PII-safe derived replacement for a staging-only array
+  of addresses) is no longer flagged `EMAIL` at 0.9, so the query firewall stops
+  refusing value-carrying aggregates on it and its min/max are surfaced again.
+  The gate is per-category impossibility, not blanket: `EMAIL`/`NAME`/`FREE_TEXT`
+  are string-only, `PHONE` excludes only boolean and temporal (a phone-as-INT
+  still flags), and `ADDRESS`/`GOVERNMENT_ID`/`FINANCIAL`/`LOCATION`/`DOB` keep
+  flagging on numeric and temporal types where they legitimately belong (`zip`,
+  `ssn`, `salary` as `INT`, `lat`/`lng` as `FLOAT`, `dob` as `DATE`). Separately,
+  a non-string column whose name ends in an aggregate suffix (`_count`, `_cnt`,
+  `_sum`, `_avg`, `_pct`, `_ratio`) is treated as a derived statistic and
+  suppressed even for those categories, so `ssn_count` and `zip_count` no longer
+  flag. `pii_overrides` still works and existing entries are untouched; they
+  simply stop being necessary for this class of column (#112).
+- **Snowflake integer and NUMBER columns now read as numeric everywhere the
+  engine reasons about type.** Snowflake's `SHOW COLUMNS` surfaces every
+  integer/NUMBER as the token `FIXED`, which matched none of the numeric type
+  hints, so on Snowflake no integer column was recognized as numeric. `FIXED` is
+  now a numeric hint. Beyond making the type-aware PII gate above effective on
+  Snowflake, this is a visible pre-existing correction: Snowflake numeric columns
+  now surface min/max in profiles (a numeric extreme is not sensitive) and become
+  eligible features for `explore cluster`, matching how every other connector's
+  integers have always been treated (#112).
 - **`explore query` now allows `COUNTIF(cond)` over a PII-flagged column.**
   `COUNTIF`/`COUNT_IF` (BigQuery, Snowflake, DuckDB) releases exactly what
   `COUNT(*) FILTER (WHERE cond)` already released a row count, with the

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -117,7 +117,19 @@ _FREE_TEXT = re.compile(
     r"(^|_)(comments?|notes?|message|body|feedback|review_text|bio|about)(_|$)"
 )
 
-_NUMERIC_HINTS = ("INT", "DECIMAL", "NUMERIC", "DOUBLE", "FLOAT", "REAL", "HUGEINT")
+# "FIXED" is Snowflake's SHOW COLUMNS token for every integer and NUMBER type
+# (surfaced by snowflake._render_type); without it no Snowflake integer column
+# reads as numeric, and the type-aware PII gates below would be inert there.
+_NUMERIC_HINTS = (
+    "INT",
+    "DECIMAL",
+    "NUMERIC",
+    "DOUBLE",
+    "FLOAT",
+    "REAL",
+    "HUGEINT",
+    "FIXED",
+)
 _TEMPORAL_HINTS = ("DATE", "TIME", "TIMESTAMP", "INTERVAL")
 _BOOLEAN_HINTS = ("BOOL",)
 _STRING_HINTS = ("CHAR", "TEXT", "STRING", "VARCHAR")
@@ -176,13 +188,61 @@ def is_numeric_type(data_type: str) -> bool:
     return any(h in upper for h in _NUMERIC_HINTS)
 
 
+# Per-category structural type gate. Type evidence is known before any scan, so
+# an impossible pairing (an EMAIL on an integer) suppresses the flag outright at
+# classification time rather than being re-scored later. The gate is
+# per-category impossibility, never blanket: several categories legitimately
+# live on non-string columns (zip as INT64, ssn as INT64, salary as NUMERIC,
+# lat/lng as FLOAT, dob as DATE) and must keep flagging there.
+def _type_permits(category: PIICategory, data_type: str) -> bool:
+    """Whether ``category`` can structurally sit on a column of ``data_type``.
+
+    Built on the existing type predicates; adds no fourth type-hint tuple.
+
+    - EMAIL / NAME / FREE_TEXT: string only (an integer cannot hold an address
+      or a person name; this matches the pre-existing generic-name/free-text
+      gate, extended to the exact-token patterns).
+    - PHONE: anything but boolean or temporal (phone-as-INT is bad practice but
+      real, so a numeric phone still flags).
+    - every other category (ADDRESS, GOVERNMENT_ID, FINANCIAL, LOCATION, DOB,
+      CREDENTIAL): unchanged, permitted on any type.
+    """
+
+    if category in {PIICategory.EMAIL, PIICategory.NAME, PIICategory.FREE_TEXT}:
+        return _is_string_type(data_type)
+    if category is PIICategory.PHONE:
+        upper = data_type.upper()
+        return not any(h in upper for h in _BOOLEAN_HINTS + _TEMPORAL_HINTS)
+    return True
+
+
+# Aggregate-name suffixes. A non-string column whose name ends in one of these
+# is a derived statistic (a COUNT/SUM/AVG), not a value, so it is suppressed even
+# for categories the type gate above still permits on numbers (ssn_count,
+# zip_count, salary_sum). The conjunction with non-string type is what keeps this
+# safe: a string column named `email_count` is odd enough to stay flagged.
+#
+# Deliberately excluded, and do not "complete" this list: `_num` (phone_num,
+# account_num, cc_num are values, and cc_num is already a FINANCIAL token) and
+# `_total` (salary_total reads as a value as readily as an aggregate).
+_AGGREGATE_SUFFIXES = ("_count", "_cnt", "_sum", "_avg", "_pct", "_ratio")
+
+
+def _is_derived_statistic(name: str, data_type: str) -> bool:
+    """A non-string column whose normalized name ends in an aggregate suffix."""
+
+    return not _is_string_type(data_type) and name.endswith(_AGGREGATE_SUFFIXES)
+
+
 def detect_pii(column_name: str, data_type: str) -> PIIFlag | None:
     """Classify a column as PII from its name (and, loosely, type). Never a value.
 
     Returns the first matching category with a base confidence; aggregate signals
-    refine the confidence later in :func:`_refine_confidence`. The exact-token
-    patterns apply to any type; the weaker generic-name and free-text patterns
-    apply only to string columns (a numeric `comments` count is not PII).
+    refine the confidence later in :func:`_refine_confidence`. Each match is
+    gated by :func:`_type_permits` (a category impossible on the column's type is
+    skipped) and :func:`_is_derived_statistic` (an aggregate-suffixed numeric
+    column is a count, not a value); the weaker generic-name and free-text
+    patterns remain string-only.
     """
 
     flag, _generic = _classify_pii(column_name, data_type)
@@ -201,6 +261,14 @@ def _classify_pii(column_name: str, data_type: str) -> tuple[PIIFlag | None, boo
     name = _normalize(column_name)
     for pattern, category, confidence in _PII_PATTERNS:
         if pattern.search(name):
+            # A type-forbidden or derived-statistic match continues past this
+            # pattern rather than returning None, so a later pattern still gets a
+            # fair look (e.g. `phone_count` on a numeric column short-circuits
+            # nothing).
+            if not _type_permits(category, data_type):
+                continue
+            if _is_derived_statistic(name, data_type):
+                continue
             return PIIFlag(category=category, confidence=confidence), False
 
     if _is_string_type(data_type):

--- a/packages/dex-core/tests/explore/test_profile.py
+++ b/packages/dex-core/tests/explore/test_profile.py
@@ -58,6 +58,15 @@ def _run(argv: list[str], capsys) -> dict:
         ("notes", "VARCHAR", PIICategory.FREE_TEXT),
         ("review_text", "VARCHAR", PIICategory.FREE_TEXT),
         ("feedback", "STRING", PIICategory.FREE_TEXT),
+        # Must-not-regress: genuinely sensitive numeric/temporal columns whose
+        # category legitimately lives off strings keep flagging (the type gate
+        # is per-category impossibility, not blanket).
+        ("zip", "INT64", PIICategory.ADDRESS),
+        ("ssn", "INT64", PIICategory.GOVERNMENT_ID),
+        ("salary", "NUMERIC", PIICategory.FINANCIAL),
+        ("latitude", "FLOAT64", PIICategory.LOCATION),
+        ("dob", "DATE", PIICategory.DOB),
+        ("phone", "INT64", PIICategory.PHONE),
     ],
 )
 def test_detect_pii_flags(column: str, data_type: str, category: PIICategory):
@@ -79,6 +88,16 @@ def test_detect_pii_flags(column: str, data_type: str, category: PIICategory):
         # The weak patterns are string-only: a numeric `comments` is a count.
         ("comments", "INTEGER"),
         ("name", "INTEGER"),
+        # Exact-token categories that cannot hold a value off a string: an
+        # integer email/name count is the PII-safe derived replacement.
+        ("user_email_count", "INT64"),
+        ("email_count", "INTEGER"),
+        ("contact_email_flag", "BOOL"),
+        ("phone_verified", "BOOLEAN"),
+        # Aggregate-suffixed numeric columns are derived statistics even where
+        # the category (GOVERNMENT_ID, ADDRESS) still permits a numeric value.
+        ("ssn_count", "BIGINT"),
+        ("zip_count", "INT64"),
         # Substrings without a word boundary do not over-trigger.
         ("username_hash", "VARCHAR"),
         ("emailable", "BOOLEAN"),
@@ -105,6 +124,23 @@ def test_new_flags_suppress_min_max():
         flag = detect_pii(column, "VARCHAR")
         assert flag is not None
         assert not is_min_max_safe("VARCHAR", flag)
+
+
+def test_derated_count_column_restores_min_max():
+    """The fix must restore min/max, not merely unblock the firewall: an integer
+    `_email_count` is unflagged, so its extreme is a plain non-sensitive number."""
+
+    assert detect_pii("user_email_count", "INT64") is None
+    assert is_min_max_safe("INT64", detect_pii("user_email_count", "INT64")) is True
+
+
+def test_snowflake_fixed_type_reads_as_numeric():
+    """Snowflake surfaces every integer/NUMBER as FIXED; without this the
+    type-aware gates and min/max safety are inert on Snowflake."""
+
+    from exmergo_dex_core.explore.profile import is_numeric_type
+
+    assert is_numeric_type("FIXED") is True
 
 
 # --- envelope: the Airbnb-shaped session --------------------------------------


### PR DESCRIPTION
Closes #112

## Problem

The name heuristic flagged an integer `<x>_email_count` as `EMAIL` at 0.9 in every
mart it appeared in. That column is the PII-safe derived replacement for a
staging-only array of addresses, yet at 0.9 it sat above `PII_BLOCK_CONFIDENCE`, so
the query firewall refused value-carrying aggregates (MAX, MIN, ANY_VALUE,
percentiles) on a plain integer count and `is_min_max_safe` stripped its min/max.
The `pii_overrides` workaround worked but did not scale (9 override entries for 2
logical columns).

All PII logic is connector-agnostic and lives in `explore/profile.py`, so the column
flagged identically on every connector. The design already gated the weak
generic-name and free-text patterns to string columns; the exact-token table never
received the same treatment.

## Changes

All in `packages/dex-core/src/exmergo_dex_core/explore/profile.py`:

1. **Per-category type gate** (`_type_permits`). Type evidence is structural and
   known before any scan, so an impossible pairing suppresses the flag at
   classification time rather than being re-scored. Reuses the existing
   `_is_string_type` / `_BOOLEAN_HINTS` / `_TEMPORAL_HINTS` predicates.
   - `EMAIL` / `NAME` / `FREE_TEXT`: string only.
   - `PHONE`: anything but boolean or temporal (phone-as-INT still flags).
   - `ADDRESS` / `GOVERNMENT_ID` / `FINANCIAL` / `LOCATION` / `DOB`: unchanged, so
     `zip`, `ssn`, `salary` as INT, `lat`/`lng` as FLOAT, `dob` as DATE keep flagging.

2. **Aggregate-suffix gate** (`_is_derived_statistic`). A non-string column whose
   name ends in `_count`, `_cnt`, `_sum`, `_avg`, `_pct`, or `_ratio` is a derived
   statistic, not a value, so it is suppressed even for categories the type gate
   still permits on numbers (`ssn_count`, `zip_count`). `_num` and `_total` are
   deliberately excluded.

   Both gates `continue` past a match (never `return None`), so a later pattern
   still gets a fair look.

3. **Snowflake `FIXED`**. Snowflake's `SHOW COLUMNS` surfaces every integer/NUMBER
   as `FIXED`, which matched no numeric hint, leaving the gates inert there.
   `FIXED` is now in `_NUMERIC_HINTS`.

## Side effect worth noting

`is_numeric_type` is also read by `is_min_max_safe` and by `explore cluster` feature
selection. Fixing `FIXED` means Snowflake numeric columns now surface min/max and
become eligible cluster features. That is the correct pre-existing behavior (every
other connector already did this) but it is a visible change beyond the bug, and it
gets its own CHANGELOG bullet.

## Testing

- `tests/explore/test_profile.py`: extended the parametrized blocks with the de-rate
  cases and the must-not-regress cases (`zip`/`ssn`/`salary`/`lat`/`dob`/`phone`),
  plus assertions that min/max is restored on `user_email_count` and that
  `is_numeric_type("FIXED")` is `True`. 87 passed.
- `tests/test_safety_spine.py`: 89 passed. Genuinely sensitive numeric columns still
  block.
- Full suite (all connector extras + cluster): 1167 passed, 60 skipped.
- ruff: clean.

## Scope

No adapter changes. No config-schema changes. `pii_overrides` is untouched and
existing entries keep working; they simply stop being necessary for this class of
column.
