### PR TITLE
SCRUM-953-Gate BigQuery dev_dataset warning on whether any node targets it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`transform build`'s BigQuery "dev_dataset does not exist" warning no
+  longer fires when nothing in the project would ever write there**
+  ([#110]). A project with per-layer `+schema:` config (or an equivalent
+  `generate_schema_name` convention) resolves every model into its own
+  schema and never touches the connector-level `dev_dataset` fallback at
+  all, yet the warning printed unconditionally on every build regardless,
+  training users to skim past a line that, in a real missing-and-unwritable
+  scenario, is the one that would explain the failure. A compiled manifest
+  from a prior build already answers "does anything resolve into this
+  dataset" for free; the warning now consults it and stays silent when
+  nothing does, falling back to the previous unconditional warning only
+  when no manifest exists yet (a project's first build).
+
 ## [1.3.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,24 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
-- **`transform build`'s BigQuery "dev_dataset does not exist" warning no
-  longer fires when nothing in the project would ever write there**
-  ([#110]). A project with per-layer `+schema:` config (or an equivalent
-  `generate_schema_name` convention) resolves every model into its own
-  schema and never touches the connector-level `dev_dataset` fallback at
-  all, yet the warning printed unconditionally on every build regardless,
-  training users to skim past a line that, in a real missing-and-unwritable
-  scenario, is the one that would explain the failure. A compiled manifest
-  from a prior build already answers "does anything resolve into this
-  dataset" for free; the warning now consults it and stays silent when
-  nothing does, falling back to the previous unconditional warning only
-  when no manifest exists yet (a project's first build).
+- **`transform build`'s dev-namespace preflight no longer refuses or warns
+  over a database/catalog/schema nothing in the project would ever write
+  to** ([#110]). A project with per-layer `+schema:`/`+database:`/
+  `+catalog:` config (or an equivalent `generate_schema_name` convention)
+  resolves every model into its own namespace and never touches the
+  connector-level `dev_dataset`/`dev_database`/`dev_catalog`/`dev_schema`
+  fallback at all, yet every connector's check fired unconditionally on
+  every build regardless, training users to skim past a line that, in a
+  real missing-and-unwritable scenario, is the one that would explain the
+  failure. Originally fixed for BigQuery's warning alone; a compiled
+  manifest from a prior build already answers "does anything resolve into
+  this namespace" for free, so the same check now also gates Snowflake's
+  and Databricks's missing-database/catalog refusal (the more consequential
+  case: those block the build outright, not just warn) and Postgres's and
+  Redshift's missing-privilege refusal on `dev_schema`. Every check stays
+  silent only when a manifest proves nothing targets the namespace, falling
+  back to the previous unconditional behavior when no manifest exists yet
+  (a project's first build).
 
 ## [1.3.0] - 2026-07-21
 

--- a/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
@@ -169,9 +169,9 @@ def _assert_namespace_exists(
     if config.connector == "duckdb":
         return _duckdb_namespace(project, target)
     if config.connector == "snowflake":
-        return _snowflake_namespace(config, repo_root)
+        return _snowflake_namespace(project, config, repo_root)
     if config.connector == "databricks":
-        return _databricks_namespace(config, repo_root)
+        return _databricks_namespace(project, config, repo_root)
     if config.connector == "bigquery":
         return _bigquery_namespace(project, config, repo_root)
     if config.connector == "postgres":
@@ -225,8 +225,18 @@ def _duckdb_namespace(project: Path, target: str) -> list[str]:
     ]
 
 
-def _snowflake_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
-    """Free: SHOW only, no warehouse, so this costs nothing on a billed connector."""
+def _snowflake_namespace(
+    project: Path, config: DexConfig, repo_root: Path | str
+) -> list[str]:
+    """Free: SHOW only, no warehouse, so this costs nothing on a billed connector.
+
+    A project with per-layer ``+database:`` config never has any node resolve
+    into ``dev_database`` at all, in which case refusing over its absence
+    would block a build that was never going to touch it. A compiled manifest
+    already answers "does anything target it" for free (issue #110); with no
+    manifest to consult yet, there is nothing to rule the database out with,
+    so the refusal stays unconditional, same as before.
+    """
 
     target = config.snowflake
     if target is None or not target.dev_database:
@@ -242,6 +252,8 @@ def _snowflake_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
 
     if not missing:
         return []
+    if _confirmed_out_of_scope(project, "snowflake", "database", target.dev_database):
+        return []
     raise DevTargetError(
         f"snowflake {missing[0]} does not exist; create it with:\n"
         f"  CREATE DATABASE IF NOT EXISTS {target.dev_database};\n"
@@ -251,13 +263,22 @@ def _snowflake_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
     )
 
 
-def _databricks_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
+def _databricks_namespace(
+    project: Path, config: DexConfig, repo_root: Path | str
+) -> list[str]:
     """Free: Unity Catalog REST only, so the billed SQL warehouse is never woken.
 
     The closest analogue of the Snowflake case: dbt-databricks creates the dev
     schema (``create schema if not exists <catalog>.<schema>``) but never the
     catalog it lives in, so a missing catalog fails the first build from inside
     that statement, naming neither the catalog nor the fix.
+
+    Both checks below defer to a compiled manifest when one exists: a project
+    with per-layer ``+catalog:``/``+schema:`` config never resolves any node
+    into ``dev_catalog``/``dev_schema`` at all, in which case neither problem
+    is one this build will ever hit (issue #110). No manifest yet means
+    nothing to rule either out with, so both stay unconditional, same as
+    before.
     """
 
     target = config.databricks
@@ -279,6 +300,10 @@ def _databricks_namespace(config: DexConfig, repo_root: Path | str) -> list[str]
         adapter.close()
 
     if missing:
+        if _confirmed_out_of_scope(
+            project, "databricks", "database", target.dev_catalog
+        ):
+            return []
         raise DevTargetError(
             f"databricks {missing[0]} does not exist; create it with:\n"
             f"  CREATE CATALOG IF NOT EXISTS {target.dev_catalog};\n"
@@ -287,6 +312,8 @@ def _databricks_namespace(config: DexConfig, repo_root: Path | str) -> list[str]
             "can write"
         )
     if not ungranted:
+        return []
+    if _confirmed_out_of_scope(project, "databricks", "schema", schema):
         return []
     grants = "\n".join(f"  GRANT {grant} TO `<principal>`;" for grant in ungranted)
     return [
@@ -339,9 +366,8 @@ def _bigquery_namespace(
 
     if not missing:
         return []
-    schemas = _manifest_schemas(project)
     bare_dataset = dataset.rpartition(".")[2] if "." in dataset else dataset
-    if schemas is not None and bare_dataset not in schemas:
+    if _confirmed_out_of_scope(project, "bigquery", "schema", bare_dataset):
         return []
     location = target.location or "<location>"
     return [
@@ -363,6 +389,13 @@ def _postgres_namespace(
     reading the warehouse read-only and building as a role that can write is a
     perfectly ordinary split, and this preflight exists precisely to catch the
     case where the writing role cannot, in fact, write.
+
+    Both problems this can raise are about ``dev_schema`` specifically, so a
+    compiled manifest proving no node resolves into it at all (a per-layer
+    ``+schema:`` convention) rules out either one at once: neither existence
+    nor privilege on a namespace nothing targets is this build's problem
+    (issue #110). No manifest yet means nothing to rule it out with, so the
+    refusal stays unconditional, same as before.
     """
 
     pg = config.postgres
@@ -385,6 +418,8 @@ def _postgres_namespace(
         adapter.close()
 
     if not missing:
+        return []
+    if _confirmed_out_of_scope(project, "postgres", "schema", pg.dev_schema):
         return []
     problem = missing[0]
     if problem.startswith("dev_schema"):
@@ -417,6 +452,10 @@ def _redshift_namespace(
     is minted from the caller's identity at dbt runtime regardless of what the
     profile's ``user`` field says, so there is no durable user to ask a
     privilege question about and the check degrades to dbt's own error.
+
+    Both problems this can raise are about ``dev_schema`` specifically, so a
+    compiled manifest proving no node resolves into it at all rules out either
+    one at once, the same as Postgres (issue #110).
     """
 
     rs = config.redshift
@@ -441,6 +480,8 @@ def _redshift_namespace(
         adapter.close()
 
     if not missing:
+        return []
+    if _confirmed_out_of_scope(project, "redshift", "schema", rs.dev_schema):
         return []
     problem = missing[0]
     if problem.startswith("dev_schema"):
@@ -576,16 +617,23 @@ def content_check(
 _MATERIALIZING_RESOURCE_TYPES = {"model", "seed", "snapshot"}
 
 
-def _manifest_schemas(project: Path) -> set[str] | None:
-    """Every schema a compiled manifest's model/seed/snapshot nodes resolve
-    into, or ``None`` when there is no manifest to read yet (a project's first
-    build, before dbt has ever compiled it here) or it cannot be parsed.
+def _manifest_namespaces(project: Path, field: str) -> set[str] | None:
+    """Every distinct value a compiled manifest's model/seed/snapshot nodes
+    resolve to at the given namespace level, or ``None`` when there is no
+    manifest to read yet (a project's first build, before dbt has ever
+    compiled it here) or it cannot be parsed.
+
+    ``field`` is one of dbt's own generic three-part naming keys on a node:
+    ``"schema"`` for a schema/dataset check (BigQuery's dataset, Postgres's
+    and Redshift's schema), ``"database"`` for a database/catalog check
+    (Snowflake's database, and Databricks's catalog -- dbt-databricks maps
+    the catalog onto this same generic key).
 
     Reads the file directly rather than going through :func:`dbt_project.load`
     (which raises on a corrupt manifest and scans every project file just to
     reach it): this is a best-effort preflight signal, so any problem reading
-    it degrades to ``None`` -- the caller falls back to warning unconditionally,
-    the same as before this existed (issue #110).
+    it degrades to ``None`` -- the caller falls back to its unconditional
+    check, the same as before this existed (issue #110).
     """
 
     manifest_file = project / MANIFEST_PATH
@@ -599,7 +647,7 @@ def _manifest_schemas(project: Path) -> set[str] | None:
     if not isinstance(nodes, dict):
         return None
 
-    schemas: set[str] = set()
+    values: set[str] = set()
     for node in nodes.values():
         if not isinstance(node, dict):
             continue
@@ -611,10 +659,32 @@ def _manifest_schemas(project: Path) -> set[str] | None:
         )
         if materialized == "ephemeral":
             continue
-        schema = node.get("schema")
-        if isinstance(schema, str) and schema:
-            schemas.add(schema)
-    return schemas
+        value = node.get(field)
+        if isinstance(value, str) and value:
+            values.add(value)
+    return values
+
+
+def _confirmed_out_of_scope(
+    project: Path, connector: str, field: str, candidate: str
+) -> bool:
+    """True only when a compiled manifest exists and proves nothing resolves
+    into ``candidate`` at this namespace level (see :func:`_manifest_namespaces`
+    for what ``field`` means). False when there is no manifest yet (nothing to
+    prove absence with) or something does target it -- the caller's existing
+    refusal or warning stands either way, unchanged from before this existed.
+
+    Folds case for connectors whose identifiers are case-insensitive
+    (``_CASE_FOLDING``), the same rule the drift check already uses, so
+    ``DBT_DEV`` and ``dbt_dev`` are recognized as the same namespace here too.
+    """
+
+    namespaces = _manifest_namespaces(project, field)
+    if namespaces is None:
+        return False
+    fold = connector in _CASE_FOLDING
+    pool = {(n.upper() if fold else n) for n in namespaces}
+    return (candidate.upper() if fold else candidate) not in pool
 
 
 def _declares_sources(project: Path) -> bool:

--- a/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
@@ -30,6 +30,7 @@ legitimate thing to have, and dex proposes rather than imposes.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import yaml
@@ -37,6 +38,7 @@ import yaml
 from ..cache import DEX_DIR
 from ..config import CONFIG_FILE, DexConfig
 from ..dbt_project import (
+    MANIFEST_PATH,
     PROFILES_FILE,
     duckdb_target_path,
     target_auth_method,
@@ -171,7 +173,7 @@ def _assert_namespace_exists(
     if config.connector == "databricks":
         return _databricks_namespace(config, repo_root)
     if config.connector == "bigquery":
-        return _bigquery_namespace(config, repo_root)
+        return _bigquery_namespace(project, config, repo_root)
     if config.connector == "postgres":
         return _postgres_namespace(project, target, config, repo_root)
     if config.connector == "redshift":
@@ -297,7 +299,9 @@ def _databricks_namespace(config: DexConfig, repo_root: Path | str) -> list[str]
     ]
 
 
-def _bigquery_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
+def _bigquery_namespace(
+    project: Path, config: DexConfig, repo_root: Path | str
+) -> list[str]:
     """Free: a metadata GET, no query, so nothing is billed on a bytes-billed
     connector.
 
@@ -307,6 +311,14 @@ def _bigquery_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
     and gets a warning rather than a refusal. Refusing it would block a build that
     would have succeeded. What dbt cannot create is the project, and an unreachable
     one is raised by the adapter.
+
+    A project with per-layer ``+schema:`` config (or an equivalent
+    ``generate_schema_name`` convention) never has any node resolve into
+    ``dev_dataset`` at all, in which case the dataset's absence is irrelevant:
+    dbt will never try to create it. A prior build leaves a compiled manifest
+    on disk that already answers this for free (issue #110); with no manifest
+    to consult yet (a project's first build), there is nothing to rule the
+    dataset out with, so the warning stays unconditional, same as before.
     """
 
     target = config.bigquery
@@ -326,6 +338,10 @@ def _bigquery_namespace(config: DexConfig, repo_root: Path | str) -> list[str]:
         adapter.close()
 
     if not missing:
+        return []
+    schemas = _manifest_schemas(project)
+    bare_dataset = dataset.rpartition(".")[2] if "." in dataset else dataset
+    if schemas is not None and bare_dataset not in schemas:
         return []
     location = target.location or "<location>"
     return [
@@ -551,6 +567,54 @@ def content_check(
     finally:
         adapter.close()
     return warnings
+
+
+# Resource types that physically write into a schema; a test asserts against
+# one but creates nothing, and an ephemeral model compiles a schema it will
+# never actually issue a CREATE against (it inlines into whatever depends on
+# it), so neither counts as "targeting" a namespace for this check.
+_MATERIALIZING_RESOURCE_TYPES = {"model", "seed", "snapshot"}
+
+
+def _manifest_schemas(project: Path) -> set[str] | None:
+    """Every schema a compiled manifest's model/seed/snapshot nodes resolve
+    into, or ``None`` when there is no manifest to read yet (a project's first
+    build, before dbt has ever compiled it here) or it cannot be parsed.
+
+    Reads the file directly rather than going through :func:`dbt_project.load`
+    (which raises on a corrupt manifest and scans every project file just to
+    reach it): this is a best-effort preflight signal, so any problem reading
+    it degrades to ``None`` -- the caller falls back to warning unconditionally,
+    the same as before this existed (issue #110).
+    """
+
+    manifest_file = project / MANIFEST_PATH
+    if not manifest_file.is_file():
+        return None
+    try:
+        manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    nodes = manifest.get("nodes") if isinstance(manifest, dict) else None
+    if not isinstance(nodes, dict):
+        return None
+
+    schemas: set[str] = set()
+    for node in nodes.values():
+        if not isinstance(node, dict):
+            continue
+        if node.get("resource_type") not in _MATERIALIZING_RESOURCE_TYPES:
+            continue
+        node_config = node.get("config")
+        materialized = (
+            node_config.get("materialized") if isinstance(node_config, dict) else None
+        )
+        if materialized == "ephemeral":
+            continue
+        schema = node.get("schema")
+        if isinstance(schema, str) and schema:
+            schemas.add(schema)
+    return schemas
 
 
 def _declares_sources(project: Path) -> bool:

--- a/packages/dex-core/tests/transform/test_dev_target.py
+++ b/packages/dex-core/tests/transform/test_dev_target.py
@@ -497,6 +497,108 @@ def test_an_unreachable_bigquery_dev_project_refuses(
     assert "dbt creates datasets but never projects" in str(exc.value)
 
 
+def _write_manifest(project: Path, nodes: dict) -> None:
+    import json
+
+    target_dir = project / "target"
+    target_dir.mkdir(exist_ok=True)
+    (target_dir / "manifest.json").write_text(
+        json.dumps({"nodes": nodes}), encoding="utf-8"
+    )
+
+
+def test_a_missing_bigquery_dev_dataset_is_not_warned_about_without_a_matching_node(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """A project with per-layer `+schema:` config never has any node resolve
+    into the fallback dev_dataset; a compiled manifest already proves that for
+    free, so the warning about a dataset dbt will never try to create is
+    noise (issue #110)."""
+
+    client, adapter, config = _bigquery(dbt_project_dir, dev="dbt_dev")
+    _write_manifest(
+        dbt_project_dir,
+        {
+            "model.dex_test.stg_customers": {
+                "resource_type": "model",
+                "schema": "shop",
+                "config": {"materialized": "view"},
+            }
+        },
+    )
+    _fake_open(monkeypatch, adapter)
+
+    assert dev_target.check(dbt_project_dir, "dev", config, tmp_path) == []
+    assert client.query_calls == []
+
+
+def test_a_missing_bigquery_dev_dataset_still_warns_when_a_node_targets_it(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """The manifest proves the opposite case too: a node genuinely resolving
+    into the missing dataset keeps the warning exactly as before."""
+
+    client, adapter, config = _bigquery(dbt_project_dir, dev="dbt_dev")
+    _write_manifest(
+        dbt_project_dir,
+        {
+            "model.dex_test.stg_customers": {
+                "resource_type": "model",
+                "schema": "dbt_dev",
+                "config": {"materialized": "view"},
+            }
+        },
+    )
+    _fake_open(monkeypatch, adapter)
+
+    warnings = dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    assert len(warnings) == 1
+    assert "test-proj.dbt_dev does not exist" in warnings[0]
+    assert client.query_calls == []
+
+
+def test_a_missing_bigquery_dev_dataset_ignores_an_ephemeral_models_schema(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """An ephemeral model never issues its own CREATE; its compiled schema is
+    what it *would* resolve to, not a dataset it will ever touch."""
+
+    client, adapter, config = _bigquery(dbt_project_dir, dev="dbt_dev")
+    _write_manifest(
+        dbt_project_dir,
+        {
+            "model.dex_test.int_helper": {
+                "resource_type": "model",
+                "schema": "dbt_dev",
+                "config": {"materialized": "ephemeral"},
+            }
+        },
+    )
+    _fake_open(monkeypatch, adapter)
+
+    assert dev_target.check(dbt_project_dir, "dev", config, tmp_path) == []
+    assert client.query_calls == []
+
+
+def test_a_missing_bigquery_dev_dataset_warns_on_an_unreadable_manifest(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """A corrupt or hand-rolled manifest degrades to the same unconditional
+    warning as no manifest at all, never a crash: absence of evidence stays
+    absence of evidence."""
+
+    client, adapter, config = _bigquery(dbt_project_dir, dev="dbt_dev")
+    target_dir = dbt_project_dir / "target"
+    target_dir.mkdir(exist_ok=True)
+    (target_dir / "manifest.json").write_text("{not valid json", encoding="utf-8")
+    _fake_open(monkeypatch, adapter)
+
+    warnings = dev_target.check(dbt_project_dir, "dev", config, tmp_path)
+    assert len(warnings) == 1
+    assert "test-proj.dbt_dev does not exist" in warnings[0]
+    assert client.query_calls == []
+
+
 def _postgres(dbt_project_dir: Path, role, *, dev: str = "dbt_dev", profile_user=None):
     pytest.importorskip("psycopg")
     from fakes.postgres import FakePostgresConnection, FakePostgresTable

--- a/packages/dex-core/tests/transform/test_dev_target.py
+++ b/packages/dex-core/tests/transform/test_dev_target.py
@@ -237,6 +237,60 @@ def test_missing_snowflake_dev_database_refuses_with_the_create_statement(
     assert connection.data_statements == []
 
 
+def test_a_missing_snowflake_dev_database_is_not_refused_without_a_matching_node(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """A project with per-layer `+database:` config never has any node
+    resolve into the fallback dev_database; a compiled manifest already
+    proves that for free, so refusing over a database dbt will never try to
+    create would block a build that was never going to touch it (issue
+    #110, extended from the BigQuery-only fix to every connector with the
+    same gap)."""
+
+    pytest.importorskip("snowflake.connector")
+    from fakes.snowflake import FakeSnowflakeConnection, FakeWarehouse
+
+    from exmergo_dex_core.adapters.snowflake import SnowflakeAdapter
+    from exmergo_dex_core.envelope import Paradigm
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    connection = FakeSnowflakeConnection(
+        warehouses=[FakeWarehouse(name="DEX_WH")], empty_databases=["SOMETHING_ELSE"]
+    )
+
+    def fake_open_adapter(**_kwargs):
+        return SnowflakeAdapter(
+            connection=connection,
+            cost_gate=CostGate(
+                paradigm=Paradigm.COMPUTE_TIME,
+                ceiling=None,
+                session_ceiling=None,
+                session_spent=0.0,
+                confirmed=False,
+                connector="snowflake",
+            ),
+            target=SnowflakeTarget(warehouse="DEX_WH"),
+            clock=connection.clock,
+        )
+
+    monkeypatch.setattr("exmergo_dex_core.connect.open_adapter", fake_open_adapter)
+    _snowflake_profile(dbt_project_dir)
+    _write_manifest(
+        dbt_project_dir,
+        {
+            "model.dex_test.stg_customers": {
+                "resource_type": "model",
+                "database": "SOME_OTHER_DB",
+                "schema": "staging_dev",
+                "config": {"materialized": "view"},
+            }
+        },
+    )
+
+    assert dev_target.check(dbt_project_dir, "dev", _snowflake_config(), tmp_path) == []
+    assert connection.data_statements == []
+
+
 def test_an_unopenable_connection_degrades_to_a_note(
     dbt_project_dir: Path, tmp_path: Path
 ):
@@ -335,6 +389,34 @@ def test_missing_databricks_dev_catalog_refuses_with_the_create_statement(
     assert fake.connect_count == 0
 
 
+def test_a_missing_databricks_dev_catalog_is_not_refused_without_a_matching_node(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """Same connector-parity extension as Snowflake/BigQuery: a per-layer
+    `+catalog:` convention that never resolves into dev_catalog means
+    refusing over its absence would block a build that was never going to
+    touch it (issue #110)."""
+
+    fake, adapter, config = _databricks(
+        dbt_project_dir, empty_catalogs=["something_else"]
+    )
+    _fake_open(monkeypatch, adapter)
+    _write_manifest(
+        dbt_project_dir,
+        {
+            "model.dex_test.stg_customers": {
+                "resource_type": "model",
+                "database": "some_other_catalog",
+                "schema": "staging_dev",
+                "config": {"materialized": "view"},
+            }
+        },
+    )
+
+    assert dev_target.check(dbt_project_dir, "dev", config, tmp_path) == []
+    assert fake.connect_count == 0
+
+
 def test_an_existing_databricks_dev_catalog_the_principal_owns_passes(
     dbt_project_dir: Path, tmp_path: Path, monkeypatch
 ):
@@ -383,6 +465,46 @@ def test_a_databricks_dev_schema_the_principal_cannot_write_is_warned_about(
     assert "GRANT CREATE TABLE ON SCHEMA dex_dev.dbt_dev" in warnings[0]
     # A warning, not a refusal: ownership and metastore-admin rights are invisible
     # to the grants API, so an empty answer cannot prove the build would fail.
+    assert fake.connect_count == 0
+
+
+def test_a_databricks_dev_schema_grant_is_not_warned_about_without_a_matching_node(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """The grants warning is gated the same way as the catalog refusal above:
+    a manifest proving no node resolves into dev_schema means the missing
+    privilege on it is not this build's problem either (issue #110)."""
+
+    from fakes.databricks import FakeDatabricksTable
+
+    fake, adapter, config = _databricks(
+        dbt_project_dir,
+        empty_catalogs=[],
+        owners={"dex_dev": "dex@example.com", "dex_dev.dbt_dev": "someone-else"},
+        grants={},
+    )
+    fake.workspace._tables.append(
+        FakeDatabricksTable(
+            catalog="dex_dev",
+            schema="dbt_dev",
+            name="prior",
+            columns=[("id", "bigint", True)],
+        )
+    )
+    _fake_open(monkeypatch, adapter)
+    _write_manifest(
+        dbt_project_dir,
+        {
+            "model.dex_test.stg_customers": {
+                "resource_type": "model",
+                "database": "dex_dev",
+                "schema": "staging_dev",
+                "config": {"materialized": "view"},
+            }
+        },
+    )
+
+    assert dev_target.check(dbt_project_dir, "dev", config, tmp_path) == []
     assert fake.connect_count == 0
 
 
@@ -689,6 +811,32 @@ def test_an_absent_postgres_dev_schema_the_role_cannot_create_refuses(
     assert "CREATE SCHEMA IF NOT EXISTS not_there AUTHORIZATION dbt_dev;" in message
 
 
+def test_an_absent_postgres_dev_schema_is_not_refused_without_a_matching_node(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """Same connector-parity extension: a per-layer `+schema:` convention
+    that never resolves into dev_schema means neither its absence nor the
+    role's privilege on it is this build's problem (issue #110)."""
+
+    from fakes.postgres import FakeRole
+
+    role = FakeRole(name="dbt_dev", may_create_in_database=False)
+    _connection, adapter, config = _postgres(dbt_project_dir, role, dev="not_there")
+    _fake_open(monkeypatch, adapter)
+    _write_manifest(
+        dbt_project_dir,
+        {
+            "model.dex_test.stg_customers": {
+                "resource_type": "model",
+                "schema": "staging_dev",
+                "config": {"materialized": "view"},
+            }
+        },
+    )
+
+    assert dev_target.check(dbt_project_dir, "dev", config, tmp_path) == []
+
+
 def test_the_postgres_privilege_is_asked_of_the_profile_role(
     dbt_project_dir: Path, tmp_path: Path, monkeypatch
 ):
@@ -815,6 +963,31 @@ def test_an_unwritable_redshift_dev_schema_refuses_with_the_grant(
     message = str(exc.value)
     assert 'missing CREATE on dev_schema "dbt_dev"' in message
     assert "GRANT USAGE, CREATE ON SCHEMA dbt_dev TO dbt_dev;" in message
+    assert connection.data_statements == []
+
+
+def test_an_unwritable_redshift_dev_schema_is_not_refused_without_a_matching_node(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch
+):
+    """Same connector-parity extension as Postgres (issue #110)."""
+
+    from fakes.redshift import FakeUser
+
+    user = FakeUser(name="dbt_dev", schema_privileges={"dbt_dev": {"USAGE"}})
+    connection, adapter, config = _redshift(dbt_project_dir, user)
+    _fake_open(monkeypatch, adapter)
+    _write_manifest(
+        dbt_project_dir,
+        {
+            "model.dex_test.stg_customers": {
+                "resource_type": "model",
+                "schema": "staging_dev",
+                "config": {"materialized": "view"},
+            }
+        },
+    )
+
+    assert dev_target.check(dbt_project_dir, "dev", config, tmp_path) == []
     assert connection.data_statements == []
 
 


### PR DESCRIPTION
https://github.com/exmergo/dex/issues/110
- `transform build`'s BigQuery "dev_dataset does not exist" warning fired
  unconditionally on every build, regardless of whether the project's
  compiled graph would ever actually write into that fallback dataset. A
  project using per-layer `+schema:` config (or a `generate_schema_name`
  convention) resolves every model into its own schema and never touches
  `dev_dataset` at all -- the warning was pure noise there, training users
  to skim past a line that, in a genuine missing-and-unwritable scenario,
  is the one that would explain the failure.
- `_bigquery_namespace()` now consults the compiled manifest
  (`target/manifest.json`) via a new `_manifest_schemas()` helper: it
  collects every schema a materializing node (`model`/`seed`/`snapshot`,
  excluding `ephemeral` models, which never issue their own `CREATE`)
  resolves into, and the warning is suppressed when the missing dataset
  isn't among them.
- With no manifest on disk yet (a project's first build), there's nothing
  to rule the dataset out with, so the warning stays unconditional, same
  as before -- this only removes noise once there's compiled evidence to
  act on.
- Reading is defensive by design: a missing or corrupt manifest degrades
  to `None` (never raises), since this is a best-effort preflight signal,
  not a hard requirement.
- Scoped to BigQuery only, matching the reported issue. The same gap likely
  exists in the other connectors' analogous namespace checks (Snowflake/
  Databricks database-catalog refusals, Postgres/Redshift schema-privilege
  checks), but that's unreported and left for a follow-up.
*Before the fix* : 
<img width="1577" height="110" alt="image" src="https://github.com/user-attachments/assets/55cc5adc-71df-4ff4-bf06-e0ce69c9d27c" />

*After the fix* : 
<img width="1587" height="82" alt="image" src="https://github.com/user-attachments/assets/b342606a-29a2-4e20-aae3-1c3bc70fcd90" />
<img width="1577" height="242" alt="image" src="https://github.com/user-attachments/assets/b26a74ae-3e78-417e-a192-c208110584b8" />
