### PR TITLE
SCRUM-957-Carry forward out-of-scope datasets and relationships in explore map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A scoped `explore map` no longer drops out-of-scope datasets from the
+  cache** ([#111]). `explore map --scope <dataset>` (or `--dataset`) rebuilt
+  `.dex/cache.json` from only this run's inventory, so a scope narrower than
+  what built the existing cache silently discarded every other dataset's
+  profile, with `carried_forward_count: 0` and no warning: a subsequent
+  `explore query` against a dropped-but-still-real table then refused with
+  "not in the .dex cache". A prior dataset entirely absent from this run's
+  inventory is now carried forward untouched, and its own count
+  (`out_of_scope_carried_count`) and a note say so explicitly. `explore
+  relationships` and `explore map` also both used to replace the cache's
+  relationships wholesale from this run's inference alone; a relationship
+  with an endpoint outside what this run examined is now carried forward the
+  same way (`carried_relationship_count`), since neither declared-resolution
+  nor inference had visibility into that endpoint to regenerate or supersede
+  it. Re-running with the same scope as before was already unaffected by
+  this; only a scope *change* between runs triggered the loss.
+
 ## [1.3.0] - 2026-07-21
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -451,6 +451,11 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         defs, [d.identifier for d in datasets]
     )
     rels, confirmed = _merge_relationships(declared, inferred)
+    # Prior relationships are only reusable when they came from the same
+    # connector, same as the profiles below.
+    reusable = prior if prior and prior.provenance.connector == connector else None
+    examined = {d.identifier for d in datasets}
+    rels, carried_relationships = _carry_forward_relationships(reusable, examined, rels)
     notes = _relationship_notes(datasets, declared, inferred, defs)
     notes.extend(declared_notes)
     notes.extend(defs.notes)
@@ -483,10 +488,18 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
             "dataset mapped alongside its source)"
         )
     notes.extend(_generic_name_notes(suppressed))
+    if carried_relationships > 0:
+        notes.append(
+            f"carried forward {carried_relationships} prior relationship(s) "
+            "with an endpoint this run did not profile or reuse fresh (a "
+            "--scope/--dataset narrower than a prior run)"
+        )
 
-    # Persist the profiles this run already paid for. Because relationships
-    # inventories and profiles the full set and infers across all of it, its
-    # relationship set is authoritative for this run and replaces the prior one.
+    # Persist the profiles this run already paid for. Relationships inventories
+    # and profiles the full set and infers across all of it, so its relationship
+    # set is authoritative for every identifier it examined; anything with an
+    # endpoint outside that (a narrower --scope/--dataset than a prior run) is
+    # carried forward above rather than dropped, same as the profiles are.
     cache, stats = _merge_profiles(prior, datasets, connector, now, relationships=rels)
     path = store.save_cache(cache, now=now)
     notes.append(_persist_note(stats, len(datasets), keeps_relationships=False))
@@ -498,6 +511,7 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
             "inferred_count": len(rels) - len(declared),
             "profiled_count": len(profiled),
             "cache_hit_count": len(fresh_reused),
+            "carried_relationship_count": carried_relationships,
             "cache_path": str(path),
             "updated_at": now.isoformat(),
             # Merge, not overwrite: a verify checkpoint envelope may already
@@ -779,8 +793,14 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
     relationships, confirmed = _merge_relationships(declared, inferred)
     # Prior profiles are only reusable when they came from the same connector.
     reusable = prior if prior and prior.provenance.connector == adapter.name else None
+    examined = {d.identifier for d in all_selected}
+    relationships, carried_relationships = _carry_forward_relationships(
+        reusable, examined, relationships
+    )
     final_scores = rank_mod.rank(metas, relationships, hints)
-    datasets, carried = _compose_datasets(metas, all_selected, final_scores, reusable)
+    datasets, carried, out_of_scope = _compose_datasets(
+        metas, all_selected, final_scores, reusable
+    )
 
     cache = DexCache(datasets=datasets, relationships=relationships)
     cache.provenance.connector = adapter.name
@@ -827,6 +847,17 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
             f"carried forward {carried} prior profile(s) for objects not "
             "re-profiled this run; per-dataset profiled_at marks their age"
         )
+    if out_of_scope > 0:
+        notes.append(
+            f"carried forward {out_of_scope} prior profile(s) for object(s) "
+            "outside this run's --scope/--dataset; the cache stays complete "
+            "across every scope it has ever been mapped with, not just this one"
+        )
+    if carried_relationships > 0:
+        notes.append(
+            f"carried forward {carried_relationships} prior relationship(s) "
+            "with an endpoint this run did not profile or reuse fresh"
+        )
     if folded_edges > 0:
         notes.append(
             f"folded {folded_edges} same-lineage duplicate relationship(s); "
@@ -853,6 +884,8 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
             "cache_hit_count": len(fresh_reused),
             "skipped_count": skipped,
             "carried_forward_count": carried,
+            "out_of_scope_carried_count": out_of_scope,
+            "carried_relationship_count": carried_relationships,
             "relationship_count": len(relationships),
             "pii_column_count": pii_columns,
             "data_quality_note_count": quality_notes,
@@ -1251,6 +1284,15 @@ def _project_definitions(
     return dbt_project.definitions(repo_root, pin)
 
 
+def _relationship_edge_key(rel: Relationship) -> tuple:
+    return (
+        rel.from_dataset.lower(),
+        tuple(c.lower() for c in rel.from_columns),
+        rel.to_dataset.lower(),
+        tuple(c.lower() for c in rel.to_columns),
+    )
+
+
 def _merge_relationships(
     declared: list[Relationship], inferred: list[Relationship]
 ) -> tuple[list[Relationship], int]:
@@ -1261,23 +1303,47 @@ def _merge_relationships(
     note, and double-reporting the edge would inflate connectivity ranking.
     """
 
-    def edge_key(rel: Relationship) -> tuple:
-        return (
-            rel.from_dataset.lower(),
-            tuple(c.lower() for c in rel.from_columns),
-            rel.to_dataset.lower(),
-            tuple(c.lower() for c in rel.to_columns),
-        )
-
-    declared_keys = {edge_key(rel) for rel in declared}
+    declared_keys = {_relationship_edge_key(rel) for rel in declared}
     merged = list(declared)
     confirmed = 0
     for rel in inferred:
-        if edge_key(rel) in declared_keys:
+        if _relationship_edge_key(rel) in declared_keys:
             confirmed += 1
             continue
         merged.append(rel)
     return merged, confirmed
+
+
+def _carry_forward_relationships(
+    prior: DexCache | None,
+    examined: set[str],
+    relationships: list[Relationship],
+) -> tuple[list[Relationship], int]:
+    """Union back in any prior relationship this run could not possibly have
+    regenerated or superseded: one with an endpoint outside ``examined`` (the
+    identifiers this run actually profiled or reused fresh, not merely
+    inventoried -- a `--scope`/`--dataset` narrower than what built the prior
+    cache, or a rank-cutoff skip on a large `explore map`).
+
+    Without this, a narrower run silently drops every cross-scope edge the
+    prior cache held, the same loss `_compose_datasets` guards against for
+    datasets (issue #111). Deduped against the newly built set by the same
+    edge key `_merge_relationships` uses, so an edge both runs agree on is
+    never doubled.
+    """
+
+    if prior is None or not prior.relationships:
+        return relationships, 0
+    existing = {_relationship_edge_key(rel) for rel in relationships}
+    carried = [
+        rel
+        for rel in prior.relationships
+        if (rel.from_dataset not in examined or rel.to_dataset not in examined)
+        and _relationship_edge_key(rel) not in existing
+    ]
+    if not carried:
+        return relationships, 0
+    return relationships + carried, len(carried)
 
 
 def _merged_hints(user_hints: list[str], metric_models: list[str]) -> list[str]:
@@ -1496,9 +1562,10 @@ def _compose_datasets(
     profiled: list[Dataset],
     scores: dict[str, float],
     prior: DexCache | None,
-) -> tuple[list[Dataset], int]:
+) -> tuple[list[Dataset], int, int]:
     """Merge this run's profiles over the full inventory. Returns the composed
-    datasets plus how many prior profiles were carried forward.
+    datasets, how many prior profiles were carried forward within this run's
+    inventory, and how many were carried forward from entirely outside it.
 
     An object not profiled this run reuses its prior profile wholesale (columns,
     keys, grain, notes, and its original ``profiled_at``, which marks the age)
@@ -1506,12 +1573,21 @@ def _compose_datasets(
     score is refreshed. ``row_count`` stays the prior one so the carried record
     is internally consistent with its own notes and counts. Carried profiles do
     not feed relationship inference, which runs on this run's profiles only.
+
+    A prior dataset absent from ``metas`` entirely (a ``--scope``/``--dataset``
+    narrower than what built the prior cache) is carried forward untouched,
+    rank score included: this run's inventory never saw it, so it is not
+    stale, not superseded, and not this run's to drop from the cache (issue
+    #111). Its rank score is left alone rather than reset, since a score of
+    ``None`` would rank it last for no reason connectivity or naming ever
+    said was true; it just was not part of this run's ranking pass.
     """
 
     by_id = {d.identifier: d for d in profiled}
     prior_by_id = (
         {d.identifier: d for d in prior.datasets if d.columns} if prior else {}
     )
+    seen = {meta.identifier for meta in metas}
     datasets: list[Dataset] = []
     carried = 0
     for meta in metas:
@@ -1532,7 +1608,14 @@ def _compose_datasets(
                 )
         ds.rank_score = scores.get(meta.identifier)
         datasets.append(ds)
-    return datasets, carried
+
+    out_of_scope = 0
+    for identifier, previous in prior_by_id.items():
+        if identifier in seen:
+            continue
+        datasets.append(previous.model_copy(deep=True))
+        out_of_scope += 1
+    return datasets, carried, out_of_scope
 
 
 # Sentinel: preserve the prior cache's relationships (profile has no inference

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -228,6 +228,60 @@ def test_fully_fresh_map_needs_no_confirmation(fake_bq_client, route_adapter, tm
     assert fake_bq_client.query_calls == []
 
 
+def test_scoped_map_carries_forward_out_of_scope_dataset_profiles(
+    fake_bq_client, tmp_path, monkeypatch
+):
+    """Regression for #111: a prior cache spanning three datasets, re-mapped
+    with --scope narrowed to just one of them, must not silently drop the
+    other two datasets' profiles from the cache."""
+
+    _seed_bq_map_cache(
+        tmp_path,
+        identifiers={
+            "test-proj.shop.customers",
+            "test-proj.shop.events",
+            "test-proj.logs.requests",
+        },
+    )
+
+    def scoped_opener(args):
+        gate = CostGate(
+            paradigm=Paradigm.BYTES_SCANNED,
+            ceiling=getattr(args, "budget", None),
+            session_ceiling=None,
+            session_spent=0.0,
+            confirmed=getattr(args, "confirm", False),
+            connector="bigquery",
+            command="explore",
+        )
+        return BigQueryAdapter(
+            project="test-proj",
+            cost_gate=gate,
+            # Simulates --scope logs: this run's inventory only ever sees the
+            # logs dataset, never shop.customers or shop.events.
+            target=BigQueryTarget(datasets=["logs"]),
+            client=fake_bq_client,
+            principal_type="user",
+        )
+
+    monkeypatch.setattr(command_args, "open_from_args", scoped_opener)
+    envelope = explore_cmds.cmd_map(_args(tmp_path, subcommand="map"))
+
+    assert envelope.status.value == "ok"
+    assert envelope.data["out_of_scope_carried_count"] == 2
+    assert any(
+        "outside this run's --scope/--dataset" in note
+        for note in envelope.data["notes"]
+    )
+    cache = DexStore(tmp_path).load_cache()
+    identifiers = {d.identifier for d in cache.datasets}
+    assert identifiers == {
+        "test-proj.shop.customers",
+        "test-proj.shop.events",
+        "test-proj.logs.requests",
+    }
+
+
 def test_unconfirmed_relationships_recommends_map(
     fake_bq_client, route_adapter, tmp_path
 ):

--- a/packages/dex-core/tests/explore/test_explore.py
+++ b/packages/dex-core/tests/explore/test_explore.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 from exmergo_dex_core import envelope as env
-from exmergo_dex_core.cache import DexStore
+from exmergo_dex_core.cache import Dataset, DexCache, DexStore
 from exmergo_dex_core.cli import main
 from exmergo_dex_core.config import DexConfig, save_config
 from exmergo_dex_core.explore.commands import _merged_hints
@@ -339,6 +339,91 @@ def test_map_carries_forward_prior_profiles(
         if d.profiled_at == first_stamps[d.identifier]
     ]
     assert len(unchanged) == 35, "carried profiles keep their original stamp"
+
+
+def _stub_meta(identifier: str):
+    from exmergo_dex_core.adapters.base import ObjectMeta
+
+    schema = identifier.rsplit(".", 2)[-2]
+    name = identifier.rsplit(".", 1)[-1]
+    return ObjectMeta(
+        identifier=identifier,
+        object_type="table",
+        schema=schema,
+        name=name,
+        row_count=10,
+        byte_size=100,
+        column_count=1,
+    )
+
+
+def _stub_dataset(identifier: str, *, profiled_at: str = "2026-01-01T00:00:00+00:00"):
+    from exmergo_dex_core.cache import ColumnProfile
+
+    return Dataset(
+        identifier=identifier,
+        columns=[ColumnProfile(name="id", data_type="INTEGER")],
+        profiled_at=profiled_at,
+    )
+
+
+def test_compose_datasets_carries_forward_objects_outside_this_runs_scope():
+    """An object in the prior cache but entirely absent from this run's
+    inventory (a --scope/--dataset narrower than what built the prior cache)
+    is carried forward untouched rather than dropped from the new cache
+    (issue #111): the prior bug replaced the whole cache with just this run's
+    scope, silently losing every other dataset's profile."""
+
+    from exmergo_dex_core.explore.commands import _compose_datasets
+
+    prior = DexCache(
+        datasets=[
+            _stub_dataset("db.shop.customers"),
+            _stub_dataset("db.marts.orders"),
+        ]
+    )
+    # This run's inventory only saw the marts dataset (a narrower --scope).
+    metas = [_stub_meta("db.marts.orders")]
+    datasets, carried, out_of_scope = _compose_datasets(metas, [], {}, prior)
+
+    identifiers = {d.identifier for d in datasets}
+    assert identifiers == {"db.shop.customers", "db.marts.orders"}
+    assert carried == 1  # marts itself: in scope, not freshly profiled
+    assert out_of_scope == 1  # customers: never even in this run's inventory
+    carried_ds = next(d for d in datasets if d.identifier == "db.shop.customers")
+    assert carried_ds.profiled_at == "2026-01-01T00:00:00+00:00"
+    assert carried_ds.columns  # not degraded to an inventory-only stub
+
+
+def test_compose_datasets_out_of_scope_dataset_keeps_its_own_rank_score():
+    """An out-of-scope carry is not part of this run's ranking pass, so its
+    rank_score is left alone rather than reset to None (which would rank it
+    last for no reason connectivity or naming ever said was true)."""
+
+    from exmergo_dex_core.explore.commands import _compose_datasets
+
+    out_of_scope_ds = _stub_dataset("db.shop.customers")
+    out_of_scope_ds.rank_score = 0.75
+    prior = DexCache(datasets=[out_of_scope_ds])
+    metas = [_stub_meta("db.marts.orders")]
+    profiled = [_stub_dataset("db.marts.orders")]
+
+    datasets, _carried, out_of_scope = _compose_datasets(
+        metas, profiled, {"db.marts.orders": 0.5}, prior
+    )
+    assert out_of_scope == 1
+    carried_ds = next(d for d in datasets if d.identifier == "db.shop.customers")
+    assert carried_ds.rank_score == 0.75
+
+
+def test_compose_datasets_without_a_prior_cache_reports_no_out_of_scope():
+    from exmergo_dex_core.explore.commands import _compose_datasets
+
+    metas = [_stub_meta("db.shop.customers")]
+    datasets, carried, out_of_scope = _compose_datasets(metas, [], {}, None)
+    assert [d.identifier for d in datasets] == ["db.shop.customers"]
+    assert carried == 0
+    assert out_of_scope == 0
 
 
 def test_map_reuses_fresh_cached_profiles(

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -16,13 +16,17 @@ from conftest import write_manifest
 from exmergo_dex_core.cache import (
     ColumnProfile,
     Dataset,
+    DexCache,
     DexStore,
     Relationship,
     RelationshipKind,
 )
 from exmergo_dex_core.cli import main
 from exmergo_dex_core.dbt_project import DeclaredForeignKey, ProjectDefinitions
-from exmergo_dex_core.explore.commands import _merge_relationships
+from exmergo_dex_core.explore.commands import (
+    _carry_forward_relationships,
+    _merge_relationships,
+)
 from exmergo_dex_core.explore.profile import profile
 from exmergo_dex_core.explore.relationships import (
     candidate_keys,
@@ -967,6 +971,53 @@ def test_merge_keeps_declared_over_matching_inferred():
     merged, confirmed = _merge_relationships([declared], [same_inferred, other])
     assert confirmed == 1
     assert merged == [declared, other]
+
+
+def test_carry_forward_relationships_keeps_an_edge_this_run_never_examined():
+    """A prior relationship with an endpoint outside this run's --scope/
+    --dataset (never profiled or reused fresh) could not have been
+    regenerated or superseded by this run's inference, so it must not be
+    silently dropped from the cache (issue #111)."""
+
+    out_of_scope_edge = Relationship(
+        from_dataset="wh.raw.orders",
+        from_columns=["customer_id"],
+        to_dataset="wh.raw.customers",
+        to_columns=["id"],
+        confidence=0.85,
+    )
+    prior = DexCache(relationships=[out_of_scope_edge])
+    # This run only examined the marts dataset; raw.orders/raw.customers were
+    # never in scope at all.
+    examined = {"wh.marts.mart_orders"}
+    merged, carried = _carry_forward_relationships(prior, examined, [])
+    assert carried == 1
+    assert merged == [out_of_scope_edge]
+
+
+def test_carry_forward_relationships_does_not_duplicate_a_regenerated_edge():
+    """When this run's own inference already reproduced the same edge (both
+    endpoints examined), the prior copy is not also carried forward."""
+
+    edge = Relationship(
+        from_dataset="wh.raw.orders",
+        from_columns=["customer_id"],
+        to_dataset="wh.raw.customers",
+        to_columns=["id"],
+        confidence=0.6,
+    )
+    prior = DexCache(relationships=[edge])
+    examined = {"wh.raw.orders", "wh.raw.customers"}
+    fresh_edge = edge.model_copy(update={"confidence": 0.9})
+    merged, carried = _carry_forward_relationships(prior, examined, [fresh_edge])
+    assert carried == 0
+    assert merged == [fresh_edge]
+
+
+def test_carry_forward_relationships_without_a_prior_cache_is_a_noop():
+    merged, carried = _carry_forward_relationships(None, {"wh.raw.orders"}, [])
+    assert merged == []
+    assert carried == 0
 
 
 def _declared_join_repo(tmp_path: Path, *, with_manifest: bool) -> tuple[Path, Path]:


### PR DESCRIPTION
https://github.com/exmergo/dex/issues/111

- `explore map --scope <dataset>` rebuilt `.dex/cache.json` purely fromthis run's inventory (`metas`), which `--scope`/`--dataset` narrows at the adapter level. `_compose_datasets()` only ever iterated `metas`, so a prior-cache dataset absent from it entirely not stale, just never seen this run -- had no code path to reach the output and silently vanished, with `carried_forward_count: 0` and no warning. A subsequent `explore query` against the dropped table then refused with "not in the .dex cache", for a table profiled and committed days earlier.
- `explore relationships` had the identical defect for `relationships` specifically: its own docstring assumed "inventories and profiles the full set, so its relationship set is authoritative" -- an assumption `--scope` breaks. Both commands replaced `relationships` wholesale from this run's inference alone.
- `_compose_datasets()` now also unions in any prior dataset absent from this run's inventory, unchanged (original `rank_score`, `profiled_at`, columns intact) -- returns a new `out_of_scope` count alongside the existing `carried` count.
- New `_carry_forward_relationships()` helper (shared by both `cmd_map` and `cmd_relationships`) unions back any prior relationship with an endpoint outside what this run actually examined (profiled or fresh-cache-reused), deduped against the freshly-built set by the same edge key `_merge_relationships` already uses.
- New envelope fields (`out_of_scope_carried_count`, `carried_relationship_count`) and explanatory notes make the carry-forward visible rather than silent.
- Re-running with the *same* scope as before was already correct; only a scope *change* between runs triggered the original loss.

*Before fix* : 

<img width="1587" height="255" alt="Screenshot 2026-07-23 140432" src="https://github.com/user-attachments/assets/8e17f07e-c9e9-4baf-891f-99f87015f902" />

*After fix* : 
<img width="1566" height="157" alt="Screenshot 2026-07-23 140453" src="https://github.com/user-attachments/assets/400080a6-bbb1-4b5d-8070-bc1a93d07b68" />
<img width="1277" height="836" alt="image" src="https://github.com/user-attachments/assets/3a928fc6-3a4f-429e-b0b4-683bdf861c84" />
