### PR TITLE
`explore profile` skips live profile if column is present in fresh cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`explore profile` now honors the same fresh-profile reuse as `explore map`
+  and `explore relationships`** ([#128]). Profiling a table whose cached profile
+  is still fresh (same connector, schema unchanged, profiled within
+  `profile_freshness_hours`) is served from the `.dex/` cache for free instead
+  of re-scanned, so a `profile` run right after a `map` no longer pays a second
+  time. The envelope gains `cache_hit_count` and `profiled_count`, and a
+  fresh-cached object never enters the cost preflight or the billed handshake.
+  `explore profile` also gains the `--refresh` flag its sibling commands already
+  had, to force a full re-profile when the source changed in a way the free
+  metadata check cannot see.
+
 ## [1.3.1] - 2026-07-21
 
 ### Changed

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -151,10 +151,10 @@ def _build_parser() -> argparse.ArgumentParser:
                         "--verify", action="store_true", default=argparse.SUPPRESS
                     )
                 # Force a full re-profile even when the cache holds a fresh,
-                # schema-matching profile for a selected object (the default is
+                # schema-matching profile for a requested object (the default is
                 # skip-if-cached; --refresh is the escape hatch when the source
                 # changed in a way the cheap metadata check cannot see).
-                if group == "explore" and name in {"map", "relationships"}:
+                if group == "explore" and name in {"profile", "map", "relationships"}:
                     sp.add_argument(
                         "--refresh", action="store_true", default=argparse.SUPPRESS
                     )

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -239,59 +239,103 @@ def cmd_profile(args: argparse.Namespace) -> env.Envelope:
     over_ceiling = False
     try:
         identifiers = _resolve_identifiers(adapter, args.objects)
-        estimate, per_table = _profile_estimate(
-            adapter, identifiers, include_blobs=blob_paths
-        )
-        unconfirmed = command_args.billed_handshake(
-            "explore profile", adapter, estimate, per_table=per_table
-        )
-        if unconfirmed is not None:
-            return unconfirmed
         connector = adapter.name
-        # Checkpoint per object only on billed connectors: DuckDB can never
-        # exhaust budget and its re-runs are free, so the extra full-file writes
-        # (and O(n^2) serialization on large warehouses) are scoped precisely to
-        # the population the bug affects.
-        checkpoint = None
-        if command_args.cost_gate(adapter) is not None:
-            checkpoint, accumulated = _profile_checkpointer(
-                store, prior, connector, now
-            )
-        profile_reporter = _reporter(len(identifiers), "profiled", "objects")
-        try:
-            datasets = profile_mod.profile(
+        # Skip re-scanning a requested object whose cached profile is still fresh
+        # (same connector, schema unchanged, within the freshness window); only
+        # the stale remainder is estimated, confirmed, and profiled below. A
+        # profile written seconds earlier by `explore map` is served free, the
+        # same reuse `map` and `relationships` already honor (issue #128).
+        stale, fresh_reused = _split_fresh_stale(
+            identifiers,
+            prior,
+            connector,
+            adapter,
+            timedelta(hours=config.profile_freshness_hours),
+            now,
+            refresh=getattr(args, "refresh", False),
+        )
+        estimate, per_table = _profile_estimate(
+            adapter, stale, include_blobs=blob_paths
+        )
+        handshake_notes = None
+        if fresh_reused:
+            handshake_notes = [
+                f"{len(fresh_reused)} object(s) excluded from this estimate as "
+                "fresh-cached (schema unchanged, profiled within the freshness "
+                "window); pass --refresh to re-profile them"
+            ]
+        profiled: list[Dataset] = []
+        # Nothing stale means nothing to price or confirm: skip the handshake and
+        # the scan entirely, and serve the cached profiles wholesale.
+        if stale:
+            unconfirmed = command_args.billed_handshake(
+                "explore profile",
                 adapter,
-                identifiers,
-                progress=profile_reporter,
-                on_complete=checkpoint,
-                pii_overrides=override_paths,
-                include_blobs=blob_paths,
+                estimate,
+                per_table=per_table,
+                notes=handshake_notes,
             )
-            profile_reporter.done()
-        except OverCeilingError:
-            over_ceiling = True
+            if unconfirmed is not None:
+                return unconfirmed
+            # Checkpoint per object only on billed connectors: DuckDB can never
+            # exhaust budget and its re-runs are free, so the extra full-file
+            # writes (and O(n^2) serialization on large warehouses) are scoped
+            # precisely to the population the bug affects.
+            checkpoint = None
+            if command_args.cost_gate(adapter) is not None:
+                checkpoint, accumulated = _profile_checkpointer(
+                    store, prior, connector, now
+                )
+            profile_reporter = _reporter(len(stale), "profiled", "objects")
+            try:
+                profiled = profile_mod.profile(
+                    adapter,
+                    stale,
+                    progress=profile_reporter,
+                    on_complete=checkpoint,
+                    pii_overrides=override_paths,
+                    include_blobs=blob_paths,
+                )
+                profile_reporter.done()
+            except OverCeilingError:
+                over_ceiling = True
         envelope = env.ok({})
         command_args.stamp_spend(envelope, adapter)
     finally:
         adapter.close()
     if over_ceiling:
-        envelope = _over_ceiling_error(store, accumulated, len(identifiers))
+        envelope = _over_ceiling_error(store, accumulated, len(stale))
         command_args.stamp_spend(envelope, adapter)
         return envelope
-    _annotate_grain(datasets, defs)
+    # Only the freshly profiled need annotation; the fresh-cached already carry
+    # their candidate_keys and grain from the cache write that stored them.
+    _annotate_grain(profiled, defs)
+    # Freshly profiled plus fresh-cached: the full requested set, whether scanned
+    # this run or served from the cache.
+    datasets = profiled + list(fresh_reused.values())
 
     # Persist what the scan already paid for: after profiling a table, `explore
     # query` on that table must work without a second warehouse scan (the query
-    # firewall's own refusal messages promise exactly this). Prior relationships
-    # are preserved because profile runs no inference pass.
-    cache, stats = _merge_profiles(prior, datasets, connector, now)
+    # firewall's own refusal messages promise exactly this). Only the freshly
+    # profiled are merged; the reused already live in the cache untouched. Prior
+    # relationships are preserved because profile runs no inference pass.
+    cache, stats = _merge_profiles(prior, profiled, connector, now)
     path = store.save_cache(cache, now=now)
 
-    notes = [_persist_note(stats, len(datasets), keeps_relationships=True)]
+    notes = [_persist_note(stats, len(profiled), keeps_relationships=True)]
     notes.extend(_override_notes(datasets))
+    if fresh_reused:
+        window = config.profile_freshness_hours
+        notes.append(
+            f"reused {len(fresh_reused)} fresh cached profile(s) (schema "
+            f"unchanged, profiled within {window:g}h); pass --refresh to force "
+            "re-profiling"
+        )
     envelope.data.update(
         {
             "datasets": [d.model_dump(mode="json") for d in datasets],
+            "profiled_count": len(profiled),
+            "cache_hit_count": len(fresh_reused),
             "cache_path": str(path),
             "updated_at": now.isoformat(),
             "notes": notes,
@@ -326,7 +370,7 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         # connector, schema unchanged, within the freshness window); only the
         # stale remainder is estimated, confirmed, and profiled below.
         stale, fresh_reused = _split_fresh_stale(
-            metas,
+            [m.identifier for m in metas],
             prior,
             connector,
             adapter,
@@ -336,7 +380,7 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
         )
         blob_paths = blob_override_paths(config.blob_overrides)
         estimate, per_table = _profile_estimate(
-            adapter, [m.identifier for m in stale], include_blobs=blob_paths
+            adapter, stale, include_blobs=blob_paths
         )
         handshake_notes = [
             "relationship inference profiles every object; on a metered "
@@ -381,7 +425,7 @@ def cmd_relationships(args: argparse.Namespace) -> env.Envelope:
             try:
                 profiled = profile_mod.profile(
                     adapter,
-                    [m.identifier for m in stale],
+                    stale,
                     progress=profile_reporter,
                     on_complete=checkpoint,
                     pii_overrides=pii_override_paths(config.pii_overrides),
@@ -671,7 +715,7 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         # (same connector, schema unchanged, within the freshness window); only
         # the stale remainder is estimated, confirmed, and profiled below.
         stale, fresh_reused = _split_fresh_stale(
-            selected,
+            [m.identifier for m in selected],
             prior,
             adapter.name,
             adapter,
@@ -683,7 +727,7 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
         # them on re-issue; only the profiling scans below need the handshake.
         blob_paths = blob_override_paths(config.blob_overrides)
         estimate, per_table = _profile_estimate(
-            adapter, [m.identifier for m in stale], include_blobs=blob_paths
+            adapter, stale, include_blobs=blob_paths
         )
         handshake_notes: list[str] = []
         if getattr(args, "verify", False):
@@ -723,7 +767,7 @@ def cmd_map(args: argparse.Namespace) -> env.Envelope:
             try:
                 profiled = profile_mod.profile(
                     adapter,
-                    [m.identifier for m in stale],
+                    stale,
                     progress=profile_reporter,
                     on_complete=checkpoint,
                     pii_overrides=pii_override_paths(config.pii_overrides),
@@ -1505,7 +1549,7 @@ def _column_signature(columns) -> list[tuple[str, str, bool]]:
 
 
 def _split_fresh_stale(
-    metas: list[ObjectMeta],
+    identifiers: list[str],
     prior: DexCache | None,
     connector: str,
     adapter: Adapter,
@@ -1513,8 +1557,9 @@ def _split_fresh_stale(
     now: datetime,
     *,
     refresh: bool,
-) -> tuple[list[ObjectMeta], dict[str, Dataset]]:
-    """Split selected metas into (still need profiling, reusable-fresh datasets).
+) -> tuple[list[str], dict[str, Dataset]]:
+    """Split requested identifiers into (still need profiling, reusable-fresh
+    datasets).
 
     An object is *fresh* (skip the re-scan) only when its cached profile came
     from this same connector, was actually profiled before (has columns and a
@@ -1526,34 +1571,39 @@ def _split_fresh_stale(
 
     Freshness is fail-closed: a missing or unparseable ``profiled_at``, or any
     doubt, re-profiles rather than trusting a stale scan.
+
+    All three profiling commands share this gate but arrive holding identifiers
+    at different points — ``map``/``relationships`` from inventory metas,
+    ``profile`` from resolved arguments — so it works on the identifier strings
+    they have in common, not on ``ObjectMeta``.
     """
 
     if refresh or prior is None or prior.provenance.connector != connector:
-        return list(metas), {}
+        return list(identifiers), {}
 
     prior_by_id = {d.identifier: d for d in prior.datasets if d.columns}
-    stale: list[ObjectMeta] = []
+    stale: list[str] = []
     fresh: dict[str, Dataset] = {}
-    for meta in metas:
-        prior_ds = prior_by_id.get(meta.identifier)
+    for identifier in identifiers:
+        prior_ds = prior_by_id.get(identifier)
         if prior_ds is None or prior_ds.profiled_at is None:
-            stale.append(meta)
+            stale.append(identifier)
             continue
         try:
             profiled_at = datetime.fromisoformat(prior_ds.profiled_at)
         except ValueError:
-            stale.append(meta)
+            stale.append(identifier)
             continue
         if now - profiled_at > max_age:
-            stale.append(meta)
+            stale.append(identifier)
             continue
         # The same free, no-scan metadata call profile() makes first: confirms
         # the schema has not drifted since the cached profile was written.
-        _meta, columns = adapter.table_metadata(meta.identifier)
+        _meta, columns = adapter.table_metadata(identifier)
         if _column_signature(columns) != _column_signature(prior_ds.columns):
-            stale.append(meta)
+            stale.append(identifier)
             continue
-        fresh[meta.identifier] = prior_ds.model_copy(deep=True)
+        fresh[identifier] = prior_ds.model_copy(deep=True)
     return stale, fresh
 
 

--- a/packages/dex-core/tests/explore/test_profile.py
+++ b/packages/dex-core/tests/explore/test_profile.py
@@ -22,6 +22,7 @@ from exmergo_dex_core.cache import (
     Relationship,
 )
 from exmergo_dex_core.cli import main
+from exmergo_dex_core.config import DexConfig, save_config
 from exmergo_dex_core.explore.profile import detect_pii, is_min_max_safe, profile
 from exmergo_dex_core.progress import PROGRESS_FIRST_AFTER, ProgressReporter
 
@@ -669,9 +670,18 @@ def test_profile_accepts_comma_separated_objects(airbnb_duckdb: Path, capsys):
 # --- persistence: profile writes through to the .dex/ cache ---------------------
 
 
-def _profile(objects: list[str], db: Path, repo: Path, capsys) -> dict:
+def _profile(objects: list[str], db: Path, repo: Path, capsys, *flags: str) -> dict:
     return _run(
-        ["explore", "profile", *objects, "--path", str(db), "--repo-root", str(repo)],
+        [
+            "explore",
+            "profile",
+            *objects,
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+            *flags,
+        ],
         capsys,
     )
 
@@ -718,7 +728,10 @@ def test_profile_merges_into_existing_map_preserving_relationships_and_rank(
     hosts_before = _dataset(before, "RAW_HOSTS")
     assert hosts_before.rank_score is not None
 
-    payload = _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys)
+    # --refresh forces the re-profile: without it the just-mapped profile is a
+    # fresh cache hit, which the reuse tests below cover; here the merge path is
+    # what's under test.
+    payload = _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys, "--refresh")
     after = store.load_cache()
 
     assert [r.model_dump() for r in after.relationships] == rels_before
@@ -734,7 +747,7 @@ def test_profile_merges_into_existing_map_preserving_relationships_and_rank(
     assert "relationships preserved" in note
 
 
-def test_profile_refreshes_stale_profile_updates_profiled_at(
+def test_profile_refresh_forces_reprofile_updates_profiled_at(
     airbnb_duckdb: Path, tmp_path: Path, capsys
 ):
     repo = tmp_path / "repo"
@@ -746,13 +759,81 @@ def test_profile_refreshes_stale_profile_updates_profiled_at(
     reviews_stamp = _dataset(before, "RAW_REVIEWS").profiled_at
     assert old.profiled_at is not None
 
-    _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys)
+    _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys, "--refresh")
     after = store.load_cache()
     new = _dataset(after, "RAW_HOSTS")
     assert new.profiled_at > old.profiled_at, "the fresh measurement wins"
     assert new.rank_score == old.rank_score
-    # A table not re-profiled keeps its older stamp, which marks its age.
+    # A table neither re-profiled nor requested keeps its older stamp.
     assert _dataset(after, "RAW_REVIEWS").profiled_at == reviews_stamp
+
+
+def test_profile_reuses_fresh_cached_profile(
+    airbnb_duckdb: Path, tmp_path: Path, capsys
+):
+    """`explore profile` on a table `explore map` just profiled serves the
+    cached profile free: nothing is re-scanned, the profile is still returned,
+    and the stamp is untouched (issue #128)."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _map(airbnb_duckdb, repo, capsys)
+    store = DexStore(repo)
+    stamp_before = _dataset(store.load_cache(), "RAW_HOSTS").profiled_at
+
+    payload = _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys)
+    assert payload["data"]["profiled_count"] == 0
+    assert payload["data"]["cache_hit_count"] == 1
+    # The cached profile is still served, columns and all, so a follow-on
+    # `explore query` on it works without a second scan.
+    served = payload["data"]["datasets"]
+    assert [d["identifier"].split(".")[-1] for d in served] == ["RAW_HOSTS"]
+    assert served[0]["columns"]
+    assert any("reused 1 fresh cached profile" in n for n in payload["data"]["notes"])
+    assert _dataset(store.load_cache(), "RAW_HOSTS").profiled_at == stamp_before
+
+    # --refresh forces the re-scan even though the cache is fresh.
+    refreshed = _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys, "--refresh")
+    assert refreshed["data"]["profiled_count"] == 1
+    assert refreshed["data"]["cache_hit_count"] == 0
+
+
+def test_profile_freshness_zero_disables_reuse(
+    airbnb_duckdb: Path, tmp_path: Path, capsys
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    save_config(DexConfig(profile_freshness_hours=0.0), repo)
+    _map(airbnb_duckdb, repo, capsys)
+    payload = _profile(["RAW_HOSTS"], airbnb_duckdb, repo, capsys)
+    assert payload["data"]["profiled_count"] == 1
+    assert payload["data"]["cache_hit_count"] == 0
+
+
+def test_profile_reprofiles_only_the_schema_changed_object(
+    airbnb_duckdb: Path, tmp_path: Path, capsys
+):
+    """When one requested table's schema drifts between runs, `explore profile`
+    re-scans only it; the rest stay fresh cache hits."""
+
+    duckdb = pytest.importorskip("duckdb")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _map(airbnb_duckdb, repo, capsys)
+
+    conn = duckdb.connect(str(airbnb_duckdb))
+    conn.execute("ALTER TABLE RAW_HOSTS ADD COLUMN extra VARCHAR")
+    conn.close()
+
+    payload = _profile(["RAW_HOSTS", "RAW_LISTINGS"], airbnb_duckdb, repo, capsys)
+    assert payload["data"]["profiled_count"] == 1
+    assert payload["data"]["cache_hit_count"] == 1
+    hosts = next(
+        d for d in payload["data"]["datasets"] if d["identifier"].endswith(".RAW_HOSTS")
+    )
+    assert any(c["name"] == "extra" for c in hosts["columns"]), (
+        "the re-profile saw the new column"
+    )
 
 
 def test_profile_inserts_new_dataset(airbnb_duckdb: Path, tmp_path: Path, capsys):

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -244,8 +244,10 @@ still fresh (same connector, schema unchanged, profiled within
 re-scan and reported as `cache_hit_count`, so it never enters the cost preflight
 or the billed handshake. `--refresh` forces a full re-profile of every selected
 object even when the cache is fresh, for a source that changed in a way the free
-metadata check cannot see. `explore relationships` reuses fresh profiles the
-same way (`cache_hit_count`); both accept `--refresh`.
+metadata check cannot see. `explore relationships` and the standalone
+`explore profile <objects>` reuse fresh profiles the same way
+(`cache_hit_count`), so a `profile` on a table `map` just wrote is served free;
+all three accept `--refresh`.
 
 Global flags (shared resolution path): `--connector`, `--path` (DuckDB),
 `--scope`, `--project` and `--dataset` (BigQuery only), `--repo-root`,

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -38,6 +38,11 @@ Subcommands, in the usual order:
    approximation noise is escalated to an exact COUNT(DISTINCT)
    (`distinct_count_exact: true`), so uniqueness and grain verdicts rest on
    proof; a `~` prefix in a warning marks a count that is still approximate.
+   A requested object whose cached profile is still fresh (same connector,
+   schema unchanged, within `profile_freshness_hours`, default 24) is served
+   from the cache (`cache_hit_count`) instead of re-scanned, so profiling a
+   table `map` just wrote costs nothing to spend; pass `--refresh` to force a
+   re-scan when the source changed in a way the free metadata check cannot see.
 4. `explore relationships` returns inferred and declared joins with confidences,
    plus notes explaining what the inference examined (so an empty list is
    meaningful). Add `--verify` to measure each inferred join with an aggregate
@@ -53,7 +58,8 @@ Subcommands, in the usual order:
    re-scan (`cache_hit_count`), so re-runs cost nothing to spend; pass
    `--refresh` to force a full re-profile when the source changed in a way the
    free metadata check cannot see (e.g. rows changed but the schema did not).
-   `explore relationships` reuses fresh profiles the same way.
+   `explore relationships` and the standalone `explore profile` reuse fresh
+   profiles the same way.
 6. `explore query "<SELECT ...>"` answers an ad-hoc question the fixed commands
    don't cover: you write the SQL, the engine's query firewall refuses or bounds
    it. Requires the `.dex/` cache (run `map` first). Results come back columnar


### PR DESCRIPTION
## What this changes

`explore profile` skips live profile if column is present in fresh cache.
Same logic that was already implemented for `explore map` and `explore relationships`

## Related issues

Closes #128