### PR TITLE
SCRUM-954-Classify orphaned warehouse relations in maintain check

### DIFF
--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -216,7 +216,10 @@ def load(project_dir: Path | str = ".") -> DbtProjectView:
         for path in sorted(base.rglob("*")):
             if path.suffix not in {".sql", ".yml", ".yaml"} or not path.is_file():
                 continue
-            rel = str(path.relative_to(root))
+            # Posix-separated regardless of OS: every consumer of `files` keys
+            # (transform_layer's model-name parsing, scaffolded model paths,
+            # this module's own backed_relation_names) assumes "/".
+            rel = path.relative_to(root).as_posix()
             content = path.read_text(encoding="utf-8")
             files[rel] = SourceFile(
                 path=rel, content=content, sha256=content_hash(content)
@@ -579,6 +582,32 @@ def yaml_documents(view: DbtProjectView) -> list[tuple[dict[str, Any], str]]:
     return documents
 
 
+def backed_relation_names(view: DbtProjectView) -> set[str]:
+    """Bare table names (lowered) this project currently builds or sources,
+    from files and YAML only -- no compiled manifest required, unlike
+    ``model_relations`` (empty without one, see ``_declared_from_yaml``).
+
+    Explore uses this (not ``maintain``'s ``transform_layer``/``drift.py``
+    logic, which computes the same thing) to keep from importing ``maintain``,
+    which already imports ``explore.relationships`` -- the reverse edge would
+    risk a cycle.
+    """
+
+    names = {
+        path.rsplit("/", 1)[-1][: -len(".sql")].lower()
+        for path in view.files
+        if path.endswith(".sql")
+    }
+    for parsed, _path in yaml_documents(view):
+        for src in parsed.get("sources") or []:
+            if not isinstance(src, dict):
+                continue
+            for table in src.get("tables") or []:
+                if isinstance(table, dict) and table.get("name"):
+                    names.add(str(table["name"]).lower())
+    return names
+
+
 def semantic_yaml_entries(
     view: DbtProjectView,
 ) -> list[tuple[str, dict[str, Any], str]]:
@@ -697,8 +726,12 @@ class ProjectDefinitions(BaseModel):
     exact, ``"yaml"`` resolves by name). ``model_relations`` maps referable
     names (model names and ``source.table``) to quote-stripped physical
     relations. ``primary_entities`` maps model names to their declared grain
-    column; ``metric_models`` lists models reachable from any metric. ``notes``
-    are analyst-readable caveats for the caller's envelope.
+    column; ``metric_models`` lists models reachable from any metric.
+    ``built_relation_names`` is bare table names (lowered) the project builds
+    or sources, from files/YAML alone (populated even with no compiled
+    manifest, unlike ``model_relations``) -- explore's orphan-relation
+    down-ranking reads this. ``notes`` are analyst-readable caveats for the
+    caller's envelope.
     """
 
     present: bool = False
@@ -712,6 +745,7 @@ class ProjectDefinitions(BaseModel):
     model_relations: dict[str, str] = Field(default_factory=dict)
     primary_entities: dict[str, str] = Field(default_factory=dict)
     metric_models: list[str] = Field(default_factory=list)
+    built_relation_names: list[str] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
 
 
@@ -757,6 +791,7 @@ def definitions(
         )
 
     defs = ProjectDefinitions(present=True, project_dir=str(project))
+    defs.built_relation_names = sorted(backed_relation_names(view))
 
     nodes = (view.manifest or {}).get("nodes")
     if isinstance(nodes, dict) and nodes:

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -846,9 +846,10 @@ def map(
     warnings: list[str] = []
 
     metas = inventory_mod.inventory(adapter)
+    orphaned = _orphan_candidates(metas, defs)
     # First-pass rank on cheap signals (no connectivity yet) to choose what to
     # profile; re-ranked with connectivity once relationships are known.
-    first_pass = rank_mod.rank(metas, None, hints)
+    first_pass = rank_mod.rank(metas, None, hints, orphaned)
     selected = _select_for_profiling(metas, first_pass, config, full)
     # Skip re-scanning a selected object whose cached profile is still fresh
     # (same connector, schema unchanged, within the freshness window); only
@@ -919,7 +920,7 @@ def map(
     # scanned this run or reused. Only the freshly profiled need annotation;
     # the reused already carry theirs from the cache write that stored them.
     all_selected = profiled + list(fresh_reused.values())
-    _annotate_grain(profiled, defs)
+    _annotate_grain(profiled, defs, orphaned=orphaned)
     suppressed: list[rel_mod.SuppressedMatch] = []
     inferred = rel_mod.infer_relationships(all_selected, suppressed=suppressed)
     if verify:
@@ -971,7 +972,7 @@ def map(
     relationship_set, carried_relationships = _carry_forward_relationships(
         reusable, examined, relationship_set
     )
-    final_scores = rank_mod.rank(metas, relationship_set, hints)
+    final_scores = rank_mod.rank(metas, relationship_set, hints, orphaned)
     datasets, carried, out_of_scope = _compose_datasets(
         metas, all_selected, final_scores, reusable
     )
@@ -1531,6 +1532,35 @@ def _carry_forward_relationships(
     return relationships + carried, len(carried)
 
 
+def _orphan_candidates(
+    metas: list[ObjectMeta], defs: dbt_project.ProjectDefinitions
+) -> set[str]:
+    """Identifiers no current model/source builds or sources, restricted to
+    schemas the project *does* build/source at least one other object into --
+    that schema-membership check stands in for maintain's baseline-vs-current
+    comparison, which explore has no snapshot to perform, so a raw, never
+    dbt-modeled schema is never miscast as full of orphans."""
+
+    if not defs.present or not defs.built_relation_names:
+        return set()
+    backed = {name.lower() for name in defs.built_relation_names}
+    owned_schemas = {
+        meta.identifier.rpartition(".")[0].lower()
+        for meta in metas
+        if "." in meta.identifier
+        and meta.identifier.rpartition(".")[2].lower() in backed
+    }
+    if not owned_schemas:
+        return set()
+    return {
+        meta.identifier
+        for meta in metas
+        if "." in meta.identifier
+        and meta.identifier.rpartition(".")[0].lower() in owned_schemas
+        and meta.identifier.rpartition(".")[2].lower() not in backed
+    }
+
+
 def _merged_hints(user_hints: list[str], metric_models: list[str]) -> list[str]:
     """User-configured ranking hints plus the models metric definitions ground
     in. User hints come first and are never displaced; metric-backed models are
@@ -1546,7 +1576,10 @@ def _merged_hints(user_hints: list[str], metric_models: list[str]) -> list[str]:
 
 
 def _annotate_grain(
-    datasets: list[Dataset], defs: dbt_project.ProjectDefinitions | None = None
+    datasets: list[Dataset],
+    defs: dbt_project.ProjectDefinitions | None = None,
+    *,
+    orphaned: set[str] | None = None,
 ) -> None:
     """Attach the interpretation layer to raw profiles: candidate keys, the likely
     grain, and the data-quality warnings an analyst would write (non-unique own
@@ -1558,6 +1591,7 @@ def _annotate_grain(
     disagreement), and a profiled column contradicting its declared ``unique``
     test gets a data-quality note. ``candidate_keys`` stays measurement-only:
     an unmeasured declared key is a claim, and the cache is a drift baseline.
+    ``orphaned`` (map only) badges a relation no current model/source builds.
     """
 
     declared_grain: dict[str, str] = {}
@@ -1583,6 +1617,12 @@ def _annotate_grain(
         ds.candidate_keys = rel_mod.candidate_keys(ds)
         ds.grain = rel_mod.detect_grain(ds)
         ds.data_quality.extend(rel_mod.data_quality_notes(ds))
+        if orphaned and ds.identifier in orphaned:
+            ds.data_quality.append(
+                "no current dbt model or source builds this relation, though "
+                "the project builds/sources others in this schema; likely "
+                "orphaned residue of a rename or removal"
+            )
 
         grain_column = declared_grain.get(ds.identifier.lower())
         if grain_column is not None:

--- a/packages/dex-core/src/exmergo_dex_core/explore/rank.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/rank.py
@@ -32,16 +32,24 @@ _NAME_PENALTY = re.compile(
 # meaningful, too wide to be a modeled table) and are damped.
 _SHAPE_IDEAL = (2, 60)
 
+# An orphan relation (no current dbt model/source backs it, though the project
+# builds/sources others in its schema) is down-ranked, not hidden: it can still
+# be worth surfacing for cleanup.
+_ORPHAN_PENALTY = 0.5
+
 
 def rank(
     objects: list[ObjectMeta],
     relationships: list[Relationship] | None = None,
     ranking_hints: list[str] | None = None,
+    orphaned: set[str] | None = None,
 ) -> dict[str, float]:
     """Map identifier -> rank_score in [0, 1]. Pure; no I/O."""
 
     if not objects:
         return {}
+
+    orphan_set = {i.lower() for i in (orphaned or [])}
 
     degree = _connectivity_degree(relationships or [])
     max_degree = max(degree.values(), default=0)
@@ -64,13 +72,15 @@ def rank(
         connectivity = (
             degree.get(obj.identifier, 0) / max_degree if max_degree > 0 else 0.0
         )
-        scores[obj.identifier] = round(
+        score = (
             _W_SIZE * size
             + _W_CONNECTIVITY * connectivity
             + _W_NAMING * _naming_score(obj.name, hints)
-            + _W_SHAPE * _shape_score(obj.column_count),
-            4,
+            + _W_SHAPE * _shape_score(obj.column_count)
         )
+        if obj.identifier.lower() in orphan_set:
+            score *= _ORPHAN_PENALTY
+        scores[obj.identifier] = round(score, 4)
     return scores
 
 

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -151,9 +151,50 @@ def cmd_snapshot(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
 
 
 def schema_drift(engine: DexEngine, objects: list[str] | None = None) -> DriftResult:
-    """Source columns and tables added, dropped, retyped, or renamed."""
+    """Source columns and tables added, dropped, retyped, or renamed.
 
-    return _detect_free_axis(engine, "schema", drift_mod.schema_drift, objects)
+    Unlike ``volume_drift``, this loads the live project (degrading quietly,
+    never raising, when none is available) so ``orphan_relation`` can compare
+    the baseline's project fingerprint against the current one; that need is
+    schema-only, so this has its own body instead of going through
+    ``_detect_free_axis``.
+    """
+
+    store = engine.store
+    snap = store.load_snapshot()
+    if snap is None:
+        raise NoBaselineError(_NO_SNAPSHOT_ERROR)
+
+    warnings: list[str] = []
+    current_transform = None
+    try:
+        view = load_project(engine.project_dir())
+        current_transform = snapshot_mod.transform_layer(view)
+    except (DbtProjectError, ValueError) as exc:
+        warnings.append(
+            f"orphan-relation classification skipped (no dbt project: {exc})"
+        )
+
+    adapter = engine._adapter("maintain schema")
+    current = snapshot_mod.warehouse_from_metadata(adapter).datasets
+    cost = command_args.preflight_cost(adapter)
+    connector = adapter.name
+
+    scope_names = list(objects or [])
+    scope = _resolve_scope(scope_names, current, snap)
+    findings = drift_mod.schema_drift(current, snap, scope, current_transform)
+    drift_mod.annotate_impacts(findings, snap)
+    ranked = drift_mod.rank_findings(findings)
+
+    _record_axes(store, snap, connector, {"schema": (ranked, scope_names)})
+    result = _drift_result(
+        {"schema": ranked},
+        snap,
+        store,
+        warnings=warnings + _staleness_warnings(store, snap),
+    )
+    result.cost = cost
+    return result
 
 
 def volume_drift(engine: DexEngine, objects: list[str] | None = None) -> DriftResult:
@@ -334,7 +375,9 @@ def check(engine: DexEngine) -> DriftResult:
     adapter = engine._adapter("maintain check")
     connector = adapter.name
     current_datasets = snapshot_mod.warehouse_from_metadata(adapter).datasets
-    schema_findings = drift_mod.schema_drift(current_datasets, snap)
+    schema_findings = drift_mod.schema_drift(
+        current_datasets, snap, current_transform=current_transform
+    )
     volume_findings = drift_mod.volume_drift(current_datasets, snap)
     semantic_findings = (
         drift_mod.semantic_free_drift(

--- a/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
@@ -115,9 +115,18 @@ def resolve_scope(names: list[str], identifiers: Iterable[str]) -> set[str]:
 
 
 def schema_drift(
-    current: list[Dataset], snap: Snapshot, scope: set[str] | None = None
+    current: list[Dataset],
+    snap: Snapshot,
+    scope: set[str] | None = None,
+    current_transform: TransformLayer | None = None,
 ) -> list[DriftFinding]:
-    """Structural drift: metadata only, free on every connector."""
+    """Structural drift: metadata only, free on every connector.
+
+    ``current_transform`` (the live project's fingerprint, not the baseline's)
+    enables ``orphan_relation``: a table present at the baseline and now, that
+    the baseline's project built or sourced but the live project no longer
+    does. Without it (no project available), that check is skipped.
+    """
 
     baseline = {d.identifier: d for d in snap.warehouse.datasets}
     now = {d.identifier: d for d in current}
@@ -149,9 +158,30 @@ def schema_drift(
         if scoped(identifier)
     )
 
+    baseline_backed = _backed_tables(snap.transform_layer)
+    current_backed = _backed_tables(current_transform)
+
     for identifier in sorted(baseline.keys() & now.keys()):
         if not scoped(identifier):
             continue
+        if snap.transform_layer is not None and current_transform is not None:
+            table = identifier.rsplit(".", 1)[-1].lower()
+            if table in baseline_backed and table not in current_backed:
+                findings.append(
+                    DriftFinding(
+                        axis="schema",
+                        code="orphan_relation",
+                        identifier=identifier,
+                        severity="medium",
+                        detail=(
+                            f"{identifier} was built by the dbt project at the "
+                            "last snapshot but no model or source currently "
+                            "backs it; the warehouse still holds it as residue "
+                            "of a rename or removal"
+                        ),
+                        data={"drop_statement": f"DROP TABLE {identifier};"},
+                    )
+                )
         old_cols = {c.name: c for c in baseline[identifier].columns}
         new_cols = {c.name: c for c in now[identifier].columns}
         added = sorted(new_cols.keys() - old_cols.keys())
@@ -941,6 +971,21 @@ def _distinct_combination_stand_in(
     import sqlglot
 
     return sqlglot.transpile(sql, read="duckdb", write=dialect)[0]
+
+
+def _backed_tables(transform: TransformLayer | None) -> set[str]:
+    """Table-name suffixes (lowered) this transform layer claims: a model's
+    own name (it *is* the relation), or a declared ``source()`` table. Reads
+    ``.sources`` directly rather than going through ``_models_by_table``'s
+    regex-derived ``model_sources``, so a declared source with no model
+    currently calling ``source()`` on it still counts as known to the
+    project (the same data ``dangling_source`` already reads)."""
+
+    if transform is None:
+        return set()
+    names = {model.lower() for model in transform.models}
+    names.update(source.table.lower() for source in transform.sources)
+    return names
 
 
 def _models_by_table(transform: TransformLayer) -> dict[str, set[str]]:

--- a/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
@@ -144,6 +144,22 @@ def build(
 
 
 def _advisory(finding: DriftFinding, view: DbtProjectView) -> Proposal:
+    if finding.code == "orphan_relation":
+        drop_statement = finding.data.get(
+            "drop_statement", f"DROP TABLE {finding.identifier};"
+        )
+        return Proposal(
+            axis=finding.axis,
+            kind="advisory",
+            finding_code=finding.code,
+            identifier=finding.identifier,
+            column=finding.column,
+            action=(
+                "no dbt model or source declares this relation anymore; once "
+                "you've confirmed nothing reads it, drop it by hand (dex "
+                f"never executes this): {drop_statement}"
+            ),
+        )
     actions = {
         "table_added": (
             "a new table appeared; scaffold a staging model with "

--- a/packages/dex-core/tests/explore/test_explore.py
+++ b/packages/dex-core/tests/explore/test_explore.py
@@ -684,7 +684,9 @@ def test_map_downranks_and_badges_orphan_relation(tmp_path: Path, capsys):
         capsys,
     )
     cache = FilesystemStore(repo).load_cache()
-    orphan = next(d for d in cache.datasets if d.identifier.endswith(".stg_legacy_orders"))
+    orphan = next(
+        d for d in cache.datasets if d.identifier.endswith(".stg_legacy_orders")
+    )
     backed = next(d for d in cache.datasets if d.identifier.endswith(".stg_orders"))
     assert any("orphaned residue" in n for n in orphan.data_quality)
     assert orphan.rank_score < backed.rank_score

--- a/packages/dex-core/tests/explore/test_explore.py
+++ b/packages/dex-core/tests/explore/test_explore.py
@@ -663,9 +663,7 @@ def _orphan_repo(tmp_path: Path) -> tuple[Path, Path]:
         'name: dex_test\nversion: "1.0.0"\nmodel-paths: ["models"]\n',
         encoding="utf-8",
     )
-    (repo / "models" / "stg_orders.sql").write_text(
-        "select * from x", encoding="utf-8"
-    )
+    (repo / "models" / "stg_orders.sql").write_text("select * from x", encoding="utf-8")
     return db, repo
 
 

--- a/packages/dex-core/tests/explore/test_explore.py
+++ b/packages/dex-core/tests/explore/test_explore.py
@@ -646,6 +646,50 @@ def _semantic_repo(tmp_path: Path) -> tuple[Path, Path]:
     return db, repo
 
 
+def _orphan_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """A warehouse with a staging model's built table (stg_orders) plus a
+    same-schema leftover (stg_legacy_orders) no model or source claims."""
+
+    duckdb = pytest.importorskip("duckdb")
+    db = tmp_path / "wh.duckdb"
+    conn = duckdb.connect(str(db))
+    conn.execute("CREATE TABLE stg_orders (id INTEGER)")
+    conn.execute("CREATE TABLE stg_legacy_orders (id INTEGER)")
+    conn.close()
+
+    repo = tmp_path / "repo"
+    (repo / "models").mkdir(parents=True)
+    (repo / "dbt_project.yml").write_text(
+        'name: dex_test\nversion: "1.0.0"\nmodel-paths: ["models"]\n',
+        encoding="utf-8",
+    )
+    (repo / "models" / "stg_orders.sql").write_text(
+        "select * from x", encoding="utf-8"
+    )
+    return db, repo
+
+
+def test_map_downranks_and_badges_orphan_relation(tmp_path: Path, capsys):
+    db, repo = _orphan_repo(tmp_path)
+    _run(
+        [
+            "explore",
+            "map",
+            "--use-project",
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    cache = FilesystemStore(repo).load_cache()
+    orphan = next(d for d in cache.datasets if d.identifier.endswith(".stg_legacy_orders"))
+    backed = next(d for d in cache.datasets if d.identifier.endswith(".stg_orders"))
+    assert any("orphaned residue" in n for n in orphan.data_quality)
+    assert orphan.rank_score < backed.rank_score
+
+
 def test_map_declared_grain_overrides_heuristic(tmp_path: Path, capsys):
     db, repo = _semantic_repo(tmp_path)
     _run(

--- a/packages/dex-core/tests/maintain/test_reconcile.py
+++ b/packages/dex-core/tests/maintain/test_reconcile.py
@@ -270,3 +270,19 @@ def test_dropped_source_reconcile_is_advisory_when_no_scaffold(maintain_repo):
     assert all(p["kind"] == "advisory" for p in payload["data"]["proposals"])
     codes = {p["finding_code"] for p in payload["data"]["proposals"]}
     assert "dangling_source" in codes or "table_dropped" in codes
+
+
+def test_orphan_relation_reconcile_is_advisory_with_drop_statement(maintain_repo):
+    maintain_repo.snapshot()
+    (maintain_repo.project_dir / "models" / "staging" / "stg_orders.sql").unlink()
+    maintain_repo.dex("maintain", "schema")
+
+    rc, payload = maintain_repo.dex("maintain", "reconcile", "schema")
+    assert rc == 0 and payload["status"] == "ok"
+    by_axis = _proposals_by_axis(payload)
+    orphan_proposals = [
+        p for p in by_axis["schema"] if p["finding_code"] == "orphan_relation"
+    ]
+    assert orphan_proposals and all(p["kind"] == "advisory" for p in orphan_proposals)
+    assert "DROP TABLE" in orphan_proposals[0]["action"]
+    assert "warehouse.main.stg_orders" in orphan_proposals[0]["action"]

--- a/packages/dex-core/tests/maintain/test_schema.py
+++ b/packages/dex-core/tests/maintain/test_schema.py
@@ -94,6 +94,36 @@ def test_new_table_is_reported_added(maintain_repo):
     assert by_code["table_added"][0]["severity"] == "low"
 
 
+def test_orphan_relation_is_flagged_when_model_removed(maintain_repo):
+    maintain_repo.snapshot()
+    (maintain_repo.project_dir / "models" / "staging" / "stg_orders.sql").unlink()
+
+    _rc, payload = maintain_repo.dex("maintain", "schema")
+    by_code = _by_code(payload)
+    orphan = by_code["orphan_relation"][0]
+    assert orphan["identifier"] == "warehouse.main.stg_orders"
+    assert orphan["severity"] == "medium"
+    assert "DROP TABLE" in orphan["data"]["drop_statement"]
+    # It already existed at snapshot time, so it must never double-report as
+    # table_added, and the physical table is untouched, so never table_dropped.
+    assert "table_added" not in by_code
+    assert "table_dropped" not in by_code
+
+
+def test_orphan_relation_not_reported_for_never_backed_table(maintain_repo):
+    """A table with no baseline backing (never in transform_layer.models or
+    .sources) keeps today's table_added behavior -- orphan_relation is
+    strictly for identifiers backed at the baseline."""
+
+    maintain_repo.snapshot()
+    maintain_repo.sql("CREATE TABLE payments (id INTEGER, amount DOUBLE)")
+
+    _rc, payload = maintain_repo.dex("maintain", "schema")
+    by_code = _by_code(payload)
+    assert by_code["table_added"][0]["identifier"] == "warehouse.main.payments"
+    assert "orphan_relation" not in by_code
+
+
 def test_scope_filters_findings_to_named_objects(maintain_repo):
     maintain_repo.snapshot()
     maintain_repo.sql(


### PR DESCRIPTION
Closes: https://github.com/exmergo/dex/issues/113

Adds orphan_relation detection for warehouse relations left behind by a model rename/removal dbt never drops them, so today they're invisible or misreported.

maintain check: new orphan_relation finding fires when a relation was model/source-backed at the last snapshot but isn't anymore, while still present in the warehouse
maintain reconcile: advisory proposal with a DROP TABLE statement for a human to run (dex never executes it)
explore map --use-project: down-ranks and badges orphan relations so they don't surface as top objects
Fixes a pre-existing Windows path-separator bug in dbt_project.py that silently broke this (and prior impacted_models tracing)
Scope: detection + advisory only, two-state classification (no snapshot history) per the issue's own suggested split; execution (macro + dbt run-operation) deferred to a follow-up issue

the issue : 
<img width="977" height="190" alt="image" src="https://github.com/user-attachments/assets/97b28ffc-502a-458f-b41e-973dcf9165ad" />
After fix : 
<img width="1647" height="667" alt="image" src="https://github.com/user-attachments/assets/ab5f040b-62ee-42fa-8644-d5375a25f595" />
