### PR TITLE
Fix SQLGlot dependency issue in [semantic-api] and cleanup dependencies

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,19 @@ jobs:
   # The query firewall matches sqlglot expression classes by name at module scope,
   # so a sqlglot major that renames one breaks every install that resolves it. The
   # declared dependency is therefore capped, and this job is how the cap stays
-  # honest: it installs the newest sqlglot over the cap and runs the guards against
-  # it, so a breaking release surfaces here on the next push instead of on a user's
-  # machine after we raise the ceiling blind.
+  # honest: it installs the newest sqlglot over the cap and re-runs the suite
+  # against it, so a breaking release surfaces here on the next push instead of on
+  # a user's machine after we raise the ceiling blind.
+  #
+  # Deliberately a mirror of the `tests` job rather than a narrower selection: the
+  # firewall is not the only dialect-dependent code (relationship probes and drift
+  # checks transpile per connector), and this job is only informative if a red run
+  # means "the new sqlglot broke something" rather than "the canary environment was
+  # missing something". Two safety-spine tests import boto3 and httpx unguarded and
+  # get them transitively from the [redshift] and [databricks] extras, so a narrower
+  # sync fails for reasons that have nothing to do with sqlglot. Packaging tests are
+  # excluded because they resolve sqlglot inside isolated installs from the declared
+  # cap, so they would report on the capped version and not the one under test.
   #
   # Advisory by design (continue-on-error): it reports on code we do not control,
   # so a red canary is a signal to investigate upstream, never a reason to block a
@@ -74,8 +84,8 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-      - name: Sync (duckdb + dev extras)
-        run: uv sync --extra duckdb --extra dev
+      - name: Sync (duckdb + bigquery + snowflake + databricks + postgres + redshift + dev extras)
+        run: uv sync --extra duckdb --extra bigquery --extra snowflake --extra databricks --extra postgres --extra redshift --extra dev
       # A direct install into the synced environment, which is what lets it ignore
       # the ceiling the project declares. `uv sync` would resolve back to the cap.
       - name: Install the newest sqlglot over the declared ceiling
@@ -84,10 +94,10 @@ jobs:
       # report a green canary that tested nothing, which would be worse than having
       # no canary at all. The version is echoed in the same step for that reason:
       # the log has to show which sqlglot actually ran.
-      - name: Guards and the safety spine against the newest sqlglot
+      - name: Suite against the newest sqlglot
         run: |
           uv run --no-sync python -c "import sqlglot; print('testing sqlglot', sqlglot.__version__)"
-          uv run --no-sync pytest -q tests/guards tests/test_safety_spine.py
+          uv run --no-sync pytest -q -m "not packaging"
 
   # The Tier-2 eval harness scoring core (triggering, output-quality, uplift math),
   # exercised with fake backends: deterministic, free, no model in the loop. The

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,42 @@ jobs:
       - name: Safety-critical assertions
         run: uv run pytest -q tests/test_safety_spine.py
 
+  # The query firewall matches sqlglot expression classes by name at module scope,
+  # so a sqlglot major that renames one breaks every install that resolves it. The
+  # declared dependency is therefore capped, and this job is how the cap stays
+  # honest: it installs the newest sqlglot over the cap and runs the guards against
+  # it, so a breaking release surfaces here on the next push instead of on a user's
+  # machine after we raise the ceiling blind.
+  #
+  # Advisory by design (continue-on-error): it reports on code we do not control,
+  # so a red canary is a signal to investigate upstream, never a reason to block a
+  # merge of unrelated work. The `tests` and `safety` jobs remain the real gates.
+  sqlglot-canary:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: packages/dex-core
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync (duckdb + dev extras)
+        run: uv sync --extra duckdb --extra dev
+      # A direct install into the synced environment, which is what lets it ignore
+      # the ceiling the project declares. `uv sync` would resolve back to the cap.
+      - name: Install the newest sqlglot over the declared ceiling
+        run: uv pip install --upgrade sqlglot
+      # --no-sync so the test run cannot quietly restore the capped version and
+      # report a green canary that tested nothing, which would be worse than having
+      # no canary at all. The version is echoed in the same step for that reason:
+      # the log has to show which sqlglot actually ran.
+      - name: Guards and the safety spine against the newest sqlglot
+        run: |
+          uv run --no-sync python -c "import sqlglot; print('testing sqlglot', sqlglot.__version__)"
+          uv run --no-sync pytest -q tests/guards tests/test_safety_spine.py
+
   # The Tier-2 eval harness scoring core (triggering, output-quality, uplift math),
   # exercised with fake backends: deterministic, free, no model in the loop. The
   # live Claude-driven evals run on release, not here. Stdlib only, so uvx supplies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ uv run scripts/run.py <subcommand> [flags]
 
 Install the engine with the connector extra you use: `exmergo-dex-core[duckdb]`
 for the zero-credential on-ramp, or `[snowflake]`, `[bigquery]`, `[databricks]`,
-`[postgres]`, `[redshift]`, or `[all]` for every connector at once. The shipped wrapper pins
+`[postgres]`, `[redshift]`, or `[all]` for every optional capability at once. The shipped wrapper pins
 only the engine version and selects that extra for you at runtime from the active
 connector (an explicit `--connector`, then the `connector:` in the `.dex/config.yml`
 found by walking up from the run directory to the git root, then DuckDB), so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,42 +11,83 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [1.4.1] - 2026-07-26
 
+### Added
+
+- **`maintain check` classifies orphaned warehouse relations** ([#146]). A model
+  that is renamed or removed leaves its old relation behind in the warehouse, since
+  dbt never drops it, so the leftover table was either invisible to drift detection
+  or misreported as an unrelated finding. A new `orphan_relation` finding fires when
+  a relation was model-backed or source-backed at the last snapshot, no longer is,
+  and is still present in the warehouse. `maintain reconcile` proposes the matching
+  `DROP TABLE` as an advisory statement for a human to run, never executing it, and
+  `explore map --use-project` down-ranks and badges orphans so they stop surfacing
+  as top objects. Detection and advice only: the drop itself stays manual.
+
+### Changed
+
+- **The hosted semantic layer is a genuinely standalone install: no warehouse
+  client, no dbt-core, no SQL parser.** `[semantic-api]` used to require a dialect
+  engine it could never use, because dbt Cloud renders and executes the query
+  server-side and dex never sees a statement to validate. The coupling was one
+  float: the PII block threshold lived in the query firewall, so reading it pulled
+  in a SQL parser. The threshold now lives with the guards' shared policy, where
+  every surface that gates on PII can read it without paying for a parser, and the
+  `explore semantic` handlers moved out of the explore command module (which
+  imports the firewall for the commands that do parse SQL) into the semantic
+  package. `DexEngine.semantic_list` and `semantic_query` route there too, so a
+  host serving metric queries with a `SemanticSource` and nothing on the filesystem
+  needs only this extra, which is what the documentation already promised.
+
+  A command that does parse SQL, run on an install that named no connector, now
+  refuses and names the extra to install. There is deliberately no weaker fallback
+  check: a query dex cannot parse is a query it cannot promise is read-only, so
+  refusing is the only safe answer. `explore semantic list --local`, documented as
+  a read-view needing no extra, works on a bare install for the first time.
+
 ### Fixed
 
-- **Every install now declares the dialect engine it actually imports.** sqlglot
-  was pinned inside each of the six connector extras, but the guards that parse
-  SQL (the query firewall and the SELECT-only assertion) are cross-cutting and
-  eagerly imported, so any install that picked no connector extra failed on an
-  import the metadata never promised. `[semantic-api]`, documented as a
-  pure-remote install needing nothing but an httpx client, could not import the
-  hosted dbt Cloud backend at all; `[cluster]` on its own and a bare install
-  running the read-only `explore semantic list --local` failed the same way. The
-  CLI caught the `ModuleNotFoundError` and reported it inside an error envelope,
-  so it read as a broken environment rather than a packaging bug. sqlglot is now
-  a base dependency, declared once: it is connector-agnostic, pure Python with no
-  dependencies of its own, and required by the guards on every surface. Importing
-  the package still pulls in no sqlglot, so per-command CLI latency is unchanged.
+- **Extras no longer under-declare what the code imports, and the sqlglot bound no
+  longer lags what the code needs.** sqlglot was pinned inside each of the six
+  connector extras, so any install that picked no connector failed on an import the
+  metadata never promised: `[semantic-api]` could not import the hosted dbt Cloud
+  backend at all, and `[cluster]` alone and a bare install failed the same way. The
+  CLI caught the `ModuleNotFoundError` and reported it inside an error envelope, so
+  it read as a broken environment rather than a packaging bug. Compounding it, the
+  declared floor was `>=25` while the firewall's unnest allowlist referenced
+  expression classes that only exist from 28.6 (`exp.JSONKeys`), so an environment
+  whose resolver settled on an older sqlglot satisfied the metadata and then failed
+  on an `AttributeError` at import.
+
+  sqlglot is now declared exactly once, in a `[sql]` extra that every extra
+  reaching a warehouse self-references, and bounded at both ends: `>=28.6,<31`.
+  There is a ceiling because the firewall matches expression classes by name at
+  module scope and sqlglot majors have already broken this code twice (the `Union`
+  to `SetOperation` and `from` to `from_` renames both needed accommodating), so an
+  open bound let a future release break every new install on something no test here
+  could anticipate. Two guards keep the pair honest: a packaging test installs the
+  wheel at exactly the declared floor and imports the guards, and a new advisory
+  `sqlglot-canary` CI job runs the guards and the safety spine against the newest
+  sqlglot on every push, so a breaking release surfaces on our side first and
+  raising the ceiling is a deliberate act taken on evidence.
 
 - **`[all]` now installs every optional capability, not just every connector.**
   The extra covered the six connectors and stopped there, so an install documented
   as everything silently omitted both semantic-layer backends (`[semantic]`,
   `[semantic-api]`) and clustering (`[cluster]`), and a user who asked for all of
-  it still got `not_implemented`-shaped failures on `explore semantic` and
-  `explore cluster`. It self-references the other extras, so their requirement
-  lists stay defined once, and a packaging test now asserts the reference list
-  covers every declared extra except `dev` (contributor tooling, not a
-  capability), then installs it and imports every client, dbt adapter, and
-  semantic backend to prove they co-resolve. `[all]` is correspondingly the
-  heaviest install available; the light default and the `[duckdb]` on-ramp are
-  unchanged.
+  it still got failures telling them to install an extra they had already named. It
+  self-references the other extras, so their requirement lists stay defined once,
+  and a packaging test now asserts the reference list covers every declared extra
+  except `dev` (contributor tooling, not a capability), then installs it and imports
+  every client, dbt adapter, and semantic backend to prove they co-resolve. `[all]`
+  is correspondingly the heaviest install available; the light default and the
+  `[duckdb]` on-ramp are unchanged.
 
-- **The declared sqlglot floor matches what the code needs.** The bound was
-  `>=25` while the firewall's unnest allowlist referenced expression classes at
-  module scope that only exist from 28.6 (`exp.JSONKeys`), so any environment
-  whose resolver settled on an older sqlglot, satisfying the declared bound, hit
-  an `AttributeError` on import. The floor is now `>=28.6`, and a packaging test
-  installs the wheel at exactly the declared floor and imports the guards, so a
-  newly referenced expression class cannot silently outrun the bound again.
+- **Windows path separators no longer break model-name parsing** ([#146]). The
+  project file index keyed its entries with OS-native separators, while every
+  consumer of those keys splits on `/`: the transform layer's model-name parsing,
+  scaffolded model paths, and the relation names the orphan classification above
+  depends on. On Windows they all quietly found nothing rather than failing loudly.
+  Keys are now posix-separated regardless of platform.
 
 ## [1.4.0] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-26
+
 ### Fixed
 
 - **Every install now declares the dialect engine it actually imports.** sqlglot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Every install now declares the dialect engine it actually imports.** sqlglot
+  was pinned inside each of the six connector extras, but the guards that parse
+  SQL (the query firewall and the SELECT-only assertion) are cross-cutting and
+  eagerly imported, so any install that picked no connector extra failed on an
+  import the metadata never promised. `[semantic-api]`, documented as a
+  pure-remote install needing nothing but an httpx client, could not import the
+  hosted dbt Cloud backend at all; `[cluster]` on its own and a bare install
+  running the read-only `explore semantic list --local` failed the same way. The
+  CLI caught the `ModuleNotFoundError` and reported it inside an error envelope,
+  so it read as a broken environment rather than a packaging bug. sqlglot is now
+  a base dependency, declared once: it is connector-agnostic, pure Python with no
+  dependencies of its own, and required by the guards on every surface. Importing
+  the package still pulls in no sqlglot, so per-command CLI latency is unchanged.
+
+- **`[all]` now installs every optional capability, not just every connector.**
+  The extra covered the six connectors and stopped there, so an install documented
+  as everything silently omitted both semantic-layer backends (`[semantic]`,
+  `[semantic-api]`) and clustering (`[cluster]`), and a user who asked for all of
+  it still got `not_implemented`-shaped failures on `explore semantic` and
+  `explore cluster`. It self-references the other extras, so their requirement
+  lists stay defined once, and a packaging test now asserts the reference list
+  covers every declared extra except `dev` (contributor tooling, not a
+  capability), then installs it and imports every client, dbt adapter, and
+  semantic backend to prove they co-resolve. `[all]` is correspondingly the
+  heaviest install available; the light default and the `[duckdb]` on-ramp are
+  unchanged.
+
+- **The declared sqlglot floor matches what the code needs.** The bound was
+  `>=25` while the firewall's unnest allowlist referenced expression classes at
+  module scope that only exist from 28.6 (`exp.JSONKeys`), so any environment
+  whose resolver settled on an older sqlglot, satisfying the declared bound, hit
+  an `AttributeError` on import. The floor is now `>=28.6`, and a packaging test
+  installs the wheel at exactly the declared floor and imports the guards, so a
+  newly referenced expression class cannot silently outrun the bound again.
+
 ## [1.4.0] - 2026-07-26
 
 ### Added

--- a/packages/dex-core/README.md
+++ b/packages/dex-core/README.md
@@ -27,8 +27,12 @@ exmergo-dex-core[bigquery]
 exmergo-dex-core[databricks]
 exmergo-dex-core[redshift]
 exmergo-dex-core[postgres]
-exmergo-dex-core[all]          # every connector at once
+exmergo-dex-core[all]          # every optional capability at once
 ```
+
+Two capabilities sit behind their own extras rather than a connector's:
+`[semantic]` and `[semantic-api]` for the local and hosted semantic-layer query
+backends, and `[cluster]` for `explore cluster`. `[all]` covers all of these too.
 
 ## Two surfaces, one engine
 

--- a/packages/dex-core/README.md
+++ b/packages/dex-core/README.md
@@ -34,6 +34,13 @@ Two capabilities sit behind their own extras rather than a connector's:
 `[semantic]` and `[semantic-api]` for the local and hosted semantic-layer query
 backends, and `[cluster]` for `explore cluster`. `[all]` covers all of these too.
 
+`[semantic-api]` is the one extra that stands completely alone: dbt Cloud owns the
+warehouse connection and executes server-side, so a deployment that only queries a
+hosted semantic layer needs no connector, no dbt-core, and no SQL parser. Every
+other command validates SQL before running it, which is why the connector extras
+carry the dialect engine; run one without a connector installed and dex refuses
+with the install to use rather than guessing.
+
 ## Two surfaces, one engine
 
 ### The Python API

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -22,62 +22,83 @@ keywords = [
   "agent",
 ]
 
-# Base dependencies are connector-agnostic: the canonical model (pydantic),
-# config parsing (pyyaml), and the dialect engine (sqlglot). Connector client
-# libraries live behind the extras below, so the zero-credential DuckDB on-ramp
-# never pulls the cloud client stack.
-#
-# sqlglot is base, not per-connector, because the guards are cross-cutting: the
-# query firewall and the SELECT-only assertion parse SQL on every guarded surface,
-# and they are imported eagerly by design (a safety check that loads lazily is one
-# that can be missing when it matters). It used to be duplicated across every
-# connector extra, which made a sqlglot-free install (`[semantic-api]`, `[cluster]`,
-# or a bare install running the read-only `explore semantic list --local`) fail on
-# an import the metadata never declared.
-#
-# The floor is 28.6 because the firewall's unnest allowlist references sqlglot
-# expression classes at module scope, and `exp.JSONKeys` (Snowflake/Databricks/
-# DuckDB key enumeration) first exists there. Bump this floor whenever a newly
-# referenced expression class raises the real minimum, or the failure lands on the
-# user as an AttributeError at import.
+# Base dependencies are the canonical model (pydantic) and config parsing (pyyaml):
+# what every surface needs regardless of what it talks to. Connector clients and
+# the dialect engine live behind the extras below, so the zero-credential DuckDB
+# on-ramp never pulls the cloud client stack, and a deployment that queries a
+# hosted semantic layer over HTTP pulls neither.
 dependencies = [
   "pydantic>=2",
   "pyyaml>=6",
-  "sqlglot>=28.6",
 ]
 
 [project.scripts]
 dex = "exmergo_dex_core.cli:main"
 
 [project.optional-dependencies]
+# The dialect engine behind the guards. Not a user-facing choice: every extra that
+# reaches a warehouse self-references it, so installing a connector always brings
+# it. It exists as its own extra so the floor and the ceiling are declared in one
+# place; duplicating the pin across the connector extras is what once let the
+# declared floor (>=25) drift years behind what the code needed (>=28.6), and the
+# resulting AttributeError landed on users at import.
+#
+# The floor is 28.6 because the query firewall's unnest allowlist references
+# sqlglot expression classes at module scope, and `exp.JSONKeys` (Snowflake,
+# Databricks, and DuckDB key enumeration) first exists there. Raise it whenever a
+# newly referenced class raises the real minimum.
+#
+# There is a ceiling for the same reason there is a floor: those references are
+# version-sensitive, and sqlglot majors have already broken this code twice (the
+# `Union` to `SetOperation` rename, which `_QUERY_ROOTS` still accommodates, and
+# the `from` to `from_` arg-key rename, which `_resolve_sources` still handles).
+# Without a ceiling a future major renames a class and every new install breaks on
+# something we could not have known about. The `sqlglot-canary` CI job runs the
+# guards against the newest release on every push, so raising this ceiling is a
+# deliberate act taken on evidence rather than a surprise.
+#
+# Absent it, the guarded commands refuse with an actionable message naming the
+# connector extra to install (see `guards/dialect.py`); they never silently fall
+# back to a weaker check.
+sql = ["sqlglot>=28.6,<31"]
 # The DuckDB on-ramp and the full local ETM loop: the duckdb client and
 # dbt-duckdb (which pulls dbt-core). All three skills install this one
 # extra, and transform/maintain author and build a dbt project against a DuckDB
 # dev target, so dbt-duckdb belongs here. (This makes the on-ramp heavier than a
 # pure explore-only install would need; a separate lighter explore extra can be
 # split out later if that tradeoff matters.)
-duckdb = ["duckdb>=1", "dbt-duckdb>=1.9"]
+duckdb = ["duckdb>=1", "dbt-duckdb>=1.9", "exmergo-dex-core[sql]"]
 # 3.17 is the floor for workload-identity auth (the keyless CI path). Like
 # [duckdb], the extra carries the dbt adapter so transform can build against a
 # Snowflake dev target with one install.
-snowflake = ["snowflake-connector-python>=3.17", "dbt-snowflake>=1.9"]
+snowflake = ["snowflake-connector-python>=3.17", "dbt-snowflake>=1.9", "exmergo-dex-core[sql]"]
 # Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
 # transform can build against a BigQuery dev target with one install.
-bigquery = ["google-cloud-bigquery>=3", "dbt-bigquery>=1.9"]
+bigquery = ["google-cloud-bigquery>=3", "dbt-bigquery>=1.9", "exmergo-dex-core[sql]"]
 # Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
 # transform can build against a Databricks dev target with one install. The SDK
 # rides alongside the SQL driver: free Unity Catalog metadata and warehouse facts
 # come from the REST API, so nothing billable is touched until a statement runs.
-databricks = ["databricks-sql-connector>=3", "databricks-sdk>=0.30", "dbt-databricks>=1.9"]
+databricks = [
+  "databricks-sql-connector>=3",
+  "databricks-sdk>=0.30",
+  "dbt-databricks>=1.9",
+  "exmergo-dex-core[sql]",
+]
 # Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
 # transform can build against a Postgres dev schema with one install.
-postgres = ["psycopg[binary]>=3", "dbt-postgres>=1.9"]
+postgres = ["psycopg[binary]>=3", "dbt-postgres>=1.9", "exmergo-dex-core[sql]"]
 # Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
 # transform can build against a Redshift dev schema with one install. boto3
 # rides alongside the driver: Serverless workgroup facts (endpoint, base
 # capacity) come from the control plane, and the driver mints IAM temporary
 # database credentials through the same chain.
-redshift = ["redshift-connector>=2.1", "boto3>=1.34", "dbt-redshift>=1.9"]
+redshift = [
+  "redshift-connector>=2.1",
+  "boto3>=1.34",
+  "dbt-redshift>=1.9",
+  "exmergo-dex-core[sql]",
+]
 # The local semantic-layer query backend (`explore semantic query --local`):
 # MetricFlow renders metric SQL via explain(), and dex executes it through its own
 # connector and cost guard. Just the metricflow library (not dbt-metricflow, whose
@@ -85,7 +106,7 @@ redshift = ["redshift-connector>=2.1", "boto3>=1.34", "dbt-redshift>=1.9"]
 # is the floor that resolves against a released dbt-semantic-interfaces (0.209 pins
 # a prerelease). `explore semantic list --local` is a pure manifest read-view and
 # needs none of this.
-semantic = ["metricflow>=0.211,<0.212"]
+semantic = ["metricflow>=0.211,<0.212", "exmergo-dex-core[sql]"]
 # The hosted dbt Cloud Semantic Layer backend (`explore semantic --api`): a thin
 # GraphQL client over httpx, nothing else. No warehouse client and no dbt-core:
 # dbt Cloud owns the warehouse connection and executes server-side, so a
@@ -107,9 +128,13 @@ cluster = ["scikit-learn>=1.4"]
 # capability. This is the heaviest install there is (six dbt adapters, MetricFlow,
 # and scikit-learn); the light default and the [duckdb] on-ramp are unchanged.
 all = [
-  "exmergo-dex-core[bigquery,cluster,databricks,duckdb,postgres,redshift,semantic,semantic-api,snowflake]",
+  "exmergo-dex-core[bigquery,cluster,databricks,duckdb,postgres,redshift,semantic,semantic-api,snowflake,sql]",
 ]
-dev = ["pytest>=8", "ruff==0.15.19", "scikit-learn>=1.4"]
+# Contributor tooling, plus the optional libraries the suite exercises directly
+# (the clustering tests need scikit-learn, the firewall tests need the dialect
+# engine), so `uv sync --extra dev` runs the whole suite without also picking a
+# connector.
+dev = ["pytest>=8", "ruff==0.15.19", "scikit-learn>=1.4", "exmergo-dex-core[sql]"]
 
 [project.urls]
 Homepage = "https://www.exmergo.com/dex"

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -99,11 +99,16 @@ semantic-api = ["httpx>=0.27"]
 # when it sees an `explore cluster` invocation. Connector-agnostic (clustering
 # runs on the feature sample in-process, whatever warehouse it came from).
 cluster = ["scikit-learn>=1.4"]
-# One command for users who want every connector at once (e.g. driving multiple
-# warehouses). Self-references the connector extras so their client lists stay
-# defined in exactly one place. Excludes dev, which is contributor tooling, not a
-# connector. The light default and the [duckdb] on-ramp are unchanged.
-all = ["exmergo-dex-core[bigquery,databricks,duckdb,postgres,redshift,snowflake]"]
+# One command for users who want every optional capability at once: every
+# connector, both semantic-layer backends, and clustering. Self-references the
+# other extras so their requirement lists stay defined in exactly one place, which
+# does mean this reference list is the part that rots, so a test asserts it covers
+# every extra. Excludes only dev, which is contributor tooling rather than a
+# capability. This is the heaviest install there is (six dbt adapters, MetricFlow,
+# and scikit-learn); the light default and the [duckdb] on-ramp are unchanged.
+all = [
+  "exmergo-dex-core[bigquery,cluster,databricks,duckdb,postgres,redshift,semantic,semantic-api,snowflake]",
+]
 dev = ["pytest>=8", "ruff==0.15.19", "scikit-learn>=1.4"]
 
 [project.urls]

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -22,46 +22,62 @@ keywords = [
   "agent",
 ]
 
-# Base dependencies are connector-agnostic: the canonical model (pydantic) and
-# config parsing (pyyaml). Connector client libraries live behind the extras
-# below, so the zero-credential DuckDB on-ramp never pulls the cloud client stack.
+# Base dependencies are connector-agnostic: the canonical model (pydantic),
+# config parsing (pyyaml), and the dialect engine (sqlglot). Connector client
+# libraries live behind the extras below, so the zero-credential DuckDB on-ramp
+# never pulls the cloud client stack.
+#
+# sqlglot is base, not per-connector, because the guards are cross-cutting: the
+# query firewall and the SELECT-only assertion parse SQL on every guarded surface,
+# and they are imported eagerly by design (a safety check that loads lazily is one
+# that can be missing when it matters). It used to be duplicated across every
+# connector extra, which made a sqlglot-free install (`[semantic-api]`, `[cluster]`,
+# or a bare install running the read-only `explore semantic list --local`) fail on
+# an import the metadata never declared.
+#
+# The floor is 28.6 because the firewall's unnest allowlist references sqlglot
+# expression classes at module scope, and `exp.JSONKeys` (Snowflake/Databricks/
+# DuckDB key enumeration) first exists there. Bump this floor whenever a newly
+# referenced expression class raises the real minimum, or the failure lands on the
+# user as an AttributeError at import.
 dependencies = [
   "pydantic>=2",
   "pyyaml>=6",
+  "sqlglot>=28.6",
 ]
 
 [project.scripts]
 dex = "exmergo_dex_core.cli:main"
 
 [project.optional-dependencies]
-# The DuckDB on-ramp and the full local ETM loop: the duckdb client, the dialect
-# engine, and dbt-duckdb (which pulls dbt-core). All three skills install this one
+# The DuckDB on-ramp and the full local ETM loop: the duckdb client and
+# dbt-duckdb (which pulls dbt-core). All three skills install this one
 # extra, and transform/maintain author and build a dbt project against a DuckDB
 # dev target, so dbt-duckdb belongs here. (This makes the on-ramp heavier than a
 # pure explore-only install would need; a separate lighter explore extra can be
 # split out later if that tradeoff matters.)
-duckdb = ["duckdb>=1", "sqlglot>=25", "dbt-duckdb>=1.9"]
+duckdb = ["duckdb>=1", "dbt-duckdb>=1.9"]
 # 3.17 is the floor for workload-identity auth (the keyless CI path). Like
 # [duckdb], the extra carries the dbt adapter so transform can build against a
 # Snowflake dev target with one install.
-snowflake = ["snowflake-connector-python>=3.17", "sqlglot>=25", "dbt-snowflake>=1.9"]
+snowflake = ["snowflake-connector-python>=3.17", "dbt-snowflake>=1.9"]
 # Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
 # transform can build against a BigQuery dev target with one install.
-bigquery = ["google-cloud-bigquery>=3", "sqlglot>=25", "dbt-bigquery>=1.9"]
+bigquery = ["google-cloud-bigquery>=3", "dbt-bigquery>=1.9"]
 # Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
 # transform can build against a Databricks dev target with one install. The SDK
 # rides alongside the SQL driver: free Unity Catalog metadata and warehouse facts
 # come from the REST API, so nothing billable is touched until a statement runs.
-databricks = ["databricks-sql-connector>=3", "databricks-sdk>=0.30", "sqlglot>=25", "dbt-databricks>=1.9"]
+databricks = ["databricks-sql-connector>=3", "databricks-sdk>=0.30", "dbt-databricks>=1.9"]
 # Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
 # transform can build against a Postgres dev schema with one install.
-postgres = ["psycopg[binary]>=3", "sqlglot>=25", "dbt-postgres>=1.9"]
+postgres = ["psycopg[binary]>=3", "dbt-postgres>=1.9"]
 # Like [duckdb], the extra carries the dbt adapter (which pulls dbt-core) so
 # transform can build against a Redshift dev schema with one install. boto3
 # rides alongside the driver: Serverless workgroup facts (endpoint, base
 # capacity) come from the control plane, and the driver mints IAM temporary
 # database credentials through the same chain.
-redshift = ["redshift-connector>=2.1", "boto3>=1.34", "sqlglot>=25", "dbt-redshift>=1.9"]
+redshift = ["redshift-connector>=2.1", "boto3>=1.34", "dbt-redshift>=1.9"]
 # The local semantic-layer query backend (`explore semantic query --local`):
 # MetricFlow renders metric SQL via explain(), and dex executes it through its own
 # connector and cost guard. Just the metricflow library (not dbt-metricflow, whose
@@ -69,7 +85,7 @@ redshift = ["redshift-connector>=2.1", "boto3>=1.34", "sqlglot>=25", "dbt-redshi
 # is the floor that resolves against a released dbt-semantic-interfaces (0.209 pins
 # a prerelease). `explore semantic list --local` is a pure manifest read-view and
 # needs none of this.
-semantic = ["metricflow>=0.211,<0.212", "sqlglot>=25"]
+semantic = ["metricflow>=0.211,<0.212"]
 # The hosted dbt Cloud Semantic Layer backend (`explore semantic --api`): a thin
 # GraphQL client over httpx, nothing else. No warehouse client and no dbt-core:
 # dbt Cloud owns the warehouse connection and executes server-side, so a

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -27,6 +27,8 @@ from . import command_args
 from . import envelope as env
 from .engine import DexEngine
 from .guards.cost_guard import ConfirmationRequiredError
+from .guards.dialect import DialectDependencyError
+from .guards.dialect import ensure_available as ensure_dialect_available
 from .results import BudgetExhaustedError
 
 # The full command surface. Group -> its subcommands.
@@ -219,14 +221,18 @@ def _build_parser() -> argparse.ArgumentParser:
 def dispatch(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     """Route one parsed command to its handler and return exactly one envelope.
 
-    Total by construction: the two refusals the engine raises rather than returns
-    (an unmet confirmation, a mid-run budget exhaustion) are transport concerns
-    at this boundary and become envelopes here, so no handler has to know about
-    them and every path out of dispatch is an envelope.
+    Total by construction: the refusals the engine raises rather than returns (an
+    unmet confirmation, a mid-run budget exhaustion, an install that cannot parse
+    SQL) are transport concerns at this boundary and become envelopes here, so no
+    handler has to know about them and every path out of dispatch is an envelope.
     """
 
     try:
         return _run(args, engine)
+    except DialectDependencyError as exc:
+        # A missing extra, caught before the command imported anything that needed
+        # it, so nothing has been opened or priced. The message names the install.
+        return env.error(str(exc))
     except ConfirmationRequiredError as exc:
         return env.needs_confirmation(
             exc.request.data, cost=exc.request.cost, warnings=exc.request.warnings
@@ -246,6 +252,19 @@ def _run(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
         return to_envelope(engine.connect_test())
 
     if args.group == "explore":
+        # `explore semantic` is routed before the rest of the group and from a
+        # different module on purpose: on the hosted backend dbt Cloud renders and
+        # executes the SQL, so the command needs no dialect engine, and a
+        # pure-remote install ([semantic-api], no connector) must be able to reach
+        # it. Importing the module below would pull the query firewall and defeat
+        # that. `--local` lands here too: `list` is a manifest read-view, and a
+        # local `query` reaches the dialect engine through MetricFlow's own path.
+        if args.subcommand == "semantic":
+            from .explore.semantic.commands import cmd_semantic
+
+            return cmd_semantic(args, engine)
+
+        ensure_dialect_available()
         from .explore import commands as explore_cmds
 
         handlers = {
@@ -255,11 +274,11 @@ def _run(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
             "map": explore_cmds.cmd_map,
             "query": explore_cmds.cmd_query,
             "cluster": explore_cmds.cmd_cluster,
-            "semantic": explore_cmds.cmd_semantic,
         }
         return handlers[args.subcommand](args, engine)
 
     if args.group == "maintain":
+        ensure_dialect_available()
         from .maintain import commands as maintain_cmds
 
         handlers = {
@@ -293,6 +312,7 @@ def _run(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     }
     handler = authoring.get((args.group, args.subcommand))
     if handler is not None:
+        ensure_dialect_available()
         from .transform import commands as transform_cmds
 
         return getattr(transform_cmds, handler)(args, engine)

--- a/packages/dex-core/src/exmergo_dex_core/engine.py
+++ b/packages/dex-core/src/exmergo_dex_core/engine.py
@@ -387,12 +387,18 @@ class DexEngine:
 
         return explore.cluster(self, obj, features=features, k=k)
 
+    # The two semantic methods import from `explore.semantic.commands`, not from
+    # `explore.commands`: on the hosted backend dbt Cloud renders and executes the
+    # SQL, so this is the one guarded surface that needs no dialect engine and no
+    # warehouse client. Together with a `SemanticSource`, that is what lets a host
+    # serve metric queries with nothing on the filesystem and only [semantic-api]
+    # installed. Reaching through the heavier module would quietly require both.
     def semantic_list(
         self, *, api: bool = False, local: bool = False
     ) -> SemanticListResult:
-        from .explore import commands as explore
+        from .explore.semantic import commands as semantic_cmds
 
-        return explore.semantic_list(self, api=api, local=local)
+        return semantic_cmds.semantic_list(self, api=api, local=local)
 
     def semantic_query(
         self,
@@ -405,9 +411,9 @@ class DexEngine:
         api: bool = False,
         local: bool = False,
     ) -> SemanticQueryResult:
-        from .explore import commands as explore
+        from .explore.semantic import commands as semantic_cmds
 
-        return explore.semantic_query(
+        return semantic_cmds.semantic_query(
             self,
             list(metrics),
             group_by=group_by,

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -70,8 +70,6 @@ from .results import (
     QueryResult,
     RankedObject,
     RelationshipsResult,
-    SemanticListResult,
-    SemanticQueryResult,
 )
 
 if TYPE_CHECKING:
@@ -726,87 +724,6 @@ def cmd_query(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
         return to_envelope(query(engine, args.sql))
     except QueryRefusedError as exc:
         return env.error(f"query refused: {exc}")
-
-
-def semantic_list(engine: DexEngine, *, api: bool = False, local: bool = False):
-    """The metrics, dimensions, and entities the semantic layer exposes."""
-
-    from .semantic import resolve_backend
-
-    backend = resolve_backend(engine, api=api, local=local)
-    catalog = backend.list_definitions()
-    return SemanticListResult(catalog=catalog, notes=list(catalog.notes))
-
-
-def semantic_query(
-    engine: DexEngine,
-    metrics: list[str],
-    *,
-    group_by: list[str] | None = None,
-    where: list[str] | None = None,
-    order_by: list[str] | None = None,
-    grain: str | None = None,
-    limit: int | None = None,
-    api: bool = False,
-    local: bool = False,
-) -> SemanticQueryResult:
-    """Run one governed metric query against the dbt semantic layer.
-
-    Which backend answers decides who governs spend: local renders the metric
-    SQL and executes it under dex's cost guard, while dbt Cloud executes
-    server-side where that guard is structurally unavailable.
-    """
-
-    from .semantic import SemanticBackendError, SemanticQuery, resolve_backend
-
-    if not metrics:
-        raise SemanticBackendError(
-            "a metric query needs at least one metric (discover them with "
-            "`explore semantic list`)"
-        )
-    backend = resolve_backend(engine, api=api, local=local)
-    return backend.query(
-        SemanticQuery(
-            metrics=metrics,
-            group_by=group_by or [],
-            where=where or [],
-            order_by=order_by or [],
-            grain=grain,
-            limit=limit,
-        )
-    )
-
-
-def cmd_semantic(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
-    """`explore semantic list|query`: discover and query the dbt semantic layer.
-
-    Backend resolution and the two guard postures live in the
-    ``explore.semantic`` package; this shim resolves the mode and turns any
-    backend refusal into a clean envelope rather than a stack trace.
-    """
-
-    from .semantic import SemanticBackendError
-
-    api = bool(getattr(args, "api", False))
-    local = bool(getattr(args, "local", False))
-    try:
-        if getattr(args, "mode", None) == "list":
-            return to_envelope(semantic_list(engine, api=api, local=local))
-        return to_envelope(
-            semantic_query(
-                engine,
-                getattr(args, "metric", None) or [],
-                group_by=getattr(args, "group_by", None),
-                where=getattr(args, "where", None),
-                order_by=getattr(args, "order_by", None),
-                grain=getattr(args, "grain", None),
-                limit=getattr(args, "limit", None),
-                api=api,
-                local=local,
-            )
-        )
-    except SemanticBackendError as exc:
-        return env.error(str(exc))
 
 
 def map(

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/__init__.py
@@ -28,7 +28,9 @@ from typing import Any, Protocol
 
 # The confidence at or above which a name-detected PII category refuses a query,
 # shared with the query firewall so the two surfaces block at the same threshold.
-from ...guards.query_firewall import PII_BLOCK_CONFIDENCE
+# Imported from the guards package, not from the firewall: this package must stay
+# importable without a dialect engine, because the hosted backend parses no SQL.
+from ...guards import PII_BLOCK_CONFIDENCE
 from ..profile import detect_pii
 
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/commands.py
@@ -1,0 +1,109 @@
+"""The `explore semantic` command surface, kept apart from the rest of explore.
+
+Every other explore command parses SQL, so `explore/commands.py` imports the query
+firewall and the clustering module and cannot be imported without the dialect
+engine. The semantic subcommand needs neither on the hosted backend: dbt Cloud
+renders and executes the query, and dex governs the request by dimension name and
+the response by capping it.
+
+So these three handlers live here rather than there, and the CLI routes to them
+without touching the heavier module. That is what lets `[semantic-api]` be the
+whole install for a deployment with no local project and no warehouse client, and
+what keeps `explore semantic list --local` (a pure manifest read-view) working on
+an install that picked no connector extra. The chain from here stays free of the
+dialect engine, so adding an import that needs it here silently undoes that: the
+packaging suite installs `[semantic-api]` alone and asserts sqlglot is absent.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+
+from ... import envelope as env
+from ...results import to_envelope
+from ..results import SemanticListResult, SemanticQueryResult
+
+if TYPE_CHECKING:
+    from ...engine import DexEngine
+
+
+def semantic_list(engine: DexEngine, *, api: bool = False, local: bool = False):
+    """The metrics, dimensions, and entities the semantic layer exposes."""
+
+    from . import resolve_backend
+
+    backend = resolve_backend(engine, api=api, local=local)
+    catalog = backend.list_definitions()
+    return SemanticListResult(catalog=catalog, notes=list(catalog.notes))
+
+
+def semantic_query(
+    engine: DexEngine,
+    metrics: list[str],
+    *,
+    group_by: list[str] | None = None,
+    where: list[str] | None = None,
+    order_by: list[str] | None = None,
+    grain: str | None = None,
+    limit: int | None = None,
+    api: bool = False,
+    local: bool = False,
+) -> SemanticQueryResult:
+    """Run one governed metric query against the dbt semantic layer.
+
+    Which backend answers decides who governs spend: local renders the metric
+    SQL and executes it under dex's cost guard, while dbt Cloud executes
+    server-side where that guard is structurally unavailable.
+    """
+
+    from . import SemanticBackendError, SemanticQuery, resolve_backend
+
+    if not metrics:
+        raise SemanticBackendError(
+            "a metric query needs at least one metric (discover them with "
+            "`explore semantic list`)"
+        )
+    backend = resolve_backend(engine, api=api, local=local)
+    return backend.query(
+        SemanticQuery(
+            metrics=metrics,
+            group_by=group_by or [],
+            where=where or [],
+            order_by=order_by or [],
+            grain=grain,
+            limit=limit,
+        )
+    )
+
+
+def cmd_semantic(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
+    """`explore semantic list|query`: discover and query the dbt semantic layer.
+
+    Backend resolution and the two guard postures live in the
+    ``explore.semantic`` package; this shim resolves the mode and turns any
+    backend refusal into a clean envelope rather than a stack trace.
+    """
+
+    from . import SemanticBackendError
+
+    api = bool(getattr(args, "api", False))
+    local = bool(getattr(args, "local", False))
+    try:
+        if getattr(args, "mode", None) == "list":
+            return to_envelope(semantic_list(engine, api=api, local=local))
+        return to_envelope(
+            semantic_query(
+                engine,
+                getattr(args, "metric", None) or [],
+                group_by=getattr(args, "group_by", None),
+                where=getattr(args, "where", None),
+                order_by=getattr(args, "order_by", None),
+                grain=getattr(args, "grain", None),
+                limit=getattr(args, "limit", None),
+                api=api,
+                local=local,
+            )
+        )
+    except SemanticBackendError as exc:
+        return env.error(str(exc))

--- a/packages/dex-core/src/exmergo_dex_core/guards/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/__init__.py
@@ -3,6 +3,22 @@
 These enforce hard constraints the rest of the engine leans on (read-only against
 data, cost surfaced before spend), independent of any single connector or
 capability.
+
+This module holds the guards' shared policy and nothing else, so it must stay
+importable with no dialect engine and no warehouse client present. Surfaces that
+govern without parsing SQL depend on that: the hosted semantic layer screens PII
+by dimension name and never sees a statement, so it reads the threshold below
+without paying for a SQL parser it has no use for.
 """
 
 from __future__ import annotations
+
+# A flag at or above this confidence blocks projection; below it, the query runs
+# and the envelope carries a warning naming the column, category, and number.
+# Hard-coded engine policy, uniform across categories: a configurable threshold
+# would let a one-line config edit quietly widen the PII boundary. At today's base
+# confidences everything blocks; only evidence-de-rated flags fall below.
+#
+# It lives here rather than in the query firewall because it is policy shared by
+# every surface that gates on PII, and two of those surfaces parse no SQL at all.
+PII_BLOCK_CONFIDENCE = 0.5

--- a/packages/dex-core/src/exmergo_dex_core/guards/dialect.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/dialect.py
@@ -1,0 +1,46 @@
+"""Whether the dialect engine is installed, asked before it is needed.
+
+sqlglot backs every guard that parses SQL, and it ships with the connector extras
+rather than in the base install: a deployment that only queries a hosted semantic
+layer over HTTP never sees a statement, so it should not have to carry a SQL
+parser to get one metric. That makes "this install cannot guard SQL" a real state,
+and a guarded command has to be able to say so cleanly instead of dying on an
+import from a frame the caller did not write.
+
+This module must stay importable with sqlglot absent, which is the entire reason
+it is separate from the guards that use it.
+"""
+
+from __future__ import annotations
+
+
+class DialectDependencyError(Exception):
+    """The dialect engine (sqlglot, carried by every connector extra) is missing.
+
+    Surfaced as a clean error envelope naming the install to fix, never as a
+    fallback to a weaker check: a query dex cannot parse is a query dex cannot
+    promise is read-only, so the only safe answer is to refuse.
+    """
+
+
+def ensure_available() -> None:
+    """Raise :class:`DialectDependencyError` if the dialect engine is missing.
+
+    Call this before importing the modules that parse SQL, so the failure names
+    the fix. Mirrors :func:`exmergo_dex_core.explore.cluster.ensure_available` for
+    scikit-learn, and like it runs before any connection is opened or any query is
+    priced, so a missing extra costs nothing: no warehouse round-trip, no spend.
+    """
+
+    try:
+        import sqlglot  # noqa: F401  (imported for availability, not for use)
+    except ImportError as exc:
+        raise DialectDependencyError(
+            "this command validates SQL before it runs, which needs sqlglot. It "
+            "ships with every connector extra, so reinstall the engine with the "
+            "connector you use: exmergo-dex-core[duckdb] for the local on-ramp, or "
+            "[snowflake], [bigquery], [databricks], [postgres], [redshift]. Only "
+            "the hosted semantic layer (`explore semantic --api`, the "
+            "[semantic-api] extra) runs without it, because dbt Cloud renders and "
+            "executes that SQL rather than dex."
+        ) from exc

--- a/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
@@ -47,6 +47,7 @@ from sqlglot import expressions as exp
 
 from ..cache import CACHE_SCHEMA_VERSION, Dataset, DexCache, match_identifier
 from ..config import QueryLimits
+from . import PII_BLOCK_CONFIDENCE
 from .sql_guard import NotSelectOnlyError, assert_select_only
 
 
@@ -54,14 +55,6 @@ class QueryRefusedError(Exception):
     """Raised when a query violates the firewall policy. The message always
     names the offending construct and the fix, so a refusal costs the agent one
     rewrite, not a debugging session."""
-
-
-# A flag at or above this confidence blocks projection; below it, the query runs
-# and the envelope carries a warning naming the column, category, and number.
-# Hard-coded engine policy, uniform across categories: a configurable threshold
-# would let a one-line config edit quietly widen the PII boundary. At today's
-# base confidences everything blocks; only evidence-de-rated flags fall below.
-PII_BLOCK_CONFIDENCE = 0.5
 
 
 @dataclass(frozen=True)

--- a/packages/dex-core/tests/guards/test_dialect.py
+++ b/packages/dex-core/tests/guards/test_dialect.py
@@ -1,0 +1,94 @@
+"""The dialect-engine availability guard.
+
+sqlglot ships with the connector extras rather than the base install, because the
+hosted semantic layer parses no SQL and should not have to carry a parser. That
+makes "this install cannot validate SQL" a reachable state, and these assert it is
+reached the way it should be: refused, before any warehouse work, with the install
+to run named, and without gating the one surface that genuinely does not need it.
+
+Forced with monkeypatch rather than gated on what happens to be installed, so they
+run in every environment including the dev one where sqlglot is always present.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from exmergo_dex_core import cli
+from exmergo_dex_core.guards import dialect
+
+
+def test_a_missing_dialect_engine_names_the_install_not_the_module(monkeypatch):
+    # Importing a module whose sys.modules entry is None raises ImportError, which
+    # is how an absent sqlglot is simulated without uninstalling anything.
+    monkeypatch.setitem(sys.modules, "sqlglot", None)
+
+    with pytest.raises(dialect.DialectDependencyError) as caught:
+        dialect.ensure_available()
+
+    message = str(caught.value)
+    # The failure a consumer actually hit read `No module named 'sqlglot'`, which
+    # looks like a broken environment rather than a missing extra. The message has
+    # to name the fix, and the hosted alternative for a deployment that wants one.
+    assert "sqlglot" in message
+    assert "exmergo-dex-core[duckdb]" in message
+    assert "[semantic-api]" in message
+    assert "No module named" not in message
+
+
+def test_the_engine_is_available_in_a_normal_install():
+    # The other side of the guard: it must not refuse when the extra is present, or
+    # every guarded command breaks at once.
+    dialect.ensure_available()
+
+
+def test_a_guarded_command_refuses_before_any_warehouse_work(monkeypatch, capsys):
+    """The refusal is an envelope, and it arrives before a connection is opened.
+
+    `explore inventory` is given no target at all: if the guard ran late, the
+    failure would be about the missing connection instead, which is how a
+    late-checked dependency announces itself.
+    """
+
+    def _boom() -> None:
+        raise dialect.DialectDependencyError("the dialect engine is not installed")
+
+    monkeypatch.setattr(cli, "ensure_dialect_available", _boom)
+
+    assert cli.main(["explore", "inventory"]) == 1
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1, "exactly one line on stdout"
+    payload = json.loads(out)
+    assert payload["status"] == "error"
+    assert "dialect engine" in payload["errors"][0]
+
+
+@pytest.mark.parametrize("backend_flag", ["--api", "--local"])
+def test_the_semantic_subcommand_is_not_gated_on_the_dialect_engine(
+    backend_flag, monkeypatch, capsys
+):
+    """`explore semantic` must reach its backend without the guard.
+
+    The hosted backend sends the query to dbt Cloud, which renders and executes it,
+    so dex has no statement to validate and a pure-remote install has no parser to
+    validate it with. `--local` is here too: `list` is a manifest read-view, and a
+    local `query` reaches the dialect engine through MetricFlow's own path, not
+    through this gate.
+
+    If someone later routes this subcommand through the guard, or back through the
+    heavier explore command module, this fails: the envelope stops being about the
+    backend and starts being about the missing engine.
+    """
+
+    def _boom() -> None:  # pragma: no cover - must never be called on this route
+        raise dialect.DialectDependencyError("the dialect engine is not installed")
+
+    monkeypatch.setattr(cli, "ensure_dialect_available", _boom)
+
+    cli.main(["explore", "semantic", backend_flag, "--repo-root", "missing-dex-dir"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "error"
+    assert "dialect engine" not in payload["errors"][0], payload["errors"]

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -51,24 +51,37 @@ def wheel(tmp_path_factory: pytest.TempPathFactory) -> str:
     return str(built[0])
 
 
-def _run_isolated(wheel: str, code: str, *extras: str) -> subprocess.CompletedProcess:
+def _run_isolated(
+    wheel: str,
+    code: str,
+    *,
+    extras: list[str] | None = None,
+    pins: list[str] | None = None,
+) -> subprocess.CompletedProcess:
     """Run ``code`` against the built wheel in a fresh environment.
 
     ``--isolated --no-project`` keeps the repo's own virtualenv, lockfile, and
     settings out of it, so what runs is the wheel and its declared dependencies
     and nothing else. That isolation is the whole point: without it the dev
     environment would satisfy imports the wheel never declared.
+
+    ``pins`` adds extra requirements to the resolve, which is how a test can hold
+    a declared dependency at its floor instead of taking whatever the resolver
+    would otherwise pick (always the newest release, so always the version least
+    likely to expose a stale lower bound).
     """
 
     spec = f"exmergo-dex-core[{','.join(extras)}] @ {wheel}" if extras else wheel
+    withs = [
+        arg for requirement in [spec, *(pins or [])] for arg in ("--with", requirement)
+    ]
     return subprocess.run(  # noqa: S603  (a fixed argv, no shell)
         [
             _uv(),
             "run",
             "--isolated",
             "--no-project",
-            "--with",
-            spec,
+            *withs,
             "python",
             "-c",
             code,
@@ -79,10 +92,32 @@ def _run_isolated(wheel: str, code: str, *extras: str) -> subprocess.CompletedPr
     )
 
 
+def _project_metadata() -> dict:
+    """The `[project]` table as declared, so a test asserts against the numbers and
+    names the wheel actually ships rather than copies that can drift from them."""
+
+    import tomllib
+
+    parsed = tomllib.loads(
+        (PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    return parsed["project"]
+
+
+def _declared_sqlglot_floor() -> str:
+    """The `sqlglot>=X` floor the package metadata declares."""
+
+    pins = [d for d in _project_metadata()["dependencies"] if d.startswith("sqlglot")]
+    assert len(pins) == 1, f"expected exactly one base sqlglot pin, got {pins}"
+    floor = pins[0].removeprefix("sqlglot>=")
+    assert floor != pins[0], f"expected a >= floor, got {pins[0]}"
+    return floor
+
+
 def test_a_bare_install_imports_and_exposes_the_api(wheel: str):
-    """No extras at all. The connector clients and the dialect engine live
-    behind extras, so an `__init__` that imported them eagerly would fail here
-    while every other test in this suite passed."""
+    """No extras at all. The connector clients live behind extras, so an
+    `__init__` that imported them eagerly would fail here while every other test
+    in this suite passed."""
 
     done = _run_isolated(
         wheel,
@@ -113,6 +148,121 @@ def test_importing_the_package_pulls_in_no_connector_client(wheel: str):
     assert done.stdout.strip() == "[]"
 
 
+def test_the_guards_import_with_no_extras_at_all(wheel: str):
+    """The guards parse SQL and are imported eagerly, so the dialect engine is a
+    base dependency, not a per-connector one.
+
+    While sqlglot was duplicated across the connector extras, every install that
+    picked no connector (`[semantic-api]`, `[cluster]`, or a bare install running
+    the read-only `explore semantic list --local`) died on an import the metadata
+    never declared. The failure was invisible because the CLI catches it and
+    reports `No module named 'sqlglot'` in an error envelope, which reads like a
+    broken environment rather than a packaging bug.
+    """
+
+    done = _run_isolated(
+        wheel,
+        "from exmergo_dex_core.guards import query_firewall, sql_guard;"
+        "import exmergo_dex_core.explore.commands;"
+        "import exmergo_dex_core.explore.semantic;"
+        "print(query_firewall.PII_BLOCK_CONFIDENCE, sql_guard.__name__)",
+    )
+    assert done.returncode == 0, done.stderr
+    assert "0.5" in done.stdout
+
+
+def test_the_declared_sqlglot_floor_is_high_enough_for_the_guards(wheel: str):
+    """Installed at exactly the declared floor, the guards must import.
+
+    The firewall's unnest allowlist names sqlglot expression classes at module
+    scope, so a floor below the release that introduced one of them turns into an
+    `AttributeError` on import for any user whose resolver picks an older sqlglot.
+    A `>=` bound that the code has outgrown is the same bug as an undeclared
+    dependency, and neither shows up when tests run against the newest release.
+    """
+
+    done = _run_isolated(
+        wheel,
+        "import sqlglot;"
+        "from exmergo_dex_core.guards import query_firewall, sql_guard;"
+        "import exmergo_dex_core.explore.commands, exmergo_dex_core.maintain.drift;"
+        "print(sqlglot.__version__)",
+        pins=[f"sqlglot=={_declared_sqlglot_floor()}"],
+    )
+    assert done.returncode == 0, done.stderr
+    assert done.stdout.strip().startswith(_declared_sqlglot_floor())
+
+
+def test_the_hosted_semantic_backend_needs_only_its_own_extra(wheel: str):
+    """`[semantic-api]` is the whole install for a pure-remote user: dbt Cloud owns
+    the warehouse connection, so there is no local project, no connector client,
+    and no dbt-core. Reaching the CLI with only that extra has to end in a real
+    envelope (here: the missing coordinates it cannot invent), never an import
+    error for something the extra does not name."""
+
+    import json
+
+    done = _run_isolated(
+        wheel,
+        "from exmergo_dex_core.explore.semantic.hosted import HostedDbtCloudBackend;"
+        "print(HostedDbtCloudBackend.__name__)",
+        extras=["semantic-api"],
+    )
+    assert done.returncode == 0, done.stderr
+    assert "HostedDbtCloudBackend" in done.stdout
+
+    done = _run_isolated(
+        wheel,
+        "from exmergo_dex_core.cli import main;main(['explore', 'semantic', '--api'])",
+        extras=["semantic-api"],
+    )
+    envelope = json.loads(done.stdout)
+    assert envelope["status"] == "error", done.stdout
+    assert "environment id" in envelope["errors"][0]
+
+
+def test_the_all_extra_installs_every_optional_capability(wheel: str):
+    """`[all]` has to mean all of them, and they have to co-resolve.
+
+    Two failure modes, one test, because either one alone makes the promise false.
+    The extra self-references the others rather than restating their requirement
+    lists, which keeps each client list defined once but makes the reference list
+    the part that silently rots: an extra added later is simply absent from `[all]`
+    and nothing complains. It named only the six connectors for exactly that
+    reason, leaving both semantic backends and clustering out of an install
+    documented as everything. Then, because this is the only install that puts six
+    dbt adapters and MetricFlow in one environment, it is also the only place a
+    version conflict between them can surface at all.
+
+    `dev` is excluded deliberately: contributor tooling, not a capability.
+    """
+
+    extras = _project_metadata()["optional-dependencies"]
+    assert len(extras["all"]) == 1, f"[all] should be one self-reference: {extras}"
+    referenced = set(
+        extras["all"][0].removeprefix("exmergo-dex-core[").removesuffix("]").split(",")
+    )
+    assert referenced == set(extras) - {"all", "dev"}, (
+        f"[all] does not cover {sorted(set(extras) - {'all', 'dev'} - referenced)}"
+    )
+
+    # Every client the extras exist to deliver, plus each dbt adapter, since a
+    # co-resolution that installs but cannot import an adapter is still broken.
+    done = _run_isolated(
+        wheel,
+        "import duckdb, google.cloud.bigquery, snowflake.connector, psycopg;"
+        "import redshift_connector, databricks.sql, sklearn, httpx, metricflow;"
+        "import dbt.adapters.duckdb, dbt.adapters.bigquery, dbt.adapters.snowflake;"
+        "import dbt.adapters.postgres, dbt.adapters.redshift, dbt.adapters.databricks;"
+        "from exmergo_dex_core.explore.semantic.hosted import HostedDbtCloudBackend;"
+        "from exmergo_dex_core.explore.semantic.local import LocalMetricFlowBackend;"
+        "print('every capability imported')",
+        extras=["all"],
+    )
+    assert done.returncode == 0, done.stderr
+    assert "every capability imported" in done.stdout
+
+
 def test_the_quickstart_example_runs_against_the_installed_package(wheel: str):
     """The documented example, run as a consumer runs it.
 
@@ -121,7 +271,9 @@ def test_the_quickstart_example_runs_against_the_installed_package(wheel: str):
     publish fails here.
     """
 
-    done = _run_isolated(wheel, QUICKSTART.read_text(encoding="utf-8"), "duckdb")
+    done = _run_isolated(
+        wheel, QUICKSTART.read_text(encoding="utf-8"), extras=["duckdb"]
+    )
     assert done.returncode == 0, done.stderr
 
     out = done.stdout

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -105,12 +105,22 @@ def _project_metadata() -> dict:
 
 
 def _declared_sqlglot_floor() -> str:
-    """The `sqlglot>=X` floor the package metadata declares."""
+    """The floor from the one place sqlglot is pinned, the `[sql]` extra.
 
-    pins = [d for d in _project_metadata()["dependencies"] if d.startswith("sqlglot")]
-    assert len(pins) == 1, f"expected exactly one base sqlglot pin, got {pins}"
-    floor = pins[0].removeprefix("sqlglot>=")
-    assert floor != pins[0], f"expected a >= floor, got {pins[0]}"
+    Also asserts the pin is bounded at both ends. The ceiling is not decoration:
+    the firewall matches sqlglot expression classes by name at module scope, so an
+    open upper bound means a future major can break every new install on something
+    no test here could have seen. If this assertion ever fails, read the `[sql]`
+    comment in pyproject.toml before deleting it.
+    """
+
+    extras = _project_metadata()["optional-dependencies"]
+    pins = [d for d in extras["sql"] if d.startswith("sqlglot")]
+    assert len(pins) == 1, f"expected exactly one sqlglot pin in [sql], got {pins}"
+    floor, _, ceiling = pins[0].removeprefix("sqlglot>=").partition(",")
+    assert floor and ceiling.startswith("<"), (
+        f"expected a floor and a ceiling, got {pins[0]}"
+    )
     return floor
 
 
@@ -148,27 +158,42 @@ def test_importing_the_package_pulls_in_no_connector_client(wheel: str):
     assert done.stdout.strip() == "[]"
 
 
-def test_the_guards_import_with_no_extras_at_all(wheel: str):
-    """The guards parse SQL and are imported eagerly, so the dialect engine is a
-    base dependency, not a per-connector one.
+def test_an_install_that_cannot_parse_sql_refuses_and_names_the_fix(wheel: str):
+    """A guarded command on an install with no connector extra must refuse with the
+    install to run, not die on an import.
 
-    While sqlglot was duplicated across the connector extras, every install that
-    picked no connector (`[semantic-api]`, `[cluster]`, or a bare install running
-    the read-only `explore semantic list --local`) died on an import the metadata
-    never declared. The failure was invisible because the CLI catches it and
-    reports `No module named 'sqlglot'` in an error envelope, which reads like a
-    broken environment rather than a packaging bug.
+    Absent the dialect engine dex cannot promise a query is read-only, so refusing
+    is the only safe answer and there is deliberately no weaker fallback. What is
+    tested here is that the refusal is *usable*: the earlier failure surfaced as
+    `No module named 'sqlglot'` inside an error envelope, which reads as a broken
+    environment rather than a missing extra, and cost a consumer a day of
+    diagnosis. The message has to name the extra instead.
     """
 
+    import json
+
+    done = _run_isolated(
+        wheel, "from exmergo_dex_core.cli import main;main(['explore', 'inventory'])"
+    )
+    envelope = json.loads(done.stdout)
+    assert envelope["status"] == "error", done.stdout
+    message = envelope["errors"][0]
+    assert "sqlglot" in message and "exmergo-dex-core[duckdb]" in message, message
+    assert "No module named" not in message, (
+        f"the refusal must name the extra, not the missing module: {message}"
+    )
+
+    # And the guard is reached before anything is opened or priced, so asking is
+    # free: `ensure_available` must not need the thing whose absence it reports.
     done = _run_isolated(
         wheel,
-        "from exmergo_dex_core.guards import query_firewall, sql_guard;"
-        "import exmergo_dex_core.explore.commands;"
-        "import exmergo_dex_core.explore.semantic;"
-        "print(query_firewall.PII_BLOCK_CONFIDENCE, sql_guard.__name__)",
+        "from exmergo_dex_core.guards.dialect import ensure_available,"
+        " DialectDependencyError;"
+        "\ntry: ensure_available(); print('unexpectedly available')"
+        "\nexcept DialectDependencyError: print('refused cleanly')",
     )
     assert done.returncode == 0, done.stderr
-    assert "0.5" in done.stdout
+    assert "refused cleanly" in done.stdout
 
 
 def test_the_declared_sqlglot_floor_is_high_enough_for_the_guards(wheel: str):
@@ -179,6 +204,10 @@ def test_the_declared_sqlglot_floor_is_high_enough_for_the_guards(wheel: str):
     `AttributeError` on import for any user whose resolver picks an older sqlglot.
     A `>=` bound that the code has outgrown is the same bug as an undeclared
     dependency, and neither shows up when tests run against the newest release.
+
+    The companion risk, a *ceiling* the code has outgrown, cannot be tested here
+    because the breaking release does not exist yet. The `sqlglot-canary` CI job
+    covers that direction by running the guards against the newest sqlglot.
     """
 
     done = _run_isolated(
@@ -187,6 +216,7 @@ def test_the_declared_sqlglot_floor_is_high_enough_for_the_guards(wheel: str):
         "from exmergo_dex_core.guards import query_firewall, sql_guard;"
         "import exmergo_dex_core.explore.commands, exmergo_dex_core.maintain.drift;"
         "print(sqlglot.__version__)",
+        extras=["duckdb"],
         pins=[f"sqlglot=={_declared_sqlglot_floor()}"],
     )
     assert done.returncode == 0, done.stderr
@@ -195,22 +225,32 @@ def test_the_declared_sqlglot_floor_is_high_enough_for_the_guards(wheel: str):
 
 def test_the_hosted_semantic_backend_needs_only_its_own_extra(wheel: str):
     """`[semantic-api]` is the whole install for a pure-remote user: dbt Cloud owns
-    the warehouse connection, so there is no local project, no connector client,
-    and no dbt-core. Reaching the CLI with only that extra has to end in a real
-    envelope (here: the missing coordinates it cannot invent), never an import
-    error for something the extra does not name."""
+    the warehouse connection and executes server-side, so there is no local
+    project, no warehouse client, no dbt-core, and no SQL for dex to parse.
+
+    The first assertion is that sqlglot is genuinely absent. Without it the rest of
+    this test passes for the wrong reason the moment anything puts a dialect engine
+    back in this environment, which is exactly the regression that shipped once
+    already.
+    """
 
     import json
 
     done = _run_isolated(
         wheel,
         "from exmergo_dex_core.explore.semantic.hosted import HostedDbtCloudBackend;"
-        "print(HostedDbtCloudBackend.__name__)",
+        "\ntry: import sqlglot; raise SystemExit('sqlglot must not be installed here')"
+        "\nexcept ImportError: pass"
+        "\nprint(HostedDbtCloudBackend.__name__)",
         extras=["semantic-api"],
     )
     assert done.returncode == 0, done.stderr
     assert "HostedDbtCloudBackend" in done.stdout
 
+    # Both entry points, because they route differently: the CLI through its own
+    # dispatch, the library through DexEngine. Each must reach the backend and come
+    # back with the real refusal (coordinates it cannot invent), never an
+    # ImportError for something this extra does not name.
     done = _run_isolated(
         wheel,
         "from exmergo_dex_core.cli import main;main(['explore', 'semantic', '--api'])",
@@ -219,6 +259,18 @@ def test_the_hosted_semantic_backend_needs_only_its_own_extra(wheel: str):
     envelope = json.loads(done.stdout)
     assert envelope["status"] == "error", done.stdout
     assert "environment id" in envelope["errors"][0]
+
+    done = _run_isolated(
+        wheel,
+        "from exmergo_dex_core import DexEngine, DexConfig;"
+        "from exmergo_dex_core.explore.semantic import SemanticBackendError;"
+        "eng = DexEngine(config=DexConfig(connector='duckdb'));"
+        "\ntry: eng.semantic_list(api=True); print('unexpectedly succeeded')"
+        "\nexcept SemanticBackendError as exc: print('refused:', exc)",
+        extras=["semantic-api"],
+    )
+    assert done.returncode == 0, done.stderr
+    assert "environment id" in done.stdout, done.stdout
 
 
 def test_the_all_extra_installs_every_optional_capability(wheel: str):
@@ -252,6 +304,7 @@ def test_the_all_extra_installs_every_optional_capability(wheel: str):
         wheel,
         "import duckdb, google.cloud.bigquery, snowflake.connector, psycopg;"
         "import redshift_connector, databricks.sql, sklearn, httpx, metricflow;"
+        "import sqlglot;"
         "import dbt.adapters.duckdb, dbt.adapters.bigquery, dbt.adapters.snowflake;"
         "import dbt.adapters.postgres, dbt.adapters.redshift, dbt.adapters.databricks;"
         "from exmergo_dex_core.explore.semantic.hosted import HostedDbtCloudBackend;"
@@ -261,6 +314,30 @@ def test_the_all_extra_installs_every_optional_capability(wheel: str):
     )
     assert done.returncode == 0, done.stderr
     assert "every capability imported" in done.stdout
+
+
+def test_the_local_semantic_read_view_needs_no_connector_extra(wheel: str):
+    """`explore semantic list --local` is a read of the compiled manifest, so it is
+    documented as needing no extra, and it has to actually hold.
+
+    It shares a command module with the hosted backend for that reason. Reaching it
+    must produce the refusal that belongs to the missing *project* (there is no
+    manifest in a temp directory), not a refusal about a missing dialect engine or
+    connector client, which is what a shared module with the rest of explore would
+    have produced.
+    """
+
+    import json
+
+    done = _run_isolated(
+        wheel,
+        "from exmergo_dex_core.cli import main;"
+        "main(['explore', 'semantic', '--local'])",
+    )
+    envelope = json.loads(done.stdout)
+    assert envelope["status"] == "error", done.stdout
+    message = envelope["errors"][0]
+    assert "sqlglot" not in message and "No module named" not in message, message
 
 
 def test_the_quickstart_example_runs_against_the_installed_package(wheel: str):

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -142,6 +142,29 @@ def test_query_firewall_refuses_writes_pragmas_and_multistatement():
             inspect_query(bad, cache, QueryLimits())
 
 
+def test_an_install_that_cannot_validate_sql_refuses_rather_than_degrading():
+    # The dialect engine ships with the connector extras, not the base install, so
+    # an install that cannot parse SQL is reachable. The only safe answer is to
+    # refuse: a query dex cannot parse is a query it cannot promise is read-only,
+    # so there must be no weaker fallback path (a regex screen, a warn-and-run)
+    # that would let an unvalidated statement reach a warehouse. This pins the
+    # refusal itself; `tests/guards/test_dialect.py` covers the mechanics.
+    import sys
+
+    from exmergo_dex_core.guards import dialect
+
+    original = sys.modules.get("sqlglot")
+    sys.modules["sqlglot"] = None  # type: ignore[assignment]
+    try:
+        with pytest.raises(dialect.DialectDependencyError):
+            dialect.ensure_available()
+    finally:
+        if original is None:
+            del sys.modules["sqlglot"]
+        else:
+            sys.modules["sqlglot"] = original
+
+
 def test_prod_target_execution_is_refused():
     from exmergo_dex_core import transform
 
@@ -284,11 +307,25 @@ def test_firewall_block_threshold_is_a_hard_coded_engine_constant():
     # never be able to widen the PII boundary. Its value is load-bearing (every
     # base confidence in the detector sits at or above it, so nothing unblocks
     # without value-shape evidence), so the number itself is pinned here.
+    #
+    # It is asserted at the guards package, which is where the policy lives, and
+    # the firewall reads it from there. That indirection is what keeps the PII
+    # gate on a SQL-free surface (the hosted semantic layer screens dimension
+    # names) from dragging in a SQL parser: every gate still blocks at one number,
+    # but only the surfaces that actually parse SQL depend on the parser.
     from exmergo_dex_core.config import DexConfig
-    from exmergo_dex_core.guards.query_firewall import PII_BLOCK_CONFIDENCE
+    from exmergo_dex_core.guards import PII_BLOCK_CONFIDENCE
 
     assert PII_BLOCK_CONFIDENCE == 0.5
     assert not any("threshold" in name for name in DexConfig.model_fields)
+
+    # One threshold, not a copy per surface: the firewall and the semantic PII
+    # gate must read the same number, or they can drift apart silently.
+    from exmergo_dex_core.explore import semantic
+    from exmergo_dex_core.guards import query_firewall
+
+    assert query_firewall.PII_BLOCK_CONFIDENCE == PII_BLOCK_CONFIDENCE
+    assert semantic.PII_BLOCK_CONFIDENCE == PII_BLOCK_CONFIDENCE
 
 
 def test_firewall_threshold_boundary_and_warning_carry_no_values():

--- a/packages/dex-core/uv.lock
+++ b/packages/dex-core/uv.lock
@@ -778,7 +778,6 @@ source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
-    { name = "sqlglot" },
 ]
 
 [package.optional-dependencies]
@@ -800,10 +799,12 @@ all = [
     { name = "redshift-connector" },
     { name = "scikit-learn" },
     { name = "snowflake-connector-python" },
+    { name = "sqlglot" },
 ]
 bigquery = [
     { name = "dbt-bigquery" },
     { name = "google-cloud-bigquery" },
+    { name = "sqlglot" },
 ]
 cluster = [
     { name = "scikit-learn" },
@@ -812,27 +813,33 @@ databricks = [
     { name = "databricks-sdk" },
     { name = "databricks-sql-connector" },
     { name = "dbt-databricks" },
+    { name = "sqlglot" },
 ]
 dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "scikit-learn" },
+    { name = "sqlglot" },
 ]
 duckdb = [
     { name = "dbt-duckdb" },
     { name = "duckdb" },
+    { name = "sqlglot" },
 ]
 postgres = [
     { name = "dbt-postgres" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "sqlglot" },
 ]
 redshift = [
     { name = "boto3" },
     { name = "dbt-redshift" },
     { name = "redshift-connector" },
+    { name = "sqlglot" },
 ]
 semantic = [
     { name = "metricflow" },
+    { name = "sqlglot" },
 ]
 semantic-api = [
     { name = "httpx" },
@@ -840,6 +847,10 @@ semantic-api = [
 snowflake = [
     { name = "dbt-snowflake" },
     { name = "snowflake-connector-python" },
+    { name = "sqlglot" },
+]
+sql = [
+    { name = "sqlglot" },
 ]
 
 [package.metadata]
@@ -883,9 +894,18 @@ requires-dist = [
     { name = "scikit-learn", marker = "extra == 'dev'", specifier = ">=1.4" },
     { name = "snowflake-connector-python", marker = "extra == 'all'", specifier = ">=3.17" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.17" },
-    { name = "sqlglot", specifier = ">=28.6" },
+    { name = "sqlglot", marker = "extra == 'all'", specifier = ">=28.6,<31" },
+    { name = "sqlglot", marker = "extra == 'bigquery'", specifier = ">=28.6,<31" },
+    { name = "sqlglot", marker = "extra == 'databricks'", specifier = ">=28.6,<31" },
+    { name = "sqlglot", marker = "extra == 'dev'", specifier = ">=28.6,<31" },
+    { name = "sqlglot", marker = "extra == 'duckdb'", specifier = ">=28.6,<31" },
+    { name = "sqlglot", marker = "extra == 'postgres'", specifier = ">=28.6,<31" },
+    { name = "sqlglot", marker = "extra == 'redshift'", specifier = ">=28.6,<31" },
+    { name = "sqlglot", marker = "extra == 'semantic'", specifier = ">=28.6,<31" },
+    { name = "sqlglot", marker = "extra == 'snowflake'", specifier = ">=28.6,<31" },
+    { name = "sqlglot", marker = "extra == 'sql'", specifier = ">=28.6,<31" },
 ]
-provides-extras = ["all", "bigquery", "cluster", "databricks", "dev", "duckdb", "postgres", "redshift", "semantic", "semantic-api", "snowflake"]
+provides-extras = ["all", "bigquery", "cluster", "databricks", "dev", "duckdb", "postgres", "redshift", "semantic", "semantic-api", "snowflake", "sql"]
 
 [[package]]
 name = "fastjsonschema"

--- a/packages/dex-core/uv.lock
+++ b/packages/dex-core/uv.lock
@@ -778,6 +778,7 @@ source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "sqlglot" },
 ]
 
 [package.optional-dependencies]
@@ -793,15 +794,16 @@ all = [
     { name = "dbt-snowflake" },
     { name = "duckdb" },
     { name = "google-cloud-bigquery" },
+    { name = "httpx" },
+    { name = "metricflow" },
     { name = "psycopg", extra = ["binary"] },
     { name = "redshift-connector" },
+    { name = "scikit-learn" },
     { name = "snowflake-connector-python" },
-    { name = "sqlglot" },
 ]
 bigquery = [
     { name = "dbt-bigquery" },
     { name = "google-cloud-bigquery" },
-    { name = "sqlglot" },
 ]
 cluster = [
     { name = "scikit-learn" },
@@ -810,7 +812,6 @@ databricks = [
     { name = "databricks-sdk" },
     { name = "databricks-sql-connector" },
     { name = "dbt-databricks" },
-    { name = "sqlglot" },
 ]
 dev = [
     { name = "pytest" },
@@ -820,22 +821,18 @@ dev = [
 duckdb = [
     { name = "dbt-duckdb" },
     { name = "duckdb" },
-    { name = "sqlglot" },
 ]
 postgres = [
     { name = "dbt-postgres" },
     { name = "psycopg", extra = ["binary"] },
-    { name = "sqlglot" },
 ]
 redshift = [
     { name = "boto3" },
     { name = "dbt-redshift" },
     { name = "redshift-connector" },
-    { name = "sqlglot" },
 ]
 semantic = [
     { name = "metricflow" },
-    { name = "sqlglot" },
 ]
 semantic-api = [
     { name = "httpx" },
@@ -843,7 +840,6 @@ semantic-api = [
 snowflake = [
     { name = "dbt-snowflake" },
     { name = "snowflake-connector-python" },
-    { name = "sqlglot" },
 ]
 
 [package.metadata]
@@ -870,7 +866,9 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=1" },
     { name = "google-cloud-bigquery", marker = "extra == 'all'", specifier = ">=3" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3" },
+    { name = "httpx", marker = "extra == 'all'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'semantic-api'", specifier = ">=0.27" },
+    { name = "metricflow", marker = "extra == 'all'", specifier = ">=0.211,<0.212" },
     { name = "metricflow", marker = "extra == 'semantic'", specifier = ">=0.211,<0.212" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'all'", specifier = ">=3" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3" },
@@ -880,18 +878,12 @@ requires-dist = [
     { name = "redshift-connector", marker = "extra == 'all'", specifier = ">=2.1" },
     { name = "redshift-connector", marker = "extra == 'redshift'", specifier = ">=2.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.19" },
+    { name = "scikit-learn", marker = "extra == 'all'", specifier = ">=1.4" },
     { name = "scikit-learn", marker = "extra == 'cluster'", specifier = ">=1.4" },
     { name = "scikit-learn", marker = "extra == 'dev'", specifier = ">=1.4" },
     { name = "snowflake-connector-python", marker = "extra == 'all'", specifier = ">=3.17" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.17" },
-    { name = "sqlglot", marker = "extra == 'all'", specifier = ">=25" },
-    { name = "sqlglot", marker = "extra == 'bigquery'", specifier = ">=25" },
-    { name = "sqlglot", marker = "extra == 'databricks'", specifier = ">=25" },
-    { name = "sqlglot", marker = "extra == 'duckdb'", specifier = ">=25" },
-    { name = "sqlglot", marker = "extra == 'postgres'", specifier = ">=25" },
-    { name = "sqlglot", marker = "extra == 'redshift'", specifier = ">=25" },
-    { name = "sqlglot", marker = "extra == 'semantic'", specifier = ">=25" },
-    { name = "sqlglot", marker = "extra == 'snowflake'", specifier = ">=25" },
+    { name = "sqlglot", specifier = ">=28.6" },
 ]
 provides-extras = ["all", "bigquery", "cluster", "databricks", "dev", "duckdb", "postgres", "redshift", "semantic", "semantic-api", "snowflake"]
 

--- a/references/semantic-layer.md
+++ b/references/semantic-layer.md
@@ -76,7 +76,11 @@ an environment id, and a service token. dex talks to the dbt Cloud Semantic Laye
 GraphQL API (`createQuery` then poll then read the result). The token is
 discovered from `DBT_SL_TOKEN` (then `~/.dbt/dbt_cloud.yml`), held only for the
 `Authorization` header, and never written to config or an envelope. Needs the
-`[semantic-api]` extra (an httpx client, nothing heavier).
+`[semantic-api]` extra, which is an httpx client and nothing heavier: no warehouse
+client, no dbt-core, and no SQL parser, because dbt Cloud renders and executes the
+query and dex never sees a statement to validate. That makes this the one surface a
+pure-remote deployment can run on its own, and the packaging suite holds it to that
+by installing the extra alone and asserting the parser is absent.
 
 A library caller can supply the token instead of having it discovered, with
 `SemanticSource` on the engine. That matters for a process serving several end

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.4.0"
+DEX_CORE_VERSION = "1.4.1"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.4.0"
+DEX_CORE_VERSION = "1.4.1"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.4.0"
+DEX_CORE_VERSION = "1.4.1"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
## What this changes

Depency issues fixed:
- Fix SQLGlot dependency issue with [semantic-api] specifically, by removing erroneous SQLGlot import
- SQLGlot now its own dependency with canary testing in place in case major release breaks any dex internals
- [all] now properly imports all extra dependencies, not just extra connectors

## Related issues

Closes #147 
