### PR TITLE
docs are clarify explore query cells are row-major not columnar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`explore query` docs now say row-major, matching what `cells` actually
+  returns** ([#152]). The `explore` skill and command contract described
+  `query` results as columnar, but `cells` is a list of rows; a square-ish
+  result set could be silently misread with no error. Docs updated to say
+  row-major across `explore query` and `explore semantic query`; no behavior
+  change.
+
 ## [1.4.1] - 2026-07-26
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -1304,7 +1304,7 @@ def _shape_query_payload(
     inspected: InspectedQuery,
     limits: QueryLimits,
 ) -> dict:
-    """Cap the result for agent context: columnar cells, cell-width truncation,
+    """Cap the result for agent context: row-major cells, cell-width truncation,
     and a total payload byte cap, each announced in `notes` so a cut result is
     never mistaken for a complete one."""
 

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -318,7 +318,7 @@ only refuses or bounds. The gate, in order:
    query that projected sub-threshold flagged columns records those warnings
    under `pii_warnings`, so the audit trail keeps every such projection findable.
 
-Results are columnar (`columns`, `cells` as a list of lists, `row_count`,
+Results are row-major (`columns`, `cells` as a list of lists, `row_count`,
 `truncated`, `notes`), which is cheaper in tokens than records and keeps the
 envelope sanitizer's list-of-dicts raw-row rule intact as a backstop.
 

--- a/references/evaluation.md
+++ b/references/evaluation.md
@@ -30,7 +30,7 @@ benchmark score:
 4. Propose-don't-impose: changes are diffs, hand-written dbt never silently
    overwritten.
 5. Sanitized envelope: credentials never appear in stdout `data`, and data
-   values only via `explore query`'s firewall-cleared columnar results.
+   values only via `explore query`'s firewall-cleared row-major results.
 
 The spine lives in `tests/test_safety_spine.py`. Families whose engine lands in a
 later phase are wired as explicit `xfail` placeholders so the spine is complete

--- a/references/semantic-layer.md
+++ b/references/semantic-layer.md
@@ -12,7 +12,7 @@ difference between them is load-bearing, so it is spelled out here.
   metrics (name, type, label, description, and the dimensions each can be grouped
   by), dimensions, and entities. This is the discovery surface an agent reads to
   decide what to query.
-- `explore semantic query` runs a metric query and returns a capped, columnar
+- `explore semantic query` runs a metric query and returns a capped, row-major
   result, the same envelope shape as `explore query`. It takes `--metric <m>`
   (repeatable), and optionally `--group-by <entity__dim>` (repeatable),
   `--where "<jinja>"`, `--order-by <c>`, `--grain <g>`, and `--limit N`.

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -62,7 +62,7 @@ Subcommands, in the usual order:
    profiles the same way.
 6. `explore query "<SELECT ...>"` answers an ad-hoc question the fixed commands
    don't cover: you write the SQL, the engine's query firewall refuses or bounds
-   it. Requires the `.dex/` cache (run `map` first). Results come back columnar
+   it. Requires the `.dex/` cache (run `map` first). Results come back row-major
    and capped; a refusal names the offending column and the fix, so one rewrite
    is enough. Read `${CLAUDE_SKILL_DIR}/references/probe-playbook.md` before
    writing a probe: it maps common questions to effective probe shapes.


### PR DESCRIPTION
## What this changes

The explore query skill and command contract said results come back "columnar," but the cells envelope key is actually a list of rows. Consuming it as documented transposes the result, which fails silently on a square-ish result set (only surfaces as an IndexError on a ragged final row, as reported in #152).

Fixed the wording in four docs (skills/explore/SKILL.md, references/command-contract.md, references/semantic-layer.md, references/evaluation.md) to say "row-major" instead, matching what the code actually does. Also fixed a matching docstring in commands.py. No behavior change, no key rename — went with the docs fix over renaming cells to rows since the key is used across many tests and connector adapters and a rename felt like a bigger, riskier change for what's fundamentally a wording bug.

## Related issues

Closes #152

## Checklist

- [x] Tests pass (`uv run pytest` in `packages/dex-core`)
- [x] Eval scoring-core tests pass (`uvx pytest evals`)
- [x] If a safety path is touched, the spine still holds: read-only against data,
      cost-guarded, PII flagged not surfaced, propose-don't-impose
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free (checked in CI)
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures
