### PR TITLE
Make the storage seam a public extension point, and give every refusal a name

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,3 +175,4 @@ them.
 - Connector and methodology notes: `references/`.
 - The contract in full: `references/command-contract.md`.
 - The source of truth (dbt) and `.dex/` cache: `references/canonical-model.md`.
+- Where `.dex/` state lives, and writing a storage backend: `references/storage.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-07-28
+
 ### Changed
 
 - **Every refusal dex raises deliberately is catchable as one type** ([#144]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,112 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **The storage seam is a public extension point: a shipped conformance suite, a
+  tiered protocol, and a typed package** ([#144]). `.dex/` state has lived behind
+  a `Store` protocol since the storage seam landed, but the seam was only usable
+  by someone willing to read the engine's source and infer several contracts that
+  existed nowhere but its tests. It is now implementable from what is published.
+
+  The protocol is three nested tiers, so a backend implements what its host
+  actually uses instead of stubbing what it does not. `ExploreStore` is six
+  members (the exploration cache, the two ledgers, locators) and covers a host
+  that explores, profiles, and queries; `MaintainStore` adds the reconcile
+  baseline and the drift report; `Store` adds the five transform plan members and
+  is unchanged in shape, so existing annotations and backends keep working. The
+  transform surface is the one place the widest tier is required, and it now
+  refuses an explore-only store by naming the tier and the missing members rather
+  than failing on a missing attribute several frames down.
+
+  `exmergo_dex_core.storage.conformance` ships the contract as an executable
+  suite. A backend outside this distribution installs `[storage-conformance]`, subclasses
+  the class matching its tier, supplies a `make_store(key)` factory, and runs
+  every assertion dex holds its own backends to, isolation across keys included.
+  A packaging test proves this end to end: it builds the wheel, installs it in an
+  environment with no access to this source tree, writes a backend there against
+  the published protocol alone, and runs the shipped suite at it.
+
+  The package now ships a `py.typed` marker. The seam is enforced entirely by
+  structural typing, so without it a downstream type checker treated the whole
+  package as untyped and verified nothing about a candidate backend.
+
+  Six behavioral contracts that previously existed only inside the test tree are
+  written onto the protocol members they govern: documents do not alias the
+  caller's object in either direction, `save_cache` stamps the caller's object as
+  well as the stored copy, documents round-trip as pydantic models, a corrupt
+  document raises while a corrupt ledger line is skipped, a stored
+  `schema_version` is not the store's to police, and the ledger read-then-write is
+  not atomic at the protocol level (the session ceiling binds exactly under
+  serialized commands, and the overshoot under concurrency is bounded by the sum
+  of the concurrent estimates). `save_cache` is now explicitly a whole-document
+  atomic write: cache membership decides what a query may name, so a backend with
+  a document size cap chunks internally rather than getting a per-dataset seam
+  that would let a reader observe half a cache.
+
+  A seventh contract, reported from the field: **the spend ledger is scoped to the
+  store instance**, so store granularity is ceiling granularity. One principal
+  spanning two stores has two independent session ceilings and nothing bounds
+  their sum. The existing docstring was specific about `field` and `connector`
+  keeping paradigms apart, which read as the complete set of scoping rules, and
+  the store axis was the one it omitted. It errs permissive and nothing warns, so
+  a host federating state per user should key stores exactly as it keys
+  principals.
+
+  Every assertion in the shipped contract now carries a message naming the rule it
+  enforces. In-repo a bare comparison was fine because a failure sent you to the
+  source; as the artifact an outside implementer debugs against, the assertion
+  text is the documentation. The no-aliasing and clock-stamping rules matter most
+  there, since both fail silently and late and present as data corruption rather
+  than as a protocol violation.
+
+  New reference page `references/storage.md` covers the tiers, those contracts,
+  which calls need nothing on the filesystem, and how a backend is selected.
+
+### Changed
+
+- **Every refusal dex raises deliberately is catchable as one type** ([#144]).
+  The CLI renders refusals into an error envelope behind a catch-all, so it never
+  needed a hierarchy; a library consumer cannot do that, and catching `Exception`
+  at an API boundary swallows real bugs alongside deliberate refusals. All of
+  them now descend from `DexError`, with `ConfigurationError` for an engine built
+  without something it needs and `RequestError` for a call that named something
+  unusable. `NoConnectorSelectedError`, `RepoRootRequiredError`, and
+  `StoreRequiredError` replace the bare `ValueError`s that the public API raised
+  for the three refusals a host hits most.
+
+  **Nothing breaks for an existing consumer.** Both families also inherit
+  `ValueError`, which is what those refusals raised before they were typed, so
+  code written against the previous API keeps catching what it caught.
+
+  Two families name the distinctions a host actually branches on.
+  **`PrerequisiteError`** covers refusals where the engine is fine, the call is
+  fine, and some state does not exist yet that a named command creates:
+  `CacheRequiredError` and `NoBaselineError`. It is the one family a caller can
+  resolve automatically, by running the command the message names and retrying.
+  **`ConnectorError`** covers a warehouse connection that could not be
+  established, so a host writes one `except` instead of importing a name per
+  connector. `CredentialDiscoveryError` is deliberately outside it: a credential
+  that was never configured will not appear on a retry.
+
+  **Eleven refusals that were typed but not importable are now exported**:
+  `PrerequisiteError`, `CacheRequiredError`, `NoBaselineError`, `ConnectorError`,
+  `CredentialDiscoveryError`, `ScopeError`, `ClusterError`,
+  `ClusterDependencyError`, `DialectDependencyError`, `PlanError`, and
+  `PlanNotFoundError`. Being a distinct class is not enough on its own: with no
+  importable name, a consumer branches by matching on message prose, and prose is
+  not an interface anyone owes stability on, so rewording an error silently
+  changes which branch a caller takes. `PlanNotFoundError` is the sharpest case,
+  because `Store.load_plan` is documented as raising it and a third-party backend
+  could not satisfy that contract without importing from a private module. A test
+  now asserts every refusal reachable from the public API is importable, with an
+  explicit internal set, so the next one added forces a decision.
+
+  `SemanticBackendError` and `SemanticQueryRefusedError` are now exported from the
+  package root. They are the documented catch for the hosted semantic-layer path
+  and previously required importing from `exmergo_dex_core.explore.semantic`, a
+  module layout that was never public surface.
+
 ## [1.4.1] - 2026-07-26
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,6 +220,38 @@ installed) with `python -m evals skills/<skill>`. If a future backend needs a
 real Python dependency, promote `evals/` to its own uv project at that point and
 not before. See `evals/README.md` for the rationale and full usage.
 
+## Writing a storage backend
+
+`.dex/` state lives behind a `Store` protocol, and the contract is public so a
+backend does not have to live in this repository. The usual reason to write one is
+a process serving several end users, which needs state federated per user in its
+own datastore rather than in one repo directory.
+
+Implement the tier your host actually uses (`ExploreStore` is six methods;
+`MaintainStore` and `Store` add to it), then prove it with the suite dex ships:
+
+```
+pip install "exmergo-dex-core[conformance]"
+```
+
+```python
+from exmergo_dex_core.storage.conformance import ExploreStoreContract
+
+
+class TestMyStore(ExploreStoreContract):
+    def make_store(self, key):
+        return MyStore(tenant=key)
+```
+
+pytest collects the inherited tests and runs the whole contract against your
+backend, isolation assertions included. `references/storage.md` covers the tiers,
+the contracts that are not obvious from the signatures, and which calls need
+nothing on the filesystem.
+
+Backends contributed here run the same suite: see
+`packages/dex-core/tests/storage/test_parity.py`, which is deliberately the same
+three lines a third party writes.
+
 ## Linting and formatting (Ruff)
 
 We use [Ruff](https://docs.astral.sh/ruff/) as both the linter and the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ Implement the tier your host actually uses (`ExploreStore` is six methods;
 `MaintainStore` and `Store` add to it), then prove it with the suite dex ships:
 
 ```
-pip install "exmergo-dex-core[conformance]"
+pip install "exmergo-dex-core[storage-conformance]"
 ```
 
 ```python

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -123,9 +123,10 @@ cluster = ["scikit-learn>=1.4"]
 # The storage conformance contract (`exmergo_dex_core.storage.conformance`), for
 # anyone implementing a `Store` backend outside this distribution: it is the
 # executable copy of the rules stated on the protocol, and it needs a test runner
-# to execute them. Contributor tooling rather than a capability, which is why
-# [all] does not reference it.
-conformance = ["pytest>=8"]
+# to execute them. Named for what it is conformance *to*, matching every other
+# extra here: an install line has to answer "conformance to what?" on its own.
+# Contributor tooling rather than a capability, which is why [all] omits it.
+storage-conformance = ["pytest>=8"]
 # One command for users who want every optional capability at once: every
 # connector, both semantic-layer backends, and clustering. Self-references the
 # other extras so their requirement lists stay defined in exactly one place, which
@@ -140,7 +141,7 @@ all = [
 # (the clustering tests need scikit-learn, the firewall tests need the dialect
 # engine), so `uv sync --extra dev` runs the whole suite without also picking a
 # connector.
-dev = ["ruff==0.15.19", "scikit-learn>=1.4", "exmergo-dex-core[conformance,sql]"]
+dev = ["ruff==0.15.19", "scikit-learn>=1.4", "exmergo-dex-core[sql,storage-conformance]"]
 
 [project.urls]
 Homepage = "https://www.exmergo.com/dex"

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -120,6 +120,12 @@ semantic-api = ["httpx>=0.27"]
 # when it sees an `explore cluster` invocation. Connector-agnostic (clustering
 # runs on the feature sample in-process, whatever warehouse it came from).
 cluster = ["scikit-learn>=1.4"]
+# The storage conformance contract (`exmergo_dex_core.storage.conformance`), for
+# anyone implementing a `Store` backend outside this distribution: it is the
+# executable copy of the rules stated on the protocol, and it needs a test runner
+# to execute them. Contributor tooling rather than a capability, which is why
+# [all] does not reference it.
+conformance = ["pytest>=8"]
 # One command for users who want every optional capability at once: every
 # connector, both semantic-layer backends, and clustering. Self-references the
 # other extras so their requirement lists stay defined in exactly one place, which
@@ -134,7 +140,7 @@ all = [
 # (the clustering tests need scikit-learn, the firewall tests need the dialect
 # engine), so `uv sync --extra dev` runs the whole suite without also picking a
 # connector.
-dev = ["pytest>=8", "ruff==0.15.19", "scikit-learn>=1.4", "exmergo-dex-core[sql]"]
+dev = ["ruff==0.15.19", "scikit-learn>=1.4", "exmergo-dex-core[conformance,sql]"]
 
 [project.urls]
 Homepage = "https://www.exmergo.com/dex"

--- a/packages/dex-core/src/exmergo_dex_core/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/__init__.py
@@ -53,44 +53,88 @@ from typing import TYPE_CHECKING
 # latency on every invocation.
 _EXPORTS = {
     "BudgetExhaustedError": "results",
+    "CacheRequiredError": "explore.commands",
     "CeilingRequiredError": "guards.cost_guard",
+    "ClusterDependencyError": "explore.cluster",
+    "ClusterError": "explore.cluster",
     "ColumnProfile": "cache",
+    "ConfigurationError": "errors",
     "ConfirmationRequest": "results",
     "ConfirmationRequiredError": "guards.cost_guard",
     "ConnectionSource": "connect",
+    "ConnectorError": "errors",
     "Cost": "envelope",
     "CostGuardError": "guards.cost_guard",
+    "CredentialDiscoveryError": "connect",
     "Dataset": "cache",
     "DexCache": "cache",
     "DexConfig": "config",
-    "Document": "storage",
     "DexEngine": "engine",
+    "DexError": "errors",
+    "DialectDependencyError": "guards.dialect",
+    "Document": "storage",
+    "ExploreStore": "storage",
     "FilesystemStore": "storage",
+    "MaintainStore": "storage",
     "MemoryStore": "storage",
+    "NoBaselineError": "maintain.commands",
+    "NoConnectorSelectedError": "errors",
     "OverCeilingError": "guards.cost_guard",
     "Paradigm": "envelope",
+    "PlanError": "transform.plans",
+    "PlanNotFoundError": "transform.plans",
+    "PrerequisiteError": "errors",
     "QueryRefusedError": "guards.query_firewall",
     "Relationship": "cache",
+    "RepoRootRequiredError": "errors",
+    "RequestError": "errors",
     "Result": "results",
+    "ScopeError": "connect",
+    "SemanticBackendError": "explore.semantic",
+    "SemanticQueryRefusedError": "explore.semantic",
     "SemanticSource": "connect",
     "Snapshot": "maintain.snapshot",
     "Store": "storage",
+    "StoreRequiredError": "errors",
     "to_envelope": "results",
 }
 
 if TYPE_CHECKING:  # what a type checker and an IDE see; never run
     from .cache import ColumnProfile, Dataset, DexCache, Relationship
     from .config import DexConfig
-    from .connect import ConnectionSource, SemanticSource
+    from .connect import (
+        ConnectionSource,
+        CredentialDiscoveryError,
+        ScopeError,
+        SemanticSource,
+    )
     from .engine import DexEngine
     from .envelope import Cost, Paradigm
+    from .errors import (
+        ConfigurationError,
+        ConnectorError,
+        DexError,
+        NoConnectorSelectedError,
+        PrerequisiteError,
+        RepoRootRequiredError,
+        RequestError,
+        StoreRequiredError,
+    )
+    from .explore.cluster import ClusterDependencyError, ClusterError
+    from .explore.commands import CacheRequiredError
+    from .explore.semantic import (
+        SemanticBackendError,
+        SemanticQueryRefusedError,
+    )
     from .guards.cost_guard import (
         CeilingRequiredError,
         ConfirmationRequiredError,
         CostGuardError,
         OverCeilingError,
     )
+    from .guards.dialect import DialectDependencyError
     from .guards.query_firewall import QueryRefusedError
+    from .maintain.commands import NoBaselineError
     from .maintain.snapshot import Snapshot
     from .results import (
         BudgetExhaustedError,
@@ -98,7 +142,15 @@ if TYPE_CHECKING:  # what a type checker and an IDE see; never run
         Result,
         to_envelope,
     )
-    from .storage import Document, FilesystemStore, MemoryStore, Store
+    from .storage import (
+        Document,
+        ExploreStore,
+        FilesystemStore,
+        MaintainStore,
+        MemoryStore,
+        Store,
+    )
+    from .transform.plans import PlanError, PlanNotFoundError
 
 try:
     __version__ = version("exmergo-dex-core")
@@ -111,28 +163,49 @@ except PackageNotFoundError:
 # test_engine.py` asserts the two stay in step and that every name resolves.
 __all__ = [
     "BudgetExhaustedError",
+    "CacheRequiredError",
     "CeilingRequiredError",
+    "ClusterDependencyError",
+    "ClusterError",
     "ColumnProfile",
+    "ConfigurationError",
     "ConfirmationRequest",
     "ConfirmationRequiredError",
     "ConnectionSource",
+    "ConnectorError",
     "Cost",
     "CostGuardError",
+    "CredentialDiscoveryError",
     "Dataset",
     "DexCache",
     "DexConfig",
     "DexEngine",
+    "DexError",
+    "DialectDependencyError",
     "Document",
+    "ExploreStore",
     "FilesystemStore",
+    "MaintainStore",
     "MemoryStore",
+    "NoBaselineError",
+    "NoConnectorSelectedError",
     "OverCeilingError",
     "Paradigm",
+    "PlanError",
+    "PlanNotFoundError",
+    "PrerequisiteError",
     "QueryRefusedError",
     "Relationship",
+    "RepoRootRequiredError",
+    "RequestError",
     "Result",
+    "ScopeError",
+    "SemanticBackendError",
+    "SemanticQueryRefusedError",
     "SemanticSource",
     "Snapshot",
     "Store",
+    "StoreRequiredError",
     "__version__",
     "to_envelope",
 ]

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from ..config import BigQueryTarget
 from ..envelope import Paradigm
+from ..errors import ConnectorError
 from ..guards.cost_guard import CostGate, OverCeilingError
 from ..guards.sql_guard import assert_select_only
 from .base import (
@@ -60,7 +61,7 @@ def _regexp_predicate(qcol: str, pattern: str) -> str:
     return f"REGEXP_CONTAINS({qcol}, r'{pattern}')"
 
 
-class BigQueryConnectionError(Exception):
+class BigQueryConnectionError(ConnectorError):
     """Raised when a source scope (or the dev project) cannot be resolved. The
     message always names the fix, never a credential."""
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
@@ -34,6 +34,7 @@ from typing import Any
 
 from ..config import DatabricksTarget
 from ..envelope import Paradigm
+from ..errors import ConnectorError
 from ..guards.cost_guard import CostGate, OverCeilingError
 from ..guards.sql_guard import assert_select_only
 from .base import (
@@ -137,7 +138,7 @@ def warehouse_id_of(value: str) -> str:
     return value.strip().rstrip("/").rsplit("/", 1)[-1]
 
 
-class DatabricksConnectionError(Exception):
+class DatabricksConnectionError(ConnectorError):
     """Raised when the pinned warehouse (or a queried object) cannot be
     resolved. The message always names the fix, never a credential."""
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/duckdb.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/duckdb.py
@@ -13,6 +13,7 @@ import threading
 from pathlib import Path
 
 from ..envelope import Paradigm
+from ..errors import ConnectorError
 from ..guards.sql_guard import assert_select_only
 from .base import (
     ColumnAggregate,
@@ -45,7 +46,7 @@ _COLUMN_BATCH = 50
 _NESTED_TYPE_PREFIXES = ("STRUCT", "MAP", "LIST", "UNION")
 
 
-class DuckDBReadOnlyError(Exception):
+class DuckDBReadOnlyError(ConnectorError):
     """Raised when a DuckDB path cannot be opened read-only.
 
     A read-only open is non-negotiable: rather than silently falling back to a

--- a/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
@@ -40,6 +40,7 @@ from typing import Any
 
 from ..config import PostgresTarget
 from ..envelope import Paradigm
+from ..errors import ConnectorError
 from ..guards.cost_guard import CostGate, OverCeilingError
 from ..guards.sql_guard import assert_select_only
 from .base import (
@@ -110,7 +111,7 @@ def _regexp_predicate(qcol: str, pattern: str) -> str:
     return f"{qcol} ~ '{pattern}'"
 
 
-class PostgresConnectionError(Exception):
+class PostgresConnectionError(ConnectorError):
     """Raised when a queried object cannot be resolved in the configured
     scope. The message always names the fix, never a credential."""
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
@@ -45,6 +45,7 @@ from typing import Any
 
 from ..config import RedshiftTarget
 from ..envelope import Paradigm
+from ..errors import ConnectorError
 from ..guards.cost_guard import CostGate, OverCeilingError
 from ..guards.sql_guard import assert_select_only
 from .base import (
@@ -146,7 +147,7 @@ def _regexp_predicate(qcol: str, pattern: str) -> str:
     return f"{qcol} ~ '{pattern}'"
 
 
-class RedshiftConnectionError(Exception):
+class RedshiftConnectionError(ConnectorError):
     """Raised when a queried object cannot be resolved in the configured
     scope. The message always names the fix, never a credential."""
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
@@ -32,6 +32,7 @@ from typing import Any
 
 from ..config import SnowflakeTarget
 from ..envelope import Paradigm
+from ..errors import ConnectorError
 from ..guards.cost_guard import CostGate, OverCeilingError
 from ..guards.sql_guard import assert_select_only
 from .base import (
@@ -122,7 +123,7 @@ def _regexp_predicate(qcol: str, pattern: str) -> str:
     return f"RLIKE({qcol}, '{pattern}')"
 
 
-class SnowflakeConnectionError(Exception):
+class SnowflakeConnectionError(ConnectorError):
     """Raised when the pinned warehouse (or a queried object) cannot be
     resolved. The message always names the fix, never a credential."""
 

--- a/packages/dex-core/src/exmergo_dex_core/connect.py
+++ b/packages/dex-core/src/exmergo_dex_core/connect.py
@@ -49,8 +49,14 @@ from .config import (
     load_config,
 )
 from .envelope import Paradigm
+from .errors import (
+    ConfigurationError,
+    DexError,
+    NoConnectorSelectedError,
+    StoreRequiredError,
+)
 from .guards.cost_guard import CostGate, ledger_field
-from .storage import Store
+from .storage import ExploreStore
 
 # What each connector bills in. Absent means free and local (DuckDB), which is
 # also what an unknown name resolves to: no gate, no ceiling, no confirmation.
@@ -167,31 +173,31 @@ def assert_connection_source(
     if connection is None:
         return
     if connector == "duckdb":
-        raise ValueError(
+        raise ConfigurationError(
             "connection= does not apply to the duckdb connector: the target is a "
             "single local file, which dex opens read-only itself (an injected "
             "handle could be writable). Select it with path= instead"
         )
     if connector not in _INJECTABLE:
-        raise ValueError(
+        raise ConfigurationError(
             f"connection= is not supported for connector '{connector}': pass one "
             f"of {', '.join(sorted(_INJECTABLE))}"
         )
     if connector == "databricks":
         if connection.workspace is None:
-            raise ValueError(
+            raise ConfigurationError(
                 "an injected databricks connection needs workspace= too: the "
                 "Unity Catalog REST client serves every free metadata path, and "
                 "connect= opens the billed SQL session only. Pass "
                 "ConnectionSource(connect=..., workspace=WorkspaceClient(...))"
             )
     elif connection.workspace is not None:
-        raise ValueError(
+        raise ConfigurationError(
             f"workspace= is Databricks vocabulary and has no meaning for the "
             f"{connector} connector; pass the connection itself as connect="
         )
     if connection.principal_type is not None and connector != "bigquery":
-        raise ValueError(
+        raise ConfigurationError(
             f"principal_type= is BigQuery vocabulary and has no meaning for the "
             f"{connector} connector; describe the credential in auth_method="
         )
@@ -200,7 +206,7 @@ def assert_connection_source(
 def new_cost_gate(
     connector: str,
     config: DexConfig,
-    store: Store,
+    store: ExploreStore,
     *,
     budget: float | None = None,
     confirmed: bool = False,
@@ -237,7 +243,7 @@ def new_cost_gate(
     )
 
 
-def no_connector_selected(repo_root: str | Path | None) -> ValueError:
+def no_connector_selected(repo_root: str | Path | None) -> NoConnectorSelectedError:
     """The connector-selection half of "no silent connector default".
 
     Nothing resolved a connector and nothing explicit was passed, so there is no
@@ -247,24 +253,24 @@ def no_connector_selected(repo_root: str | Path | None) -> ValueError:
     """
 
     if repo_root is None:
-        return ValueError(
+        return NoConnectorSelectedError(
             "no connector selected: pass connector= (with path= for duckdb) or a "
             "config= that declares one, or build from a project on disk with "
             "DexEngine.from_repo(repo_root)"
         )
-    return ValueError(
+    return NoConnectorSelectedError(
         f"no .dex/config.yml found searching from '{repo_root}' up to the git "
         "root: run inside your dex project, pass --repo-root, or pass "
         "--connector/--path for an ad-hoc read"
     )
 
 
-class CredentialDiscoveryError(Exception):
+class CredentialDiscoveryError(DexError):
     """Raised when a cloud connection cannot be discovered. The message always
     names the command or config that fixes it, never a credential value."""
 
 
-class ScopeError(Exception):
+class ScopeError(ConfigurationError):
     """Raised when a source scope is not one this connector can honor: a flag it
     does not speak, or an entry outside the committed allowlist. The message
     always names the offending entry and the vocabulary that would work."""
@@ -298,7 +304,7 @@ def open_adapter(
     scopes: list[str] | None = None,
     repo_root: str | Path = ".",
     config: DexConfig | None = None,
-    store: Store | None = None,
+    store: ExploreStore | None = None,
     budget: float | None = None,
     confirmed: bool = False,
     command: str | None = None,
@@ -362,7 +368,7 @@ def open_adapter(
         else:
             resolved = None
         if not resolved:
-            raise ValueError(
+            raise ConfigurationError(
                 "no DuckDB path: pass --path or set duckdb.path in .dex/config.yml"
             )
         return get_adapter("duckdb", path=resolved)
@@ -434,7 +440,7 @@ def open_adapter(
     return get_adapter(connector)
 
 
-def _require_store(store: Store | None, connector: str) -> Store:
+def _require_store(store: ExploreStore | None, connector: str) -> ExploreStore:
     """The store a billed connector's cost gate cannot do without.
 
     The gate settles the cumulative session budget against the spend ledger and
@@ -444,7 +450,7 @@ def _require_store(store: Store | None, connector: str) -> Store:
     """
 
     if store is None:
-        raise ValueError(
+        raise StoreRequiredError(
             f"opening '{connector}' needs a store: its cost gate settles the "
             "session budget against the spend ledger and records spend back into "
             "it. Pass store= (the CLI passes the filesystem store it built from "
@@ -543,7 +549,7 @@ def _open_bigquery(
     config: DexConfig,
     repo_root: str | Path,
     *,
-    store: Store,
+    store: ExploreStore,
     budget: float | None,
     confirmed: bool,
     command: str | None,
@@ -606,7 +612,7 @@ def _open_snowflake(
     config: DexConfig,
     repo_root: str | Path,
     *,
-    store: Store,
+    store: ExploreStore,
     budget: float | None,
     confirmed: bool,
     command: str | None,
@@ -869,7 +875,7 @@ def _open_databricks(
     config: DexConfig,
     repo_root: str | Path,
     *,
-    store: Store,
+    store: ExploreStore,
     budget: float | None,
     confirmed: bool,
     command: str | None,
@@ -1109,7 +1115,7 @@ def _open_postgres(
     config: DexConfig,
     repo_root: str | Path,
     *,
-    store: Store,
+    store: ExploreStore,
     budget: float | None,
     confirmed: bool,
     command: str | None,
@@ -1380,7 +1386,7 @@ def _open_redshift(
     config: DexConfig,
     repo_root: str | Path,
     *,
-    store: Store,
+    store: ExploreStore,
     budget: float | None,
     confirmed: bool,
     command: str | None,

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -33,6 +33,7 @@ import yaml
 from pydantic import BaseModel, Field, model_validator
 
 from .diffs import file_diff
+from .errors import DexError
 
 PROJECT_FILE = "dbt_project.yml"
 PROFILES_FILE = "profiles.yml"
@@ -57,7 +58,7 @@ _ALLOWED_ROOT_FILES = frozenset(
 )
 
 
-class DbtProjectError(Exception):
+class DbtProjectError(DexError):
     pass
 
 

--- a/packages/dex-core/src/exmergo_dex_core/engine.py
+++ b/packages/dex-core/src/exmergo_dex_core/engine.py
@@ -39,8 +39,9 @@ from typing import TYPE_CHECKING, Any
 from . import command_args, connect
 from .config import DexConfig, load_config
 from .connect import ConnectionSource, SemanticSource
+from .errors import RepoRootRequiredError, StoreRequiredError
 from .results import ConnectResult
-from .storage import FilesystemStore, MemoryStore, Store
+from .storage import ExploreStore, FilesystemStore, MemoryStore, Store
 
 if TYPE_CHECKING:
     from .adapters.base import Adapter
@@ -134,7 +135,7 @@ class DexEngine:
         connector: str | None = None,
         path: str | None = None,
         config: DexConfig | None = None,
-        store: Store | None = None,
+        store: ExploreStore | None = None,
         repo_root: str | Path | None = None,
         scopes: list[str] | None = None,
         project: str | None = None,
@@ -152,7 +153,7 @@ class DexEngine:
         # that exists, never a fallback for one that does not.
         self._declared = config
         self.config: DexConfig = config if config is not None else DexConfig()
-        self.store: Store = store if store is not None else MemoryStore()
+        self.store: ExploreStore = store if store is not None else MemoryStore()
         self.repo_root: str | None = None if repo_root is None else str(repo_root)
         self.connector = connector
         self.path = path
@@ -298,12 +299,44 @@ class DexEngine:
         """
 
         if self.repo_root is None:
-            raise ValueError(
+            raise RepoRootRequiredError(
                 f"{what} needs a repo root: the dbt project is a git-reviewable "
                 "filesystem artifact, so build the engine with "
                 "DexEngine.from_repo(repo_root) or pass repo_root="
             )
         return self.repo_root
+
+    def require_full_store(self, what: str) -> Store:
+        """The store the transform surface needs, or a refusal naming what needed it.
+
+        The storage contract is tiered: a host that only explores implements
+        :class:`~.storage.ExploreStore` and stops there, which is a complete
+        implementation of a declared contract rather than a partial one. The plan
+        members it leaves out are exactly what transform stores its reviewable
+        diffs in, so this is the one boundary where the wider tier is required and
+        the one place the difference is worth a runtime check.
+        """
+
+        store = self.store
+        if not isinstance(store, Store):
+            missing = sorted(
+                name
+                for name in (
+                    "save_plan",
+                    "load_plan",
+                    "list_plans",
+                    "latest_plan",
+                    "plan_locator",
+                )
+                if not hasattr(store, name)
+            )
+            raise StoreRequiredError(
+                f"{what} needs a full store and this one implements the explore "
+                f"tier only (missing: {', '.join(missing)}). Transform keeps its "
+                "plans in the store, so a backend serving transform has to "
+                "implement exmergo_dex_core.storage.Store, not just ExploreStore"
+            )
+        return store
 
     # --- connect --------------------------------------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/envelope.py
+++ b/packages/dex-core/src/exmergo_dex_core/envelope.py
@@ -20,6 +20,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from .errors import DexError
+
 
 class Status(str, Enum):
     OK = "ok"
@@ -93,7 +95,7 @@ _SECRET_KEY_PATTERNS = (
 _RAW_ROW_KEY_PATTERNS = ("rows", "records", "sample_rows", "raw", "preview_rows")
 
 
-class SanitizationError(Exception):
+class SanitizationError(DexError):
     """Raised when an envelope payload would leak secrets or raw rows.
 
     This is intentionally a hard failure rather than a silent scrub: a leak is a

--- a/packages/dex-core/src/exmergo_dex_core/errors.py
+++ b/packages/dex-core/src/exmergo_dex_core/errors.py
@@ -1,0 +1,122 @@
+"""The refusals a programmatic caller can catch, rooted in one base class.
+
+The CLI hides refusals behind a catch-all that renders an error envelope, so it
+never needed a hierarchy. A library consumer cannot do that: it has to map a
+refusal onto its own response, and catching ``Exception`` at an API boundary
+swallows real bugs alongside deliberate refusals. So everything dex raises on
+purpose descends from :class:`DexError`, and the families below are the
+distinctions a host actually branches on.
+
+    from exmergo_dex_core import ConfigurationError, DexError, RequestError
+
+    try:
+        result = engine.query(sql)
+    except RequestError as bad_input:      # the call named something unusable
+        return http(400, str(bad_input))
+    except ConfigurationError as misbuilt:  # the engine was built without something
+        return http(500, str(misbuilt))
+    except DexError as refused:             # a guard said no, deliberately
+        return http(422, str(refused))
+
+Exception classes stay next to the code that raises them (a credential refusal
+lives in ``connect``, a firewall refusal in ``guards.query_firewall``); this
+module holds only the shared roots they inherit from, so importing it pulls in
+nothing.
+
+**Why the two families below also inherit ``ValueError``.** Both raised a bare
+``ValueError`` before they were typed. A consumer written against that API keeps
+working, which is the whole point of adding the type rather than trading one
+breaking change for another. Do not remove the second base thinking it is
+redundant.
+"""
+
+from __future__ import annotations
+
+
+class DexError(Exception):
+    """Base for every refusal dex raises deliberately.
+
+    Deliberately is the operative word: a caller catching this is catching
+    "dex declined, and the message says how to fix it", never an internal bug.
+    Anything dex did not intend surfaces as its own type and should not be
+    caught here.
+    """
+
+
+class ConfigurationError(DexError, ValueError):
+    """The engine was built without something it needs, or with a contradiction.
+
+    Missing input rather than bad input: no connector selected, no repo root
+    where a dbt project was required, no store where a metered connector needed
+    a ledger, a connection injected for a connector that cannot take one. A host
+    seeing this has a wiring bug in how it constructed the engine, not a bad
+    request from its user.
+    """
+
+
+class RequestError(DexError, ValueError):
+    """The call named something this engine cannot resolve or cannot use.
+
+    Bad input rather than missing input: an object that is not in the cache, an
+    identifier that matches several relations, a clustering feature that is not
+    numeric. A host seeing this can usually surface the message to whoever made
+    the request, because the message names what to pass instead.
+    """
+
+
+class PrerequisiteError(DexError):
+    """A prior dex command has not been run, and this one needs what it produces.
+
+    Neither a bad request nor a broken engine: the call is well formed and the
+    engine is wired correctly, some state simply does not exist yet, and a named
+    command creates it. That makes this the one refusal family a caller can
+    resolve automatically, by running the command the message names and retrying,
+    which is why it is worth telling apart from a failure.
+
+    The message always names the command rather than a file, because where state
+    lives is the store's business: on the filesystem backend it is a file, in a
+    hosted deployment it is a row, and "run `explore map` first" is the fix
+    either way.
+    """
+
+
+class ConnectorError(DexError):
+    """A warehouse connection could not be established.
+
+    The family a caller retries or backs off on, as distinct from
+    :class:`ConfigurationError` (which retrying cannot fix) and
+    :class:`CredentialDiscoveryError` (a credential that is absent rather than a
+    connection that failed). Each connector raises its own subclass carrying its
+    own vocabulary; catch this when what matters is that the warehouse is not
+    reachable and not which warehouse it was.
+
+    No message in this family ever carries a credential value.
+    """
+
+
+class NoConnectorSelectedError(ConfigurationError):
+    """Nothing named a connector: not a flag, not a path, not a config file.
+
+    Its own class because it is the refusal a host hits first and the one whose
+    fix is most often a deployment change rather than a code change.
+    """
+
+
+class RepoRootRequiredError(ConfigurationError):
+    """An operation needed the dbt project, and the engine was never told where
+    it lives.
+
+    The dbt project is a git-reviewable filesystem artifact by design and stays
+    one, so this refusal is structural: the whole transform surface and the
+    project-reading parts of explore are unavailable to an engine built without
+    a ``repo_root``, and no storage backend changes that.
+    """
+
+
+class StoreRequiredError(ConfigurationError):
+    """A metered connector was opened with nowhere to keep its spend ledger.
+
+    The cost gate settles the cumulative session budget against the ledger and
+    records every billed statement back into it, so opening a billed connection
+    with no store would run unbudgeted rather than merely unrecorded.
+    """

--- a/packages/dex-core/src/exmergo_dex_core/explore/cluster.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/cluster.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass, field
 
 from sqlglot import exp
 
+from ..errors import DexError
+
 # Percent-sampling dialects need a floor so a tiny fraction on a huge table does
 # not round to zero percent (which reads the whole table on some engines).
 _MIN_SAMPLE_PERCENT = 0.01
@@ -35,12 +37,12 @@ _MIN_SAMPLE_PERCENT = 0.01
 _DEGENERATE_CLUSTER_FRACTION = 0.01
 
 
-class ClusterError(Exception):
+class ClusterError(DexError):
     """A clustering request that cannot be satisfied (too few rows, too few
     usable features, k out of range). Surfaced as a clean error envelope."""
 
 
-class ClusterDependencyError(Exception):
+class ClusterDependencyError(ClusterError):
     """scikit-learn (the ``[cluster]`` extra) is not installed."""
 
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -47,6 +47,7 @@ from ..config import (
     blob_override_paths,
     pii_override_paths,
 )
+from ..errors import PrerequisiteError, RequestError
 from ..guards.cost_guard import ConfirmationRequiredError, OverCeilingError
 from ..guards.query_firewall import (
     InspectedQuery,
@@ -55,7 +56,7 @@ from ..guards.query_firewall import (
 )
 from ..progress import ProgressReporter
 from ..results import BudgetExhaustedError, ConfirmationRequest, to_envelope
-from ..storage import Document, Store
+from ..storage import Document, ExploreStore
 from . import cluster as cluster_mod
 from . import inventory as inventory_mod
 from . import profile as profile_mod
@@ -80,7 +81,7 @@ if TYPE_CHECKING:
 _AUTO_PROFILE_ALL = 50
 
 
-class CacheRequiredError(Exception):
+class CacheRequiredError(PrerequisiteError):
     """A command needs profiled objects and the exploration cache has none.
 
     The message names the command that fills the gap rather than a filename,
@@ -1043,7 +1044,7 @@ def cluster(
             f"`explore profile {obj}` (or `explore map`) first"
         )
     if len(matches) > 1:
-        raise ValueError(f"'{obj}' is ambiguous: {', '.join(matches)}; qualify it")
+        raise RequestError(f"'{obj}' is ambiguous: {', '.join(matches)}; qualify it")
     dataset = next(d for d in cache.datasets if d.identifier == matches[0])
 
     feature_names, selection_notes = _select_cluster_features(
@@ -1215,12 +1216,12 @@ def _select_cluster_features(
         for name in requested:
             col = by_lower.get(name.lower())
             if col is None:
-                raise ValueError(
+                raise RequestError(
                     f"column '{name}' is not among the profiled columns of "
                     f"{dataset.identifier}"
                 )
             if not profile_mod.is_numeric_type(col.data_type):
-                raise ValueError(
+                raise RequestError(
                     f"column '{name}' is {col.data_type}, not numeric; k-means "
                     "clusters numeric features only"
                 )
@@ -1291,7 +1292,7 @@ def _select_cluster_features(
         )
     if len(features) < 2:
         why = f" ({'; '.join(notes)})" if notes else ""
-        raise ValueError(
+        raise RequestError(
             f"found {len(features)} usable numeric feature column(s) for "
             f"{dataset.identifier}; k-means needs at least 2. Pass --features to "
             f"choose columns, or profile a table with more numeric columns{why}"
@@ -1769,7 +1770,7 @@ def _compose_datasets(
 # Sentinel: preserve the prior cache's relationships (profile has no inference
 # pass, so it has no business touching them).
 def _profile_checkpointer(
-    store: Store,
+    store: ExploreStore,
     prior: DexCache | None,
     connector: str,
     now: datetime,
@@ -1794,7 +1795,7 @@ def _profile_checkpointer(
 
 
 def _budget_exhausted(
-    store: Store, adapter: Adapter, accumulated: list[Dataset], selected: int
+    store: ExploreStore, adapter: Adapter, accumulated: list[Dataset], selected: int
 ) -> BudgetExhaustedError:
     """The partial-completion refusal for a mid-run budget exhaustion.
 
@@ -1929,8 +1930,10 @@ def _resolve_identifiers(adapter: Adapter, requested: list[str]) -> list[str]:
     for name in (n for n in names if n):
         unique = match_identifier(name, known)
         if not unique:
-            raise ValueError(f"no object named '{name}' in this connection")
+            raise RequestError(f"no object named '{name}' in this connection")
         if len(unique) > 1:
-            raise ValueError(f"'{name}' is ambiguous: {', '.join(unique)}; qualify it")
+            raise RequestError(
+                f"'{name}' is ambiguous: {', '.join(unique)}; qualify it"
+            )
         resolved.append(unique[0])
     return resolved

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/__init__.py
@@ -26,6 +26,8 @@ from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from typing import Any, Protocol
 
+from ...errors import DexError
+
 # The confidence at or above which a name-detected PII category refuses a query,
 # shared with the query firewall so the two surfaces block at the same threshold.
 # Imported from the guards package, not from the firewall: this package must stay
@@ -99,7 +101,7 @@ class SemanticCatalog:
         }
 
 
-class SemanticBackendError(Exception):
+class SemanticBackendError(DexError):
     """A backend cannot be constructed, reached, or asked what was asked of it: a
     missing extra, missing hosted coordinates, missing credentials, a missing local
     project, an unresolvable metric. The message names the fix; the caller turns it

--- a/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
@@ -24,10 +24,11 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 
 from ..envelope import Cost, Paradigm
+from ..errors import DexError
 from ..results import ConfirmationRequest
 
 
-class CostGuardError(Exception):
+class CostGuardError(DexError):
     """Base for every cost-guard refusal."""
 
 

--- a/packages/dex-core/src/exmergo_dex_core/guards/dialect.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/dialect.py
@@ -13,8 +13,10 @@ it is separate from the guards that use it.
 
 from __future__ import annotations
 
+from ..errors import DexError
 
-class DialectDependencyError(Exception):
+
+class DialectDependencyError(DexError):
     """The dialect engine (sqlglot, carried by every connector extra) is missing.
 
     Surfaced as a clean error envelope naming the install to fix, never as a

--- a/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
@@ -47,11 +47,12 @@ from sqlglot import expressions as exp
 
 from ..cache import CACHE_SCHEMA_VERSION, Dataset, DexCache, match_identifier
 from ..config import QueryLimits
+from ..errors import DexError
 from . import PII_BLOCK_CONFIDENCE
 from .sql_guard import NotSelectOnlyError, assert_select_only
 
 
-class QueryRefusedError(Exception):
+class QueryRefusedError(DexError):
     """Raised when a query violates the firewall policy. The message always
     names the offending construct and the fix, so a refusal costs the agent one
     rewrite, not a debugging session."""

--- a/packages/dex-core/src/exmergo_dex_core/guards/sql_guard.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/sql_guard.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 import sqlglot
 from sqlglot import expressions as exp
 
+from ..errors import DexError
 
-class NotSelectOnlyError(Exception):
+
+class NotSelectOnlyError(DexError):
     """Raised when SQL is not a single read-only SELECT statement."""
 
 

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -21,8 +21,9 @@ from .. import envelope as env
 from ..config import pii_override_paths
 from ..dbt_project import DbtProjectError
 from ..dbt_project import load as load_project
+from ..errors import PrerequisiteError
 from ..results import ConfirmationRequest, to_envelope
-from ..storage import Document, Store
+from ..storage import Document, MaintainStore
 from . import drift as drift_mod
 from . import snapshot as snapshot_mod
 from .results import DriftResult, LayerFingerprint, ReconcileResult, SnapshotResult
@@ -42,7 +43,7 @@ _NO_SNAPSHOT_ERROR = (
 )
 
 
-class NoBaselineError(Exception):
+class NoBaselineError(PrerequisiteError):
     """A detector was asked to measure drift with nothing to measure against.
 
     Named for the state rather than for a missing file: on the filesystem
@@ -606,7 +607,7 @@ def _resolve_scope(
 
 
 def _record_axes(
-    store: Store,
+    store: MaintainStore,
     snap: snapshot_mod.Snapshot,
     connector: str | None,
     results: dict[str, tuple[list[drift_mod.DriftFinding], list[str]]],
@@ -631,7 +632,7 @@ def _record_axes(
 def _drift_result(
     by_axis: dict[str, list[drift_mod.DriftFinding]],
     snap: snapshot_mod.Snapshot,
-    store: Store,
+    store: MaintainStore,
     *,
     warnings: list[str],
 ) -> DriftResult:
@@ -703,7 +704,7 @@ def _semantic_scope(
     return [finding for finding in findings if in_scope(finding)]
 
 
-def _staleness_warnings(store: Store, snap: snapshot_mod.Snapshot) -> list[str]:
+def _staleness_warnings(store: MaintainStore, snap: snapshot_mod.Snapshot) -> list[str]:
     warnings: list[str] = []
     cache = store.load_cache()
     if (

--- a/packages/dex-core/src/exmergo_dex_core/results.py
+++ b/packages/dex-core/src/exmergo_dex_core/results.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 
 from . import envelope as env
 from .envelope import Cost
+from .errors import DexError
 
 
 class ConfirmationRequest(BaseModel):
@@ -44,7 +45,7 @@ class ConfirmationRequest(BaseModel):
     warnings: list[str] = Field(default_factory=list)
 
 
-class BudgetExhaustedError(Exception):
+class BudgetExhaustedError(DexError):
     """The ceiling was reached partway through, and the run stopped there.
 
     Not the same as refusing up front: work was done and paid for, so the message

--- a/packages/dex-core/src/exmergo_dex_core/storage/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/__init__.py
@@ -1,18 +1,25 @@
 """Storage backends for dex's `.dex/` scratch state.
 
-``base`` holds the contract (see :class:`~.base.Store` for what a backend owes its
-callers); the sibling modules are the backends. Callers receive a ``Store``; only
-the entry point picks which one.
+``base`` holds the contract as three nested tiers (:class:`~.base.ExploreStore`,
+:class:`~.base.MaintainStore`, :class:`~.base.Store`), so a backend implements
+only what its host uses; the sibling modules are the backends. Callers receive a
+store; only the entry point picks which one.
+
+``conformance`` is the executable contract, for anyone writing a backend outside
+this package. It is deliberately not imported here: it needs pytest, and a bare
+``import exmergo_dex_core`` must not.
 """
 
-from .base import Document, Store, spend_total
+from .base import Document, ExploreStore, MaintainStore, Store, spend_total
 from .filesystem import DEX_DIR, FilesystemStore
 from .memory import MemoryStore
 
 __all__ = [
     "DEX_DIR",
     "Document",
+    "ExploreStore",
     "FilesystemStore",
+    "MaintainStore",
     "MemoryStore",
     "Store",
     "spend_total",

--- a/packages/dex-core/src/exmergo_dex_core/storage/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/base.py
@@ -13,6 +13,18 @@ under `.dex/`, persistence is git, not a service), while an in-process library
 caller can select :class:`~.memory.MemoryStore` and write nothing at all.
 
 Secrets never live in any backend.
+
+**Writing your own backend.** The contract is three nested protocols, so a host
+implements only the tier it uses (see below), and every rule it has to satisfy is
+stated on the member it governs rather than left for a reader to infer from the
+two shipped backends. :mod:`~.conformance` ships the executable copy of those
+rules: subclass ``StoreContract``, hand it a factory, and the whole contract runs
+against your backend. ``references/storage.md`` is the prose version.
+
+The protocol is **synchronous**. A backend whose client is async wraps it (run the
+coroutine to completion inside the method) rather than the protocol growing an
+async variant: every caller in the engine is synchronous, and a second async
+surface would double the contract for no caller that exists.
 """
 
 from __future__ import annotations
@@ -29,7 +41,12 @@ if TYPE_CHECKING:
 
 
 class Document(str, Enum):
-    """The addressable pieces of `.dex/` state, for locator lookups."""
+    """The addressable pieces of `.dex/` state, for locator lookups.
+
+    One enum across all three tiers rather than one per tier: which documents a
+    backend actually stores follows from the tier it implements, and an
+    explore-only backend is simply never asked for ``SNAPSHOT`` or ``DRIFT``.
+    """
 
     CACHE = "cache"
     SNAPSHOT = "snapshot"
@@ -39,8 +56,12 @@ class Document(str, Enum):
 
 
 @runtime_checkable
-class Store(Protocol):
-    """Behavioral contract for a `.dex/` state backend.
+class ExploreStore(Protocol):
+    """The state an exploring, profiling, querying host needs, and nothing more.
+
+    The narrowest useful tier, and the one a host embedding dex for read-only
+    sense-making should implement. It carries the exploration cache and the two
+    ledgers; it does not carry the reconcile baseline or the transform plans.
 
     Backend state lives inside the store instance (class DI): it holds the
     connection, directory, or dictionaries the documents live in, so no caller
@@ -51,26 +72,62 @@ class Store(Protocol):
     where the document went, for the envelope field an agent surfaces to a human.
     It is deliberately not a ``Path``, so a backend with no filesystem is
     representable.
+
+    Three rules hold across every member here, because the shipped backends both
+    honor them and a backend that does not will diverge in ways that surface much
+    later as a data bug rather than an error:
+
+    **Documents do not alias the caller's object.** What a caller saves and what
+    a later ``load_*`` returns must be independent objects, in both directions.
+    :class:`~.filesystem.FilesystemStore` gets this for free by serializing;
+    :class:`~.memory.MemoryStore` deep-copies on the way in and on the way out
+    specifically to match it. A backend holding a live in-process reference lets
+    a mutation after a save silently rewrite history.
+
+    **Documents are pydantic models.** They round-trip through
+    ``model_validate_json`` and ``model_dump_json``. A backend that stores its own
+    hand-rolled dict shape instead will diverge on the first schema change; use
+    the model's own serialization and store the result.
+
+    **A stored ``schema_version`` is not the store's to police.** Documents carry
+    one and the engine reads it (the query firewall degrades on an old cache);
+    a backend loads what it was given and lets the engine decide.
     """
 
     # --- documents ------------------------------------------------------------
 
     def load_cache(self) -> DexCache | None:
-        """The stored exploration cache, or None when nothing has been stored."""
+        """The stored exploration cache, or None when nothing has been stored.
+
+        Raises rather than returning None when what is stored cannot be parsed: a
+        corrupt cache is a different situation from an absent one, and silently
+        treating the first as the second would re-profile a warehouse (and bill
+        for it) as if nothing had ever been explored.
+        """
         ...
 
     def save_cache(self, cache: DexCache, *, now: datetime | None = None) -> str:
         """Store the cache, stamping ``provenance.updated_at`` when ``now`` is
-        given. Returns the locator."""
+        given. Returns the locator.
+
+        Two contracts here that a backend has to honor deliberately.
+
+        **The stamp lands on the caller's object too**, not only on the stored
+        copy. The command layer reports the timestamp it just persisted, so a
+        backend that stamps only what it writes makes the reported time and the
+        stored time disagree.
+
+        **This is a whole-document write, and it is atomic from the caller's
+        view.** The query firewall resolves every table and column reference
+        against the cache, so cache membership decides what a query may name and
+        under whose PII policy; a half-written cache is a security-relevant state
+        rather than merely an inconsistent one. A backend whose store caps
+        document size (a document database typically does) chunks internally and
+        presents one logical document. It does not get a per-dataset seam to
+        write through, because that seam is exactly what would let a reader
+        observe half a cache.
+        """
         ...
-
-    def load_snapshot(self) -> Snapshot | None: ...
-
-    def save_snapshot(self, snapshot: Snapshot) -> str: ...
-
-    def load_drift(self) -> DriftReport | None: ...
-
-    def save_drift(self, report: DriftReport) -> str: ...
 
     # --- ledgers --------------------------------------------------------------
 
@@ -80,6 +137,9 @@ class Store(Protocol):
         Refusals are logged too: the ledger is the audit trail and the product
         signal for which probe shapes recur often enough to deserve promotion to
         a named command. SQL text only, never result values.
+
+        The stored entry does not alias the caller's dict, for the same reason
+        documents do not.
         """
         ...
 
@@ -103,11 +163,77 @@ class Store(Protocol):
 
         ``field`` and ``connector`` keep paradigms separate: a session budget in
         bytes must never absorb a seconds entry from another connector sharing
-        the ledger, so callers sum their own connector's own unit.
+        the ledger, so callers sum their own connector's own unit. Use
+        :func:`spend_total` rather than reimplementing the arithmetic, so every
+        backend answers the budget question identically.
+
+        **Those two are not the whole scoping story, and the third axis is the
+        store itself.** The ledger is scoped to the store instance, so store
+        granularity is ceiling granularity: one principal spanning two stores has
+        two independent ceilings and nothing bounds their sum. Nothing warns about
+        it and it errs permissive, so a host federating state per user should key
+        stores exactly as it keys principals, and a host that splits stores for
+        another reason (one per repo root, say) should know it has split the
+        budget too.
+
+        A malformed ledger entry is skipped rather than raised on. This is the
+        opposite policy from :meth:`load_cache`, deliberately: an unreadable
+        cache means dex does not know what it may query, while an unreadable
+        ledger line means one spend record is lost, and refusing to run every
+        subsequent billed command because of one bad line is the worse failure.
+
+        **Concurrency.** The cost gate calls this and then calls
+        :meth:`append_spend_log`, and that read-then-write is not atomic at the
+        protocol level. The cumulative session ceiling therefore binds exactly
+        when commands are serialized, which is the CLI's one-command-per-process
+        shape, and under genuinely concurrent commands the overshoot is bounded
+        by the sum of the concurrent estimates. A backend that can make the pair
+        atomic for one key (a transaction, a conditional write) should, and a
+        multi-tenant backend serving concurrent requests per tenant is where that
+        stops being optional. The protocol does not grow a member for it, because
+        an optional member no implementer can rely on is worse than a stated
+        bound.
         """
         ...
 
-    # --- plans ----------------------------------------------------------------
+    # --- locators -------------------------------------------------------------
+
+    def locator(self, document: Document) -> str:
+        """Where ``document`` lives, whether or not it has been stored yet. For
+        the callers that report a location without writing one (a drift path in a
+        detector envelope, a partial-write path in a budget-exhaustion error)."""
+        ...
+
+
+@runtime_checkable
+class MaintainStore(ExploreStore, Protocol):
+    """Adds the drift-detection state: the baseline and the last report.
+
+    A host that reconciles a dbt project against a warehouse needs this tier. The
+    snapshot is the known-good baseline every drift axis compares against, so a
+    backend that cannot retain it across requests cannot support `maintain`.
+    """
+
+    def load_snapshot(self) -> Snapshot | None: ...
+
+    def save_snapshot(self, snapshot: Snapshot) -> str: ...
+
+    def load_drift(self) -> DriftReport | None: ...
+
+    def save_drift(self, report: DriftReport) -> str: ...
+
+
+@runtime_checkable
+class Store(MaintainStore, Protocol):
+    """The full contract: everything above, plus the transform plan store.
+
+    The name every internal annotation used before the tiers existed, kept so a
+    backend implementing all sixteen members is still just a ``Store``. The five
+    plan members are the transform surface's alone; nothing in explore or
+    maintain calls them, which is why a host that only explores can stop at
+    :class:`ExploreStore` and still satisfy a declared contract rather than
+    shipping five methods that raise.
+    """
 
     def save_plan(self, plan: TransformPlan) -> str: ...
 
@@ -121,14 +247,6 @@ class Store(Protocol):
 
     def latest_plan(self, kind: EditKind | None = None) -> TransformPlan | None:
         """The most recent unapplied plan, optionally only-of-``kind`` edits."""
-        ...
-
-    # --- locators -------------------------------------------------------------
-
-    def locator(self, document: Document) -> str:
-        """Where ``document`` lives, whether or not it has been stored yet. For
-        the callers that report a location without writing one (a drift path in a
-        detector envelope, a partial-write path in a budget-exhaustion error)."""
         ...
 
     def plan_locator(self, plan_id: str) -> str: ...

--- a/packages/dex-core/src/exmergo_dex_core/storage/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/conformance.py
@@ -1,0 +1,577 @@
+"""The executable contract a storage backend has to satisfy, shipped for reuse.
+
+The rules a backend owes its callers are stated on the protocol members in
+:mod:`.base`. This module is the same rules as assertions, packaged so a backend
+living outside this distribution can run them in its own test suite:
+
+    from exmergo_dex_core.storage.conformance import StoreContract
+
+    class TestMyStore(StoreContract):
+        def make_store(self, key):
+            return MyStore(tenant=key)
+
+That is the whole integration. pytest collects the inherited ``test_*`` methods
+and runs the entire contract against your backend.
+
+**Pick the class that matches the tier you implement**, mirroring the three
+protocols exactly: :class:`ExploreStoreContract` for a backend that only carries
+the cache and the ledgers, :class:`MaintainStoreContract` when it also carries the
+snapshot and the drift report, :class:`StoreContract` when it carries the
+transform plans too. Subclassing a wider contract than your backend implements is
+how you find out you have not finished, so the narrow classes are a feature rather
+than a convenience.
+
+``make_store(key)`` must return a store that shares nothing with a store built
+from a different key. That is what the isolation assertions check, and it is the
+property a host federating state per end user is actually relying on: two tenants
+in one process must not be able to see each other's cache, ledgers, or plans.
+Whether ``key`` is a directory, a tenant id, or a table prefix is the backend's
+business.
+
+This module imports pytest, so it is deliberately not imported by
+``exmergo_dex_core.storage``: a bare ``import exmergo_dex_core`` must not require
+a test framework. Install the ``[conformance]`` extra to get pytest alongside it.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from ..cache import CacheProvenance, Dataset, DexCache
+from ..maintain.drift import AxisResult, DriftFinding, DriftReport
+from ..maintain.snapshot import Snapshot, WarehouseBaseline
+from .base import Document
+
+__all__ = [
+    "ExploreStoreContract",
+    "MaintainStoreContract",
+    "StoreContract",
+]
+
+
+def a_cache(identifier: str = "db.main.orders") -> DexCache:
+    """A minimal valid cache. Exposed so a backend's own tests can reuse it."""
+
+    return DexCache(
+        datasets=[Dataset(identifier=identifier, row_count=3)],
+        provenance=CacheProvenance(connector="duckdb"),
+    )
+
+
+def a_snapshot(created_at: str = "2026-07-03T10:00:00+00:00") -> Snapshot:
+    return Snapshot(
+        created_at=created_at,
+        connector="duckdb",
+        warehouse=WarehouseBaseline(datasets=[]),
+        warehouse_from="metadata",
+    )
+
+
+def a_drift_report() -> DriftReport:
+    return DriftReport(
+        connector="duckdb",
+        snapshot_created_at="2026-07-03T10:00:00+00:00",
+        axes={
+            "schema": AxisResult(
+                run_at="2026-07-03T11:00:00+00:00",
+                findings=[
+                    DriftFinding(
+                        axis="schema",
+                        code="column_added",
+                        identifier="db.main.orders",
+                        column="discount",
+                        detail="a new column appeared in the source",
+                    )
+                ],
+            )
+        },
+    )
+
+
+def a_plan(plan_id: str, created_at: str, *, kind: Any | None = None) -> Any:
+    """A minimal valid transform plan.
+
+    Imports lazily: the plan model reaches the SQL guard, and so the dialect
+    engine, which a host implementing only the explore tier has no reason to have
+    installed. Keeping this out of module scope is what lets
+    :class:`ExploreStoreContract` run on a bare install.
+    """
+
+    from ..transform.plans import EditKind, PlanEdit, TransformPlan
+
+    return TransformPlan(
+        plan_id=plan_id,
+        created_at=created_at,
+        intent="add a model",
+        project_dir="analytics",
+        edits=[
+            PlanEdit(
+                path="models/staging/stg_orders.sql",
+                kind=kind if kind is not None else EditKind.MODEL_SQL,
+                new_content="select 1 as id\n",
+            )
+        ],
+    )
+
+
+class ExploreStoreContract:
+    """What every backend owes, whatever tier it implements.
+
+    The exploration cache, the two ledgers, and the locators: the state an
+    exploring, profiling, querying host needs.
+    """
+
+    # --- the one hook an implementer provides ---------------------------------
+
+    def make_store(self, key: str) -> Any:
+        """Return a store bound to ``key``, sharing nothing with another key.
+
+        Called with an arbitrary short string. A filesystem backend can treat it
+        as a directory name, a database backend as a tenant identifier. It is
+        called more than once per test class, so it must be cheap and must not
+        assume it is building the only store in the process.
+        """
+
+        raise NotImplementedError(
+            "a conformance subclass must implement make_store(key) -> Store"
+        )
+
+    @pytest.fixture
+    def store(self) -> Any:
+        return self.make_store("primary")
+
+    # --- documents ------------------------------------------------------------
+
+    def test_absent_documents_read_as_none(self, store):
+        # Absence is not an error: every caller treats None as "nothing learned
+        # yet" and says so with an actionable message of its own.
+        assert store.load_cache() is None, (
+            "an absent cache must read as None, not raise and not return an empty "
+            f"cache; got {store.load_cache()!r}"
+        )
+
+    def test_cache_round_trips(self, store):
+        store.save_cache(a_cache())
+        loaded = store.load_cache()
+        assert loaded is not None, "a cache that was just saved must load back"
+        assert [d.identifier for d in loaded.datasets] == ["db.main.orders"], (
+            "the cache did not round-trip: datasets came back as "
+            f"{[d.identifier for d in loaded.datasets]}"
+        )
+        assert loaded.provenance.connector == "duckdb", (
+            "provenance must round-trip with the document; got "
+            f"{loaded.provenance.connector!r}"
+        )
+
+    def test_saving_a_cache_replaces_the_previous_one(self, store):
+        store.save_cache(a_cache("db.main.orders"))
+        store.save_cache(a_cache("db.main.customers"))
+        loaded = store.load_cache()
+        assert loaded is not None, "a cache that was just saved must load back"
+        assert [d.identifier for d in loaded.datasets] == ["db.main.customers"], (
+            "save_cache replaces the stored cache, it does not merge into it; got "
+            f"{[d.identifier for d in loaded.datasets]}"
+        )
+
+    def test_save_cache_stamps_updated_at_when_given_a_clock(self, store):
+        now = datetime(2026, 7, 3, 12, 0, tzinfo=UTC)
+        cache = a_cache()
+        store.save_cache(cache, now=now)
+        # Stamped on the caller's object as well as the stored copy: the command
+        # layer reports the same timestamp it just persisted.
+        assert cache.provenance.updated_at == now.isoformat(), (
+            "save_cache(now=...) must stamp provenance.updated_at on the CALLER'S "
+            "object as well as the stored copy: the command layer reports the "
+            "timestamp it just persisted, so stamping only what you write makes "
+            f"the reported and stored times disagree; caller's object says "
+            f"{cache.provenance.updated_at!r}"
+        )
+        loaded = store.load_cache()
+        assert loaded is not None, "a cache that was just saved must load back"
+        assert loaded.provenance.updated_at == now.isoformat(), (
+            "the stamp must also reach the stored copy; stored says "
+            f"{loaded.provenance.updated_at!r}"
+        )
+
+    def test_save_cache_without_a_clock_leaves_updated_at_alone(self, store):
+        cache = a_cache()
+        cache.provenance.updated_at = "2026-07-01T00:00:00+00:00"
+        store.save_cache(cache)
+        loaded = store.load_cache()
+        assert loaded is not None, "a cache that was just saved must load back"
+        assert loaded.provenance.updated_at == "2026-07-01T00:00:00+00:00", (
+            "save_cache without a clock must leave provenance.updated_at alone, "
+            f"never stamp 'now' of its own; got {loaded.provenance.updated_at!r}"
+        )
+
+    def test_a_stored_document_is_not_aliased_to_the_callers_object(self, store):
+        # A filesystem backend serializes, so a caller cannot reach back into what
+        # it already saved. Every backend must behave that way or a mutation after
+        # the save would silently rewrite history on some backends and not others.
+        cache = a_cache()
+        store.save_cache(cache)
+        cache.datasets[0].identifier = "mutated.after.save"
+        cache.datasets.append(Dataset(identifier="db.main.appended"))
+        loaded = store.load_cache()
+        assert loaded is not None, "a cache that was just saved must load back"
+        assert [d.identifier for d in loaded.datasets] == ["db.main.orders"], (
+            "a stored document must not alias the caller's object: mutating what "
+            "you saved reached into the store, so a mutation after a save "
+            "silently rewrites history. Serialize on write, or deep-copy. Got "
+            f"{[d.identifier for d in loaded.datasets]}"
+        )
+
+    def test_a_loaded_document_is_not_aliased_to_the_stored_one(self, store):
+        # The other direction: mutating what a load returned must not reach back
+        # into the store, or one caller's scratch edit becomes everyone's state.
+        store.save_cache(a_cache())
+        first = store.load_cache()
+        assert first is not None, "a cache that was just saved must load back"
+        first.datasets[0].identifier = "mutated.after.load"
+        second = store.load_cache()
+        assert second is not None, "the cache must still load after a caller edit"
+        assert [d.identifier for d in second.datasets] == ["db.main.orders"], (
+            "a loaded document must not alias the stored one: editing what a load "
+            "returned reached back into the store, so one caller's scratch edit "
+            f"becomes everyone's state. Got {[d.identifier for d in second.datasets]}"
+        )
+
+    # --- ledgers --------------------------------------------------------------
+
+    def test_spend_since_sums_only_from_the_cutoff(self, store):
+        store.append_spend_log(
+            {"at": "2026-07-02T23:59:00+00:00", "billed_bytes": 1_000}
+        )
+        store.append_spend_log({"at": "2026-07-03T00:01:00+00:00", "billed_bytes": 200})
+        store.append_spend_log({"at": "2026-07-03T12:00:00+00:00", "billed_bytes": 300})
+        assert store.spend_since("2026-07-03T00:00:00+00:00") == 500, (
+            "spend_since must sum only entries at or after the cutoff; expected "
+            f"500, got {store.spend_since('2026-07-03T00:00:00+00:00')}"
+        )
+
+    def test_spend_since_is_zero_on_an_empty_ledger(self, store):
+        assert store.spend_since("2026-07-03T00:00:00+00:00") == 0.0, (
+            "an empty ledger must sum to 0.0, never raise: the cost gate reads "
+            "this before the first billed command of every session"
+        )
+
+    def test_spend_since_keeps_units_and_connectors_apart(self, store):
+        # The safety-critical case: one ledger, several paradigms. A bytes budget
+        # must never absorb another connector's seconds entry.
+        store.append_spend_log(
+            {
+                "at": "2026-07-03T10:00:00+00:00",
+                "connector": "bigquery",
+                "billed_bytes": 90,
+            }
+        )
+        store.append_spend_log(
+            {
+                "at": "2026-07-03T10:05:00+00:00",
+                "connector": "snowflake",
+                "billed_seconds": 42,
+            }
+        )
+        cutoff = "2026-07-03T00:00:00+00:00"
+        assert store.spend_since(cutoff, connector="bigquery") == 90, (
+            "spend_since must filter by connector; expected 90, got "
+            f"{store.spend_since(cutoff, connector='bigquery')}"
+        )
+        assert (
+            store.spend_since(cutoff, field="billed_seconds", connector="snowflake")
+            == 42
+        ), "spend_since must sum the requested field, not always billed_bytes"
+        # Asking for the wrong unit or the wrong connector yields nothing, never a
+        # cross-paradigm number.
+        assert store.spend_since(cutoff, connector="snowflake") == 0.0, (
+            "a bytes budget must never absorb another connector's seconds entry: "
+            "asking for the wrong unit yields nothing, never a cross-paradigm "
+            f"number. Got {store.spend_since(cutoff, connector='snowflake')}"
+        )
+        assert (
+            store.spend_since(cutoff, field="billed_seconds", connector="bigquery")
+            == 0.0
+        ), "asking for the wrong connector's unit must yield nothing"
+
+    def test_a_ledger_entry_is_not_aliased_to_the_callers_dict(self, store):
+        entry = {"at": "2026-07-03T10:00:00+00:00", "billed_bytes": 100}
+        store.append_spend_log(entry)
+        entry["billed_bytes"] = 999_999
+        assert store.spend_since("2026-07-03T00:00:00+00:00") == 100, (
+            "a stored ledger entry must not alias the caller's dict: mutating the "
+            "dict after appending it changed recorded spend, which silently "
+            f"rewrites the audit trail. Got "
+            f"{store.spend_since('2026-07-03T00:00:00+00:00')}"
+        )
+
+    def test_a_malformed_ledger_entry_does_not_poison_the_budget(self, store):
+        # Losing one spend record is bad; refusing every subsequent billed command
+        # because of one bad record is worse. The opposite policy from the cache,
+        # deliberately.
+        store.append_spend_log({"at": "2026-07-03T10:00:00+00:00", "billed_bytes": 100})
+        store.append_spend_log({"at": None, "billed_bytes": "not a number"})
+        store.append_spend_log({"at": "2026-07-03T11:00:00+00:00", "billed_bytes": 50})
+        assert store.spend_since("2026-07-03T00:00:00+00:00") == 150, (
+            "a malformed ledger entry must be skipped, not raised on: losing one "
+            "spend record is bad, refusing every subsequent billed command "
+            "because of one bad record is worse. This is the opposite policy from "
+            f"load_cache, deliberately. Got "
+            f"{store.spend_since('2026-07-03T00:00:00+00:00')}"
+        )
+
+    def test_query_log_accepts_every_decision(self, store):
+        # Refusals are logged too; the ledger is the audit trail, not a success log.
+        for decision in ("allowed", "refused", "needs_confirmation", "failed"):
+            store.append_query_log(
+                {
+                    "at": "2026-07-03T10:00:00+00:00",
+                    "sql": "select 1",
+                    "decision": decision,
+                }
+            )
+
+    # --- locators -------------------------------------------------------------
+
+    def test_the_cache_has_a_locator_before_it_is_written(self, store):
+        # The over-ceiling error and the drift envelope both report a location
+        # without having written one, so a locator must not depend on the
+        # document existing.
+        assert isinstance(store.locator(Document.CACHE), str), (
+            "a locator is an opaque display string, never a Path, so a backend "
+            f"with no filesystem is representable; got "
+            f"{type(store.locator(Document.CACHE)).__name__}"
+        )
+        assert store.locator(Document.CACHE), (
+            "a locator must be non-empty before the document exists: the "
+            "over-ceiling error and the drift envelope both report a location "
+            "without having written one"
+        )
+
+    def test_the_ledgers_have_locators_before_they_are_written(self, store):
+        for document in (Document.QUERY_LOG, Document.SPEND_LOG):
+            assert store.locator(document), (
+                f"{document.value} has no locator before it is written; a locator "
+                "must not depend on the document existing"
+            )
+
+    def test_saving_the_cache_returns_the_locator_the_store_reports(self, store):
+        assert store.save_cache(a_cache()) == store.locator(Document.CACHE), (
+            "save_cache must return the same locator the store reports for "
+            "Document.CACHE, or an agent surfaces one location and reads another"
+        )
+
+    # --- isolation ------------------------------------------------------------
+
+    def test_two_keys_do_not_share_a_cache(self, store):
+        one, two = self.make_store("tenant-one"), self.make_store("tenant-two")
+        one.save_cache(a_cache("db.one.orders"))
+        # The firewall resolves every table reference against the cache, so a
+        # cache leaking across keys is a leak of what the other tenant may query,
+        # not merely of what it has profiled.
+        assert two.load_cache() is None, (
+            "two keys share a cache. The query firewall resolves every table "
+            "reference against the cache, so this leaks what the other tenant may "
+            "query, not merely what it has profiled. Check that make_store(key) "
+            "actually keys storage"
+        )
+        two.save_cache(a_cache("db.two.orders"))
+        first = one.load_cache()
+        assert first is not None, "the first key's cache disappeared"
+        assert [d.identifier for d in first.datasets] == ["db.one.orders"], (
+            "writing under one key overwrote another key's cache; got "
+            f"{[d.identifier for d in first.datasets]}"
+        )
+
+    def test_two_keys_do_not_share_a_spend_ledger(self, store):
+        one, two = self.make_store("tenant-one"), self.make_store("tenant-two")
+        one.append_spend_log({"at": "2026-07-03T10:00:00+00:00", "billed_bytes": 500})
+        # A shared ledger would charge one tenant's spend against another's
+        # session ceiling, which reads as a budget bug and is a tenancy bug.
+        assert two.spend_since("2026-07-03T00:00:00+00:00") == 0.0, (
+            "two keys share a spend ledger, so one tenant's spend counts against "
+            "another's session ceiling. That reads as a budget bug and is a "
+            f"tenancy bug. Got {two.spend_since('2026-07-03T00:00:00+00:00')}"
+        )
+        assert one.spend_since("2026-07-03T00:00:00+00:00") == 500, (
+            "the first key's ledger did not retain its own entry"
+        )
+
+    # The query ledger is append-only with no reader on the protocol, so its
+    # isolation cannot be asserted from out here. A backend must still key it the
+    # same way it keys everything else: it holds SQL text, which names the tables
+    # and columns one tenant asked about.
+
+
+class MaintainStoreContract(ExploreStoreContract):
+    """Adds the drift-detection state: the baseline and the last report."""
+
+    def test_absent_maintain_documents_read_as_none(self, store):
+        assert store.load_snapshot() is None, (
+            "an absent snapshot must read as None; maintain reports 'no baseline "
+            "yet, run maintain snapshot' off this and cannot if it raises"
+        )
+        assert store.load_drift() is None, "an absent drift report must read as None"
+
+    def test_snapshot_round_trips(self, store):
+        store.save_snapshot(a_snapshot())
+        loaded = store.load_snapshot()
+        assert loaded is not None, "a snapshot that was just saved must load back"
+        assert loaded.created_at == "2026-07-03T10:00:00+00:00", (
+            "the snapshot did not round-trip: created_at is the baseline every "
+            f"drift axis compares against; got {loaded.created_at!r}"
+        )
+        assert loaded.warehouse_from == "metadata", (
+            f"snapshot fields must round-trip intact; got {loaded.warehouse_from!r}"
+        )
+
+    def test_drift_round_trips_with_its_findings(self, store):
+        store.save_drift(a_drift_report())
+        loaded = store.load_drift()
+        assert loaded is not None, "a drift report that was just saved must load back"
+        assert loaded.snapshot_created_at == "2026-07-03T10:00:00+00:00", (
+            f"the drift report did not round-trip; got {loaded.snapshot_created_at!r}"
+        )
+        assert [f.column for f in loaded.axes["schema"].findings] == ["discount"], (
+            "nested findings must survive the round-trip: a backend storing only "
+            "the top level loses the drift detail the report exists for. Got "
+            f"{[f.column for f in loaded.axes['schema'].findings]}"
+        )
+
+    def test_maintain_documents_have_locators_before_they_are_written(self, store):
+        for document in (Document.SNAPSHOT, Document.DRIFT):
+            assert store.locator(document), (
+                f"{document.value} has no locator before it is written; the drift "
+                "envelope reports a location without having written one"
+            )
+
+    def test_saving_maintain_documents_returns_the_reported_locators(self, store):
+        assert store.save_snapshot(a_snapshot()) == store.locator(Document.SNAPSHOT), (
+            "save_snapshot must return the locator the store reports for "
+            "Document.SNAPSHOT"
+        )
+        assert store.save_drift(a_drift_report()) == store.locator(Document.DRIFT), (
+            "save_drift must return the locator the store reports for Document.DRIFT"
+        )
+
+    def test_two_keys_do_not_share_a_snapshot(self, store):
+        one, two = self.make_store("tenant-one"), self.make_store("tenant-two")
+        one.save_snapshot(a_snapshot())
+        assert two.load_snapshot() is None, (
+            "two keys share a snapshot, so one tenant's drift baseline is another's. "
+            "Check that make_store(key) actually keys storage"
+        )
+
+
+class StoreContract(MaintainStoreContract):
+    """The full contract: everything above, plus the transform plan store."""
+
+    def test_plan_round_trips(self, store):
+        store.save_plan(a_plan("pabc", "2026-07-03T10:00:00+00:00"))
+        loaded = store.load_plan("pabc")
+        assert loaded.intent == "add a model", (
+            f"the plan did not round-trip; intent came back {loaded.intent!r}"
+        )
+        assert loaded.edits[0].path == "models/staging/stg_orders.sql", (
+            "a plan's edits are the reviewable diff it exists to carry and must "
+            f"round-trip intact; got {loaded.edits[0].path!r}"
+        )
+
+    def test_loading_an_unknown_plan_raises(self, store):
+        from ..transform.plans import PlanNotFoundError
+
+        with pytest.raises(PlanNotFoundError):
+            # Not a generic KeyError or None: the protocol names this type, and a
+            # caller distinguishes "no such plan" from "the store is broken" by it.
+            store.load_plan("pnope")
+
+    def test_list_plans_is_newest_first(self, store):
+        store.save_plan(a_plan("pold", "2026-07-01T10:00:00+00:00"))
+        store.save_plan(a_plan("pnew", "2026-07-03T10:00:00+00:00"))
+        assert [p.plan_id for p in store.list_plans()] == ["pnew", "pold"], (
+            "list_plans must return newest first; got "
+            f"{[p.plan_id for p in store.list_plans()]}"
+        )
+
+    def test_list_plans_is_empty_before_anything_is_planned(self, store):
+        assert store.list_plans() == [], (
+            "list_plans must return an empty list before anything is stored, "
+            f"never None and never raise; got {store.list_plans()!r}"
+        )
+
+    def test_latest_plan_skips_applied_ones(self, store):
+        applied = a_plan("papplied", "2026-07-03T12:00:00+00:00")
+        applied.applied_at = "2026-07-03T12:30:00+00:00"
+        store.save_plan(applied)
+        store.save_plan(a_plan("ppending", "2026-07-03T10:00:00+00:00"))
+        latest = store.latest_plan()
+        assert latest is not None and latest.plan_id == "ppending", (
+            "latest_plan must skip plans with an applied_at: returning an applied "
+            "plan makes `transform apply` re-apply work already on disk. Got "
+            f"{latest.plan_id if latest else None!r}"
+        )
+
+    def test_latest_plan_filters_by_kind(self, store):
+        from ..transform.plans import EditKind
+
+        store.save_plan(a_plan("pmodel", "2026-07-03T10:00:00+00:00"))
+        store.save_plan(
+            a_plan("psemantic", "2026-07-03T11:00:00+00:00", kind=EditKind.SEMANTIC_YML)
+        )
+        semantic = store.latest_plan(EditKind.SEMANTIC_YML)
+        assert semantic is not None and semantic.plan_id == "psemantic", (
+            "latest_plan(kind) must return only plans whose every edit is of that "
+            f"kind; got {semantic.plan_id if semantic else None!r}"
+        )
+        model = store.latest_plan(EditKind.MODEL_SQL)
+        assert model is not None and model.plan_id == "pmodel", (
+            f"kind filtering returned the wrong plan; got "
+            f"{model.plan_id if model else None!r}"
+        )
+
+    def test_latest_plan_is_none_when_everything_is_applied(self, store):
+        applied = a_plan("papplied", "2026-07-03T12:00:00+00:00")
+        applied.applied_at = "2026-07-03T12:30:00+00:00"
+        store.save_plan(applied)
+        assert store.latest_plan() is None, (
+            "latest_plan must be None when every stored plan is applied, not fall "
+            "back to the most recent one"
+        )
+
+    def test_resaving_a_plan_updates_it_in_place(self, store):
+        # This is how apply marks a plan applied: same id, new applied_at.
+        plan = a_plan("pabc", "2026-07-03T10:00:00+00:00")
+        store.save_plan(plan)
+        plan.applied_at = "2026-07-03T10:30:00+00:00"
+        store.save_plan(plan)
+        assert len(store.list_plans()) == 1, (
+            "re-saving a plan under the same id must update it in place, not "
+            f"append a second copy; got {len(store.list_plans())} plans"
+        )
+        assert store.load_plan("pabc").applied_at == "2026-07-03T10:30:00+00:00", (
+            "the update did not persist: this is how apply marks a plan applied, "
+            "so losing it re-applies work already written to the dbt project"
+        )
+
+    def test_plan_locators_are_per_plan(self, store):
+        first = store.save_plan(a_plan("pone", "2026-07-03T10:00:00+00:00"))
+        second = store.save_plan(a_plan("ptwo", "2026-07-03T11:00:00+00:00"))
+        assert first == store.plan_locator("pone"), (
+            "save_plan must return the same locator plan_locator reports for that id"
+        )
+        assert second == store.plan_locator("ptwo"), (
+            "save_plan must return the same locator plan_locator reports for that id"
+        )
+        assert first != second, (
+            "plan locators must be per plan, not one location for the whole store"
+        )
+
+    def test_two_keys_do_not_share_plans(self, store):
+        one, two = self.make_store("tenant-one"), self.make_store("tenant-two")
+        one.save_plan(a_plan("pabc", "2026-07-03T10:00:00+00:00"))
+        assert two.list_plans() == [], (
+            "two keys share the plan store, so one tenant can read and apply "
+            f"another's proposed dbt changes. Got {two.list_plans()!r}"
+        )

--- a/packages/dex-core/src/exmergo_dex_core/storage/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/conformance.py
@@ -30,7 +30,8 @@ business.
 
 This module imports pytest, so it is deliberately not imported by
 ``exmergo_dex_core.storage``: a bare ``import exmergo_dex_core`` must not require
-a test framework. Install the ``[conformance]`` extra to get pytest alongside it.
+a test framework. Install the ``[storage-conformance]`` extra to get pytest
+alongside it.
 """
 
 from __future__ import annotations

--- a/packages/dex-core/src/exmergo_dex_core/transform/build.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/build.py
@@ -37,6 +37,7 @@ from ..dbt_project import (
 )
 from ..dbt_project import load as load_project
 from ..envelope import Cost, Paradigm, redact
+from ..errors import DexError
 from ..guards.cost_guard import preflight
 
 # Names that mean production no matter what the config says. The build target
@@ -56,11 +57,11 @@ _MESSAGE_CAP = 20
 Runner = Callable[[list[str]], subprocess.CompletedProcess]
 
 
-class ProdTargetRefusedError(Exception):
+class ProdTargetRefusedError(DexError):
     pass
 
 
-class DbtRunError(Exception):
+class DbtRunError(DexError):
     pass
 
 

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -29,6 +29,7 @@ from .. import command_args
 from .. import envelope as env
 from ..dbt_project import ApplyResult as PlanApplyResult
 from ..dbt_project import EditOp
+from ..errors import DexError
 from ..results import to_envelope
 from ..storage import Store
 from . import plans as plans_mod
@@ -63,7 +64,7 @@ _DEFAULT_COMPUTE_TIME_CAP_NOTE = (
 )
 
 
-class BuildFailedError(Exception):
+class BuildFailedError(DexError):
     """A dbt run that started and did not succeed.
 
     Carries the run summary and the cost, because a failed build still consumed
@@ -321,7 +322,7 @@ def apply(engine: DexEngine, plan_id: str | None = None) -> ApplyResult:
     nothing written until the caller confirms deliberately.
     """
 
-    store = engine.store
+    store = engine.require_full_store("applying a plan")
     if not plan_id:
         # No id means the latest unapplied plan of any kind: apply does not
         # dispatch on kind, a plan is a plan (a semantic plan applies the same
@@ -387,7 +388,7 @@ def plans(engine: DexEngine) -> PlanListResult:
                 "applied_at": p.applied_at,
                 "pending": p.applied_at is None,
             }
-            for p in engine.store.list_plans()
+            for p in engine.require_full_store("listing plans").list_plans()
         ]
     )
 
@@ -636,7 +637,7 @@ def _semantic_envelope(
 # --- helpers -----------------------------------------------------------------
 
 
-class DbtParseError(Exception):
+class DbtParseError(DexError):
     """dbt's own parser refused the authored edits, so nothing was stored.
 
     The authoritative gate: dex's checks are precise and dbt's is final, and a
@@ -801,13 +802,19 @@ def _failure_message(prefix: str, messages: list[str]) -> str:
 def _make_plan(engine: DexEngine, intent: str, edits: list[PlanEdit]) -> PlanResult:
     repo_root = engine.require_repo_root("storing a transform plan")
     stored, diffs, warnings = plans_mod.plan(
-        intent, edits, engine.project_dir(), repo_root, store=engine.store
+        intent,
+        edits,
+        engine.project_dir(),
+        repo_root,
+        store=engine.require_full_store("storing a semantic plan"),
     )
     return PlanResult(
         plan_id=stored.plan_id,
         intent=stored.intent,
         paths=[e.path for e in stored.edits],
-        plan_path=engine.store.plan_locator(stored.plan_id),
+        plan_path=engine.require_full_store("locating a plan").plan_locator(
+            stored.plan_id
+        ),
         diffs=diffs,
         warnings=warnings,
     )

--- a/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
@@ -47,13 +47,14 @@ from ..dbt_project import (
     target_role,
 )
 from ..dbt_project import load as load_project
-from ..storage import DEX_DIR, Store
+from ..errors import DexError
+from ..storage import DEX_DIR, ExploreStore
 
 if TYPE_CHECKING:
     from ..connect import ConnectionSource
 
 
-class DevTargetError(Exception):
+class DevTargetError(DexError):
     """Raised when the dev target cannot be built against. The message always
     names both of the values that disagree, or the statement that fixes it."""
 
@@ -92,7 +93,7 @@ def check(
     config: DexConfig,
     repo_root: Path | str = ".",
     *,
-    store: Store | None = None,
+    store: ExploreStore | None = None,
     connection: ConnectionSource | None = None,
 ) -> list[str]:
     """Refuse a dev target that has drifted or does not exist. Returns warnings.
@@ -213,7 +214,7 @@ _UNREACHABLE = (
 
 def preflight_opener(
     repo_root: Path | str,
-    store: Store | None,
+    store: ExploreStore | None,
     config: DexConfig | None = None,
     connection: ConnectionSource | None = None,
     *,
@@ -584,7 +585,7 @@ def content_check(
     repo_root: Path | str = ".",
     *,
     layered: bool = False,
-    store: Store | None = None,
+    store: ExploreStore | None = None,
     connection: ConnectionSource | None = None,
 ) -> list[str]:
     """Warn when a namespace the new project will build into already holds

--- a/packages/dex-core/src/exmergo_dex_core/transform/init.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/init.py
@@ -41,6 +41,7 @@ from ..config import (
 )
 from ..dbt_project import PROFILES_FILE, PROJECT_FILE, discover_projects
 from ..diffs import file_diff
+from ..errors import DexError
 from ..storage import DEX_DIR
 
 VALID_CONNECTORS = (
@@ -53,7 +54,7 @@ VALID_CONNECTORS = (
 )
 
 
-class InitError(Exception):
+class InitError(DexError):
     pass
 
 

--- a/packages/dex-core/src/exmergo_dex_core/transform/plans.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/plans.py
@@ -37,13 +37,14 @@ from ..dbt_project import (
     load as load_project,
 )
 from ..diffs import file_diff
+from ..errors import DexError
 from .validate import find_inlined_secret, validate_edit
 
 if TYPE_CHECKING:
     from ..storage import Store
 
 
-class PlanError(Exception):
+class PlanError(DexError):
     pass
 
 

--- a/packages/dex-core/src/exmergo_dex_core/transform/scaffold.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/scaffold.py
@@ -22,7 +22,8 @@ from importlib import resources
 
 from ..cache import Dataset
 from ..dbt_project import DbtProjectView
-from ..storage import Store
+from ..errors import DexError
+from ..storage import ExploreStore
 from .plans import EditKind, PlanEdit
 
 _SOURCES_FILE = "models/staging/_dex_sources.yml"
@@ -42,11 +43,11 @@ MACRO_ASSETS: dict[str, str] = {
 }
 
 
-class ScaffoldError(Exception):
+class ScaffoldError(DexError):
     pass
 
 
-def scaffold_edits(tables: list[str], store: Store) -> list[PlanEdit]:
+def scaffold_edits(tables: list[str], store: ExploreStore) -> list[PlanEdit]:
     """Build the plan edits that scaffold staging models for the named tables."""
 
     cache = store.load_cache()

--- a/packages/dex-core/src/exmergo_dex_core/transform/validate.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/validate.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from ..errors import DexError
 from ..guards.sql_guard import assert_select_only
 
 if TYPE_CHECKING:
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
     from .plans import PlanEdit
 
 
-class EditValidationError(Exception):
+class EditValidationError(DexError):
     pass
 
 

--- a/packages/dex-core/tests/storage/test_conformance.py
+++ b/packages/dex-core/tests/storage/test_conformance.py
@@ -1,0 +1,372 @@
+"""The seam as a third party meets it: a backend that is neither shipped backend.
+
+Everything else in this directory tests the two backends dex ships, which share
+an author with the protocol and so cannot show whether the contract is
+implementable by someone reading only what is published. These build a backend
+that is neither a directory nor a live in-process object, and drive it the way a
+host actually would.
+
+Two shapes matter here and are not covered anywhere else:
+
+- **A store outliving the engine that wrote it.** A request-per-engine host builds
+  a fresh engine per call and keeps state in its own datastore. Today's in-memory
+  coverage runs every step through one engine, which would pass even if the cache
+  never reached the store at all.
+- **A partial implementation that is still complete.** A host that only explores
+  implements ``ExploreStore`` and stops, and that has to be a satisfied contract
+  rather than five methods that raise.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from exmergo_dex_core import DexConfig, DexEngine, StoreRequiredError
+from exmergo_dex_core.cache import DexCache
+from exmergo_dex_core.storage import Document, ExploreStore, Store, spend_total
+from exmergo_dex_core.storage.conformance import (
+    ExploreStoreContract,
+    StoreContract,
+)
+from exmergo_dex_core.transform.plans import PlanNotFoundError, TransformPlan
+
+
+class DocumentStore:
+    """A document-database-shaped backend, serialized, keyed by tenant.
+
+    Deliberately unlike both shipped backends: state lives in a process-wide
+    registry rather than on disk or in the instance, documents are stored as JSON
+    strings the way a document store holds them, and two instances built with the
+    same tenant see the same state. That last property is the one a hosted
+    deployment depends on and neither shipped backend exercises, because
+    ``FilesystemStore`` gets it from the filesystem and ``MemoryStore`` does not
+    have it at all.
+    """
+
+    _registry: ClassVar[dict[str, dict[str, object]]] = {}
+
+    def __init__(self, tenant: str):
+        self.tenant = tenant
+        self._docs = self._registry.setdefault(tenant, {})
+
+    @classmethod
+    def reset(cls) -> None:
+        cls._registry.clear()
+
+    # --- documents ------------------------------------------------------------
+
+    def load_cache(self) -> DexCache | None:
+        raw = self._docs.get("cache")
+        return None if raw is None else DexCache.model_validate_json(str(raw))
+
+    def save_cache(self, cache: DexCache, *, now: datetime | None = None) -> str:
+        if now is not None:
+            cache.provenance.updated_at = now.isoformat()
+        self._docs["cache"] = cache.model_dump_json()
+        return self.locator(Document.CACHE)
+
+    def load_snapshot(self):
+        from exmergo_dex_core.maintain.snapshot import Snapshot
+
+        raw = self._docs.get("snapshot")
+        return None if raw is None else Snapshot.model_validate_json(str(raw))
+
+    def save_snapshot(self, snapshot) -> str:
+        self._docs["snapshot"] = snapshot.model_dump_json()
+        return self.locator(Document.SNAPSHOT)
+
+    def load_drift(self):
+        from exmergo_dex_core.maintain.drift import DriftReport
+
+        raw = self._docs.get("drift")
+        return None if raw is None else DriftReport.model_validate_json(str(raw))
+
+    def save_drift(self, report) -> str:
+        self._docs["drift"] = report.model_dump_json()
+        return self.locator(Document.DRIFT)
+
+    # --- ledgers --------------------------------------------------------------
+
+    def _ledger(self, name: str) -> list[str]:
+        return self._docs.setdefault(name, [])  # type: ignore[return-value]
+
+    def append_query_log(self, entry: dict) -> None:
+        self._ledger("queries").append(json.dumps(entry))
+
+    def append_spend_log(self, entry: dict) -> None:
+        self._ledger("spend").append(json.dumps(entry))
+
+    def spend_since(
+        self,
+        cutoff_iso: str,
+        *,
+        field: str = "billed_bytes",
+        connector: str | None = None,
+    ) -> float:
+        entries = []
+        for raw in self._ledger("spend"):
+            try:
+                entries.append(json.loads(raw))
+            except json.JSONDecodeError:
+                continue
+        return spend_total(entries, cutoff_iso, field=field, connector=connector)
+
+    # --- plans ----------------------------------------------------------------
+
+    def _plans(self) -> dict[str, str]:
+        return self._docs.setdefault("plans", {})  # type: ignore[return-value]
+
+    def save_plan(self, plan: TransformPlan) -> str:
+        self._plans()[plan.plan_id] = plan.model_dump_json()
+        return self.plan_locator(plan.plan_id)
+
+    def load_plan(self, plan_id: str) -> TransformPlan:
+        raw = self._plans().get(plan_id)
+        if raw is None:
+            raise PlanNotFoundError(f"no plan '{plan_id}' for tenant {self.tenant}")
+        return TransformPlan.model_validate_json(raw)
+
+    def list_plans(self) -> list[TransformPlan]:
+        plans = [TransformPlan.model_validate_json(r) for r in self._plans().values()]
+        return sorted(plans, key=lambda p: p.created_at, reverse=True)
+
+    def latest_plan(self, kind=None) -> TransformPlan | None:
+        candidates = [
+            p
+            for p in self.list_plans()
+            if p.applied_at is None
+            and (kind is None or all(e.kind is kind for e in p.edits))
+        ]
+        return max(candidates, key=lambda p: p.created_at, default=None)
+
+    # --- locators -------------------------------------------------------------
+
+    def locator(self, document: Document) -> str:
+        return f"docstore://{self.tenant}/{document.value}"
+
+    def plan_locator(self, plan_id: str) -> str:
+        return f"docstore://{self.tenant}/plans/{plan_id}"
+
+
+class ExploreOnlyStore:
+    """The narrow tier, with the five plan members genuinely absent.
+
+    Not a subclass of :class:`DocumentStore` with methods deleted: written from
+    the ``ExploreStore`` protocol alone, which is what a host that only explores
+    would actually write.
+    """
+
+    _registry: ClassVar[dict[str, dict[str, object]]] = {}
+
+    def __init__(self, tenant: str):
+        self.tenant = tenant
+        self._docs = self._registry.setdefault(tenant, {})
+
+    @classmethod
+    def reset(cls) -> None:
+        cls._registry.clear()
+
+    def load_cache(self) -> DexCache | None:
+        raw = self._docs.get("cache")
+        return None if raw is None else DexCache.model_validate_json(str(raw))
+
+    def save_cache(self, cache: DexCache, *, now: datetime | None = None) -> str:
+        if now is not None:
+            cache.provenance.updated_at = now.isoformat()
+        self._docs["cache"] = cache.model_dump_json()
+        return self.locator(Document.CACHE)
+
+    def append_query_log(self, entry: dict) -> None:
+        self._docs.setdefault("queries", []).append(json.dumps(entry))  # type: ignore[union-attr]
+
+    def append_spend_log(self, entry: dict) -> None:
+        self._docs.setdefault("spend", []).append(json.dumps(entry))  # type: ignore[union-attr]
+
+    def spend_since(
+        self,
+        cutoff_iso: str,
+        *,
+        field: str = "billed_bytes",
+        connector: str | None = None,
+    ) -> float:
+        raws = self._docs.setdefault("spend", [])
+        entries = [json.loads(r) for r in raws]  # type: ignore[union-attr]
+        return spend_total(entries, cutoff_iso, field=field, connector=connector)
+
+    def locator(self, document: Document) -> str:
+        return f"explore-only://{self.tenant}/{document.value}"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries():
+    DocumentStore.reset()
+    ExploreOnlyStore.reset()
+    yield
+    DocumentStore.reset()
+    ExploreOnlyStore.reset()
+
+
+# --- the shipped contract, run against a backend dex does not ship -------------
+
+
+class TestDocumentStoreConformance(StoreContract):
+    def make_store(self, key: str) -> DocumentStore:
+        return DocumentStore(tenant=key)
+
+
+class TestExploreOnlyStoreConformance(ExploreStoreContract):
+    def make_store(self, key: str) -> ExploreOnlyStore:
+        return ExploreOnlyStore(tenant=key)
+
+
+# --- the tiers are what they claim to be --------------------------------------
+
+
+def test_a_broken_backend_fails_with_the_rule_it_broke_not_a_bare_compare():
+    """The suite is documentation for someone who cannot read this source.
+
+    In-repo a bare `assert stored == original` is fine, because a failure sends
+    you to the source and the source is right here. Shipped, the assertion text is
+    all an outside implementer gets, and the no-aliasing rule is the worst case:
+    it fails silently and late, and presents as data corruption rather than as a
+    protocol violation. So the message has to name the contract.
+    """
+
+    class AliasingStore(ExploreOnlyStore):
+        """Returns the live stored object, the mistake an in-process cache invites."""
+
+        def save_cache(self, cache: DexCache, *, now: datetime | None = None) -> str:
+            if now is not None:
+                cache.provenance.updated_at = now.isoformat()
+            self._docs["live"] = cache  # the bug: no serialize, no copy
+            return self.locator(Document.CACHE)
+
+        def load_cache(self) -> DexCache | None:
+            return self._docs.get("live")  # type: ignore[return-value]
+
+    contract = ExploreStoreContract()
+    contract.make_store = lambda key: AliasingStore(key)  # type: ignore[method-assign]
+    store = contract.make_store("broken")
+
+    with pytest.raises(AssertionError) as failure:
+        contract.test_a_stored_document_is_not_aliased_to_the_callers_object(store)
+
+    message = str(failure.value)
+    assert "must not alias the caller's object" in message
+    # And it says what to do about it, not merely that something differed.
+    assert "Serialize on write, or deep-copy" in message
+
+
+def test_a_full_backend_satisfies_every_tier():
+    store = DocumentStore("t")
+    assert isinstance(store, ExploreStore)
+    assert isinstance(store, Store)
+
+
+def test_an_explore_only_backend_satisfies_the_explore_tier_and_no_more():
+    # The point of the tiers: this is a complete implementation of a declared
+    # contract, not a partial implementation of a wider one.
+    store = ExploreOnlyStore("t")
+    assert isinstance(store, ExploreStore)
+    assert not isinstance(store, Store)
+
+
+# --- the request-per-engine shape ----------------------------------------------
+
+
+def test_state_written_by_one_engine_is_visible_to_the_next(duckdb_file: Path):
+    # The shape a host serving requests actually has: an engine per call, state in
+    # the host's own datastore. Nothing here shares an engine, so a cache that
+    # never reached the store would fail rather than pass on a live object.
+    config = DexConfig(connector="duckdb")
+
+    with DexEngine(
+        connector="duckdb",
+        path=str(duckdb_file),
+        config=config,
+        store=DocumentStore("tenant-a"),
+    ) as first:
+        first.map()
+
+    with DexEngine(
+        connector="duckdb",
+        path=str(duckdb_file),
+        config=config,
+        store=DocumentStore("tenant-a"),
+    ) as second:
+        # The query firewall resolves this table against the cache the *previous*
+        # engine wrote, which is the whole reason a durable store is required and
+        # not merely convenient.
+        result = second.query("select count(*) as n from customers")
+
+    assert result.cells[0][0] == 2
+
+
+def test_one_tenants_cache_is_invisible_to_another(duckdb_file: Path):
+    config = DexConfig(connector="duckdb")
+    with DexEngine(
+        connector="duckdb",
+        path=str(duckdb_file),
+        config=config,
+        store=DocumentStore("tenant-a"),
+    ) as owner:
+        owner.map()
+
+    other = DocumentStore("tenant-b")
+    assert other.load_cache() is None
+    # And the firewall refuses for the other tenant, because cache membership is
+    # what decides that a query may name this table at all.
+    with (
+        DexEngine(
+            connector="duckdb",
+            path=str(duckdb_file),
+            config=config,
+            store=other,
+        ) as stranger,
+        pytest.raises(Exception),
+    ):
+        stranger.query("select count(*) as n from customers")
+
+
+def test_an_explore_only_store_drives_a_full_explore_flow(duckdb_file: Path):
+    config = DexConfig(connector="duckdb")
+    with DexEngine(
+        connector="duckdb",
+        path=str(duckdb_file),
+        config=config,
+        store=ExploreOnlyStore("tenant-a"),
+    ) as first:
+        first.map()
+
+    with DexEngine(
+        connector="duckdb",
+        path=str(duckdb_file),
+        config=config,
+        store=ExploreOnlyStore("tenant-a"),
+    ) as second:
+        result = second.query("select count(*) as n from orders")
+
+    assert result.cells[0][0] == 3
+
+
+def test_transform_refuses_an_explore_only_store_by_naming_the_tier(tmp_path: Path):
+    engine = DexEngine(
+        connector="duckdb",
+        path="x.duckdb",
+        config=DexConfig(connector="duckdb"),
+        store=ExploreOnlyStore("tenant-a"),
+        repo_root=str(tmp_path),
+    )
+    with pytest.raises(StoreRequiredError) as refusal:
+        engine.plans()
+    message = str(refusal.value)
+    # The refusal has to name the tier and the missing members, or an implementer
+    # reads it as "storage is broken" rather than "I implemented the narrow one".
+    assert "explore tier" in message
+    assert "list_plans" in message
+    assert "ExploreStore" in message

--- a/packages/dex-core/tests/storage/test_parity.py
+++ b/packages/dex-core/tests/storage/test_parity.py
@@ -1,306 +1,38 @@
-"""One contract, every backend: the assertions each ``Store`` owes its callers.
+"""One contract, every backend: the assertions each store owes its callers.
 
-Parameterized over both backends deliberately. The engine talks to the store
-through the protocol, so the interesting question is never "does the filesystem
-work" but "do the backends agree". Adding a backend means adding it to
-``store_factory`` here, and the whole contract runs against it for free.
+The contract itself lives in `exmergo_dex_core.storage.conformance`, shipped in
+the wheel so a backend outside this distribution runs exactly these assertions.
+This file is the in-repo consumer of it, and it is deliberately the same three
+lines a third party writes: if driving the shipped contract were awkward here, it
+would be awkward there.
+
+Backend-specific behavior lives in test_filesystem.py and test_memory.py. What is
+here is only "do the backends agree".
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
-from exmergo_dex_core.cache import CacheProvenance, Dataset, DexCache
-from exmergo_dex_core.maintain.drift import AxisResult, DriftFinding, DriftReport
-from exmergo_dex_core.maintain.snapshot import Snapshot, WarehouseBaseline
-from exmergo_dex_core.storage import Document, FilesystemStore, MemoryStore, Store
-from exmergo_dex_core.transform.plans import (
-    EditKind,
-    PlanEdit,
-    PlanNotFoundError,
-    TransformPlan,
-)
+from exmergo_dex_core.storage import FilesystemStore, MemoryStore
+from exmergo_dex_core.storage.conformance import StoreContract
 
 
-@pytest.fixture(params=["filesystem", "memory"])
-def store(request: pytest.FixtureRequest, tmp_path: Path) -> Store:
-    if request.param == "filesystem":
-        return FilesystemStore(tmp_path)
-    return MemoryStore()
+class TestFilesystemStore(StoreContract):
+    @pytest.fixture(autouse=True)
+    def _root(self, tmp_path: Path):
+        # One root per test, with the key as a subdirectory: two keys are two
+        # directories, which is what "shares nothing" means for this backend.
+        self.root = tmp_path
 
+    def make_store(self, key: str) -> FilesystemStore:
+        return FilesystemStore(self.root / key)
 
-def _cache(identifier: str = "db.main.orders") -> DexCache:
-    return DexCache(
-        datasets=[Dataset(identifier=identifier, row_count=3)],
-        provenance=CacheProvenance(connector="duckdb"),
-    )
 
-
-def _snapshot(created_at: str = "2026-07-03T10:00:00+00:00") -> Snapshot:
-    return Snapshot(
-        created_at=created_at,
-        connector="duckdb",
-        warehouse=WarehouseBaseline(datasets=[]),
-        warehouse_from="metadata",
-    )
-
-
-def _drift() -> DriftReport:
-    return DriftReport(
-        connector="duckdb",
-        snapshot_created_at="2026-07-03T10:00:00+00:00",
-        axes={
-            "schema": AxisResult(
-                run_at="2026-07-03T11:00:00+00:00",
-                findings=[
-                    DriftFinding(
-                        axis="schema",
-                        code="column_added",
-                        identifier="db.main.orders",
-                        column="discount",
-                        detail="a new column appeared in the source",
-                    )
-                ],
-            )
-        },
-    )
-
-
-def _plan(plan_id: str, created_at: str, *, kind=EditKind.MODEL_SQL) -> TransformPlan:
-    return TransformPlan(
-        plan_id=plan_id,
-        created_at=created_at,
-        intent="add a model",
-        project_dir="analytics",
-        edits=[
-            PlanEdit(
-                path="models/staging/stg_orders.sql",
-                kind=kind,
-                new_content="select 1 as id\n",
-            )
-        ],
-    )
-
-
-# --- documents ----------------------------------------------------------------
-
-
-def test_absent_documents_read_as_none(store: Store):
-    # Absence is not an error: every caller treats None as "nothing learned yet"
-    # and says so with an actionable message of its own.
-    assert store.load_cache() is None
-    assert store.load_snapshot() is None
-    assert store.load_drift() is None
-
-
-def test_cache_round_trips(store: Store):
-    store.save_cache(_cache())
-    loaded = store.load_cache()
-    assert loaded is not None
-    assert [d.identifier for d in loaded.datasets] == ["db.main.orders"]
-    assert loaded.provenance.connector == "duckdb"
-
-
-def test_saving_a_cache_replaces_the_previous_one(store: Store):
-    store.save_cache(_cache("db.main.orders"))
-    store.save_cache(_cache("db.main.customers"))
-    loaded = store.load_cache()
-    assert loaded is not None
-    assert [d.identifier for d in loaded.datasets] == ["db.main.customers"]
-
-
-def test_save_cache_stamps_updated_at_when_given_a_clock(store: Store):
-    now = datetime(2026, 7, 3, 12, 0, tzinfo=UTC)
-    cache = _cache()
-    store.save_cache(cache, now=now)
-    # Stamped on the caller's object as well as the stored copy: the command
-    # layer reports the same timestamp it just persisted.
-    assert cache.provenance.updated_at == now.isoformat()
-    loaded = store.load_cache()
-    assert loaded is not None
-    assert loaded.provenance.updated_at == now.isoformat()
-
-
-def test_save_cache_without_a_clock_leaves_updated_at_alone(store: Store):
-    cache = _cache()
-    cache.provenance.updated_at = "2026-07-01T00:00:00+00:00"
-    store.save_cache(cache)
-    loaded = store.load_cache()
-    assert loaded is not None
-    assert loaded.provenance.updated_at == "2026-07-01T00:00:00+00:00"
-
-
-def test_a_stored_document_is_not_aliased_to_the_callers_object(store: Store):
-    # A filesystem backend serializes, so a caller cannot reach back into what it
-    # already saved. Every backend must behave that way or a mutation after the
-    # save would silently rewrite history on some backends and not others.
-    cache = _cache()
-    store.save_cache(cache)
-    cache.datasets[0].identifier = "mutated.after.save"
-    cache.datasets.append(Dataset(identifier="db.main.appended"))
-    loaded = store.load_cache()
-    assert loaded is not None
-    assert [d.identifier for d in loaded.datasets] == ["db.main.orders"]
-
-
-def test_snapshot_round_trips(store: Store):
-    store.save_snapshot(_snapshot())
-    loaded = store.load_snapshot()
-    assert loaded is not None
-    assert loaded.created_at == "2026-07-03T10:00:00+00:00"
-    assert loaded.warehouse_from == "metadata"
-
-
-def test_drift_round_trips_with_its_findings(store: Store):
-    store.save_drift(_drift())
-    loaded = store.load_drift()
-    assert loaded is not None
-    assert loaded.snapshot_created_at == "2026-07-03T10:00:00+00:00"
-    assert [f.column for f in loaded.axes["schema"].findings] == ["discount"]
-
-
-# --- ledgers ------------------------------------------------------------------
-
-
-def test_spend_since_sums_only_from_the_cutoff(store: Store):
-    store.append_spend_log({"at": "2026-07-02T23:59:00+00:00", "billed_bytes": 1_000})
-    store.append_spend_log({"at": "2026-07-03T00:01:00+00:00", "billed_bytes": 200})
-    store.append_spend_log({"at": "2026-07-03T12:00:00+00:00", "billed_bytes": 300})
-    assert store.spend_since("2026-07-03T00:00:00+00:00") == 500
-
-
-def test_spend_since_is_zero_on_an_empty_ledger(store: Store):
-    assert store.spend_since("2026-07-03T00:00:00+00:00") == 0.0
-
-
-def test_spend_since_keeps_units_and_connectors_apart(store: Store):
-    # The safety-critical case: one ledger, several paradigms. A bytes budget must
-    # never absorb another connector's seconds entry.
-    store.append_spend_log(
-        {"at": "2026-07-03T10:00:00+00:00", "connector": "bigquery", "billed_bytes": 90}
-    )
-    store.append_spend_log(
-        {
-            "at": "2026-07-03T10:05:00+00:00",
-            "connector": "snowflake",
-            "billed_seconds": 42,
-        }
-    )
-    cutoff = "2026-07-03T00:00:00+00:00"
-    assert store.spend_since(cutoff, connector="bigquery") == 90
-    assert (
-        store.spend_since(cutoff, field="billed_seconds", connector="snowflake") == 42
-    )
-    # Asking for the wrong unit or the wrong connector yields nothing, never a
-    # cross-paradigm number.
-    assert store.spend_since(cutoff, connector="snowflake") == 0.0
-    assert (
-        store.spend_since(cutoff, field="billed_seconds", connector="bigquery") == 0.0
-    )
-
-
-def test_a_ledger_entry_is_not_aliased_to_the_callers_dict(store: Store):
-    entry = {"at": "2026-07-03T10:00:00+00:00", "billed_bytes": 100}
-    store.append_spend_log(entry)
-    entry["billed_bytes"] = 999_999
-    assert store.spend_since("2026-07-03T00:00:00+00:00") == 100
-
-
-def test_query_log_accepts_every_decision(store: Store):
-    # Refusals are logged too; the ledger is the audit trail, not a success log.
-    for decision in ("allowed", "refused", "needs_confirmation", "failed"):
-        store.append_query_log(
-            {"at": "2026-07-03T10:00:00+00:00", "sql": "select 1", "decision": decision}
-        )
-
-
-# --- plans --------------------------------------------------------------------
-
-
-def test_plan_round_trips(store: Store):
-    store.save_plan(_plan("pabc", "2026-07-03T10:00:00+00:00"))
-    loaded = store.load_plan("pabc")
-    assert loaded.intent == "add a model"
-    assert loaded.edits[0].path == "models/staging/stg_orders.sql"
-
-
-def test_loading_an_unknown_plan_raises(store: Store):
-    with pytest.raises(PlanNotFoundError):
-        store.load_plan("pnope")
-
-
-def test_list_plans_is_newest_first(store: Store):
-    store.save_plan(_plan("pold", "2026-07-01T10:00:00+00:00"))
-    store.save_plan(_plan("pnew", "2026-07-03T10:00:00+00:00"))
-    assert [p.plan_id for p in store.list_plans()] == ["pnew", "pold"]
-
-
-def test_list_plans_is_empty_before_anything_is_planned(store: Store):
-    assert store.list_plans() == []
-
-
-def test_latest_plan_skips_applied_ones(store: Store):
-    applied = _plan("papplied", "2026-07-03T12:00:00+00:00")
-    applied.applied_at = "2026-07-03T12:30:00+00:00"
-    store.save_plan(applied)
-    store.save_plan(_plan("ppending", "2026-07-03T10:00:00+00:00"))
-    latest = store.latest_plan()
-    assert latest is not None and latest.plan_id == "ppending"
-
-
-def test_latest_plan_filters_by_kind(store: Store):
-    store.save_plan(_plan("pmodel", "2026-07-03T10:00:00+00:00"))
-    store.save_plan(
-        _plan("psemantic", "2026-07-03T11:00:00+00:00", kind=EditKind.SEMANTIC_YML)
-    )
-    semantic = store.latest_plan(EditKind.SEMANTIC_YML)
-    assert semantic is not None and semantic.plan_id == "psemantic"
-    model = store.latest_plan(EditKind.MODEL_SQL)
-    assert model is not None and model.plan_id == "pmodel"
-
-
-def test_latest_plan_is_none_when_everything_is_applied(store: Store):
-    applied = _plan("papplied", "2026-07-03T12:00:00+00:00")
-    applied.applied_at = "2026-07-03T12:30:00+00:00"
-    store.save_plan(applied)
-    assert store.latest_plan() is None
-
-
-def test_resaving_a_plan_updates_it_in_place(store: Store):
-    # This is how apply marks a plan applied: same id, new applied_at.
-    plan = _plan("pabc", "2026-07-03T10:00:00+00:00")
-    store.save_plan(plan)
-    plan.applied_at = "2026-07-03T10:30:00+00:00"
-    store.save_plan(plan)
-    assert len(store.list_plans()) == 1
-    assert store.load_plan("pabc").applied_at == "2026-07-03T10:30:00+00:00"
-
-
-# --- locators -----------------------------------------------------------------
-
-
-@pytest.mark.parametrize("document", list(Document))
-def test_every_document_has_a_locator_before_it_is_written(
-    store: Store, document: Document
-):
-    # The over-ceiling error and the drift envelope both report a location without
-    # having written one, so a locator must not depend on the document existing.
-    assert isinstance(store.locator(document), str)
-    assert store.locator(document)
-
-
-def test_saving_returns_the_same_locator_the_store_reports(store: Store):
-    assert store.save_cache(_cache()) == store.locator(Document.CACHE)
-    assert store.save_snapshot(_snapshot()) == store.locator(Document.SNAPSHOT)
-    assert store.save_drift(_drift()) == store.locator(Document.DRIFT)
-
-
-def test_plan_locators_are_per_plan(store: Store):
-    first = store.save_plan(_plan("pone", "2026-07-03T10:00:00+00:00"))
-    second = store.save_plan(_plan("ptwo", "2026-07-03T11:00:00+00:00"))
-    assert first == store.plan_locator("pone")
-    assert second == store.plan_locator("ptwo")
-    assert first != second
+class TestMemoryStore(StoreContract):
+    def make_store(self, key: str) -> MemoryStore:
+        # Nothing to key on: a MemoryStore's state is the instance, so a distinct
+        # instance is a distinct key by construction.
+        return MemoryStore()

--- a/packages/dex-core/tests/test_errors.py
+++ b/packages/dex-core/tests/test_errors.py
@@ -1,0 +1,282 @@
+"""The refusal surface a library consumer maps onto its own responses.
+
+The CLI renders every refusal into an error envelope behind a catch-all, so it
+never needed a hierarchy and would not notice if one regressed. A library
+consumer cannot do that: catching ``Exception`` at an API boundary swallows real
+bugs alongside deliberate refusals, so the guarantee these pin is that everything
+dex refuses on purpose is reachable as ``DexError`` and nothing requires reaching
+into a private module to catch.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+import exmergo_dex_core as public
+from exmergo_dex_core import (
+    ConfigurationError,
+    DexConfig,
+    DexEngine,
+    DexError,
+    MemoryStore,
+    NoConnectorSelectedError,
+    RepoRootRequiredError,
+    RequestError,
+    StoreRequiredError,
+)
+from exmergo_dex_core.errors import ConfigurationError as _ConfigurationError
+
+
+def _every_refusal_class() -> list[type]:
+    """Every exception class the engine defines, found by walking the package.
+
+    Walked rather than listed: a new refusal added in a future change is caught
+    here without anyone remembering to update a list, which is the only way this
+    assertion keeps its value.
+    """
+
+    import importlib
+    import pkgutil
+
+    found: list[type] = []
+    package = importlib.import_module("exmergo_dex_core")
+    for info in pkgutil.walk_packages(package.__path__, f"{package.__name__}."):
+        if info.name.endswith(".conformance"):
+            continue  # ships pytest-dependent test code, not engine code
+        try:
+            module = importlib.import_module(info.name)
+        except ImportError:
+            continue  # a module behind an extra that is not installed
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if (
+                issubclass(obj, BaseException)
+                and obj.__module__.startswith("exmergo_dex_core")
+                and obj is not DexError
+            ):
+                found.append(obj)
+    return sorted(set(found), key=lambda c: (c.__module__, c.__name__))
+
+
+def test_every_refusal_the_engine_defines_roots_on_dex_error():
+    stragglers = [c for c in _every_refusal_class() if not issubclass(c, DexError)]
+    assert stragglers == [], (
+        "these refusals cannot be caught as DexError, so a library consumer has "
+        f"to catch Exception to see them: {[c.__name__ for c in stragglers]}"
+    )
+
+
+# Refusals a library consumer is not expected to catch by name, each for a
+# stated reason. Everything else must be importable from the package root, and
+# the test below enforces that, so adding a refusal forces a deliberate choice
+# here rather than a silent omission. That omission is exactly how
+# CacheRequiredError and NoBaselineError stayed unreachable long enough for
+# someone embedding the engine to have to match on prose instead.
+INTERNAL_REFUSALS = {
+    # Connector-specific connection failures. A host catches the ConnectorError
+    # family instead of importing six names, one per warehouse it does not use.
+    "BigQueryConnectionError",
+    "DatabricksConnectionError",
+    "DuckDBReadOnlyError",
+    "PostgresConnectionError",
+    "RedshiftConnectionError",
+    "SnowflakeConnectionError",
+    # Wrapped before a caller sees it: the firewall turns this into
+    # QueryRefusedError, which is what carries the refusal to the boundary.
+    "NotSelectOnlyError",
+    # An envelope-layer invariant, raised at the CLI boundary rather than
+    # returned from the engine.
+    "SanitizationError",
+    # The transform surface. Every one of these needs a repo_root, so they sit
+    # outside "reachable from the public API without a repo_root". Worth
+    # revisiting as a family if a host ever drives transform programmatically.
+    "BuildFailedError",
+    "DbtParseError",
+    "DbtProjectError",
+    "DbtRunError",
+    "DevTargetError",
+    "EditValidationError",
+    "InitError",
+    "ProdTargetRefusedError",
+    "ScaffoldError",
+}
+
+
+def test_every_refusal_a_host_can_hit_is_importable_from_the_package_root():
+    """Typed is not enough; a consumer has to be able to name the type.
+
+    A refusal that is a distinct class but not exported leaves a host matching on
+    prose, and prose is not an interface anyone owes stability on. Rewording an
+    error message then silently changes which branch a consumer takes, which is a
+    behavior change nothing in this repo would catch.
+    """
+
+    missing = sorted(
+        cls.__name__
+        for cls in _every_refusal_class()
+        if cls.__name__ not in INTERNAL_REFUSALS and cls.__name__ not in public.__all__
+    )
+    assert missing == [], (
+        "these refusals are typed but not importable from exmergo_dex_core, so a "
+        "consumer has to match on message prose to branch on them: "
+        f"{missing}. Export them, or add them to INTERNAL_REFUSALS with a reason."
+    )
+
+
+def test_the_prerequisite_family_is_what_a_host_retries_on():
+    """The distinction the export gap cost a consumer real money to discover.
+
+    A prerequisite refusal means state is missing and a named command creates it,
+    so a caller can resolve it automatically and retry. A connector failure means
+    the warehouse is unreachable. Both are DexError, and catching DexError cannot
+    tell them apart, which is the whole reason these two families exist.
+    """
+
+    from exmergo_dex_core import (
+        CacheRequiredError,
+        ConnectorError,
+        NoBaselineError,
+        PrerequisiteError,
+    )
+
+    for cls in (CacheRequiredError, NoBaselineError):
+        assert issubclass(cls, PrerequisiteError), cls
+        assert not issubclass(cls, ConnectorError), cls
+
+    from exmergo_dex_core.adapters.duckdb import DuckDBReadOnlyError
+
+    assert issubclass(DuckDBReadOnlyError, ConnectorError)
+    assert not issubclass(DuckDBReadOnlyError, PrerequisiteError)
+
+
+def test_a_missing_credential_is_not_a_connector_failure():
+    """Deliberate, and the opposite of what the family names suggest at a glance.
+
+    A host backs off and retries on ConnectorError. A credential that was never
+    configured will not appear on retry, and the message names the config that
+    fixes it, so filing it under the retry family would send hosts down a loop
+    that cannot terminate.
+    """
+
+    from exmergo_dex_core import ConnectorError, CredentialDiscoveryError, DexError
+
+    assert issubclass(CredentialDiscoveryError, DexError)
+    assert not issubclass(CredentialDiscoveryError, ConnectorError)
+
+
+def test_a_backend_author_can_import_what_the_protocol_tells_them_to_raise():
+    """`Store.load_plan` is documented as raising PlanNotFoundError.
+
+    A third-party backend cannot satisfy that from a private module, so the name
+    has to be public for the storage contract to be implementable at all.
+    """
+
+    from exmergo_dex_core import PlanNotFoundError
+    from exmergo_dex_core.storage.base import Store
+
+    assert "PlanNotFoundError" in Store.load_plan.__doc__
+    assert issubclass(PlanNotFoundError, DexError)
+
+
+def test_the_hosted_semantic_refusals_are_importable_from_the_package_root():
+    # The documented catch for the hosted semantic path. Reaching them through
+    # exmergo_dex_core.explore.semantic makes a consumer depend on a module
+    # layout that is not public surface.
+    assert issubclass(public.SemanticQueryRefusedError, public.SemanticBackendError)
+    assert issubclass(public.SemanticBackendError, DexError)
+
+
+def test_the_configuration_family_still_catches_as_value_error():
+    # These raised bare ValueError before they were typed. A consumer written
+    # against that API keeps working; that is the point of adding the type rather
+    # than trading one breaking change for another.
+    for cls in (
+        ConfigurationError,
+        RequestError,
+        NoConnectorSelectedError,
+        RepoRootRequiredError,
+        StoreRequiredError,
+    ):
+        assert issubclass(cls, ValueError), cls
+        assert issubclass(cls, DexError), cls
+
+
+def test_configuration_error_is_the_same_class_through_both_import_paths():
+    assert ConfigurationError is _ConfigurationError
+
+
+# --- the refusals reachable from the public API without a repo root -----------
+
+
+def test_no_connector_selected_is_typed():
+    engine = DexEngine(store=MemoryStore())
+    with pytest.raises(NoConnectorSelectedError) as refusal:
+        engine.connect_test()
+    assert "connector" in str(refusal.value)
+
+
+def test_a_missing_repo_root_names_what_needed_it():
+    engine = DexEngine(
+        connector="duckdb", path="x.duckdb", config=DexConfig(connector="duckdb")
+    )
+    with pytest.raises(RepoRootRequiredError) as refusal:
+        engine.project_dir()
+    assert "repo root" in str(refusal.value)
+
+
+def test_a_metered_connector_with_no_store_is_typed():
+    from exmergo_dex_core.connect import _require_store
+
+    with pytest.raises(StoreRequiredError) as refusal:
+        _require_store(None, "bigquery")
+    assert "spend ledger" in str(refusal.value)
+
+
+def test_an_unusable_column_in_the_call_is_a_request_error(duckdb_file: Path):
+    pytest.importorskip("sklearn")
+    with DexEngine(
+        connector="duckdb",
+        path=str(duckdb_file),
+        config=DexConfig(connector="duckdb"),
+        store=MemoryStore(),
+    ) as engine:
+        engine.map()
+        with pytest.raises(RequestError) as refusal:
+            engine.cluster("customers", features=["email"])
+    # Bad input rather than missing input: the object is profiled and the column
+    # exists, the call just asked to cluster on text.
+    assert "not numeric" in str(refusal.value)
+
+
+def test_an_unprofiled_object_is_still_catchable_as_dex_error(duckdb_file: Path):
+    # Deliberately not a RequestError: the fix is a dex command (`explore map`),
+    # not a corrected argument, and the refusal says so. What matters to a
+    # consumer is that one catch covers both.
+    pytest.importorskip("sklearn")
+    with DexEngine(
+        connector="duckdb",
+        path=str(duckdb_file),
+        config=DexConfig(connector="duckdb"),
+        store=MemoryStore(),
+    ) as engine:
+        engine.map()
+        with pytest.raises(DexError) as refusal:
+            engine.cluster("no_such_table")
+    assert "no_such_table" in str(refusal.value)
+
+
+def test_an_injected_connection_for_duckdb_is_a_configuration_error():
+    from exmergo_dex_core import ConnectionSource
+
+    engine = DexEngine(
+        connector="duckdb",
+        path="x.duckdb",
+        config=DexConfig(connector="duckdb"),
+        store=MemoryStore(),
+        connection=ConnectionSource(connect=lambda: object()),
+    )
+    with pytest.raises(ConfigurationError) as refusal:
+        engine.connect_test()
+    assert "duckdb" in str(refusal.value)

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -287,8 +287,9 @@ def test_the_all_extra_installs_every_optional_capability(wheel: str):
     version conflict between them can surface at all.
 
     `dev` and `conformance` are excluded deliberately: contributor tooling, not
-    capabilities. `conformance` carries a test runner for people implementing a
-    storage backend, and nobody installing "everything dex can do" wants pytest.
+    capabilities. `storage-conformance` carries a test runner for people
+    implementing a storage backend, and nobody installing "everything dex can do"
+    wants pytest.
     """
 
     extras = _project_metadata()["optional-dependencies"]
@@ -296,7 +297,7 @@ def test_the_all_extra_installs_every_optional_capability(wheel: str):
     referenced = set(
         extras["all"][0].removeprefix("exmergo-dex-core[").removesuffix("]").split(",")
     )
-    tooling = {"all", "conformance", "dev"}
+    tooling = {"all", "dev", "storage-conformance"}
     assert referenced == set(extras) - tooling, (
         f"[all] does not cover {sorted(set(extras) - tooling - referenced)}"
     )
@@ -504,7 +505,7 @@ def test_a_backend_outside_the_distribution_passes_the_shipped_contract(
             "--isolated",
             "--no-project",
             "--with",
-            f"exmergo-dex-core[conformance] @ {wheel}",
+            f"exmergo-dex-core[storage-conformance] @ {wheel}",
             "pytest",
             "-q",
             str(suite),

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -286,7 +286,9 @@ def test_the_all_extra_installs_every_optional_capability(wheel: str):
     dbt adapters and MetricFlow in one environment, it is also the only place a
     version conflict between them can surface at all.
 
-    `dev` is excluded deliberately: contributor tooling, not a capability.
+    `dev` and `conformance` are excluded deliberately: contributor tooling, not
+    capabilities. `conformance` carries a test runner for people implementing a
+    storage backend, and nobody installing "everything dex can do" wants pytest.
     """
 
     extras = _project_metadata()["optional-dependencies"]
@@ -294,8 +296,9 @@ def test_the_all_extra_installs_every_optional_capability(wheel: str):
     referenced = set(
         extras["all"][0].removeprefix("exmergo-dex-core[").removesuffix("]").split(",")
     )
-    assert referenced == set(extras) - {"all", "dev"}, (
-        f"[all] does not cover {sorted(set(extras) - {'all', 'dev'} - referenced)}"
+    tooling = {"all", "conformance", "dev"}
+    assert referenced == set(extras) - tooling, (
+        f"[all] does not cover {sorted(set(extras) - tooling - referenced)}"
     )
 
     # Every client the extras exist to deliver, plus each dbt adapter, since a
@@ -400,3 +403,115 @@ def test_the_installed_console_script_speaks_the_command_contract(wheel: str):
     envelope = json.loads(done.stdout)
     assert envelope["status"] == "not_implemented"
     assert envelope["data"]["command"] == "viz preview"
+
+
+def test_the_wheel_ships_the_typed_marker(wheel: str):
+    """`py.typed` is what makes the storage protocol checkable by anyone else.
+
+    The seam is enforced entirely by structural typing: a backend "implements"
+    `Store` by having the right methods with the right signatures, and nothing at
+    runtime re-checks that. Without this marker a downstream type checker treats
+    the whole package as untyped and silently verifies nothing, so an implementer
+    gets no signal at all until something fails in production.
+    """
+
+    import zipfile
+
+    with zipfile.ZipFile(wheel) as archive:
+        names = archive.namelist()
+    assert "exmergo_dex_core/py.typed" in names, (
+        "py.typed is not in the wheel, so the storage seam is unverifiable "
+        f"downstream: {sorted(n for n in names if n.count('/') <= 1)[:15]}"
+    )
+
+
+OUTSIDE_BACKEND = '''
+import json
+
+from exmergo_dex_core.cache import DexCache
+from exmergo_dex_core.storage import Document, ExploreStore, spend_total
+from exmergo_dex_core.storage.conformance import ExploreStoreContract
+
+
+class TinyStore:
+    """A backend written against the published protocol and nothing else."""
+
+    _state: dict = {}
+
+    def __init__(self, key):
+        self.key = key
+        self._docs = self._state.setdefault(key, {})
+
+    def load_cache(self):
+        raw = self._docs.get("cache")
+        return None if raw is None else DexCache.model_validate_json(raw)
+
+    def save_cache(self, cache, *, now=None):
+        if now is not None:
+            cache.provenance.updated_at = now.isoformat()
+        self._docs["cache"] = cache.model_dump_json()
+        return self.locator(Document.CACHE)
+
+    def append_query_log(self, entry):
+        self._docs.setdefault("q", []).append(json.dumps(entry))
+
+    def append_spend_log(self, entry):
+        self._docs.setdefault("s", []).append(json.dumps(entry))
+
+    def spend_since(self, cutoff_iso, *, field="billed_bytes", connector=None):
+        entries = [json.loads(r) for r in self._docs.setdefault("s", [])]
+        return spend_total(entries, cutoff_iso, field=field, connector=connector)
+
+    def locator(self, document):
+        return "tiny://" + self.key + "/" + document.value
+
+
+def test_the_published_protocol_is_satisfied():
+    assert isinstance(TinyStore("k"), ExploreStore)
+
+
+class TestTinyStore(ExploreStoreContract):
+    def make_store(self, key):
+        TinyStore._state.pop(key, None)
+        return TinyStore(key)
+'''
+
+
+def test_a_backend_outside_the_distribution_passes_the_shipped_contract(
+    wheel: str, tmp_path: Path
+):
+    """A storage backend implemented by someone who cannot see this source tree.
+
+    Everything else about the storage contract is tested from inside this repo,
+    against backends written by the same person as the protocol, importing from a
+    source tree. None of that shows whether anyone else can do it. So: build the
+    wheel, install it somewhere isolated from this repo, write a backend there
+    against the published protocol alone, and run the conformance suite dex ships
+    at that backend.
+
+    If this passes, an outside contributor can implement a storage backend from
+    what is published, which is the entire point of publishing it. If it fails,
+    they cannot, whatever the in-repo tests say.
+    """
+
+    suite = tmp_path / "test_outside_backend.py"
+    suite.write_text(OUTSIDE_BACKEND.lstrip(), encoding="utf-8")
+
+    done = subprocess.run(  # noqa: S603  (a fixed argv, no shell)
+        [
+            _uv(),
+            "run",
+            "--isolated",
+            "--no-project",
+            "--with",
+            f"exmergo-dex-core[conformance] @ {wheel}",
+            "pytest",
+            "-q",
+            str(suite),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert "passed" in done.stdout

--- a/packages/dex-core/uv.lock
+++ b/packages/dex-core/uv.lock
@@ -809,9 +809,6 @@ bigquery = [
 cluster = [
     { name = "scikit-learn" },
 ]
-conformance = [
-    { name = "pytest" },
-]
 databricks = [
     { name = "databricks-sdk" },
     { name = "databricks-sql-connector" },
@@ -855,6 +852,9 @@ snowflake = [
 sql = [
     { name = "sqlglot" },
 ]
+storage-conformance = [
+    { name = "pytest" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -887,8 +887,8 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "extra == 'all'", specifier = ">=3" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3" },
     { name = "pydantic", specifier = ">=2" },
-    { name = "pytest", marker = "extra == 'conformance'", specifier = ">=8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest", marker = "extra == 'storage-conformance'", specifier = ">=8" },
     { name = "pyyaml", specifier = ">=6" },
     { name = "redshift-connector", marker = "extra == 'all'", specifier = ">=2.1" },
     { name = "redshift-connector", marker = "extra == 'redshift'", specifier = ">=2.1" },
@@ -909,7 +909,7 @@ requires-dist = [
     { name = "sqlglot", marker = "extra == 'snowflake'", specifier = ">=28.6,<31" },
     { name = "sqlglot", marker = "extra == 'sql'", specifier = ">=28.6,<31" },
 ]
-provides-extras = ["all", "bigquery", "cluster", "conformance", "databricks", "dev", "duckdb", "postgres", "redshift", "semantic", "semantic-api", "snowflake", "sql"]
+provides-extras = ["all", "bigquery", "cluster", "databricks", "dev", "duckdb", "postgres", "redshift", "semantic", "semantic-api", "snowflake", "sql", "storage-conformance"]
 
 [[package]]
 name = "fastjsonschema"

--- a/packages/dex-core/uv.lock
+++ b/packages/dex-core/uv.lock
@@ -809,6 +809,9 @@ bigquery = [
 cluster = [
     { name = "scikit-learn" },
 ]
+conformance = [
+    { name = "pytest" },
+]
 databricks = [
     { name = "databricks-sdk" },
     { name = "databricks-sql-connector" },
@@ -884,6 +887,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "extra == 'all'", specifier = ">=3" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3" },
     { name = "pydantic", specifier = ">=2" },
+    { name = "pytest", marker = "extra == 'conformance'", specifier = ">=8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pyyaml", specifier = ">=6" },
     { name = "redshift-connector", marker = "extra == 'all'", specifier = ">=2.1" },
@@ -905,7 +909,7 @@ requires-dist = [
     { name = "sqlglot", marker = "extra == 'snowflake'", specifier = ">=28.6,<31" },
     { name = "sqlglot", marker = "extra == 'sql'", specifier = ">=28.6,<31" },
 ]
-provides-extras = ["all", "bigquery", "cluster", "databricks", "dev", "duckdb", "postgres", "redshift", "semantic", "semantic-api", "snowflake", "sql"]
+provides-extras = ["all", "bigquery", "cluster", "conformance", "databricks", "dev", "duckdb", "postgres", "redshift", "semantic", "semantic-api", "snowflake", "sql"]
 
 [[package]]
 name = "fastjsonschema"

--- a/references/storage.md
+++ b/references/storage.md
@@ -1,0 +1,210 @@
+# Storage: where dex keeps its scratch state
+
+dex writes two kinds of things, and only one of them is a storage backend's
+business.
+
+The **source of truth** is the dbt project: model SQL, `schema.yml`, semantic
+definitions. It is a git-reviewable filesystem artifact by design, it stays one,
+and it never moves into a datastore. No backend choice changes that.
+
+The **scratch state** is everything dex learns along the way: the exploration
+cache, the reconcile baseline, the last drift report, the append-only query and
+spend ledgers, and the stored transform plans. Delete all of it and nothing
+canonical is lost. That is what a `Store` holds.
+
+Two backends ship. `FilesystemStore` writes plain files under `.dex/` and is what
+the CLI uses, so persistence is git and a reviewer can read the state in a pull
+request. `MemoryStore` writes nothing and is the library default, which is why
+`import exmergo_dex_core` cannot leave a `.dex/` directory in a consumer's repo.
+
+Secrets never live in any backend.
+
+## Why you would write your own
+
+One reason, and it is a real one: a process that serves more than one end user.
+Such a host federates state per user in its own datastore, so that user A's cache
+is not user B's, and it wants that state to outlive a single request without
+putting anything on a shared disk.
+
+Note that `MemoryStore` does not cover this. It gives you "nothing on disk" but
+not "durable across requests", and those are different requirements. The
+distinction matters more than it looks: the query firewall resolves every table
+and column reference against the exploration cache, so cache membership decides
+what a query is permitted to name and under whose PII policy. A `map()` in one
+request must still be visible to a `query()` in the next, or the firewall refuses
+work the user has already paid to make legal.
+
+## The three tiers
+
+The contract is three nested protocols. Implement the one that matches what your
+host actually does, and stop there: a narrower implementation is a complete
+implementation of a declared contract, not a partial one.
+
+| Tier | Members | For a host that |
+|---|---|---|
+| `ExploreStore` | `load_cache`, `save_cache`, `append_query_log`, `append_spend_log`, `spend_since`, `locator` | explores, profiles, and queries |
+| `MaintainStore` | the above, plus `load_snapshot`, `save_snapshot`, `load_drift`, `save_drift` | also detects drift and reconciles |
+| `Store` | the above, plus `save_plan`, `load_plan`, `list_plans`, `latest_plan`, `plan_locator` | also authors dbt changes |
+
+`ExploreStore` is six methods, which is the useful thing to know before starting:
+a host embedding dex for read-only sense-making is not signing up for sixteen.
+
+The transform surface is the one place the widest tier is required, and it checks
+at runtime. Passing an explore-only store to a transform command refuses with a
+message naming the tier and the missing members, rather than failing on a missing
+attribute several frames down.
+
+## Writing one
+
+```python
+from datetime import datetime
+
+from exmergo_dex_core.cache import DexCache
+from exmergo_dex_core.storage import Document, spend_total
+
+
+class MyStore:
+    def __init__(self, tenant: str):
+        self.tenant = tenant
+
+    def load_cache(self) -> DexCache | None:
+        raw = self._fetch("cache")
+        return None if raw is None else DexCache.model_validate_json(raw)
+
+    def save_cache(self, cache: DexCache, *, now: datetime | None = None) -> str:
+        if now is not None:
+            cache.provenance.updated_at = now.isoformat()
+        self._put("cache", cache.model_dump_json())
+        return self.locator(Document.CACHE)
+
+    def spend_since(self, cutoff_iso, *, field="billed_bytes", connector=None):
+        return spend_total(self._entries("spend"), cutoff_iso,
+                           field=field, connector=connector)
+
+    def locator(self, document: Document) -> str:
+        return f"mystore://{self.tenant}/{document.value}"
+
+    # ... append_query_log, append_spend_log
+```
+
+There is no base class to inherit and no registration step. The protocols are
+structural: a class with the right methods is a `Store`, and
+`isinstance(store, ExploreStore)` confirms it. Pass the instance to the engine:
+
+```python
+engine = DexEngine(connector="bigquery", config=cfg, store=MyStore(tenant))
+```
+
+Use `spend_total` rather than reimplementing the ledger arithmetic. It is exported
+for exactly this reason: every backend then answers the session-budget question
+identically, which is a property you want in a guard.
+
+## The contracts that are not obvious from the signatures
+
+Each of these is stated on the protocol member it governs in `storage/base.py`,
+and each is asserted by the conformance suite. They are collected here because
+they are the ones an implementer gets wrong.
+
+**Documents do not alias the caller's object, in either direction.** What a caller
+saves and what a later `load_*` returns must be independent objects. The
+filesystem backend gets this free by serializing; the memory backend deep-copies
+both ways specifically to match. A backend that hands back a live reference lets
+a mutation after a save silently rewrite history.
+
+**`save_cache(cache, now=...)` stamps the caller's object too**, not only the
+stored copy. The command layer reports the timestamp it just persisted, so a
+backend that stamps only what it writes makes the reported and stored times
+disagree.
+
+**Documents are pydantic models.** Round-trip them with `model_validate_json` and
+`model_dump_json`. A backend storing its own hand-rolled dict shape diverges on
+the first schema change.
+
+**`save_cache` is a whole-document, atomic write.** Cache membership decides what
+a query may name, so a half-written cache is a security-relevant state rather than
+merely an inconsistent one. A backend whose store caps document size chunks
+internally and presents one logical document. There is deliberately no
+per-dataset write seam, because that seam is what would let a reader observe half
+a cache.
+
+**A corrupt document raises; a corrupt ledger line is skipped.** Two opposite
+policies, both deliberate. An unreadable cache means dex does not know what it may
+query, and treating that as "nothing explored yet" would silently re-profile a
+warehouse and bill for it. An unreadable ledger line means one spend record is
+lost, and refusing every subsequent billed command over one bad line is the worse
+failure.
+
+**A stored `schema_version` is not the store's to police.** Documents carry one and
+the engine reads it. Load what you were given.
+
+**The ledger is scoped to the store instance, so store granularity is ceiling
+granularity.** One principal spanning two stores has two independent session
+ceilings and nothing bounds their sum. Nothing warns about it and it errs
+permissive, which makes it worth stating plainly: key stores exactly as you key
+principals. A host that splits stores for some other reason, one per repo root
+say, has split the budget too and will not be told.
+
+**The ledger read-then-write is not atomic at the protocol level.** The cost gate
+calls `spend_since` and then `append_spend_log`. The cumulative session ceiling
+therefore binds exactly when commands are serialized, which is the CLI's
+one-command-per-process shape; under genuinely concurrent commands the overshoot
+is bounded by the sum of the concurrent estimates. A backend that can make the
+pair atomic for one key should, and a multi-tenant backend serving concurrent
+requests per tenant is where that stops being optional.
+
+**The protocol is synchronous.** A backend whose client is async wraps it, running
+the coroutine to completion inside the method. Every caller in the engine is
+synchronous, and a second async surface would double the contract for no caller
+that exists.
+
+## Proving it works
+
+The contract ships as an executable suite. Install it and subclass the class for
+your tier:
+
+```
+pip install "exmergo-dex-core[conformance]"
+```
+
+```python
+from exmergo_dex_core.storage.conformance import ExploreStoreContract
+
+
+class TestMyStore(ExploreStoreContract):
+    def make_store(self, key):
+        return MyStore(tenant=key)
+```
+
+That is the whole integration. pytest collects the inherited tests and runs the
+contract against your backend, including the isolation assertions: `make_store`
+must return a store that shares nothing with a store built from a different key.
+Whether the key is a directory, a tenant id, or a table prefix is your business.
+
+Two tenants leaking into each other is the failure this seam exists to prevent, so
+those assertions are the ones worth reading if any fail.
+
+## Which calls need nothing on the filesystem
+
+A host with no project on disk can run the whole explore surface: `inventory`,
+`profile`, `relationships`, `map`, `query`, and `cluster` need a connector and a
+store and nothing else. Hosted semantic-layer calls (`semantic_list` and
+`semantic_query` against dbt Cloud) need even less: no store, no connector, no
+repo root.
+
+Everything in transform needs `repo_root`, because the dbt project is a
+filesystem artifact and stays one. So does `explore map --use-project`, which
+reads the dbt project to rank and annotate what it found. Those refuse with a
+message naming what needed the root rather than inventing one.
+
+## Selecting a backend
+
+Today a backend is passed to the engine directly, `DexEngine(store=...)`, which is
+the library path and the only path. There is no way to select one from the CLI.
+
+The decided direction, when a CLI selector arrives: it is an **open registry**, not
+a closed enum. A `cache.backend` setting will accept the names dex ships plus
+either a dotted `module:ClassName` path or a name registered through an
+`exmergo_dex_core.stores` entry-point group, so a backend published as its own
+package is selectable without a change to dex. Recording it here because the
+alternative, a closed set of shipped names, would make out-of-tree backends
+library-only permanently and opening it later would be a config-schema change.

--- a/references/storage.md
+++ b/references/storage.md
@@ -163,7 +163,7 @@ The contract ships as an executable suite. Install it and subclass the class for
 your tier:
 
 ```
-pip install "exmergo-dex-core[conformance]"
+pip install "exmergo-dex-core[storage-conformance]"
 ```
 
 ```python

--- a/ruff.toml
+++ b/ruff.toml
@@ -31,6 +31,10 @@ ignore = ["UP042"]
 # Tests: assert is the pytest idiom (S101), and the safety-spine tests
 # deliberately assert that *any* exception is raised on a refused write (B017).
 "packages/dex-core/tests/**" = ["S101", "B017"]
+# The storage conformance contract is a test suite that happens to ship inside
+# the package (so a backend outside this distribution can run it), so it is
+# written in the pytest idiom like any other test file (S101).
+"packages/dex-core/src/exmergo_dex_core/storage/conformance.py" = ["S101"]
 # The skill wrappers shell out to the pinned dex CLI by design; the command is
 # a fixed path plus an argv passthrough, not untrusted input (S603).
 "skills/**/scripts/run.py" = ["S603"]

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.4.1"
+DEX_CORE_VERSION = "1.4.2"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.4.1"
+DEX_CORE_VERSION = "1.4.2"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.4.1"
+DEX_CORE_VERSION = "1.4.2"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
Closes #144.

## Summary

`.dex/` state has lived behind a `Store` protocol since the storage seam landed,
and configuration and credentials became injectable after it. On paper that was
already most of what an embedding host needs. In practice the seam was only usable
by someone willing to read the engine's source and infer several contracts that
existed nowhere but its tests, which is a different thing from a public extension
point.

This makes it implementable from what is published. A backend can now live in
someone else's package, prove itself against a suite it installs, and know the
rules from written contracts rather than from reading our code.

Four changes carry that, plus a refusal taxonomy that turned out to be the same
problem one layer up.

**The protocol is tiered.** `ExploreStore` is six members and covers a host that
explores, profiles, and queries. `MaintainStore` adds the reconcile baseline and
the drift report. `Store` adds the five transform plan members and is unchanged in
shape, so existing annotations and backends keep working. The split is not a
judgment call; it falls out of the call sites exactly. A host implementing the
narrow tier is now writing a complete implementation of a declared contract rather
than a partial one, and the transform surface, the single place the widest tier is
required, refuses an explore-only store by naming the tier and the missing members
instead of failing on a missing attribute several frames down.

**The conformance contract ships.** `exmergo_dex_core.storage.conformance` holds
what `tests/storage/test_parity.py` used to hold alone. A backend installs
`[storage-conformance]`, subclasses the class matching its tier, supplies a
`make_store(key)` factory, and runs every assertion we hold our own backends to,
isolation across keys included. The in-repo file is now the same three lines a
third party writes, so exactly one copy of the contract exists.

**Refusals have a taxonomy a host can branch on.** Everything the engine refuses
on purpose descends from `DexError`. Below it, `ConfigurationError` and
`RequestError` (both also `ValueError`, so nothing breaks for existing callers),
`PrerequisiteError` for state that a named command creates, and `ConnectorError`
for a warehouse that could not be reached. Eleven refusals that were typed but
not importable are now exported, alongside the new bases.

**`py.typed` ships.** The seam is enforced entirely by structural typing, so
without the marker a downstream type checker treated the package as untyped and
verified nothing about a candidate backend.

Plus `references/storage.md`, the seven behavioral contracts written onto the
protocol members they govern, and pointers from `AGENTS.md` and `CONTRIBUTING.md`.

43 files changed, 2,242 insertions, 402 deletions.

## Decisions worth a reviewer's attention

**`save_cache` is a whole-document, atomic write, and there is deliberately no
per-dataset seam.** The query firewall resolves every table and column reference
against the cache, so cache membership decides what a query may name and under
whose PII policy. A half-written cache is a security-relevant state, not merely an
inconsistent one. A backend with a document size cap chunks internally and
presents one logical document; the seam that would let it shard is the same seam
that would let a reader observe half a cache.

**The ledger read-then-write is not atomic at the protocol level, and the bound is
stated rather than fixed.** The session ceiling binds exactly under serialized
commands, which is the CLI's one-command-per-process shape. Under genuinely
concurrent commands the overshoot is bounded by the sum of the concurrent
estimates. A backend that can make the pair atomic for one key should. The
protocol does not grow a member for it, because an optional member no implementer
can rely on is worse than a stated bound.

**The ledger is scoped to the store instance**, so store granularity is ceiling
granularity. One principal spanning two stores has two independent ceilings and
nothing bounds their sum. It errs permissive and nothing warns, so this is stated
on the protocol and in the reference page: key stores exactly as you key
principals.

**`ConfigurationError` and `RequestError` also inherit `ValueError`.** Those
refusals raised bare `ValueError` before they were typed, and a consumer written
against that API keeps catching what it caught. The retained base has a docstring
saying so, otherwise a later reader deletes it as redundant.

**`CredentialDiscoveryError` is deliberately not a `ConnectorError`.** A host backs
off and retries on connector failures. A credential that was never configured will
not appear on a retry, and its message names the config that fixes it, so filing
it under the retry family would send hosts into a loop that cannot terminate.
There is a test pinning this.

**The two missing-extra errors were not re-parented under `ConfigurationError`,**
even though it would have made a tidier tree. Neither is a `ValueError` today, and
`ConfigurationError` carries `ValueError` for compatibility, so re-parenting would
newly make `except ValueError` swallow a missing-extra error somewhere it does not
today. Not worth a silent behavior change for tidiness.

**Backend selection is decided but not built.** An open registry, not a closed
enum: `cache.backend` should accept the shipped names plus a dotted
`module:ClassName` path or an entry-point group. Recorded in `references/storage.md`
and on #139, which is where the first alternate backend arrives and where the
field belongs. Shipping a resolver with no caller here would have been dead code.

## Verification

1472 tests pass, ruff and format clean, em-dash check clean.

The end-to-end proof is a packaging test, because nothing else answers the actual
question. It builds the wheel, installs it into an environment with no access to
this source tree, writes a backend there against the published protocol alone, and
runs the shipped conformance suite at it. If that passes, an outside contributor
can do the same. It also caught a real bug while being written: the conformance
module imported the plan model at top level, which reaches the SQL guard and so
the dialect engine, meaning an explore-only implementer on a light install could
not import the contract at all. Those imports are lazy now, and only the tier that
stores plans pays for them.

Live, because the exception tree moved under the connectors and the storage seam
is what the cost gate writes through:

- BigQuery 11 passed, Snowflake 14 passed, Databricks 9 passed 3 skipped
- Hosted dbt Cloud Semantic Layer: catalog read and metric query through an
  injected credential with nothing ambient left to discover, PII dimension refused
  before any query was submitted, a bogus token rejected without leaking it
- A six-method explore-only backend, written against the published protocol,
  driving a live billed flow across **two separate engines**: the first profiled a
  real table into that backend, the cost gate wrote its ledger entries through it,
  the second engine ran a firewalled query resolving against the first engine's
  cache, and a second tenant key saw none of it

One note on that last run: `billed_bytes` came back zero, which looks like broken
plumbing until you read the entries. BigQuery served the identical statements from
its own result cache. The ledger entries are real and the bytes are legitimately
zero, so the assertion checks entries rather than totals; asserting on spend would
be flaky by design.

## On the field report

@catincloudlabs, thank you for this. It was specific enough to act on directly,
and all three points are in this PR rather than waiting as follow-ups. Taking them
in order.

**§1, the two unexported refusals.** You were right, and the split was not
deliberate. `CacheRequiredError` and `NoBaselineError` are exported. We went wider
than the two, because the same wall was waiting for you at
`CredentialDiscoveryError` and the next person at `ScopeError`: eleven refusals
that were typed but unreachable are now importable from the package root.

Your 409-versus-502 case is the reason the taxonomy has the shape it does rather
than being a flat list of exports. `PrerequisiteError` is exactly the class of
refusal your worker can resolve on its own, so the branch is now a type check:

```python
def status_for(exc):
    if isinstance(exc, PrerequisiteError): return 409   # run the command, retry
    if isinstance(exc, ConnectorError):    return 502   # upstream, back off
    if isinstance(exc, DexError):          return 422   # refused on purpose
    return 500
```

A test now asserts every refusal reachable from the public API is importable, with
an explicit internal set carrying a reason per entry. That omission is precisely
how this survived, so adding a refusal now forces a decision rather than allowing
a silent one.

Worth saying plainly: your diagnosis was better than the framing in the issue. The
scope item talked about *typing* refusals, and you pointed out these were already
typed and merely unreachable, which is a different defect with the same symptom.
The rewording in 1.4.0 was not the bug; prose being the only machine-readable part
of the error was.

**§2, the ledger's scope.** Also right, and your reading of why the docstring
misleads is the part we would not have found on our own. It was specific about
`field` and `connector` keeping paradigms apart, which reads as the complete set of
scoping rules, and the store axis was the one it omitted. It now says so on the
protocol and in the reference page, close to your wording, including that it errs
permissive and nothing reports it. Your two-ledger numbers made the case better
than an abstract argument would have.

**§3, the assertion messages.** All 59 now carry one (the suite grew from the 46
you measured). You were right that the docstring pass and the message pass are one
piece of work with two outputs, so each message restates the rule its protocol
member documents. And rather than assert that this helps, there is now a test that
runs a deliberately aliasing backend against the shipped contract and checks the
failure names the rule and the fix:

```
a stored document must not alias the caller's object: mutating what you saved
reached into the store, so a mutation after a save silently rewrites history.
Serialize on write, or deep-copy.
```

**One you did not name.** Cross-checking your report against our own work found a
fourth. `Store.load_plan` is documented as raising `PlanNotFoundError`, and that
name was not exported either, so a third-party full-tier backend could not satisfy
the contract we were about to publish without importing from a private module.
That is the same defect as §1, one layer over, and we would have shipped it. It is
fixed and there is a test asserting the protocol docstring and the public name
agree.

**On your offer.** All three items you proposed are consumed here, so there is
nothing left in them to hand back, and we would rather not have you duplicate
work. The useful thing, if you still want it, is the layer above: your §3 says the
conformance suite is the piece you would use first and pin against, and a `Store`
implementation built against it once this lands is worth more to us than any of
the three. It would be the first backend written by someone who did not write the
protocol, which is the only real test of whether this PR did its job. Fixture names
and assertions are public API from this point, as you asked.

If you do build one, the isolation assertions are the ones to read first if
anything fails. Two tenants leaking into each other is the failure the whole seam
exists to prevent.
