### PR TITLE
SCRUM-956-Scope maintain check to its objects, and fix semantic cardinality pla…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **`maintain check` accepts the same object scope as its focused detectors**
+  ([#115]). The paid grain and cardinality axes always estimated and billed for
+  every configured dataset, with no way to narrow them; a session focused on one
+  environment's marts saw its estimate dominated by dozens of irrelevant raw
+  tables, so the whole paid sweep was declined and the layer under active change
+  got no grain coverage at all. `maintain check <objects>` now resolves the same
+  scope `maintain schema`/`volume`/`grain`/`semantic` already accept, narrowing
+  every axis, including the two paid ones, to what was actually asked for.
+
+### Fixed
+
+- **`maintain semantic`'s paid cardinality scan now actually narrows on scope,
+  not just its reported findings** ([#115]). `cardinality_plan` built
+  its scan over every semantic model's categorical dimensions regardless of the
+  requested object scope; only the findings returned to the caller were filtered
+  afterward, so a scoped run still paid for the unscoped one. The scope (an
+  identifier, column, dimension, or semantic model name, the same vocabulary the
+  reported findings already matched against) now filters before estimation and
+  execution, so a narrower run is priced and billed for less.
+
 ## [1.4.2] - 2026-07-28
 
 ### Changed

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -202,6 +202,7 @@ def _build_parser() -> argparse.ArgumentParser:
                 # maintain detectors take an optional object scope (default: whole
                 # project); reconcile takes an optional drift class to fix.
                 if group == "maintain" and name in {
+                    "check",
                     "schema",
                     "volume",
                     "grain",

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -304,7 +304,9 @@ def semantic_drift(engine: DexEngine, objects: list[str] | None = None) -> Drift
         ),
         scope_names,
     )
-    checks = drift_mod.cardinality_plan(current_semantic, snap)
+    checks = drift_mod.cardinality_plan(
+        current_semantic, snap, _semantic_names(scope_names) if scope_names else None
+    )
     pending: ConfirmationRequest | None = None
     billed_findings: list[drift_mod.DriftFinding] = []
     if checks:
@@ -347,13 +349,21 @@ def cmd_semantic(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     return _drift_envelope(semantic_drift(engine, getattr(args, "objects", None)))
 
 
-def check(engine: DexEngine) -> DriftResult:
+def check(engine: DexEngine, objects: list[str] | None = None) -> DriftResult:
     """The everyday sweep across every axis.
 
     Two-phase by construction: the free axes (schema, volume, semantic
     references) always run and their findings always return; the scanning axes
     (grain, cardinality) run immediately on free connectors and behind one
     combined estimate on billed ones.
+
+    ``objects`` narrows every axis exactly like the focused detectors do:
+    schema/volume/grain resolve it against known identifiers (raising if a
+    name matches nothing), while the semantic axis matches names against
+    definitions too (a metric, dimension, or measure name, not only a table).
+    Unscoped, the paid grain/cardinality estimate covers everything the
+    baseline knows about; a narrowed run prices and bills only the scoped
+    subset, not just the reported findings.
     """
 
     store = engine.store
@@ -361,6 +371,7 @@ def check(engine: DexEngine) -> DriftResult:
     if snap is None:
         raise NoBaselineError(_NO_SNAPSHOT_ERROR)
     config = engine.config
+    scope_names = list(objects or [])
 
     warnings = _grain_baseline_warnings(snap)
     current_transform = current_semantic = None
@@ -376,20 +387,26 @@ def check(engine: DexEngine) -> DriftResult:
     adapter = engine._adapter("maintain check")
     connector = adapter.name
     current_datasets = snapshot_mod.warehouse_from_metadata(adapter).datasets
+    scope = _resolve_scope(scope_names, current_datasets, snap) if scope_names else None
+    names = _semantic_names(scope_names) if scope_names else None
+
     schema_findings = drift_mod.schema_drift(
-        current_datasets, snap, current_transform=current_transform
+        current_datasets, snap, scope, current_transform
     )
-    volume_findings = drift_mod.volume_drift(current_datasets, snap)
+    volume_findings = drift_mod.volume_drift(current_datasets, snap, scope)
     semantic_findings = (
-        drift_mod.semantic_free_drift(
-            current_transform, current_semantic, current_datasets, snap
+        _semantic_scope(
+            drift_mod.semantic_free_drift(
+                current_transform, current_semantic, current_datasets, snap
+            ),
+            scope_names,
         )
         if project_available
         else []
     )
 
-    plan = drift_mod.grain_plan(adapter, snap)
-    checks = drift_mod.cardinality_plan(current_semantic, snap)
+    plan = drift_mod.grain_plan(adapter, snap, scope)
+    checks = drift_mod.cardinality_plan(current_semantic, snap, names)
     scans_needed = bool(
         plan.key_checks or plan.fanout_pairs or plan.composite_checks or checks
     )
@@ -421,7 +438,9 @@ def check(engine: DexEngine) -> DriftResult:
         }
         if project_available:
             by_axis["semantic"] = drift_mod.rank_findings(semantic_findings)
-        _record_axes(store, snap, connector, {a: (f, []) for a, f in by_axis.items()})
+        _record_axes(
+            store, snap, connector, {a: (f, scope_names) for a, f in by_axis.items()}
+        )
         result = _drift_result(by_axis, snap, store, warnings=warnings)
         result.pending_confirmation = pending
         return result
@@ -429,8 +448,8 @@ def check(engine: DexEngine) -> DriftResult:
     grain_findings = drift_mod.grain_drift(
         adapter, plan, timeout_seconds=config.query.timeout_seconds
     )
-    semantic_findings = semantic_findings + drift_mod.cardinality_drift(
-        adapter, checks, current_semantic
+    semantic_findings = semantic_findings + _semantic_scope(
+        drift_mod.cardinality_drift(adapter, checks, current_semantic), scope_names
     )
 
     drift_mod.annotate_impacts(schema_findings + volume_findings + grain_findings, snap)
@@ -441,7 +460,9 @@ def check(engine: DexEngine) -> DriftResult:
     }
     if project_available:
         by_axis["semantic"] = drift_mod.rank_findings(semantic_findings)
-    _record_axes(store, snap, connector, {a: (f, []) for a, f in by_axis.items()})
+    _record_axes(
+        store, snap, connector, {a: (f, scope_names) for a, f in by_axis.items()}
+    )
     result = _drift_result(
         by_axis, snap, store, warnings=warnings + _staleness_warnings(store, snap)
     )
@@ -449,7 +470,7 @@ def check(engine: DexEngine) -> DriftResult:
 
 
 def cmd_check(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
-    return _drift_envelope(check(engine))
+    return _drift_envelope(check(engine, getattr(args, "objects", None)))
 
 
 def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileResult:
@@ -671,6 +692,22 @@ def _adapter_notes(adapter, identifiers: list[str]) -> list[str]:
     return notes
 
 
+def _semantic_names(scope_names: list[str]) -> set[str]:
+    """Split/lower repeatable, comma-joinable scope arguments into name tokens.
+
+    Shared by ``_semantic_scope`` (filters reported findings) and
+    ``cardinality_plan``'s ``scope`` (filters *before* the paid scan runs), so
+    a name that narrows the report also narrows the bill.
+    """
+
+    return {
+        part.strip().lower()
+        for raw in scope_names
+        for part in raw.split(",")
+        if part.strip()
+    }
+
+
 def _semantic_scope(
     findings: list[drift_mod.DriftFinding], scope_names: list[str]
 ) -> list[drift_mod.DriftFinding]:
@@ -683,12 +720,7 @@ def _semantic_scope(
 
     if not scope_names:
         return findings
-    names = {
-        part.strip().lower()
-        for raw in scope_names
-        for part in raw.split(",")
-        if part.strip()
-    }
+    names = _semantic_names(scope_names)
 
     def in_scope(finding: drift_mod.DriftFinding) -> bool:
         candidates = {

--- a/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
@@ -736,11 +736,21 @@ class CardinalityCheck(NamedTuple):
 
 
 def cardinality_plan(
-    current_semantic: SemanticLayer | None, snap: Snapshot
+    current_semantic: SemanticLayer | None,
+    snap: Snapshot,
+    scope: set[str] | None = None,
 ) -> list[CardinalityCheck]:
     """Which categorical dimension columns have a cardinality baseline to diff:
     the current semantic definitions intersected with the snapshot's distinct
-    counts. Only counts are ever compared; no dimension value is read."""
+    counts. Only counts are ever compared; no dimension value is read.
+
+    ``scope`` (lowered name tokens) filters *before* estimation/execution, so a
+    narrowed scan is priced and billed for less, not just reported as less: a
+    check matches when its identifier, bare table name, column, dimension, or
+    semantic model name is in scope -- the same vocabulary ``_semantic_scope``
+    already matches findings against, since a semantic finding hangs off a
+    definition name as often as a physical object.
+    """
 
     checks: list[CardinalityCheck] = []
     if current_semantic is None:
@@ -753,14 +763,19 @@ def cardinality_plan(
         matches = match_identifier(sm.model_ref, identifiers)
         if len(matches) != 1:
             continue
-        columns = {c.name: c for c in snap_by_id[matches[0]].columns}
+        identifier = matches[0]
+        columns = {c.name: c for c in snap_by_id[identifier].columns}
         for dimension, column in sm.categorical_dimensions.items():
             profile = columns.get(column)
             if profile is None or profile.distinct_count is None:
                 continue
+            if scope is not None and not _cardinality_in_scope(
+                identifier, column, dimension, sm.name, scope
+            ):
+                continue
             checks.append(
                 CardinalityCheck(
-                    identifier=matches[0],
+                    identifier=identifier,
                     column=column,
                     dimension=dimension,
                     semantic_model=sm.name,
@@ -769,6 +784,19 @@ def cardinality_plan(
                 )
             )
     return checks
+
+
+def _cardinality_in_scope(
+    identifier: str, column: str, dimension: str, semantic_model: str, scope: set[str]
+) -> bool:
+    candidates = {
+        identifier.lower(),
+        identifier.rsplit(".", 1)[-1].lower(),
+        column.lower(),
+        dimension.lower(),
+        semantic_model.lower(),
+    }
+    return bool(candidates & scope)
 
 
 def cardinality_estimate(

--- a/packages/dex-core/tests/maintain/test_check.py
+++ b/packages/dex-core/tests/maintain/test_check.py
@@ -75,6 +75,35 @@ def test_check_warns_when_cache_outruns_snapshot(maintain_repo):
     assert any("re-run `maintain snapshot`" in w for w in payload["warnings"])
 
 
+def test_scope_narrows_every_axis_including_the_paid_ones(maintain_repo):
+    """#115: an unscoped check's grain/cardinality estimate covers everything;
+    a scoped one should price and report only the named object(s), across
+    every axis, not just the free ones."""
+
+    maintain_repo.snapshot()
+    # Grain drift on customers; semantic cardinality drift on stg_orders. Two
+    # unrelated tables, so scoping to one must exclude the other's findings.
+    maintain_repo.sql("INSERT INTO customers SELECT * FROM customers WHERE id <= 5")
+    maintain_repo.sql(
+        "INSERT INTO stg_orders VALUES (999, 1, 5.0, 'refunded', DATE '2024-03-01')"
+    )
+
+    rc, payload = maintain_repo.dex("maintain", "check", "customers")
+    assert rc == 0 and payload["status"] == "ok"
+    axes = payload["data"]["axes"]
+    assert axes["schema"] == 0
+    assert axes["semantic"] == 0
+    assert axes["grain"] >= 1
+
+    codes = {f["code"] for f in payload["data"]["findings"]}
+    assert "key_lost_uniqueness" in codes
+    assert "dimension_cardinality_changed" not in codes
+
+    report = FilesystemStore(maintain_repo.root).load_drift()
+    assert report.axes["grain"].scope == ["customers"]
+    assert report.axes["semantic"].scope == ["customers"]
+
+
 def test_check_without_project_skips_semantic_with_warning(dex, tmp_path):
     import duckdb
 

--- a/packages/dex-core/tests/maintain/test_semantic.py
+++ b/packages/dex-core/tests/maintain/test_semantic.py
@@ -6,7 +6,18 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
-from exmergo_dex_core.maintain.drift import CardinalityCheck, cardinality_drift
+from exmergo_dex_core.cache import ColumnProfile, Dataset
+from exmergo_dex_core.maintain.drift import (
+    CardinalityCheck,
+    cardinality_drift,
+    cardinality_plan,
+)
+from exmergo_dex_core.maintain.snapshot import (
+    SemanticLayer,
+    SemanticModelDef,
+    Snapshot,
+    WarehouseBaseline,
+)
 
 from .conftest import SEMANTIC_YAML
 
@@ -203,6 +214,84 @@ def test_new_categorical_value_is_a_cardinality_delta_never_a_value(maintain_rep
     # never reaches the envelope (or `.dex/`); naming it is a job for a
     # firewalled `explore query` if the user asks.
     assert "refunded" not in json.dumps(payload)
+
+
+def _snapshot_with_two_semantic_models() -> tuple[Snapshot, SemanticLayer]:
+    """Two unrelated models, each with one categorical dimension carrying a
+    distinct-count baseline: the minimum shape `cardinality_plan` needs."""
+
+    warehouse = WarehouseBaseline(
+        datasets=[
+            Dataset(
+                identifier="db.main.orders",
+                columns=[
+                    ColumnProfile(
+                        name="status",
+                        data_type="VARCHAR",
+                        distinct_count=5,
+                        distinct_count_exact=True,
+                    )
+                ],
+            ),
+            Dataset(
+                identifier="db.main.customers",
+                columns=[
+                    ColumnProfile(
+                        name="region",
+                        data_type="VARCHAR",
+                        distinct_count=4,
+                        distinct_count_exact=True,
+                    )
+                ],
+            ),
+        ]
+    )
+    semantic = SemanticLayer(
+        semantic_models=[
+            SemanticModelDef(
+                name="orders",
+                path="orders.yml",
+                content_sha256="a",
+                model_ref="orders",
+                categorical_dimensions={"status": "status"},
+            ),
+            SemanticModelDef(
+                name="customers",
+                path="customers.yml",
+                content_sha256="b",
+                model_ref="customers",
+                categorical_dimensions={"region": "region"},
+            ),
+        ]
+    )
+    snap = Snapshot(
+        created_at="2024-01-01T00:00:00", warehouse=warehouse, semantic_layer=semantic
+    )
+    return snap, semantic
+
+
+def test_cardinality_plan_unscoped_covers_every_semantic_model():
+    snap, semantic = _snapshot_with_two_semantic_models()
+    checks = cardinality_plan(semantic, snap)
+    assert {c.identifier for c in checks} == {"db.main.orders", "db.main.customers"}
+
+
+def test_cardinality_plan_scope_narrows_to_the_named_identifier():
+    """#115: the paid axis must actually skip the unscoped checks, not just
+    filter the findings they would have produced."""
+
+    snap, semantic = _snapshot_with_two_semantic_models()
+    checks = cardinality_plan(semantic, snap, {"orders"})
+    assert {c.identifier for c in checks} == {"db.main.orders"}
+
+
+def test_cardinality_plan_scope_matches_dimension_name_too():
+    """Scope vocabulary matches _semantic_scope's: a dimension name narrows
+    the plan just like a table name does."""
+
+    snap, semantic = _snapshot_with_two_semantic_models()
+    checks = cardinality_plan(semantic, snap, {"region"})
+    assert {c.identifier for c in checks} == {"db.main.customers"}
 
 
 def test_semantic_needs_a_dbt_project(maintain_repo):


### PR DESCRIPTION
Closes: https://github.com/exmergo/dex/issues/115

Adds object scoping to maintain check, and fixes a related bug in maintain semantic's paid scan found while implementing it.

maintain check <objects> now accepts the same scope as schema/volume/grain/semantic, narrows every axis, including the two paid ones (grain, cardinality), not just the free ones
Fixes cardinality_plan() estimating/billing for every semantic model regardless of scope; only the reported findings were filtered before, after the money was already spent
Scope vocabulary for the semantic axis matches identifier, column, dimension, or semantic model name, same as existing finding-level scoping

CHANGELOG.md updated under [Unreleased]

<img width="1642" height="220" alt="image" src="https://github.com/user-attachments/assets/2b4badc5-20a9-4d53-81b0-e5fd87a36bd0" />
