### PR TITLE
Select a storage backend from configuration, including one `dex` does not ship

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,4 +175,5 @@ them.
 - Connector and methodology notes: `references/`.
 - The contract in full: `references/command-contract.md`.
 - The source of truth (dbt) and `.dex/` cache: `references/canonical-model.md`.
-- Where `.dex/` state lives, and writing a storage backend: `references/storage.md`.
+- Where `.dex/` state lives, selecting a backend, and writing one:
+  `references/storage.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,108 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **A storage backend dex does not ship can be selected from configuration**
+  ([#157]). `.dex/config.yml` gains a `cache` block, and it is the schema change
+  worth reading first:
+
+  ```yaml
+  cache:
+    backend: mypkg.stores:my_store
+    options:
+      tenant: acme
+  ```
+
+  `backend` defaults to `filesystem`, so a repo that configures nothing behaves
+  exactly as it did before the setting existed, and `options` reaches the selected
+  backend's factory verbatim. `--cache-backend` overrides the name for one run,
+  the way `--connector` overrides the configured connector. **Credentials never
+  belong in `options`**: this file is committed, so a backend needing one reads it
+  at runtime the way `connect.py` does.
+
+  It is an **open registry, not a closed enum**, which is the part that would have
+  been expensive to get wrong: a closed set of shipped names would make out-of-tree
+  backends library-only permanently, and opening it later would be a config-schema
+  change with a deprecation attached. Three kinds of name resolve, in order: a
+  shipped name (`filesystem`), a dotted `mypkg.stores:my_store` path, or a name an
+  installed distribution registered under the `exmergo_dex_core.stores`
+  entry-point group. A shipped name always wins over a registration, so installing
+  a package can never silently move where an existing repo's state lands.
+
+  Before this, a contributor could implement a backend, watch the shipped
+  conformance suite go green, and then discover the only way to use it was to stop
+  using the CLI. `DexEngine.from_repo` now builds whatever the configuration names
+  instead of hardcoding the filesystem backend; an explicitly passed `store=` still
+  wins over both, since a caller holding an instance has already made the decision.
+
+  **`memory` is deliberately not selectable.** Each CLI command runs as its own
+  process, so a `MemoryStore` would drop the cache between `explore map` and
+  `explore query`, and the second command would refuse with "run `explore map`
+  first" having just run it. That reads as a broken tool rather than a chosen
+  backend, so it refuses by explaining the process boundary. It remains the default
+  for a library caller, where one process holds the engine.
+
+  Every failure refuses with a `ConfigurationError` naming the fix: an unknown name
+  lists what exists and both open forms, a dotted path that will not import points
+  at the environment, a name resolving to something uncallable says so, and a
+  factory that builds something which is not a store names the members it lacks.
+  The tier check is on the constructed store rather than on the factory, because a
+  callable protocol can only verify that `__call__` exists.
+
+- **A storage backend can now say how it is constructed, not just how it behaves**
+  ([#156]). #144 made the seam implementable: the tiered `Store` protocol, the
+  shipped conformance suite, `py.typed`. What it left undecided was what happens
+  between "something names a backend" and "the engine holds a store", and the
+  shapes disagree: `FilesystemStore` is built from a repo root, `MemoryStore` from
+  nothing, and a backend serving several end users from a tenant id with no
+  repository anywhere in the picture. There is no single call that satisfies all
+  three, so the contract had to be chosen.
+
+  Construction is now its own small contract, deliberately separate from `Store`.
+  A `StoreContext` carries a `repo_root` (`None` when there is no repository) and
+  an `options` mapping of the backend's own non-secret coordinates, passed through
+  verbatim; a `StoreFactory` is anything callable that turns one into a store. A
+  plain function, a class whose `__init__` takes the context, and a classmethod
+  all qualify, so a backend is constructable in whatever shape it already has.
+  `FilesystemStore.from_context` and `MemoryStore.from_context` are the shipped
+  reference implementations, one path-shaped and one that needs nothing.
+
+  **`Store` stays purely structural.** Putting a construction obligation on the
+  protocol would have cost the property that makes this seam cheap to implement,
+  that a class with the right methods is a store, with no base class to inherit
+  and no registration step. A host that builds its own store and passes it to the
+  engine is untouched by any of this.
+
+  **Construction is checkable, so the conformance suite's promise stays whole.**
+  `StoreFactoryContract` composes with the contract for your tier and routes
+  `make_store` through your own factory, so every behavioral and isolation
+  assertion then runs against stores built the way dex builds them. "The suite is
+  green" therefore still means a backend is correct *and* constructable, rather
+  than quietly meaning only the first. The packaging test that installs the wheel
+  in an environment with no access to this source tree now builds its backend
+  through a factory and a context carrying no repo root, because a construction
+  contract that only works from inside this repo has not been tested.
+
+  **No secret ever reaches a `StoreContext`.** `.dex/config.yml` is committed, so
+  a password, key, token, or connection string among the options would be a
+  credential in version control. A backend reads its credential from the
+  environment at construction, exactly as the connection and semantic-layer seams
+  already do, or a host with per-request credentials skips the contract and hands
+  the engine a store it built itself.
+
+  Both shipped backends refuse an option they would otherwise have ignored, and
+  `FilesystemStore.from_context` refuses a context with no repo root rather than
+  falling back to the working directory, which would write one project's
+  exploration cache into wherever the process happened to start. Accepted-and-
+  ignored is worse than rejected: the caller believes a setting took effect and
+  nothing in the output says otherwise.
+
+  `references/storage.md` documents the contract, both shapes a factory can take,
+  and the two rejected alternatives: always passing a `repo_root`, which cannot
+  construct a tenant-keyed backend at all, and requiring a `from_config`
+  classmethod, which puts the obligation back on the protocol.
+
 ## [1.4.2] - 2026-07-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,17 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   construct a tenant-keyed backend at all, and requiring a `from_config`
   classmethod, which puts the obligation back on the protocol.
 
+### Fixed
+
+- **`maintain snapshot` told every host to commit a file it may not have**
+  ([#157]). The hint was a fixed string: "commit `.dex/snapshot.json` like a
+  lockfile". A backend that keeps the baseline as a row or a document has no such
+  file, so the advice named something that does not exist, while the
+  `snapshot_path` beside it correctly reported that backend's own locator. The
+  half that holds everywhere, re-pinning after each known-good build, is now what
+  a backend dex does not ship gets; the git half is added only when the baseline
+  really is a file in the repo. Nothing changes for the filesystem backend.
+
 ## [1.4.2] - 2026-07-28
 
 ### Changed

--- a/packages/dex-core/README.md
+++ b/packages/dex-core/README.md
@@ -60,9 +60,12 @@ envelope never crosses this boundary.
 Nothing above touches disk. The default store keeps state in the process, so
 importing this package cannot leave a `.dex/` directory in a consumer's repo;
 pass `store=` for anything durable, or use `DexEngine.from_repo(repo_root)` to get
-the CLI's behavior (filesystem store, config read from `.dex/config.yml`). The
-`Store` protocol is public, so a host can back state with its own session store
-or database instead.
+the CLI's behavior (config read from `.dex/config.yml`, and the backend that
+config selects, which defaults to plain files under `.dex/`). The `Store` protocol
+is public, so a host can back state with its own session store or database
+instead, and a backend published as its own package is selectable by name from
+`cache.backend` without a change to dex. See
+[`references/storage.md`](../../references/storage.md).
 
 [`examples/quickstart.py`](examples/quickstart.py) is the whole flow in one
 runnable file: map a warehouse, read the inferred joins, see PII flagged, ask a

--- a/packages/dex-core/src/exmergo_dex_core/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/__init__.py
@@ -95,6 +95,8 @@ _EXPORTS = {
     "SemanticSource": "connect",
     "Snapshot": "maintain.snapshot",
     "Store": "storage",
+    "StoreContext": "storage",
+    "StoreFactory": "storage",
     "StoreRequiredError": "errors",
     "to_envelope": "results",
 }
@@ -149,6 +151,8 @@ if TYPE_CHECKING:  # what a type checker and an IDE see; never run
         MaintainStore,
         MemoryStore,
         Store,
+        StoreContext,
+        StoreFactory,
     )
     from .transform.plans import PlanError, PlanNotFoundError
 
@@ -205,6 +209,8 @@ __all__ = [
     "SemanticSource",
     "Snapshot",
     "Store",
+    "StoreContext",
+    "StoreFactory",
     "StoreRequiredError",
     "__version__",
     "to_envelope",

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -104,6 +104,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--project", default=None)
     parser.add_argument("--dataset", action="append", default=None)
     parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--cache-backend", default=None)
     parser.add_argument("--confirm", action="store_true")
     parser.add_argument("--budget", type=float, default=None)
 
@@ -326,21 +327,28 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = _build_parser()
     args = parser.parse_args(argv)
-    # One engine per process, built from the resolved repo root. That choice of
-    # backend is what lets the subcommands stay stateless across invocations:
-    # `.dex/` on disk is how the exploration cache and the cumulative session
-    # budget survive from one command to the next.
-    engine = DexEngine.from_repo(
-        repo_root(args),
-        connector=getattr(args, "connector", None),
-        path=getattr(args, "path", None),
-        project=getattr(args, "project", None),
-        datasets=getattr(args, "dataset", None),
-        scopes=getattr(args, "scope", None),
-        budget=getattr(args, "budget", None),
-        confirmed=getattr(args, "confirm", False),
-    )
+    # Building the engine is inside the handler, not before it: it reads the
+    # config file and constructs the configured storage backend, and both can
+    # refuse. Every agent wrapper expects exactly one envelope on stdout, so a
+    # refusal raised here has to render as one like any other rather than as a
+    # traceback the wrapper cannot parse.
     try:
+        # One engine per process, built from the resolved repo root. The default
+        # backend is what lets the subcommands stay stateless across invocations:
+        # `.dex/` on disk is how the exploration cache and the cumulative session
+        # budget survive from one command to the next, and any backend selected
+        # here has to be durable across processes for the same reason.
+        engine = DexEngine.from_repo(
+            repo_root(args),
+            cache_backend=getattr(args, "cache_backend", None),
+            connector=getattr(args, "connector", None),
+            path=getattr(args, "path", None),
+            project=getattr(args, "project", None),
+            datasets=getattr(args, "dataset", None),
+            scopes=getattr(args, "scope", None),
+            budget=getattr(args, "budget", None),
+            confirmed=getattr(args, "confirm", False),
+        )
         try:
             envelope = dispatch(args, engine)
         finally:

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import fnmatch
 from pathlib import Path
+from typing import Any
 
 import yaml
 from pydantic import BaseModel, Field, model_validator
@@ -367,6 +368,40 @@ class SemanticConfig(BaseModel):
     environment_id: str | None = None
 
 
+class CacheConfig(BaseModel):
+    """Where dex keeps its scratch state, and how to reach it.
+
+    Scratch state only: the exploration cache, the reconcile baseline, the last
+    drift report, the two ledgers, and the stored transform plans. The dbt project
+    is the source of truth, it is a git-reviewable filesystem artifact by design,
+    and no setting here moves it.
+
+    ``backend`` is an open registry rather than a closed set. It accepts a name
+    dex ships (``filesystem``, the default, which writes the loose JSON under
+    `.dex/` that a reviewer reads in a pull request), a dotted
+    ``mypkg.stores:my_store`` path, or a name an installed distribution registered
+    under the ``exmergo_dex_core.stores`` entry-point group. A backend published
+    as its own package is therefore selectable without a change to dex.
+    ``--cache-backend`` overrides it for one run, the way ``--connector``
+    overrides the configured connector. Naming a *different* backend that way
+    leaves ``options`` behind, because they are not namespaced by backend and one
+    backend's coordinates are not another's.
+
+    ``options`` reaches the selected backend's factory verbatim: dex does not
+    interpret it, so the keys belong to the backend and the backend validates
+    them. See ``references/storage.md``.
+
+    **Credentials are never here.** This file is committed, so a password, key,
+    token, or connection string among the options would be a secret in version
+    control. A backend needing one reads it at runtime the way ``connect.py``
+    does, or the host builds the store itself and passes it to ``DexEngine``,
+    which always wins over anything named here.
+    """
+
+    backend: str = "filesystem"
+    options: dict[str, Any] = Field(default_factory=dict)
+
+
 class DexConfig(BaseModel):
     """The shape of ``.dex/config.yml``: one optional target per connector plus
     the connector selection, budgets, and engine limits."""
@@ -392,6 +427,10 @@ class DexConfig(BaseModel):
     # hosted dbt Cloud deployment). Defaults to local; a bare project queries the
     # dbt project it lives in.
     semantic: SemanticConfig = Field(default_factory=SemanticConfig)
+    # Where the non-canonical `.dex/` scratch state lives. Defaults to the loose
+    # JSON under `.dex/`, so a repo that selects nothing behaves exactly as it did
+    # before this setting existed.
+    cache: CacheConfig = Field(default_factory=CacheConfig)
     budget: Budget = Field(default_factory=Budget)
     ranking_hints: list[str] = Field(default_factory=list)
     query: QueryLimits = Field(default_factory=QueryLimits)

--- a/packages/dex-core/src/exmergo_dex_core/engine.py
+++ b/packages/dex-core/src/exmergo_dex_core/engine.py
@@ -16,6 +16,9 @@ Nothing is written to disk by that snippet: the default store is a
 :class:`~.storage.MemoryStore`, so importing this package into a project cannot
 leave a ``.dex/`` directory behind as a side effect. Pass ``store=`` for anything
 durable, and see :class:`~.storage.Store` for what a backend has to implement.
+:meth:`DexEngine.from_repo` is the other way in: it reads ``.dex/config.yml`` and
+builds whichever backend ``cache.backend`` names, which is how the CLI reaches a
+backend dex does not ship.
 
 Two boundaries are worth naming, because both are easy to blur:
 
@@ -37,11 +40,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from . import command_args, connect
-from .config import DexConfig, load_config
+from .config import CacheConfig, DexConfig, load_config
 from .connect import ConnectionSource, SemanticSource
 from .errors import RepoRootRequiredError, StoreRequiredError
 from .results import ConnectResult
-from .storage import ExploreStore, FilesystemStore, MemoryStore, Store
+from .storage import ExploreStore, MemoryStore, Store, StoreContext, build_store
 
 if TYPE_CHECKING:
     from .adapters.base import Adapter
@@ -176,19 +179,45 @@ class DexEngine:
         self._adapter_instance: Adapter | None = None
 
     @classmethod
-    def from_repo(cls, repo_root: str | Path, **overrides: Any) -> DexEngine:
-        """Build from a project on disk: filesystem store, config from ``.dex/``.
+    def from_repo(
+        cls,
+        repo_root: str | Path,
+        *,
+        cache_backend: str | None = None,
+        **overrides: Any,
+    ) -> DexEngine:
+        """Build from a project on disk: config from ``.dex/``, store from config.
 
         The CLI's constructor, and the only path that reads configuration from
         the filesystem. When no config resolves, the engine stays unresolved
         rather than defaulting, so the refusal fires on first connection attempt
         instead of at construction (commands that need no warehouse still work
         outside a project).
+
+        The store is whatever ``cache.backend`` selects, defaulting to the
+        filesystem backend, so a repo that configures nothing behaves exactly as
+        it did before the setting existed. A ``store=`` passed here wins over the
+        configuration: a caller holding an instance has already made the decision
+        that configuration exists to make for the callers who are not.
+
+        ``cache_backend`` overrides the configured name for one run, and takes
+        the configured ``cache.options`` with it only when it names the backend
+        those options were written for. Options are not namespaced by backend, so
+        carrying them onto a different one would hand a backend another backend's
+        coordinates; the most useful thing this override does is fall back to the
+        filesystem backend for one command, and that would refuse outright if a
+        custom backend's options came along.
         """
 
         root = str(repo_root)
-        overrides.setdefault("store", FilesystemStore(root))
         overrides.setdefault("config", load_config(root))
+        if "store" not in overrides:
+            cache = getattr(overrides["config"], "cache", None) or CacheConfig()
+            selected = cache_backend or cache.backend
+            options = cache.options if selected == cache.backend else {}
+            overrides["store"] = build_store(
+                selected, StoreContext(repo_root=root, options=options)
+            )
         return cls(repo_root=root, **overrides)
 
     # --- the single adapter funnel ------------------------------------------

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -23,7 +23,7 @@ from ..dbt_project import DbtProjectError
 from ..dbt_project import load as load_project
 from ..errors import PrerequisiteError
 from ..results import ConfirmationRequest, to_envelope
-from ..storage import Document, MaintainStore
+from ..storage import Document, FilesystemStore, MaintainStore
 from . import drift as drift_mod
 from . import snapshot as snapshot_mod
 from .results import DriftResult, LayerFingerprint, ReconcileResult, SnapshotResult
@@ -32,10 +32,14 @@ if TYPE_CHECKING:
     from ..engine import DexEngine
 
 _SNAPSHOT_HINT = (
-    "commit .dex/snapshot.json like a lockfile, and re-run `maintain snapshot` "
-    "after each known-good build so drift is measured against a state someone "
-    "vouched for"
+    "re-run `maintain snapshot` after each known-good build so drift is measured "
+    "against a state someone vouched for"
 )
+
+#: Prepended when the baseline really is a file in the user's repo. Advice about
+#: git only means something there, and telling a host whose baseline is a row to
+#: commit a path would name a file it does not have.
+_REVIEWABLE_SNAPSHOT_HINT = "commit .dex/snapshot.json like a lockfile, and "
 
 _NO_SNAPSHOT_ERROR = (
     "no drift baseline yet; run `maintain snapshot` first (ideally right after "
@@ -148,7 +152,15 @@ def snapshot(engine: DexEngine) -> SnapshotResult:
 
 
 def cmd_snapshot(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
-    return to_envelope(snapshot(engine), hints={"hint": _SNAPSHOT_HINT})
+    # Which advice is true depends on where the baseline landed, so the hint is
+    # built from the store rather than fixed. The shipped filesystem backend is
+    # the only one dex knows puts a reviewable file in the repo; a backend it
+    # does not ship gets the half that holds everywhere, which is better than
+    # confidently naming a file that does not exist. `snapshot_path` carries the
+    # real location either way.
+    reviewable = isinstance(engine.store, FilesystemStore)
+    hint = (_REVIEWABLE_SNAPSHOT_HINT if reviewable else "") + _SNAPSHOT_HINT
+    return to_envelope(snapshot(engine), hints={"hint": hint})
 
 
 def schema_drift(engine: DexEngine, objects: list[str] | None = None) -> DriftResult:

--- a/packages/dex-core/src/exmergo_dex_core/storage/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/__init__.py
@@ -5,14 +5,30 @@
 only what its host uses; the sibling modules are the backends. Callers receive a
 store; only the entry point picks which one.
 
+It also holds the separate, optional construction contract
+(:class:`~.base.StoreFactory` over a :class:`~.base.StoreContext`), for a backend
+that is named somewhere rather than handed to the engine as an instance.
+``resolver`` is what turns such a name into a store, as an open registry: a
+shipped name, a dotted path, or an entry point an installed distribution
+registered.
+
 ``conformance`` is the executable contract, for anyone writing a backend outside
 this package. It is deliberately not imported here: it needs pytest, and a bare
 ``import exmergo_dex_core`` must not.
 """
 
-from .base import Document, ExploreStore, MaintainStore, Store, spend_total
+from .base import (
+    Document,
+    ExploreStore,
+    MaintainStore,
+    Store,
+    StoreContext,
+    StoreFactory,
+    spend_total,
+)
 from .filesystem import DEX_DIR, FilesystemStore
 from .memory import MemoryStore
+from .resolver import build_store, resolve_store_factory
 
 __all__ = [
     "DEX_DIR",
@@ -22,5 +38,9 @@ __all__ = [
     "MaintainStore",
     "MemoryStore",
     "Store",
+    "StoreContext",
+    "StoreFactory",
+    "build_store",
+    "resolve_store_factory",
     "spend_total",
 ]

--- a/packages/dex-core/src/exmergo_dex_core/storage/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/base.py
@@ -21,6 +21,13 @@ two shipped backends. :mod:`~.conformance` ships the executable copy of those
 rules: subclass ``StoreContract``, hand it a factory, and the whole contract runs
 against your backend. ``references/storage.md`` is the prose version.
 
+**Constructing one is a separate contract**, :class:`StoreFactory` over a
+:class:`StoreContext`, and it is optional. A host that passes its own instance to
+the engine never needs it; it exists so a backend can also be *named* somewhere
+and built by dex. Keeping it off the store protocols is what preserves the
+property that makes this seam cheap to implement: a class with the right methods
+is a store, with no base class to inherit and no registration step.
+
 The protocol is **synchronous**. A backend whose client is async wraps it (run the
 coroutine to completion inside the method) rather than the protocol growing an
 async variant: every caller in the engine is synchronous, and a second async
@@ -29,9 +36,11 @@ surface would double the contract for no caller that exists.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from ..cache import DexCache
@@ -250,6 +259,64 @@ class Store(MaintainStore, Protocol):
         ...
 
     def plan_locator(self, plan_id: str) -> str: ...
+
+
+@dataclass(frozen=True)
+class StoreContext:
+    """Everything a backend gets to build itself from when dex constructs it.
+
+    Two fields, because the backends disagree about what they are keyed by and
+    the disagreement is not resolvable by picking a winner. ``FilesystemStore``
+    takes a path, ``MemoryStore`` takes nothing, and a tenant-keyed backend
+    serving several end users has no repository at all. A construction contract
+    shaped around the path-shaped ones would leave the last group unbuildable,
+    which is the group this seam exists for.
+
+    ``repo_root`` is the directory dex was pointed at, or ``None`` when there is
+    no repository in the picture. It is not the place scratch state has to land:
+    a backend is free to ignore it, and most non-filesystem ones will.
+
+    ``options`` is the backend's own non-secret coordinates, passed through
+    verbatim from wherever the backend was named. dex does not interpret it, so
+    the keys are the backend's to define and the backend's to validate: refuse an
+    option you cannot honor rather than accepting and ignoring it, because a
+    silently dropped setting is indistinguishable from a working one until
+    something is stored in the wrong place.
+
+    **No secret ever arrives here.** A backend named in ``.dex/config.yml`` is
+    named in a committed file, so a password, key, token, or connection string in
+    ``options`` would be a credential in version control. Read the credential the
+    way the rest of the engine does, from the environment at construction time,
+    or skip this contract entirely and hand the engine a store you built yourself
+    (``DexEngine(store=...)``), which is the right shape for a host that already
+    holds per-request credentials.
+    """
+
+    repo_root: str | None = None
+    options: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class StoreFactory(Protocol):
+    """Anything that turns a :class:`StoreContext` into a store.
+
+    One call, one argument, so the shapes a backend author would reach for all
+    qualify without adapters: a module-level function, a class whose ``__init__``
+    takes the context, or a classmethod such as
+    :meth:`~.filesystem.FilesystemStore.from_context`.
+
+    The returned store need only satisfy the tier its host uses; a factory
+    building an :class:`ExploreStore` is a complete factory.
+
+    **Do not validate a factory with ``isinstance``.** This protocol is
+    ``runtime_checkable`` for symmetry with the store tiers, but a callable
+    protocol can only check that ``__call__`` exists, which every callable
+    satisfies. What is worth checking is the store that comes back, and the tiers
+    are genuinely ``isinstance``-checkable, so build first and check the result
+    against the tier the caller needs.
+    """
+
+    def __call__(self, context: StoreContext) -> ExploreStore: ...
 
 
 def spend_total(

--- a/packages/dex-core/src/exmergo_dex_core/storage/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/conformance.py
@@ -28,6 +28,12 @@ in one process must not be able to see each other's cache, ledgers, or plans.
 Whether ``key`` is a directory, a tenant id, or a table prefix is the backend's
 business.
 
+**If your backend is meant to be named in configuration rather than handed to the
+engine as an instance**, mix :class:`StoreFactoryContract` in as well. It routes
+``make_store`` through your own factory, so every assertion above then runs
+against a store built the way dex would build it, and "the suite is green" keeps
+meaning the backend is both correct and constructable rather than only the first.
+
 This module imports pytest, so it is deliberately not imported by
 ``exmergo_dex_core.storage``: a bare ``import exmergo_dex_core`` must not require
 a test framework. Install the ``[storage-conformance]`` extra to get pytest
@@ -44,12 +50,13 @@ import pytest
 from ..cache import CacheProvenance, Dataset, DexCache
 from ..maintain.drift import AxisResult, DriftFinding, DriftReport
 from ..maintain.snapshot import Snapshot, WarehouseBaseline
-from .base import Document
+from .base import Document, ExploreStore, StoreContext
 
 __all__ = [
     "ExploreStoreContract",
     "MaintainStoreContract",
     "StoreContract",
+    "StoreFactoryContract",
 ]
 
 
@@ -575,4 +582,81 @@ class StoreContract(MaintainStoreContract):
         assert two.list_plans() == [], (
             "two keys share the plan store, so one tenant can read and apply "
             f"another's proposed dbt changes. Got {two.list_plans()!r}"
+        )
+
+
+class StoreFactoryContract:
+    """The construction half, for a backend dex builds rather than receives.
+
+    Mix it in front of the contract for your tier, and the whole behavioral suite
+    runs against stores built the way dex builds them::
+
+        class TestMyStore(StoreFactoryContract, StoreContract):
+            tier = Store
+
+            def build(self, context):
+                return my_store_factory(context)
+
+            def context_for(self, key):
+                return StoreContext(options={"tenant": key})
+
+    Two hooks rather than one factory attribute, because a plain function assigned
+    to a class attribute binds as a method and would arrive with ``self`` in front
+    of the context, which is a confusing failure to meet on your first run.
+
+    ``context_for`` is where a backend says what it is keyed by. Build the context
+    the way a real configuration entry would produce it: a filesystem-shaped
+    backend varies ``repo_root``, a tenant-keyed one varies an entry in
+    ``options``. A ``context_for`` that returns the same context for every key
+    passes nothing meaningful, since the isolation assertions can only be as
+    honest as the contexts they are given.
+    """
+
+    #: The tier :meth:`build` promises to return. Widen it to ``MaintainStore`` or
+    #: ``Store`` alongside the matching contract class; the default is the floor
+    #: every backend meets.
+    tier: Any = ExploreStore
+
+    def build(self, context: StoreContext) -> Any:
+        """Your factory, called with a context. One line in most backends."""
+
+        raise NotImplementedError(
+            "a factory conformance subclass must implement "
+            "build(context) -> Store, calling the factory under test"
+        )
+
+    def context_for(self, key: str) -> StoreContext:
+        """The context that keys a store to ``key``, as configuration would."""
+
+        raise NotImplementedError(
+            "a factory conformance subclass must implement "
+            "context_for(key) -> StoreContext, keying the store the way a real "
+            "configuration entry would"
+        )
+
+    def make_store(self, key: str) -> Any:
+        return self.build(self.context_for(key))
+
+    def test_the_factory_builds_a_store_of_the_declared_tier(self):
+        built = self.build(self.context_for("primary"))
+        assert isinstance(built, self.tier), (
+            f"the factory returned {type(built).__name__}, which does not satisfy "
+            f"{self.tier.__name__}. A backend that passes the behavioral suite and "
+            "fails here is unusable from configuration: dex builds it, checks the "
+            "tier the command needs, and refuses. Check that build() returns the "
+            "store rather than a class, a coroutine, or a wrapper"
+        )
+
+    def test_two_contexts_build_stores_that_share_nothing(self):
+        # The same property the keyed isolation assertions cover, checked at the
+        # construction seam: a factory that ignores its context builds one shared
+        # store for every tenant, and every later isolation guarantee is void.
+        one = self.build(self.context_for("tenant-one"))
+        two = self.build(self.context_for("tenant-two"))
+        one.save_cache(a_cache("db.one.orders"))
+        assert two.load_cache() is None, (
+            "two contexts built stores that share a cache. The factory is probably "
+            "ignoring the part of the context that keys it, so every tenant it "
+            "builds lands in the same state. Check that context_for varies "
+            "something and that build reads it"
         )

--- a/packages/dex-core/src/exmergo_dex_core/storage/filesystem.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/filesystem.py
@@ -27,7 +27,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..cache import DexCache
-from .base import Document, spend_total
+from ..errors import ConfigurationError
+from .base import Document, StoreContext, spend_total
 
 if TYPE_CHECKING:
     from ..maintain.drift import DriftReport
@@ -58,6 +59,36 @@ class FilesystemStore:
         self.root = Path(repo_root)
         self.dex_dir = self.root / DEX_DIR
         self.plans_dir = self.dex_dir / PLANS_DIR
+
+    @classmethod
+    def from_context(cls, context: StoreContext) -> FilesystemStore:
+        """Build from a :class:`~.base.StoreContext`: the path-shaped reference
+        implementation of the construction contract.
+
+        Both refusals below are refusals rather than quiet fallbacks, the same
+        rule the connection seam applies: accepted-and-ignored is strictly worse
+        than rejected, because the caller believes a setting took effect and
+        nothing in the output says otherwise. Defaulting a missing root to the
+        working directory would be the sharpest version of that, since it would
+        write one project's exploration cache into whichever directory the
+        process happened to start in.
+        """
+
+        if context.repo_root is None:
+            raise ConfigurationError(
+                "the filesystem store keeps state in a `.dex/` directory and so "
+                "needs a repo root, and this context carries none. Point dex at a "
+                "project (DexEngine.from_repo(repo_root), or the CLI's "
+                "--repo-root), or select a backend that does not need one"
+            )
+        if context.options:
+            raise ConfigurationError(
+                "the filesystem store takes no options and this context carries "
+                f"{', '.join(sorted(context.options))}. Its only input is the repo "
+                "root; an option it silently ignored would look like a setting "
+                "that took effect"
+            )
+        return cls(context.repo_root)
 
     # --- documents ------------------------------------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/storage/memory.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/memory.py
@@ -21,7 +21,8 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from ..cache import DexCache
-from .base import Document, spend_total
+from ..errors import ConfigurationError
+from .base import Document, StoreContext, spend_total
 
 if TYPE_CHECKING:
     from ..maintain.drift import DriftReport
@@ -45,6 +46,26 @@ class MemoryStore:
         self._plans: dict[str, TransformPlan] = {}
         self._queries: list[dict] = []
         self._spend: list[dict] = []
+
+    @classmethod
+    def from_context(cls, context: StoreContext) -> MemoryStore:
+        """Build from a :class:`~.base.StoreContext`, which for this backend means
+        ignoring the repo root: the reference implementation of a store that needs
+        nothing to construct.
+
+        ``repo_root`` is ignored rather than refused, because it is present in
+        every context dex builds and carrying one is not a request to use it.
+        Options are refused, for the reason the filesystem backend refuses them.
+        """
+
+        if context.options:
+            raise ConfigurationError(
+                "the memory store takes no options and this context carries "
+                f"{', '.join(sorted(context.options))}. It holds state in process "
+                "attributes and has nothing to configure; an option it silently "
+                "ignored would look like a setting that took effect"
+            )
+        return cls()
 
     # --- documents ------------------------------------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/storage/resolver.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/resolver.py
@@ -1,0 +1,222 @@
+"""Turning a backend's *name* into a store: the open registry.
+
+A name reaches here from `.dex/config.yml` (`cache.backend`) or from
+``--cache-backend``, and leaves as a constructed store. Three kinds of name
+resolve, in this order:
+
+- a **shipped name** (``filesystem``), which can never be shadowed by anything
+  installed, so a config that says ``filesystem`` means dex's own backend on
+  every machine that reads it;
+- a **dotted path**, ``mypkg.stores:my_store``, which needs no packaging work at
+  all and is what a host reaches for first;
+- an **entry-point name**, registered by an installed distribution under
+  ``exmergo_dex_core.stores``, which is how a backend published as its own
+  package becomes selectable by a short name.
+
+An open registry rather than a closed enum, because the alternative would make
+out-of-tree backends library-only permanently, and opening a released config
+schema afterwards costs a deprecation.
+
+What a name resolves *to* is a :class:`~.base.StoreFactory`, and what it is called
+with is a :class:`~.base.StoreContext`. Neither is this module's invention; see
+``references/storage.md``. This module only chooses.
+
+Every refusal here is a :class:`~..errors.ConfigurationError` naming the fix,
+because every one of them is a wiring mistake in how the engine was configured
+rather than a bad request from a user.
+"""
+
+from __future__ import annotations
+
+from ..errors import ConfigurationError
+from .base import ExploreStore, StoreContext, StoreFactory
+from .filesystem import FilesystemStore
+
+ENTRY_POINT_GROUP = "exmergo_dex_core.stores"
+
+#: The backends dex ships and will construct by name. Checked before anything
+#: installed, so no third-party registration can take over a shipped name.
+SHIPPED: dict[str, StoreFactory] = {
+    "filesystem": FilesystemStore.from_context,
+}
+
+#: Shipped backends that are deliberately *not* selectable, and why. Refusing by
+#: name with the real reason beats letting them through into a tool that appears
+#: broken, and beats an "unknown backend" message for something that plainly
+#: exists.
+NOT_SELECTABLE = {
+    "memory": (
+        "the memory store keeps state in process attributes, and each CLI command "
+        "runs as its own process, so nothing it wrote would survive to the next "
+        "one: `explore query` would refuse with 'run `explore map` first' having "
+        "just run it. It is the default for a library caller, where one process "
+        "holds the engine (DexEngine() selects it automatically), and it is not "
+        "selectable here. For durable state outside the repo, name a backend of "
+        "your own"
+    ),
+}
+
+# The narrowest tier, and so the floor for anything selected: a store that cannot
+# serve explore cannot serve anything. Which *wider* tier a given command needs is
+# checked where the command runs (see DexEngine.require_full_store), because that
+# is where the answer depends on the command rather than on the configuration.
+_EXPLORE_MEMBERS = (
+    "load_cache",
+    "save_cache",
+    "append_query_log",
+    "append_spend_log",
+    "spend_since",
+    "locator",
+)
+
+
+def resolve_store_factory(name: str) -> StoreFactory:
+    """The factory ``name`` selects, or a refusal naming what to fix.
+
+    Resolution only. The factory is not called here, so a caller that wants to
+    inspect or wrap what a name selects can, and :func:`build_store` is the one
+    that constructs.
+    """
+
+    selected = (name or "").strip()
+    if not selected:
+        raise ConfigurationError(
+            "cache.backend is empty; name a shipped backend "
+            f"({', '.join(sorted(SHIPPED))}), a dotted path such as "
+            "'mypkg.stores:my_store', or an installed entry-point name"
+        )
+
+    if selected in SHIPPED:
+        return SHIPPED[selected]
+
+    if selected in NOT_SELECTABLE:
+        raise ConfigurationError(
+            f"the '{selected}' store cannot be selected from configuration: "
+            f"{NOT_SELECTABLE[selected]}"
+        )
+
+    if ":" in selected:
+        return _load_dotted_path(selected)
+
+    registered = _load_entry_point(selected)
+    if registered is not None:
+        return registered
+
+    raise ConfigurationError(
+        f"unknown cache backend '{selected}'. dex ships "
+        f"{', '.join(sorted(SHIPPED))}; anything else is either a dotted path "
+        "('mypkg.stores:my_store', note the colon between module and name) or a "
+        f"name registered by an installed distribution under the "
+        f"'{ENTRY_POINT_GROUP}' entry-point group. Nothing installed registers "
+        f"'{selected}'"
+    )
+
+
+def build_store(
+    name: str,
+    context: StoreContext,
+) -> ExploreStore:
+    """Resolve ``name`` and construct it, checking what comes back is a store.
+
+    The tier check is on the constructed object rather than on the factory,
+    deliberately: a factory is a callable, and a callable protocol can only
+    verify that ``__call__`` exists, which every callable satisfies. The store
+    tiers are genuinely structural, so building first is what makes the check
+    mean anything.
+    """
+
+    factory = resolve_store_factory(name)
+    try:
+        store = factory(context)
+    except ConfigurationError:
+        # The backend refused its own coordinates and said why. Re-wrapping would
+        # bury the specific message under a generic one.
+        raise
+    except Exception as exc:
+        raise ConfigurationError(
+            f"the cache backend '{name}' failed to build: {exc}. A factory takes "
+            "one StoreContext and returns a store; check that it accepts the "
+            "context dex passes and reads its coordinates out of context.options"
+        ) from exc
+
+    if not isinstance(store, ExploreStore):
+        missing = [m for m in _EXPLORE_MEMBERS if not hasattr(store, m)]
+        raise ConfigurationError(
+            f"the cache backend '{name}' built a {type(store).__name__}, which is "
+            f"not a store: it is missing {', '.join(missing)}. Every backend has "
+            "to satisfy at least exmergo_dex_core.storage.ExploreStore; run the "
+            "shipped conformance suite against it "
+            "(exmergo_dex_core.storage.conformance)"
+        )
+    return store
+
+
+def _load_dotted_path(path: str) -> StoreFactory:
+    from importlib import import_module
+
+    module_name, _, attribute = path.partition(":")
+    if not module_name or not attribute:
+        raise ConfigurationError(
+            f"'{path}' is not a usable dotted path; write it as "
+            "'module.path:name', with a colon between the module and the factory"
+        )
+    try:
+        module = import_module(module_name)
+    except ImportError as exc:
+        raise ConfigurationError(
+            f"cache backend '{path}' names a module that will not import: {exc}. "
+            "Check the spelling, and that the distribution providing it is "
+            "installed in the environment running dex"
+        ) from exc
+
+    resolved = module
+    for part in attribute.split("."):
+        try:
+            resolved = getattr(resolved, part)
+        except AttributeError as exc:
+            raise ConfigurationError(
+                f"cache backend '{path}' imported {module_name} but it has no "
+                f"'{attribute}'"
+            ) from exc
+
+    if not callable(resolved):
+        raise ConfigurationError(
+            f"cache backend '{path}' resolved to a {type(resolved).__name__}, "
+            "which cannot be called. Name a factory: a function taking a "
+            "StoreContext, a class whose __init__ takes one, or a classmethod "
+            "like FilesystemStore.from_context"
+        )
+    return resolved
+
+
+def _load_entry_point(name: str) -> StoreFactory | None:
+    """The factory an installed distribution registered under ``name``, if any.
+
+    Imported here rather than at module scope: the CLI runs as a fresh process
+    per command, and scanning installed distributions is work no invocation that
+    selects a shipped backend should pay for.
+    """
+
+    from importlib.metadata import entry_points
+
+    for entry in entry_points(group=ENTRY_POINT_GROUP):
+        if entry.name != name:
+            continue
+        try:
+            loaded = entry.load()
+        except Exception as exc:
+            raise ConfigurationError(
+                f"cache backend '{name}' is registered under "
+                f"'{ENTRY_POINT_GROUP}' by an installed distribution, but loading "
+                f"it failed: {exc}. That is a problem with the distribution "
+                "providing the backend, not with this configuration"
+            ) from exc
+        if not callable(loaded):
+            raise ConfigurationError(
+                f"cache backend '{name}' is registered under "
+                f"'{ENTRY_POINT_GROUP}' but points at a "
+                f"{type(loaded).__name__}, which cannot be called. The entry "
+                "point has to name a factory taking a StoreContext"
+            )
+        return loaded
+    return None

--- a/packages/dex-core/tests/fakes/stores.py
+++ b/packages/dex-core/tests/fakes/stores.py
@@ -1,0 +1,100 @@
+"""A storage backend and its factory, living where a third party's would.
+
+Its job is to be reachable *by name*: the resolver tests point a dotted path at
+this module, so what they exercise is the same import-a-string-and-call-it path a
+real out-of-tree backend takes. Keeping it out of the test module that uses it is
+the point, since a factory defined in the test file could be resolved from a local
+name and prove nothing.
+
+Keyed by tenant with no repo root anywhere, because that is the backend shape the
+construction contract was widened for and the one a path-shaped contract could not
+have expressed.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import ClassVar
+
+from exmergo_dex_core.cache import DexCache
+from exmergo_dex_core.errors import ConfigurationError
+from exmergo_dex_core.storage import Document, StoreContext, spend_total
+
+
+class TenantStore:
+    """A tenant-keyed explore-tier backend, shared across instances by tenant."""
+
+    _registry: ClassVar[dict[str, dict[str, object]]] = {}
+
+    def __init__(self, tenant: str):
+        self.tenant = tenant
+        self._docs = self._registry.setdefault(tenant, {})
+
+    @classmethod
+    def reset(cls) -> None:
+        cls._registry.clear()
+
+    def load_cache(self) -> DexCache | None:
+        raw = self._docs.get("cache")
+        return None if raw is None else DexCache.model_validate_json(str(raw))
+
+    def save_cache(self, cache: DexCache, *, now: datetime | None = None) -> str:
+        if now is not None:
+            cache.provenance.updated_at = now.isoformat()
+        self._docs["cache"] = cache.model_dump_json()
+        return self.locator(Document.CACHE)
+
+    def append_query_log(self, entry: dict) -> None:
+        self._docs.setdefault("queries", []).append(json.dumps(entry))  # type: ignore[union-attr]
+
+    def append_spend_log(self, entry: dict) -> None:
+        self._docs.setdefault("spend", []).append(json.dumps(entry))  # type: ignore[union-attr]
+
+    def spend_since(
+        self,
+        cutoff_iso: str,
+        *,
+        field: str = "billed_bytes",
+        connector: str | None = None,
+    ) -> float:
+        raws = self._docs.setdefault("spend", [])
+        entries = [json.loads(r) for r in raws]  # type: ignore[union-attr]
+        return spend_total(entries, cutoff_iso, field=field, connector=connector)
+
+    def locator(self, document: Document) -> str:
+        return f"tenant://{self.tenant}/{document.value}"
+
+
+def tenant_store(context: StoreContext) -> TenantStore:
+    """The function shape of the construction contract."""
+
+    tenant = context.options.get("tenant")
+    if not tenant:
+        raise ConfigurationError(
+            "this backend is keyed by tenant and the context carries none; set "
+            "cache.options.tenant"
+        )
+    return TenantStore(str(tenant))
+
+
+class ContextBuiltStore(TenantStore):
+    """The class shape: ``__init__`` takes the context, so the class is a factory."""
+
+    def __init__(self, context: StoreContext):
+        super().__init__(tenant=str(context.options["tenant"]))
+
+
+def not_a_store(context: StoreContext) -> object:
+    """A factory that returns something that is not a store, for the refusal."""
+
+    return object()
+
+
+def explodes(context: StoreContext) -> TenantStore:
+    """A factory that fails for a reason of its own, for the refusal."""
+
+    raise RuntimeError("the tenant directory is unreachable")
+
+
+NOT_CALLABLE = "a string, not a factory"

--- a/packages/dex-core/tests/maintain/test_snapshot.py
+++ b/packages/dex-core/tests/maintain/test_snapshot.py
@@ -110,3 +110,43 @@ def test_snapshot_file_carries_no_string_values(maintain_repo):
             if "VARCHAR" in column["data_type"].upper():
                 assert column["min_value"] is None
                 assert column["max_value"] is None
+
+
+def test_the_snapshot_hint_only_promises_git_when_the_baseline_is_a_file(
+    tmp_path: Path,
+):
+    """The hint is advice about where the baseline landed, so it has to follow the
+    backend.
+
+    Telling a host whose snapshot is a row or a document to commit
+    `.dex/snapshot.json` names a file it does not have. The half that holds
+    everywhere, re-pinning after a known-good build, is what a backend dex does
+    not ship should get; `snapshot_path` carries the real location either way.
+    The filesystem half is asserted by the first test in this file.
+    """
+
+    import argparse
+
+    from exmergo_dex_core import DexConfig, DexEngine, MemoryStore
+    from exmergo_dex_core.maintain.commands import cmd_snapshot
+
+    duckdb = pytest.importorskip("duckdb")
+    db_path = tmp_path / "warehouse.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE TABLE items (id INTEGER)")
+    conn.close()
+
+    with DexEngine(
+        connector="duckdb",
+        path=str(db_path),
+        config=DexConfig(connector="duckdb"),
+        store=MemoryStore(),
+    ) as engine:
+        envelope = cmd_snapshot(argparse.Namespace(), engine)
+
+    hint = envelope.data["hint"]
+    assert "commit" not in hint
+    assert ".dex/snapshot.json" not in hint
+    assert "re-run `maintain snapshot`" in hint
+    # And the location is still reported, just not as a path anyone can commit.
+    assert envelope.data["snapshot_path"] == "memory:snapshot"

--- a/packages/dex-core/tests/storage/test_conformance.py
+++ b/packages/dex-core/tests/storage/test_conformance.py
@@ -6,7 +6,7 @@ implementable by someone reading only what is published. These build a backend
 that is neither a directory nor a live in-process object, and drive it the way a
 host actually would.
 
-Two shapes matter here and are not covered anywhere else:
+Three shapes matter here and are not covered anywhere else:
 
 - **A store outliving the engine that wrote it.** A request-per-engine host builds
   a fresh engine per call and keeps state in its own datastore. Today's in-memory
@@ -15,6 +15,10 @@ Two shapes matter here and are not covered anywhere else:
 - **A partial implementation that is still complete.** A host that only explores
   implements ``ExploreStore`` and stops, and that has to be a satisfied contract
   rather than five methods that raise.
+- **A backend with no repo root, built from a context.** Both shipped backends are
+  constructed from a path or from nothing, so they cannot show whether the
+  construction contract works for the backend class it was widened for: one keyed
+  by a tenant, with no repository anywhere in the picture.
 """
 
 from __future__ import annotations
@@ -26,12 +30,24 @@ from typing import ClassVar
 
 import pytest
 
-from exmergo_dex_core import DexConfig, DexEngine, StoreRequiredError
+from exmergo_dex_core import (
+    ConfigurationError,
+    DexConfig,
+    DexEngine,
+    StoreRequiredError,
+)
 from exmergo_dex_core.cache import DexCache
-from exmergo_dex_core.storage import Document, ExploreStore, Store, spend_total
+from exmergo_dex_core.storage import (
+    Document,
+    ExploreStore,
+    Store,
+    StoreContext,
+    spend_total,
+)
 from exmergo_dex_core.storage.conformance import (
     ExploreStoreContract,
     StoreContract,
+    StoreFactoryContract,
 )
 from exmergo_dex_core.transform.plans import PlanNotFoundError, TransformPlan
 
@@ -202,6 +218,36 @@ class ExploreOnlyStore:
         return f"explore-only://{self.tenant}/{document.value}"
 
 
+def document_store_factory(context: StoreContext) -> DocumentStore:
+    """The function shape of the construction contract, keyed by nothing on disk.
+
+    What a third party would publish beside the backend so it can be named in
+    configuration. It reads its own coordinate out of ``options`` and refuses when
+    it is missing, because a backend that guessed a tenant would put one tenant's
+    exploration cache under another's key.
+    """
+
+    tenant = context.options.get("tenant")
+    if not tenant:
+        raise ConfigurationError(
+            "this backend is keyed by tenant and the context carries none; set "
+            "cache.options.tenant"
+        )
+    return DocumentStore(tenant=str(tenant))
+
+
+class ContextKeyedExploreStore(ExploreOnlyStore):
+    """The class shape: a store whose ``__init__`` is itself the factory.
+
+    The second way a dotted path can resolve, and the reason the contract is a
+    callable rather than a named classmethod: a backend written this way needs no
+    adapter and no extra method to be constructable.
+    """
+
+    def __init__(self, context: StoreContext):
+        super().__init__(tenant=str(context.options["tenant"]))
+
+
 @pytest.fixture(autouse=True)
 def _clean_registries():
     DocumentStore.reset()
@@ -222,6 +268,35 @@ class TestDocumentStoreConformance(StoreContract):
 class TestExploreOnlyStoreConformance(ExploreStoreContract):
     def make_store(self, key: str) -> ExploreOnlyStore:
         return ExploreOnlyStore(tenant=key)
+
+
+# --- the same contract, run through the construction seam ----------------------
+#
+# Composing the factory contract in front re-runs every behavioral and isolation
+# assertion above against stores built the way dex would build them, which is what
+# keeps "the suite is green" meaning correct *and* constructable.
+
+
+class TestDocumentStoreConstruction(StoreFactoryContract, StoreContract):
+    tier = Store
+
+    def build(self, context: StoreContext) -> DocumentStore:
+        return document_store_factory(context)
+
+    def context_for(self, key: str) -> StoreContext:
+        # No repo root anywhere: the case the rejected `resolve(name)(repo_root)`
+        # contract could not express at all.
+        return StoreContext(options={"tenant": key})
+
+
+class TestContextKeyedExploreStoreConstruction(
+    StoreFactoryContract, ExploreStoreContract
+):
+    def build(self, context: StoreContext) -> ContextKeyedExploreStore:
+        return ContextKeyedExploreStore(context)
+
+    def context_for(self, key: str) -> StoreContext:
+        return StoreContext(options={"tenant": key})
 
 
 # --- the tiers are what they claim to be --------------------------------------
@@ -260,6 +335,45 @@ def test_a_broken_backend_fails_with_the_rule_it_broke_not_a_bare_compare():
     assert "must not alias the caller's object" in message
     # And it says what to do about it, not merely that something differed.
     assert "Serialize on write, or deep-copy" in message
+
+
+def test_a_factory_that_ignores_its_context_fails_with_the_rule_it_broke():
+    """The construction mistake that voids every isolation guarantee downstream.
+
+    A factory that drops the part of the context keying it builds one shared store
+    for every tenant. Nothing about that looks wrong at the call site, and the
+    behavioral suite passes, because each store in isolation is correct; what
+    fails is that they are all the same store. So the message has to say which
+    part of the contract broke, not merely that a cache was not None.
+    """
+
+    contract = StoreFactoryContract()
+    contract.build = lambda context: DocumentStore("always-the-same")  # type: ignore[method-assign]
+    contract.context_for = lambda key: StoreContext(options={"tenant": key})  # type: ignore[method-assign]
+
+    with pytest.raises(AssertionError) as failure:
+        contract.test_two_contexts_build_stores_that_share_nothing()
+
+    message = str(failure.value)
+    assert "ignoring the part of the context that keys it" in message
+
+
+def test_a_factory_that_undershoots_its_declared_tier_names_the_tier():
+    # The other construction failure: the backend is fine and the factory works,
+    # but it hands back a narrower store than the config selecting it expects. dex
+    # refuses at resolution, so this has to fail here rather than several commands
+    # later on a missing attribute.
+    contract = StoreFactoryContract()
+    contract.tier = Store
+    contract.build = lambda context: ExploreOnlyStore("t")  # type: ignore[method-assign]
+    contract.context_for = lambda key: StoreContext(options={"tenant": key})  # type: ignore[method-assign]
+
+    with pytest.raises(AssertionError) as failure:
+        contract.test_the_factory_builds_a_store_of_the_declared_tier()
+
+    message = str(failure.value)
+    assert "ExploreOnlyStore" in message and "Store" in message
+    assert "unusable from configuration" in message
 
 
 def test_a_full_backend_satisfies_every_tier():
@@ -331,6 +445,55 @@ def test_one_tenants_cache_is_invisible_to_another(duckdb_file: Path):
         pytest.raises(Exception),
     ):
         stranger.query("select count(*) as n from customers")
+
+
+def test_a_backend_built_from_a_context_with_no_repo_root_drives_a_flow(
+    duckdb_file: Path,
+):
+    """The acceptance case for the construction contract, end to end.
+
+    Nothing here has a repo root: the store is built from a context carrying only
+    a tenant, which is the construction a path-shaped contract cannot express. And
+    it is built twice, once per engine, so the flow only works if the second
+    construction lands on the state the first one wrote. That is the property a
+    hosted deployment needs and the reason the contract is keyed by the backend's
+    own coordinates rather than by a directory.
+    """
+
+    config = DexConfig(connector="duckdb")
+    context = StoreContext(options={"tenant": "tenant-a"})
+
+    with DexEngine(
+        connector="duckdb",
+        path=str(duckdb_file),
+        config=config,
+        store=document_store_factory(context),
+    ) as first:
+        first.map()
+
+    with DexEngine(
+        connector="duckdb",
+        path=str(duckdb_file),
+        config=config,
+        store=document_store_factory(context),
+    ) as second:
+        result = second.query("select count(*) as n from customers")
+
+    assert result.cells[0][0] == 2
+
+    # And a different tenant's context builds a store that has never seen it, so
+    # the firewall has nothing to resolve the table against.
+    stranger_store = document_store_factory(StoreContext(options={"tenant": "other"}))
+    assert stranger_store.load_cache() is None
+
+
+def test_a_factory_refuses_a_context_missing_the_coordinate_it_is_keyed_by():
+    # The refusal a backend owes: guessing a tenant would file one tenant's
+    # exploration cache under another's key, which is the failure the whole seam
+    # exists to prevent.
+    with pytest.raises(ConfigurationError) as refusal:
+        document_store_factory(StoreContext(repo_root="/somewhere"))
+    assert "tenant" in str(refusal.value)
 
 
 def test_an_explore_only_store_drives_a_full_explore_flow(duckdb_file: Path):

--- a/packages/dex-core/tests/storage/test_filesystem.py
+++ b/packages/dex-core/tests/storage/test_filesystem.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+from exmergo_dex_core import ConfigurationError
 from exmergo_dex_core.cache import Dataset, DexCache
-from exmergo_dex_core.storage import Document, FilesystemStore
+from exmergo_dex_core.storage import Document, FilesystemStore, StoreContext
 from exmergo_dex_core.storage.filesystem import (
     CACHE_FILE,
     DEX_DIR,
@@ -99,6 +102,30 @@ def test_plans_live_one_file_per_plan(tmp_path: Path):
     path = tmp_path / DEX_DIR / PLANS_DIR / "pabc123.json"
     assert path.is_file()
     assert json.loads(path.read_text())["intent"] == "add a model"
+
+
+def test_from_context_keys_the_store_to_the_repo_root(tmp_path: Path):
+    store = FilesystemStore.from_context(StoreContext(repo_root=str(tmp_path)))
+    store.save_cache(DexCache(datasets=[Dataset(identifier="db.main.orders")]))
+    assert (tmp_path / DEX_DIR / CACHE_FILE).is_file()
+
+
+def test_from_context_refuses_a_context_with_no_repo_root():
+    # The dangerous fallback is defaulting to the working directory, which would
+    # write one project's cache into wherever the process happened to start.
+    with pytest.raises(ConfigurationError) as refusal:
+        FilesystemStore.from_context(StoreContext())
+    assert "repo root" in str(refusal.value)
+
+
+def test_from_context_refuses_options_it_would_have_ignored(tmp_path: Path):
+    # Accepted-and-ignored is worse than rejected: the caller believes the setting
+    # took effect and nothing in the output says otherwise.
+    with pytest.raises(ConfigurationError) as refusal:
+        FilesystemStore.from_context(
+            StoreContext(repo_root=str(tmp_path), options={"tenant": "acme"})
+        )
+    assert "tenant" in str(refusal.value)
 
 
 def test_locators_are_absolute_paths_under_the_repo_root(tmp_path: Path):

--- a/packages/dex-core/tests/storage/test_memory.py
+++ b/packages/dex-core/tests/storage/test_memory.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from exmergo_dex_core import ConfigurationError
 from exmergo_dex_core.cache import Dataset, DexCache
-from exmergo_dex_core.storage import Document, MemoryStore
+from exmergo_dex_core.storage import Document, MemoryStore, StoreContext
 
 
 def test_nothing_reaches_the_filesystem(tmp_path: Path, monkeypatch):
@@ -51,6 +54,18 @@ def test_a_loaded_document_is_a_copy_the_caller_can_mutate_freely():
     reloaded = store.load_cache()
     assert reloaded is not None
     assert [d.identifier for d in reloaded.datasets] == ["db.main.orders"]
+
+
+def test_from_context_ignores_a_repo_root_but_refuses_options(tmp_path: Path):
+    # A repo root is present in every context dex builds, and carrying one is not a
+    # request to use it; an option this backend has no meaning for is a mistake.
+    built = MemoryStore.from_context(StoreContext(repo_root=str(tmp_path)))
+    built.save_cache(DexCache(datasets=[Dataset(identifier="db.main.orders")]))
+    assert list(tmp_path.rglob("*")) == []
+
+    with pytest.raises(ConfigurationError) as refusal:
+        MemoryStore.from_context(StoreContext(options={"tenant": "acme"}))
+    assert "tenant" in str(refusal.value)
 
 
 def test_locators_name_the_backend_rather_than_a_path():

--- a/packages/dex-core/tests/storage/test_resolver.py
+++ b/packages/dex-core/tests/storage/test_resolver.py
@@ -1,0 +1,236 @@
+"""Turning a configured name into a store, and refusing usefully when it cannot.
+
+Every refusal here is something a human wrote in `.dex/config.yml` or typed on the
+command line, so the assertions are mostly about the message: whether it names the
+fix. A resolver that refuses correctly with an unusable message costs a support
+conversation for every backend anyone tries to write.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core import ConfigurationError
+from exmergo_dex_core.storage import (
+    ExploreStore,
+    FilesystemStore,
+    StoreContext,
+    build_store,
+    resolve_store_factory,
+)
+from exmergo_dex_core.storage.resolver import ENTRY_POINT_GROUP
+
+from ..fakes.stores import TenantStore
+
+FAKES = "tests.fakes.stores"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    TenantStore.reset()
+    yield
+    TenantStore.reset()
+
+
+# --- the shipped names ---------------------------------------------------------
+
+
+def test_the_default_name_builds_the_filesystem_backend(tmp_path: Path):
+    store = build_store("filesystem", StoreContext(repo_root=str(tmp_path)))
+    assert isinstance(store, FilesystemStore)
+    assert store.root == tmp_path
+
+
+def test_memory_is_refused_by_naming_the_process_boundary():
+    # Not an "unknown backend": it plainly exists, it is simply wrong here, and a
+    # user who selected it needs to know why rather than doubt the spelling.
+    with pytest.raises(ConfigurationError) as refusal:
+        resolve_store_factory("memory")
+    message = str(refusal.value)
+    assert "its own process" in message
+    assert "explore map" in message
+
+
+def test_an_unknown_name_lists_what_exists_and_the_two_open_forms():
+    with pytest.raises(ConfigurationError) as refusal:
+        resolve_store_factory("postgres")
+    message = str(refusal.value)
+    assert "filesystem" in message
+    assert "mypkg.stores:my_store" in message
+    assert ENTRY_POINT_GROUP in message
+
+
+def test_an_empty_name_refuses_rather_than_defaulting():
+    # Silently falling back would make a typo'd or half-written config look like a
+    # deliberate choice of the default.
+    with pytest.raises(ConfigurationError):
+        resolve_store_factory("   ")
+
+
+# --- a dotted path to a backend defined outside the package --------------------
+
+
+def test_a_dotted_path_resolves_a_function_factory():
+    store = build_store(
+        f"{FAKES}:tenant_store", StoreContext(options={"tenant": "acme"})
+    )
+    assert isinstance(store, TenantStore)
+    assert store.tenant == "acme"
+    assert isinstance(store, ExploreStore)
+
+
+def test_a_dotted_path_resolves_a_class_whose_init_takes_the_context():
+    store = build_store(
+        f"{FAKES}:ContextBuiltStore", StoreContext(options={"tenant": "acme"})
+    )
+    assert store.tenant == "acme"
+
+
+def test_a_dotted_path_resolves_a_classmethod():
+    # The shape the shipped backends use, reachable by name like any other.
+    store = build_store(
+        "exmergo_dex_core.storage:FilesystemStore.from_context",
+        StoreContext(repo_root="/somewhere"),
+    )
+    assert isinstance(store, FilesystemStore)
+
+
+def test_options_reach_the_factory_verbatim():
+    # dex does not interpret options, so a backend's own keys arrive untouched.
+    first = build_store(f"{FAKES}:tenant_store", StoreContext(options={"tenant": "a"}))
+    second = build_store(f"{FAKES}:tenant_store", StoreContext(options={"tenant": "b"}))
+    assert (first.tenant, second.tenant) == ("a", "b")
+
+
+def test_a_backend_selected_by_name_is_isolated_across_keys():
+    from exmergo_dex_core.storage.conformance import a_cache
+
+    one = build_store(f"{FAKES}:tenant_store", StoreContext(options={"tenant": "one"}))
+    two = build_store(f"{FAKES}:tenant_store", StoreContext(options={"tenant": "two"}))
+    one.save_cache(a_cache("db.one.orders"))
+    assert two.load_cache() is None
+
+
+# --- the refusals a bad dotted path earns --------------------------------------
+
+
+def test_a_path_without_a_colon_says_where_the_colon_goes():
+    with pytest.raises(ConfigurationError) as refusal:
+        resolve_store_factory("mypkg.stores.my_store")
+    # It falls through to the unknown-name refusal, which is the one that explains
+    # both open forms, so the colon has to be visible there.
+    assert "colon" in str(refusal.value)
+
+
+def test_a_module_that_does_not_import_names_the_environment():
+    with pytest.raises(ConfigurationError) as refusal:
+        resolve_store_factory("no_such_module_anywhere:my_store")
+    message = str(refusal.value)
+    assert "will not import" in message
+    assert "installed in the environment" in message
+
+
+def test_a_missing_attribute_names_the_module_it_looked_in():
+    with pytest.raises(ConfigurationError) as refusal:
+        resolve_store_factory(f"{FAKES}:no_such_factory")
+    message = str(refusal.value)
+    assert FAKES in message
+    assert "no_such_factory" in message
+
+
+def test_something_that_is_not_callable_is_refused_as_not_a_factory():
+    with pytest.raises(ConfigurationError) as refusal:
+        resolve_store_factory(f"{FAKES}:NOT_CALLABLE")
+    message = str(refusal.value)
+    assert "cannot be called" in message
+    assert "StoreContext" in message
+
+
+def test_a_factory_returning_something_that_is_not_a_store_names_the_members():
+    # The check is on what was built, not on the factory: a callable protocol can
+    # only verify __call__ exists, which every callable satisfies.
+    with pytest.raises(ConfigurationError) as refusal:
+        build_store(f"{FAKES}:not_a_store", StoreContext())
+    message = str(refusal.value)
+    assert "not a store" in message
+    assert "load_cache" in message
+    assert "conformance" in message
+
+
+def test_a_factory_that_fails_on_its_own_terms_says_so_and_keeps_the_cause():
+    with pytest.raises(ConfigurationError) as refusal:
+        build_store(f"{FAKES}:explodes", StoreContext(options={"tenant": "acme"}))
+    message = str(refusal.value)
+    assert "failed to build" in message
+    assert "tenant directory is unreachable" in message
+    assert isinstance(refusal.value.__cause__, RuntimeError)
+
+
+def test_a_backends_own_refusal_is_not_buried_under_a_generic_one():
+    # The backend said exactly what coordinate was missing. Wrapping that in "the
+    # factory failed" would cost the only actionable part of the message.
+    with pytest.raises(ConfigurationError) as refusal:
+        build_store(f"{FAKES}:tenant_store", StoreContext(repo_root="/somewhere"))
+    message = str(refusal.value)
+    assert "cache.options.tenant" in message
+    assert "failed to build" not in message
+
+
+# --- the entry-point group -----------------------------------------------------
+
+
+class _FakeEntryPoint:
+    def __init__(self, name, target):
+        self.name = name
+        self._target = target
+
+    def load(self):
+        if isinstance(self._target, Exception):
+            raise self._target
+        return self._target
+
+
+def _patch_entry_points(monkeypatch, entries):
+    import importlib.metadata
+
+    def fake(group=None):
+        assert group == ENTRY_POINT_GROUP
+        return entries
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake)
+
+
+def test_an_entry_point_name_resolves_like_a_shipped_one(monkeypatch):
+    from ..fakes.stores import tenant_store
+
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("acme", tenant_store)])
+    store = build_store("acme", StoreContext(options={"tenant": "acme-inc"}))
+    assert isinstance(store, TenantStore)
+
+
+def test_a_shipped_name_cannot_be_shadowed_by_a_registration(monkeypatch):
+    # Otherwise installing a package could silently change where an existing repo's
+    # state lands, with nothing in the config file changing.
+    from ..fakes.stores import tenant_store
+
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("filesystem", tenant_store)])
+    store = build_store("filesystem", StoreContext(repo_root="/somewhere"))
+    assert isinstance(store, FilesystemStore)
+
+
+def test_an_entry_point_that_fails_to_load_blames_the_distribution(monkeypatch):
+    _patch_entry_points(
+        monkeypatch, [_FakeEntryPoint("acme", ImportError("no module named acme"))]
+    )
+    with pytest.raises(ConfigurationError) as refusal:
+        resolve_store_factory("acme")
+    assert "problem with the distribution" in str(refusal.value)
+
+
+def test_an_entry_point_pointing_at_a_non_callable_is_refused(monkeypatch):
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("acme", "not a factory")])
+    with pytest.raises(ConfigurationError) as refusal:
+        resolve_store_factory("acme")
+    assert "cannot be called" in str(refusal.value)

--- a/packages/dex-core/tests/test_cli_contract.py
+++ b/packages/dex-core/tests/test_cli_contract.py
@@ -133,3 +133,114 @@ def test_scope_is_accepted_on_every_subcommand():
                 argv.append("select 1")
             args = parser.parse_args(argv)
             assert args.scope == ["raw"], f"{group} {sub} dropped --scope"
+
+
+# --- selecting the storage backend ------------------------------------------------
+
+
+def test_a_configured_backend_carries_state_from_one_command_to_the_next(
+    duckdb_file: Path, tmp_path: Path, capsys
+):
+    """The point of a CLI selector: a backend dex does not ship, driving a real
+    multi-step flow.
+
+    The two commands are the whole test. `explore query` resolves every table
+    reference against the cache `explore map` wrote, so the second one can only
+    succeed if state actually reached the selected backend and came back out of
+    it. A backend that quietly did nothing would fail here and nowhere else.
+    """
+
+    from exmergo_dex_core.config import CacheConfig, DexConfig, save_config
+
+    from .fakes.stores import TenantStore
+
+    TenantStore.reset()
+    save_config(
+        DexConfig(
+            connector="duckdb",
+            cache=CacheConfig(
+                backend="tests.fakes.stores:tenant_store",
+                options={"tenant": "acme"},
+            ),
+        ),
+        tmp_path,
+    )
+    base = ["--repo-root", str(tmp_path), "--path", str(duckdb_file)]
+
+    assert main([*base, "explore", "map"]) == 0
+    mapped = json.loads(capsys.readouterr().out)
+    assert mapped["status"] == "ok"
+    # The locator an agent surfaces is the selected backend's, not a path.
+    assert mapped["data"]["cache_path"].startswith("tenant://acme/")
+
+    assert main([*base, "explore", "query", "select count(*) as n from customers"]) == 0
+    queried = json.loads(capsys.readouterr().out)
+    assert queried["status"] == "ok"
+    assert queried["data"]["cells"] == [[2]]
+
+    # And the filesystem backend was genuinely not used: only the config file the
+    # test wrote is under `.dex/`.
+    assert [p.name for p in (tmp_path / ".dex").iterdir()] == ["config.yml"]
+    TenantStore.reset()
+
+
+def test_the_cache_backend_flag_overrides_the_configured_name(
+    duckdb_file: Path, tmp_path: Path, capsys
+):
+    from .fakes.stores import TenantStore
+
+    TenantStore.reset()
+    rc = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--path",
+            str(duckdb_file),
+            "--cache-backend",
+            "tests.fakes.stores:ContextBuiltStore",
+            "explore",
+            "map",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    # No config file at all, so options carry no tenant and the class-shaped
+    # factory raises on the missing key: what matters here is that the flag was
+    # honored rather than ignored, and that it failed as one envelope.
+    assert rc == 1
+    assert payload["status"] == "error"
+    assert "failed to build" in payload["errors"][0]
+    TenantStore.reset()
+
+
+def test_selecting_the_memory_backend_refuses_by_naming_the_process_boundary(
+    tmp_path: Path, capsys
+):
+    """A `MemoryStore` behind the CLI would drop the cache between commands and
+    make the tool look broken. The refusal has to explain that rather than let
+    someone debug it."""
+
+    rc = main(
+        ["--repo-root", str(tmp_path), "--cache-backend", "memory", "connect", "test"]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["status"] == "error"
+    assert "its own process" in payload["errors"][0]
+
+
+def test_an_unresolvable_backend_still_emits_exactly_one_envelope(
+    tmp_path: Path, capsys
+):
+    """The engine is built before any command runs, and it can refuse. Every agent
+    wrapper reads exactly one envelope from stdout, so a refusal there has to be
+    rendered like any other rather than escaping as a traceback."""
+
+    rc = main(
+        ["--repo-root", str(tmp_path), "--cache-backend", "nope", "connect", "test"]
+    )
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1
+    payload = json.loads(out)
+    assert rc == 1
+    assert payload["status"] == "error"
+    assert "unknown cache backend" in payload["errors"][0]

--- a/packages/dex-core/tests/test_config.py
+++ b/packages/dex-core/tests/test_config.py
@@ -8,6 +8,7 @@ import pytest
 
 from exmergo_dex_core.config import (
     BlobOverride,
+    CacheConfig,
     DexConfig,
     PIIOverride,
     blob_override_paths,
@@ -138,3 +139,32 @@ def test_config_without_blob_overrides_stays_clean(tmp_path: Path):
     text = (tmp_path / ".dex" / "config.yml").read_text()
     assert "blob_overrides" not in text
     assert load_config(tmp_path).blob_overrides == []
+
+
+def test_the_cache_block_round_trips_and_defaults_to_the_filesystem(tmp_path: Path):
+    # The default is what every existing repo depends on: a config that says
+    # nothing about the cache keeps writing loose JSON under `.dex/`.
+    assert DexConfig().cache.backend == "filesystem"
+    assert DexConfig().cache.options == {}
+
+    config = DexConfig(
+        cache=CacheConfig(
+            backend="mypkg.stores:my_store",
+            options={"tenant": "acme", "project": "shop"},
+        )
+    )
+    save_config(config, tmp_path)
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.cache.backend == "mypkg.stores:my_store"
+    # Options reach the backend verbatim, so they have to survive the YAML round
+    # trip untouched rather than being coerced into a model dex defines.
+    assert loaded.cache.options == {"tenant": "acme", "project": "shop"}
+
+
+def test_an_unset_cache_block_is_not_written_into_the_committed_file(tmp_path: Path):
+    # The committed file stays a record of explicit choices, so a repo that never
+    # chose a backend does not grow a line claiming it chose the default.
+    save_config(DexConfig(connector="duckdb"), tmp_path)
+    raw = (tmp_path / ".dex" / "config.yml").read_text(encoding="utf-8")
+    assert "cache" not in raw

--- a/packages/dex-core/tests/test_engine.py
+++ b/packages/dex-core/tests/test_engine.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from exmergo_dex_core import (
+    ConfigurationError,
     ConfirmationRequiredError,
     DexConfig,
     DexEngine,
@@ -22,7 +23,7 @@ from exmergo_dex_core import (
     MemoryStore,
 )
 from exmergo_dex_core.cache import DexCache
-from exmergo_dex_core.config import DuckDBTarget
+from exmergo_dex_core.config import CacheConfig, DuckDBTarget, save_config
 from exmergo_dex_core.envelope import Envelope
 from exmergo_dex_core.explore.results import MapResult, ProfileResult, QueryResult
 
@@ -148,6 +149,107 @@ def test_commands_needing_the_project_refuse_without_a_repo_root():
             eng.init_project("analytics", connector="duckdb")
         with pytest.raises(ValueError, match="locating the dbt project"):
             eng.project_dir()
+
+
+# --- selecting the store from configuration ---------------------------------------
+
+
+def test_from_repo_still_builds_the_filesystem_backend_by_default(tmp_path: Path):
+    """The default is what every existing repo depends on, so it is asserted
+    rather than assumed: selecting nothing keeps writing loose JSON under
+    `.dex/`, and the selector is invisible to anyone who never sets it."""
+
+    with DexEngine.from_repo(tmp_path) as eng:
+        assert isinstance(eng.store, FilesystemStore)
+        assert eng.store.root == Path(tmp_path)
+
+
+def test_a_configured_backend_outside_the_package_is_what_from_repo_builds(
+    tmp_path: Path,
+):
+    from .fakes.stores import TenantStore
+
+    TenantStore.reset()
+    save_config(
+        DexConfig(
+            connector="duckdb",
+            cache=CacheConfig(
+                backend="tests.fakes.stores:tenant_store",
+                options={"tenant": "acme"},
+            ),
+        ),
+        tmp_path,
+    )
+    with DexEngine.from_repo(tmp_path) as eng:
+        assert isinstance(eng.store, TenantStore)
+        assert eng.store.tenant == "acme"
+    # And nothing was written to the repo, because this backend is not the
+    # filesystem one; the selection actually took effect.
+    assert not (tmp_path / ".dex" / "cache.json").exists()
+    TenantStore.reset()
+
+
+def test_an_explicit_store_wins_over_the_configured_one(tmp_path: Path):
+    # A caller holding an instance has already made the decision configuration
+    # exists to make for the callers who have not.
+    save_config(
+        DexConfig(cache=CacheConfig(backend="tests.fakes.stores:tenant_store")),
+        tmp_path,
+    )
+    with DexEngine.from_repo(tmp_path, store=MemoryStore()) as eng:
+        assert isinstance(eng.store, MemoryStore)
+
+
+def test_the_cache_backend_override_beats_the_configured_name(tmp_path: Path):
+    from .fakes.stores import TenantStore
+
+    TenantStore.reset()
+    selected = "tests.fakes.stores:tenant_store"
+    save_config(
+        DexConfig(cache=CacheConfig(backend=selected, options={"tenant": "acme"})),
+        tmp_path,
+    )
+    # Overriding back to the shipped backend for one run is the whole reason this
+    # flag exists, and it has to work on a repo that configures a custom one.
+    with DexEngine.from_repo(tmp_path, cache_backend="filesystem") as eng:
+        assert isinstance(eng.store, FilesystemStore)
+    # Naming the configured backend explicitly keeps its options, so the override
+    # is not a way to accidentally drop them.
+    with DexEngine.from_repo(tmp_path, cache_backend=selected) as eng:
+        assert isinstance(eng.store, TenantStore)
+        assert eng.store.tenant == "acme"
+    TenantStore.reset()
+
+
+def test_the_override_does_not_hand_one_backends_options_to_another(tmp_path: Path):
+    """Options are not namespaced by backend, so carrying them across an override
+    would give a backend coordinates written for a different one. The shipped
+    backends refuse an option they would have ignored, so this would present as a
+    refusal for a flag that ought to be the simplest thing in the tool."""
+
+    save_config(
+        DexConfig(
+            cache=CacheConfig(
+                backend="tests.fakes.stores:tenant_store", options={"tenant": "acme"}
+            )
+        ),
+        tmp_path,
+    )
+    with DexEngine.from_repo(tmp_path, cache_backend="filesystem") as eng:
+        assert isinstance(eng.store, FilesystemStore)
+
+
+def test_a_repo_with_no_config_at_all_still_gets_the_default_backend(tmp_path: Path):
+    # load_config returns None outside a project, and the store has to be built
+    # anyway: commands that need no warehouse still work there.
+    with DexEngine.from_repo(tmp_path / "not-a-project") as eng:
+        assert isinstance(eng.store, FilesystemStore)
+
+
+def test_an_unusable_backend_refuses_at_construction_naming_the_fix(tmp_path: Path):
+    save_config(DexConfig(cache=CacheConfig(backend="nonsense")), tmp_path)
+    with pytest.raises(ConfigurationError, match="unknown cache backend"):
+        DexEngine.from_repo(tmp_path)
 
 
 # --- tenancy: one engine, one principal ------------------------------------------

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -430,8 +430,16 @@ OUTSIDE_BACKEND = '''
 import json
 
 from exmergo_dex_core.cache import DexCache
-from exmergo_dex_core.storage import Document, ExploreStore, spend_total
-from exmergo_dex_core.storage.conformance import ExploreStoreContract
+from exmergo_dex_core.storage import (
+    Document,
+    ExploreStore,
+    StoreContext,
+    spend_total,
+)
+from exmergo_dex_core.storage.conformance import (
+    ExploreStoreContract,
+    StoreFactoryContract,
+)
 
 
 class TinyStore:
@@ -467,6 +475,17 @@ class TinyStore:
         return "tiny://" + self.key + "/" + document.value
 
 
+def tiny_store_factory(context):
+    """How this backend would be named in configuration: keyed by its own
+    coordinate, with no repo root anywhere."""
+
+    tenant = context.options.get("tenant")
+    if not tenant:
+        raise ValueError("this backend needs cache.options.tenant")
+    TinyStore._state.pop(tenant, None)
+    return TinyStore(tenant)
+
+
 def test_the_published_protocol_is_satisfied():
     assert isinstance(TinyStore("k"), ExploreStore)
 
@@ -475,6 +494,16 @@ class TestTinyStore(ExploreStoreContract):
     def make_store(self, key):
         TinyStore._state.pop(key, None)
         return TinyStore(key)
+
+
+class TestTinyStoreConstruction(StoreFactoryContract, ExploreStoreContract):
+    """The whole contract, run through the construction seam from outside."""
+
+    def build(self, context):
+        return tiny_store_factory(context)
+
+    def context_for(self, key):
+        return StoreContext(options={"tenant": key})
 '''
 
 
@@ -489,6 +518,11 @@ def test_a_backend_outside_the_distribution_passes_the_shipped_contract(
     wheel, install it somewhere isolated from this repo, write a backend there
     against the published protocol alone, and run the conformance suite dex ships
     at that backend.
+
+    That covers construction as well as behavior, and it has to: a construction
+    contract that only works from inside this repo has not been tested. The
+    backend defined there is built the way configuration would build it, through a
+    factory and a `StoreContext` carrying no repo root at all.
 
     If this passes, an outside contributor can implement a storage backend from
     what is published, which is the entire point of publishing it. If it fails,
@@ -516,3 +550,126 @@ def test_a_backend_outside_the_distribution_passes_the_shipped_contract(
     )
     assert done.returncode == 0, done.stdout + done.stderr
     assert "passed" in done.stdout
+
+
+# A whole distribution, because an entry point only exists once something is
+# installed: a source tree cannot register one, so this is the only way to test
+# the registration path honestly.
+PLUGIN_PYPROJECT = """
+[project]
+name = "dex-acme-store"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[project.entry-points."exmergo_dex_core.stores"]
+acme = "dex_acme_store:acme_store"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["src/dex_acme_store.py"]
+sources = ["src"]
+"""
+
+PLUGIN_MODULE = '''
+"""A storage backend published as its own package, selectable by short name."""
+
+import json
+
+from exmergo_dex_core.cache import DexCache
+from exmergo_dex_core.storage import Document, spend_total
+
+
+class AcmeStore:
+    _state: dict = {}
+
+    def __init__(self, tenant):
+        self.tenant = tenant
+        self._docs = self._state.setdefault(tenant, {})
+
+    def load_cache(self):
+        raw = self._docs.get("cache")
+        return None if raw is None else DexCache.model_validate_json(raw)
+
+    def save_cache(self, cache, *, now=None):
+        if now is not None:
+            cache.provenance.updated_at = now.isoformat()
+        self._docs["cache"] = cache.model_dump_json()
+        return self.locator(Document.CACHE)
+
+    def append_query_log(self, entry):
+        self._docs.setdefault("q", []).append(json.dumps(entry))
+
+    def append_spend_log(self, entry):
+        self._docs.setdefault("s", []).append(json.dumps(entry))
+
+    def spend_since(self, cutoff_iso, *, field="billed_bytes", connector=None):
+        entries = [json.loads(r) for r in self._docs.setdefault("s", [])]
+        return spend_total(entries, cutoff_iso, field=field, connector=connector)
+
+    def locator(self, document):
+        return "acme://" + self.tenant + "/" + document.value
+
+
+def acme_store(context):
+    tenant = context.options.get("tenant")
+    if not tenant:
+        raise ValueError("this backend needs cache.options.tenant")
+    return AcmeStore(str(tenant))
+'''
+
+
+def test_an_entry_point_registration_selects_a_backend_dex_does_not_ship(
+    wheel: str, tmp_path: Path
+):
+    """The registration path, proved against two installed distributions.
+
+    A dotted path needs no packaging and is tested from the source tree. An entry
+    point cannot be: the group is metadata a *built and installed* distribution
+    carries, so a test that fakes it proves only that the code reads what the test
+    handed it. This builds a second wheel that registers `acme` under
+    `exmergo_dex_core.stores`, installs it beside dex with no access to this repo,
+    and selects the backend by that short name.
+    """
+
+    plugin = tmp_path / "plugin"
+    (plugin / "src").mkdir(parents=True)
+    (plugin / "pyproject.toml").write_text(PLUGIN_PYPROJECT.lstrip(), encoding="utf-8")
+    (plugin / "src" / "dex_acme_store.py").write_text(
+        PLUGIN_MODULE.lstrip(), encoding="utf-8"
+    )
+
+    out = tmp_path / "dist"
+    subprocess.run(  # noqa: S603  (a fixed argv, no shell)
+        [_uv(), "build", "--wheel", "--out-dir", str(out), str(plugin)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    built = list(out.glob("*.whl"))
+    assert len(built) == 1, built
+
+    done = subprocess.run(  # noqa: S603  (a fixed argv, no shell)
+        [
+            _uv(),
+            "run",
+            "--isolated",
+            "--no-project",
+            "--with",
+            wheel,
+            "--with",
+            str(built[0]),
+            "python",
+            "-c",
+            "from exmergo_dex_core.storage import build_store, StoreContext, Document;"
+            'store = build_store("acme", StoreContext(options={"tenant": "acme-inc"}));'
+            'print("resolved", type(store).__name__, store.locator(Document.CACHE))',
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert "resolved AcmeStore acme://acme-inc/cache" in done.stdout

--- a/references/storage.md
+++ b/references/storage.md
@@ -99,6 +99,83 @@ Use `spend_total` rather than reimplementing the ledger arithmetic. It is export
 for exactly this reason: every backend then answers the session-budget question
 identically, which is a property you want in a guard.
 
+## Constructing one
+
+The section above is the whole contract if your host builds the store itself. If
+you also want your backend **named** in configuration and built by dex (see
+[Selecting a backend](#selecting-a-backend)), there is a second contract, and it is
+deliberately separate from `Store`.
+
+It is separate because the shipped backends disagree about what they are built
+from, and the disagreement does not resolve by picking a winner:
+
+| Backend | Built from |
+|---|---|
+| `FilesystemStore` | a repo root |
+| `MemoryStore` | nothing |
+| a tenant-keyed backend | a tenant id, with no repository at all |
+
+So construction takes one argument, a `StoreContext`, and a factory is anything
+callable that turns one into a store:
+
+```python
+@dataclass(frozen=True)
+class StoreContext:
+    repo_root: str | None = None
+    options: Mapping[str, Any] = field(default_factory=dict)
+```
+
+`repo_root` is the directory dex was pointed at, or `None` when there is no
+repository in the picture. Your backend is free to ignore it, and a tenant-keyed
+one will. `options` is your own non-secret coordinates, passed through verbatim;
+dex does not interpret it, so the keys are yours to define and yours to validate.
+
+Three shapes qualify, so you can use whichever your backend already has:
+
+```python
+# a function
+def my_store(context: StoreContext) -> MyStore:
+    tenant = context.options.get("tenant")
+    if not tenant:
+        raise ConfigurationError("this backend needs cache.options.tenant")
+    return MyStore(tenant=str(tenant))
+
+
+# a class whose __init__ takes the context
+class MyStore:
+    def __init__(self, context: StoreContext): ...
+
+
+# a classmethod, which is how the shipped backends do it
+FilesystemStore.from_context
+MemoryStore.from_context
+```
+
+Two obligations come with it.
+
+**Refuse an option you cannot honor.** Accepted-and-ignored is worse than
+rejected, because the caller believes a setting took effect and nothing in the
+output says otherwise. Both shipped backends refuse an unknown option rather than
+dropping it, and `FilesystemStore.from_context` refuses a context with no repo
+root rather than falling back to the working directory, which would write one
+project's exploration cache into wherever the process happened to start. Raise
+`ConfigurationError` so a host catches your refusal with the same `except` it
+already uses for dex's.
+
+**No secret ever reaches a `StoreContext`.** `.dex/config.yml` is committed, so a
+password, key, token, or connection string in `options` is a credential in version
+control. Read your credential the way the rest of the engine does, from the
+environment at construction time. If your credentials arrive per request rather
+than per process, skip this contract entirely and hand the engine a store you
+built yourself: `DexEngine(store=...)` is the right shape for that, and it always
+wins over anything named in configuration.
+
+One note if you are writing the code that resolves a name: `StoreFactory` is
+`runtime_checkable` for symmetry with the store tiers, but a callable protocol can
+only check that `__call__` exists, which every callable satisfies. Build the store
+and check the result against the tier you need. The tiers are genuinely
+`isinstance`-checkable; the factory is not.
+
 ## The contracts that are not obvious from the signatures
 
 Each of these is stated on the protocol member it governs in `storage/base.py`,
@@ -183,6 +260,30 @@ Whether the key is a directory, a tenant id, or a table prefix is your business.
 Two tenants leaking into each other is the failure this seam exists to prevent, so
 those assertions are the ones worth reading if any fail.
 
+**If your backend is meant to be named in configuration**, mix in
+`StoreFactoryContract` as well. It routes `make_store` through your own factory, so
+everything above then runs against stores built the way dex builds them:
+
+```python
+from exmergo_dex_core.storage import Store, StoreContext
+from exmergo_dex_core.storage.conformance import StoreContract, StoreFactoryContract
+
+
+class TestMyStore(StoreFactoryContract, StoreContract):
+    tier = Store
+
+    def build(self, context):
+        return my_store(context)
+
+    def context_for(self, key):
+        return StoreContext(options={"tenant": key})
+```
+
+This is why construction is not a second, unchecked obligation: with it, "the
+conformance suite is green" still means your backend is both correct and
+constructable. Without it, the suite proves behavior only, and a backend can pass
+every assertion here and still fail the moment configuration names it.
+
 ## Which calls need nothing on the filesystem
 
 A host with no project on disk can run the whole explore surface: `inventory`,
@@ -198,13 +299,73 @@ message naming what needed the root rather than inventing one.
 
 ## Selecting a backend
 
-Today a backend is passed to the engine directly, `DexEngine(store=...)`, which is
-the library path and the only path. There is no way to select one from the CLI.
+Two ways in. A library caller passes an instance, `DexEngine(store=...)`, and that
+always wins: a caller holding a store has already made the decision configuration
+exists to make for the callers who have not. Everyone else names one in
+`.dex/config.yml`:
 
-The decided direction, when a CLI selector arrives: it is an **open registry**, not
-a closed enum. A `cache.backend` setting will accept the names dex ships plus
-either a dotted `module:ClassName` path or a name registered through an
-`exmergo_dex_core.stores` entry-point group, so a backend published as its own
-package is selectable without a change to dex. Recording it here because the
-alternative, a closed set of shipped names, would make out-of-tree backends
-library-only permanently and opening it later would be a config-schema change.
+```yaml
+cache:
+  backend: mypkg.stores:my_store
+  options:
+    tenant: acme
+```
+
+`options` reaches your factory verbatim, and `repo_root` carries whatever directory
+dex was pointed at. `--cache-backend` overrides the name for one run, the way
+`--connector` overrides the configured connector; naming a different backend that
+way leaves `options` behind, since one backend's coordinates are not another's and
+the usual reason to reach for the flag is falling back to `filesystem` for a single
+command.
+
+It is an **open registry**, not a closed enum, so a backend published as its own
+package is selectable without a change to dex. Three kinds of name resolve, in this
+order:
+
+| Name | Example | For |
+|---|---|---|
+| shipped | `filesystem` | dex's own backends, and never shadowable by anything installed |
+| dotted path | `mypkg.stores:my_store` | a factory reachable by import, with no packaging work |
+| entry point | `acme` | a name an installed distribution registered under `exmergo_dex_core.stores` |
+
+The entry point is what makes a published backend feel like a shipped one:
+
+```toml
+# in your own pyproject.toml
+[project.entry-points."exmergo_dex_core.stores"]
+acme = "dex_acme_store:acme_store"
+```
+
+Install it beside dex and `backend: acme` resolves. A shipped name always wins over
+a registration, so installing a package can never silently move where an existing
+repo's state lands.
+
+`memory` is deliberately not selectable. Each CLI command runs as its own process,
+so a `MemoryStore` would drop the cache between `explore map` and `explore query`,
+and the second command would refuse with "run `explore map` first" having just run
+it. That reads as a broken tool rather than a chosen backend, so the refusal
+explains the process boundary instead. It remains the default for a library caller,
+where one process holds the engine.
+
+Every failure here refuses with a `ConfigurationError` naming the fix: an unknown
+name lists what exists and both open forms, a dotted path that will not import says
+so and points at the environment, and a factory that builds something which is not
+a store names the members it is missing. The tier check is on the constructed store
+rather than on the factory, because a callable protocol can only verify `__call__`
+exists.
+
+### Two rejected alternatives
+
+Recorded so they are not re-argued.
+
+**Always pass `repo_root`.** It builds both shipped backends and would build an
+opt-in SQLite file, and it cannot build a tenant-keyed backend at all. That is the
+class of backend this seam was made public for, and widening a released config
+schema afterwards costs a deprecation.
+
+**Require a `from_config` classmethod on the store.** It puts an obligation on the
+structural protocol, which is what makes "no base class to inherit and no
+registration step" true, and it hands every backend author dex's whole
+configuration model to bind against. The factory contract keeps the two concerns
+apart: a store is still just a class with the right methods, and construction is a
+separate thing you implement only if you want it.


### PR DESCRIPTION
The storage seam has been public since the last release: the `Store` protocol is
tiered and structural, a conformance suite ships inside the wheel, and the package
carries `py.typed`. A third party could write a backend and prove it correct. They
could not select it.

This closes that. `.dex/config.yml` gains a `cache` block, backend selection is an
open registry rather than a closed enum, and what a named backend is constructed
with is now a documented contract instead of an open question.

```yaml
cache:
  backend: mypkg.stores:my_store
  options:
    tenant: acme
```

## What this unlocks

### A host can keep dex's state wherever it already keeps state

The exploration cache, the reconcile baseline, the drift report, the two ledgers,
and the transform plans no longer have to be loose JSON files in someone's repo. A
process serving several end users can federate all of it per user, in its own
datastore, without forking the engine and without every call site changing.

That was already possible from Python, `DexEngine(store=...)`, and it stays the
shortest path for a host that builds its own store. What is new is that the choice
can live in configuration, so the CLI reaches it too, and a deployment can change
where state lands without changing code.

The source of truth does not move. The dbt project stays a git-reviewable
filesystem artifact, as it always has. Only the non-canonical scratch state is in
scope here.

### A backend can be published as its own package and selected by name

Three kinds of name resolve, in this order:

| Name | Example | For |
|---|---|---|
| shipped | `filesystem` | dex's own backends, never shadowable by anything installed |
| dotted path | `mypkg.stores:my_store` | a factory reachable by import, with no packaging work at all |
| entry point | `acme` | a name an installed distribution registered |

The entry point is what makes a published backend feel like a shipped one:

```toml
# in your own pyproject.toml, not in dex
[project.entry-points."exmergo_dex_core.stores"]
acme = "dex_acme_store:acme_store"
```

Install it beside dex and `backend: acme` resolves. No fork, no pull request here,
no place in dex where your name has to be listed. That is the point of an open
registry: a closed set of shipped names would have made out-of-tree backends
library-only permanently, and opening it later would have been a schema change with
a deprecation attached.

Writing one is unchanged and still small. Implement the tier you actually use
(`ExploreStore` is six methods), add a factory, and prove both with the shipped
suite:

```python
from exmergo_dex_core.storage import Store, StoreContext
from exmergo_dex_core.storage.conformance import StoreContract, StoreFactoryContract


class TestMyStore(StoreFactoryContract, StoreContract):
    tier = Store

    def build(self, context):
        return my_store(context)

    def context_for(self, key):
        return StoreContext(options={"tenant": key})
```

Composing `StoreFactoryContract` in front routes every behavioral and isolation
assertion through your own factory, so "the conformance suite is green" still means
your backend is correct **and** constructable, rather than quietly meaning only the
first.

### For the skills plugin

**Nothing in `explore`, `transform`, or `maintain` changes, and nothing needed to.**
The command surface is identical, the envelope shape is identical, and the default
backend is identical. The bootstrap in each skill's `run.py` reads only an
unindented `connector:` line out of `.dex/config.yml`, so the new `cache:` block is
invisible to it.

Two things do improve for an agent driving the engine:

**A failed engine build now comes back as an envelope.** Every wrapper reads exactly
one JSON object from stdout. The CLI used to construct the engine outside its error
handler, so anything raised while reading config or building the store escaped as a
traceback that no wrapper can parse. That was already reachable through a malformed
config file. It now renders as a normal error envelope with an actionable message,
and a test pins it.

**Refusals name the fix rather than the symptom.** An unknown backend lists what
exists and both open forms; a dotted path that will not import says so and points at
the environment; a factory that builds something which is not a store names the
members it lacks. These are the messages an agent surfaces to a human, so they are
written for that reader.

Worth stating plainly, because it is the obvious next question: a skill cannot yet
*use* a third-party backend. Each skill runs the engine through
`uv run --with exmergo-dex-core[<connector>]` in an isolated environment, so a
backend published as a separate distribution is not on that environment's path.
Making that reachable is a small additive change to the skill bootstrap, and it is
deliberately not in this pull request.

## Nothing changes if you do not opt in

`backend` defaults to `filesystem`. A repo that configures nothing writes the same
loose JSON under `.dex/` it always did, reviewable in a pull request exactly as
before, and a test asserts that default rather than assuming it. `DexEngine()` still
defaults to the in-process store, so importing the package still cannot leave a
`.dex/` directory in a consumer's repo. An explicitly passed `store=` still wins over
anything configured, because a caller holding an instance has already made the
decision configuration exists to make for the callers who have not.

Two deliberate refusals rather than silent behavior:

**`memory` is not selectable from the CLI.** Each command runs as its own process, so
an in-process store would drop the cache between `explore map` and `explore query`,
and the second command would refuse with "run `explore map` first" having just run
it. That reads as a broken tool rather than a chosen backend, so it refuses by
explaining the process boundary. It remains the default for a library caller, where
one process holds the engine.

**Credentials never belong in `cache.options`.** `.dex/config.yml` is committed, so a
password, key, token, or connection string there would be a secret in version
control. A backend needing one reads it at runtime the way the connection and
semantic-layer seams already do, or the host builds the store itself and passes it
in. This is the design that looks obvious and is wrong, so it is stated on the
config model, on the context, and in the reference doc.

Closes #156. Closes #157.