### PR TITLE
SCRUM-1009-Fix explore cluster reporting dropped_null_rows: 0 despite dropping rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,29 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **`explore cluster` reported `dropped_null_rows: 0` while its own sample SQL
+  was silently dropping rows** ([#160]). `build_sample_sql` puts an
+  `IS NOT NULL` predicate for every feature column into the sample query
+  itself, so rows with any null feature are filtered by the warehouse and
+  never reach Python; the reported count only ever saw rows that arrived, so it
+  could count a non-numeric coercion failure but never a null, structurally.
+  One production run silently clustered 92% of a table (the missing 8% shared
+  a single null feature column) with no note or warning. `explore cluster` now
+  runs a companion count query, over the same table and the same sample scope
+  as the fetch, that measures exactly what the null filter excludes; a nonzero
+  count gets a notes entry attributing it to the responsible feature column(s)
+  (`"visits: 20"`, not a bare number) and flags that `total_rows` is
+  cache-derived, a different moment than this live count. The clustering
+  engine's own count (rows that arrived but failed float coercion, which is
+  what the old field actually ever measured) is renamed
+  `dropped_non_numeric_rows` so the two are never conflated again.
+
+  **Cost note**: on a billed connector, `explore cluster`'s estimate roughly
+  doubles, since two queries now price into it instead of one; each still
+  scans only the feature columns over the same sample scope, so the added cost
+  is the same order of magnitude as the sample fetch itself, not a full-table
+  scan.
+
 - **`maintain snapshot` told every host to commit a file it may not have**
   ([#157]). The hint was a fixed string: "commit `.dex/snapshot.json` like a
   lockfile". A backend that keeps the baseline as a row or a document has no such

--- a/packages/dex-core/src/exmergo_dex_core/explore/cluster.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/cluster.py
@@ -114,6 +114,17 @@ def _sample_parts(
     return "", "", "no sample clause (unrecognized dialect)"
 
 
+def _table_ref(identifier: str, dialect: str) -> str:
+    parts = identifier.split(".")
+    if len(parts) == 3:
+        table = exp.table_(parts[2], db=parts[1], catalog=parts[0])
+    elif len(parts) == 2:
+        table = exp.table_(parts[1], db=parts[0])
+    else:
+        table = exp.table_(parts[-1])
+    return table.sql(dialect=dialect, identify=True)
+
+
 def build_sample_sql(
     identifier: str,
     feature_names: list[str],
@@ -132,23 +143,20 @@ def build_sample_sql(
     result is a single SELECT of only the feature columns, so it passes
     ``guards.sql_guard.assert_select_only`` and scans no column a feature does
     not name.
+
+    This filters out any row with a null feature before it ever reaches Python
+    (right: it is why the scan stays narrow), so the rows it drops are counted
+    here, in the SQL layer, by :func:`build_null_count_sql` -- never inferred
+    downstream from cells that already excluded them.
     """
 
     if not feature_names:
         raise ClusterError("no feature columns to sample")
 
-    parts = identifier.split(".")
-    if len(parts) == 3:
-        table = exp.table_(parts[2], db=parts[1], catalog=parts[0])
-    elif len(parts) == 2:
-        table = exp.table_(parts[1], db=parts[0])
-    else:
-        table = exp.table_(parts[-1])
-
     def render(node: exp.Expression) -> str:
         return node.sql(dialect=dialect, identify=True)
 
-    table_ref = render(table)
+    table_ref = _table_ref(identifier, dialect)
     cols_sql = ", ".join(render(exp.column(name)) for name in feature_names)
     where_sql = " AND ".join(
         f"{render(exp.column(name))} IS NOT NULL" for name in feature_names
@@ -159,17 +167,66 @@ def build_sample_sql(
     return sql, method
 
 
+def build_null_count_sql(
+    identifier: str,
+    feature_names: list[str],
+    *,
+    dialect: str,
+    sample_rows: int,
+    row_count: int | None,
+    seed: int | None = None,
+) -> str:
+    """The one companion query that measures what :func:`build_sample_sql`'s
+    own ``IS NOT NULL`` filter excludes, over the same table and the same
+    sample scope (so it prices and bills at the same order of magnitude as the
+    sample fetch, not a full-table scan).
+
+    Returns one row: ``sampled`` (rows this scope drew before the null
+    filter), ``dropped`` (rows missing at least one feature), then one count
+    per feature in ``feature_names`` order (positional, like the sample
+    fetch's cells) -- which feature(s) actually caused the drop, so the
+    envelope can attribute it instead of reporting a bare count.
+    """
+
+    if not feature_names:
+        raise ClusterError("no feature columns to sample")
+
+    def render(node: exp.Expression) -> str:
+        return node.sql(dialect=dialect, identify=True)
+
+    table_ref = _table_ref(identifier, dialect)
+    cols = [render(exp.column(name)) for name in feature_names]
+    any_null = " OR ".join(f"{col} IS NULL" for col in cols)
+    per_feature = ", ".join(
+        f"SUM(CASE WHEN {col} IS NULL THEN 1 ELSE 0 END) AS f{i}"
+        for i, col in enumerate(cols)
+    )
+    select = (
+        "COUNT(*) AS sampled, "
+        f"SUM(CASE WHEN {any_null} THEN 1 ELSE 0 END) AS dropped, {per_feature}"
+    )
+    table_suffix, tail, _method = _sample_parts(dialect, sample_rows, row_count, seed)
+    return f"SELECT {select} FROM {table_ref}{table_suffix}{tail}"  # noqa: S608
+
+
 @dataclass
 class ClusterResult:
     """The clustering summary that becomes the envelope payload: aggregates
-    only, no row ever survives here."""
+    only, no row ever survives here.
+
+    ``dropped_non_numeric_rows`` is this layer's own count: a row that arrived
+    (the SQL sample's own null filter already excludes nulls before Python
+    ever sees them) but failed float coercion. It is deliberately not named
+    ``dropped_null_rows`` -- that count belongs to the SQL layer that actually
+    drops nulls, surfaced instead on the command's top-level result.
+    """
 
     k: int
     k_selection: str  # "explicit" | "silhouette"
     features: list[str]
     standardized: bool
     n_samples: int
-    dropped_null_rows: int
+    dropped_non_numeric_rows: int
     silhouette: float | None
     inertia: float
     iterations: int
@@ -185,7 +242,7 @@ class ClusterResult:
             "features": self.features,
             "standardized": self.standardized,
             "n_samples": self.n_samples,
-            "dropped_null_rows": self.dropped_null_rows,
+            "dropped_non_numeric_rows": self.dropped_non_numeric_rows,
             "silhouette": self.silhouette,
             "inertia": self.inertia,
             "iterations": self.iterations,
@@ -393,7 +450,7 @@ def cluster_features(
         features=list(feature_names),
         standardized=True,
         n_samples=n_samples,
-        dropped_null_rows=dropped,
+        dropped_non_numeric_rows=dropped,
         silhouette=silhouette,
         inertia=round(float(model.inertia_), 4),
         iterations=int(model.n_iter_),

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -1060,23 +1060,37 @@ def cluster(
         row_count=dataset.row_count,
         seed=limits.sample_seed,
     )
+    null_count_sql = cluster_mod.build_null_count_sql(
+        dataset.identifier,
+        feature_names,
+        dialect=adapter.dialect,
+        sample_rows=limits.sample_rows,
+        row_count=dataset.row_count,
+        seed=limits.sample_seed,
+    )
     repeatable = cluster_mod.sample_is_repeatable(adapter.dialect, limits.sample_seed)
     adapter_name = adapter.name
     query_estimate = getattr(adapter, "query_estimate", None)
-    estimate = query_estimate(sample_sql) if query_estimate else 0.0
+    sample_estimate = query_estimate(sample_sql) if query_estimate else 0.0
+    null_count_estimate = query_estimate(null_count_sql) if query_estimate else 0.0
     command_args.billed_handshake(
         "explore cluster",
         adapter,
-        estimate,
+        sample_estimate + null_count_estimate,
         notes=[
             f"clusters a sample of up to {limits.sample_rows} rows over "
-            f"{len(feature_names)} feature column(s); sampling: {sample_method}"
+            f"{len(feature_names)} feature column(s); sampling: {sample_method}; "
+            "a companion count query measures how many rows the null filter "
+            "excludes, over the same table and sample scope"
         ],
     )
     sample = adapter.run_query(
         sample_sql,
         max_rows=limits.sample_rows,
         timeout_seconds=limits.timeout_seconds,
+    )
+    null_counts = adapter.run_query(
+        null_count_sql, max_rows=1, timeout_seconds=limits.timeout_seconds
     )
 
     clustering = cluster_mod.cluster_features(
@@ -1100,15 +1114,53 @@ def cluster(
             "draw different rows and reach a different k. Compare runs only with "
             "an identical sample"
         )
+    dropped_null_rows, drop_note = _null_drop_note(feature_names, null_counts.cells)
+    if drop_note:
+        notes.append(drop_note)
     result = ClusterResult(
         object=dataset.identifier,
         total_rows=dataset.row_count,
+        dropped_null_rows=dropped_null_rows,
         sample_method=sample_method,
         sample_repeatable=repeatable,
         clustering=clustering,
         notes=notes,
     )
     return command_args.stamp_spend(result, adapter)
+
+
+def _null_drop_note(
+    feature_names: list[str], cells: list[list]
+) -> tuple[int | None, str | None]:
+    """Turn the null-count query's one row into a count and, when anything was
+    actually dropped, an attributed note (which feature(s) caused it) plus the
+    reminder that ``total_rows`` is cache-derived, not this run's live count --
+    the only two numbers a reader could otherwise subtract come from different
+    moments."""
+
+    if not cells:
+        return None, None
+    sampled, dropped, *per_feature = cells[0]
+    dropped = int(dropped or 0)
+    if dropped == 0:
+        return 0, None
+    sampled = int(sampled or 0)
+    contributors = sorted(
+        (
+            (name, int(count or 0))
+            for name, count in zip(feature_names, per_feature, strict=True)
+            if count
+        ),
+        key=lambda kv: -kv[1],
+    )
+    breakdown = ", ".join(f"{name}: {count}" for name, count in contributors)
+    fraction = f" ({dropped / sampled:.1%})" if sampled else ""
+    return dropped, (
+        f"the null filter excluded {dropped} row(s){fraction} of this scan's "
+        f"scope, missing at least one feature; by column: {breakdown}. "
+        "total_rows above is cache-derived (from the last explore map/profile), "
+        "a different moment than this live count"
+    )
 
 
 def cmd_cluster(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:

--- a/packages/dex-core/src/exmergo_dex_core/explore/results.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/results.py
@@ -177,13 +177,18 @@ class ClusterResult(Result):
     ``clusters`` holds sizes and centroids; no sampled row ever reaches here.
     ``sample_repeatable`` is load-bearing for interpretation: where the connector
     cannot seed its sampling, two runs draw different rows and can settle on a
-    different k, so comparing them is meaningless.
+    different k, so comparing them is meaningless. ``dropped_null_rows`` is
+    measured by the SQL layer's own null filter (a companion count query, same
+    table, same sample scope), not inferred from cells that never arrived; the
+    clustering engine's own ``dropped_non_numeric_rows`` (rows that arrived but
+    failed float coercion) lives nested in ``clustering``.
     """
 
     always_reports_notes: ClassVar[bool] = True
 
     object: str = ""
     total_rows: int | None = None
+    dropped_null_rows: int | None = None
     sample_method: str = ""
     sample_repeatable: bool = False
     clustering: dict[str, Any] = Field(default_factory=dict)
@@ -192,6 +197,7 @@ class ClusterResult(Result):
         return {
             "object": self.object,
             "total_rows": self.total_rows,
+            "dropped_null_rows": self.dropped_null_rows,
             "sample_method": self.sample_method,
             "sample_repeatable": self.sample_repeatable,
             **self.clustering,

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -405,8 +405,11 @@ def test_unconfirmed_cluster_returns_needs_confirmation(
     envelope = _dispatch(tmp_path, subcommand="cluster", object="customers")
     assert envelope.status.value == "needs_confirmation"
     assert envelope.cost.paradigm is Paradigm.BYTES_SCANNED
-    # The single-table feature scan floors to the per-query billing minimum.
-    assert envelope.cost.estimate == 10 * MB
+    # Two queries price into this estimate: the feature sample, and its
+    # companion null-count query (#160, so dropped_null_rows is measured, not
+    # structurally zero). Each floors independently to the per-query billing
+    # minimum.
+    assert envelope.cost.estimate == 20 * MB
     assert any("sampl" in note for note in envelope.data.get("notes", []))
     # Nothing executed: only free dry-runs happened.
     assert all(c.dry_run for c in fake_bq_client.query_calls)

--- a/packages/dex-core/tests/explore/test_cluster.py
+++ b/packages/dex-core/tests/explore/test_cluster.py
@@ -482,6 +482,54 @@ def test_sample_sql_skips_percent_sampling_when_row_count_unknown():
     assert_select_only(sql, dialect="bigquery")
 
 
+# --- the companion null-count query (#160: dropped_null_rows was structurally
+# near-always 0, since the sample SQL's own filter excludes nulls before
+# Python ever sees them) -----------------------------------------------------
+
+
+def test_null_count_sql_duckdb_counts_and_attributes_by_feature():
+    sql = cluster_mod.build_null_count_sql(
+        "db.main.customers",
+        ["spend", "visits"],
+        dialect="duckdb",
+        sample_rows=100,
+        row_count=1000,
+    )
+    assert "COUNT(*) AS sampled" in sql
+    assert 'SUM(CASE WHEN "spend" IS NULL THEN 1 ELSE 0 END) AS f0' in sql
+    assert 'SUM(CASE WHEN "visits" IS NULL THEN 1 ELSE 0 END) AS f1' in sql
+    assert '"spend" IS NULL OR "visits" IS NULL' in sql
+    # No null filter to attach a WHERE to: it counts what the sample's own
+    # filter would exclude, over the same scope, not a filtered subset of it.
+    assert " WHERE " not in sql
+    assert sql.rstrip().endswith("USING SAMPLE 100 ROWS")
+    assert_select_only(sql, dialect="duckdb")
+
+
+@pytest.mark.parametrize(
+    "dialect,marker",
+    [
+        ("snowflake", "SAMPLE (100 ROWS)"),
+        ("databricks", "TABLESAMPLE (100 ROWS)"),
+        ("bigquery", "TABLESAMPLE SYSTEM (10.0 PERCENT)"),
+        ("postgres", "TABLESAMPLE SYSTEM (10.0)"),
+        ("redshift", "ORDER BY RANDOM() LIMIT 100"),
+    ],
+)
+def test_null_count_sql_per_dialect_sampling(dialect: str, marker: str):
+    sql = cluster_mod.build_null_count_sql(
+        "db.sch.customers",
+        ["spend", "visits"],
+        dialect=dialect,
+        sample_rows=100,
+        row_count=1000,
+    )
+    assert marker in sql, sql
+    assert "IS NULL" in sql
+    assert " WHERE " not in sql
+    assert_select_only(sql, dialect=dialect)
+
+
 # --- a seeded sample draws the same rows twice -------------------------------
 
 
@@ -591,6 +639,65 @@ def test_a_degenerate_cluster_is_called_out(
     assert "inflates" in note
 
 
+@pytest.fixture
+def nulls_in_one_feature_duckdb(tmp_path: Path) -> Path:
+    """100 rows, two numeric features; 20 of them null in `visits` only.
+    Small enough that DuckDB's reservoir sample (n=20000 default cap) always
+    returns the whole table, so the null-count query and the fetch draw
+    identical rows -- the counts below are exact, not merely likely."""
+
+    duckdb = pytest.importorskip("duckdb")
+    path = tmp_path / "gappy.duckdb"
+    conn = duckdb.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE customers AS
+        SELECT
+            i AS id,
+            (10.0 + (i % 5)) AS spend,
+            CASE WHEN i < 20 THEN NULL ELSE (1.0 + (i % 5)) END AS visits
+        FROM range(100) t(i)
+        """
+    )
+    conn.close()
+    return path
+
+
+@requires_sklearn
+def test_null_rows_are_reported_and_attributed_by_column(
+    nulls_in_one_feature_duckdb: Path, tmp_path: Path, capsys
+):
+    """The bug: dropped_null_rows read 0 while the sample SQL silently dropped
+    rows missing a feature. Now it must report the real count, attribute it to
+    the column that caused it, and flag total_rows as a different moment."""
+
+    repo = _mapped_repo(nulls_in_one_feature_duckdb, tmp_path, capsys)
+    payload = _cluster(nulls_in_one_feature_duckdb, repo, capsys=capsys)
+    data = payload["data"]
+
+    assert data["total_rows"] == 100
+    assert data["dropped_null_rows"] == 20
+    assert data["n_samples"] == 80
+    assert data["dropped_non_numeric_rows"] == 0
+
+    note = " ".join(data["notes"])
+    assert "excluded 20 row(s)" in note
+    assert "visits: 20" in note
+    assert "cache-derived" in note
+    assert "spend" not in note.split("by column:")[1].split(".")[0]
+
+
+@requires_sklearn
+def test_no_null_drop_note_when_nothing_is_dropped(
+    clusterable_duckdb: Path, tmp_path: Path, capsys
+):
+    repo = _mapped_repo(clusterable_duckdb, tmp_path, capsys)
+    payload = _cluster(clusterable_duckdb, repo, capsys=capsys)
+    data = payload["data"]
+    assert data["dropped_null_rows"] == 0
+    assert "null filter excluded" not in " ".join(data["notes"])
+
+
 @requires_sklearn
 def test_even_clusters_are_not_called_degenerate(
     clusterable_duckdb: Path, tmp_path: Path, capsys
@@ -615,7 +722,7 @@ def test_cluster_features_drops_null_rows_and_counts_them():
         silhouette_sample=5000,
         random_state=0,
     )
-    assert result.dropped_null_rows == 1
+    assert result.dropped_non_numeric_rows == 1
     assert result.n_samples == 4
     assert result.k == 2
 


### PR DESCRIPTION
Closes https://github.com/exmergo/dex/issues/160

Fixes explore cluster reporting dropped_null_rows: 0 while its own sample SQL was silently dropping rows with any null feature.

build_sample_sql's IS NOT NULL filter excludes null rows in the warehouse before Python ever sees them, so the old count only ever measured post-arrival non-numeric coercion failures never nulls, structurally
Added a companion count query (build_null_count_sql), same table and sample scope as the fetch, that measures exactly what the filter excludes and attributes it per feature column
Renamed the clustering engine's own count to dropped_non_numeric_rows (what it actually measures); dropped_null_rows is now a real, SQL-measured top-level field
Nonzero drops get a notes entry naming the responsible column(s) (e.g. visits: 20) and flagging that total_rows is cache-derived, a different moment than the live count
Cost note: billed connectors see ~2x the estimate for explore cluster (two queries instead of one), same order of magnitude as the sample fetch, not a full-table scan
Tests: 8 new (per-dialect SQL builder tests + an end-to-end DuckDB test proving 20 known-null rows are correctly reported and attributed, not swallowed as 0), 1 existing test updated for the new combined cost estimate
CHANGELOG.md updated under [Unreleased] / Fixed

<img width="1420" height="402" alt="image" src="https://github.com/user-attachments/assets/aab0286e-a8d0-47fc-9051-dec3ee287ba6" />
