### PR TITLE
SCRUM-1015-Derate low-cardinality name-column PII flags via value-shape cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,25 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **Low-cardinality enumerations (weekday names, month names, status codes) no
+  longer keep a blocking name-only PII flag** ([#167]). A string column matching
+  the generic `*_name` pattern (`day_name`, `month_name`) starts at 0.6
+  confidence, above the query firewall's 0.5 blocking threshold; value-shape
+  profiling can already de-rate a name-only flag when the values are visibly an
+  all-caps reference vocabulary or long multi-token labels, but a closed set of
+  single-token Title Case values (`Monday`, `January`) matched neither rule, so
+  a conventional date dimension's weekday/month columns stayed blocked on every
+  fresh re-profile. Cardinality is now its own corroborating signal: a column
+  whose distinct count is small both in absolute terms and as a fraction of
+  non-null rows de-rates the same way the existing shape rules do. The fraction
+  half is the guard on the guard, verbatim from the report: a genuinely small
+  table of distinct people has a low absolute distinct count but a *high*
+  fraction (most rows are their own distinct value), so it is not cleared by
+  this rule, and a person-shaped distribution still corroborates as a real name
+  before cardinality is ever considered. The flag itself is never removed,
+  consistent with every other shape rule; only where it lands relative to the
+  blocking threshold.
+
 - **`maintain snapshot` told every host to commit a file it may not have**
   ([#157]). The hint was a fixed string: "commit `.dex/snapshot.json` like a
   lockfile". A backend that keeps the baseline as a row or a document has no such

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -148,16 +148,27 @@ _SHAPE_REFERENCE_CONFIDENCE = 0.3
 
 # Shape-rule thresholds. A column where half the values look like "Given
 # Surname" is treated as person names. The reference verdict requires person
-# shape to be essentially absent AND either a tiny closed all-caps vocabulary
+# shape to be essentially absent AND one of: a tiny closed all-caps vocabulary
 # (the R_NAME/N_NAME shape; the distinct cap keeps a large all-caps
 # customer-name column blocked, since an all-caps person name defeats the
-# person-shape check) or long multi-token labels (person names essentially
-# never average 3.5+ tokens; part and product descriptions do).
+# person-shape check), long multi-token labels (person names essentially never
+# average 3.5+ tokens; part and product descriptions do), or a closed
+# enumeration regardless of case or token count (weekday/month names, status
+# codes: neither all-caps nor multi-token, so the two rules above miss them,
+# but cardinality alone is conclusive).
 _PERSON_FRACTION_RAISE = 0.5
 _PERSON_FRACTION_ABSENT = 0.05
 _UPPER_VOCAB_FRACTION = 0.9
 _UPPER_VOCAB_MAX_DISTINCT = 32
 _LABEL_AVG_TOKENS = 3.5
+
+# A closed enumeration: distinct count small in absolute terms AND as a
+# fraction of non-null rows, so a genuinely small table of distinct people
+# (few rows, each one a different name) is not cleared by the same rule -- a
+# small table has a HIGH distinct/row fraction; an enumeration column on a
+# real fact table has a tiny one.
+_ENUM_MAX_DISTINCT = 32
+_ENUM_MAX_DISTINCT_FRACTION = 0.01
 
 # Splits camelCase boundaries so patterns written against snake_case also match
 # camelCase warehouses ("firstName" -> "first_name", "reviewerName" -> "reviewer_name").
@@ -419,7 +430,10 @@ def profile(
         for col in columns:
             agg = aggregates.get(col.name)
             pii = _refine_confidence(
-                prelim_pii[col.name], agg, generic=col.name in shape
+                prelim_pii[col.name],
+                agg,
+                generic=col.name in shape,
+                row_count=meta.row_count,
             )
             profiles.append(
                 ColumnProfile(
@@ -581,6 +595,7 @@ def _refine_confidence(
     aggregate: ColumnAggregate | None,
     *,
     generic: bool = False,
+    row_count: int | None = None,
 ) -> PIIFlag | None:
     """Nudge PII confidence using aggregate signals (never raw values).
 
@@ -589,6 +604,9 @@ def _refine_confidence(
     a de-rated flag stays recorded at reference-data confidence, and what to do
     with a weak flag is the consumer's decision (the query firewall blocks at
     its threshold; min/max suppression and dbt meta stay presence-based).
+    ``row_count`` backs the closed-enumeration shape rule; ``None`` (unknown
+    row count) simply leaves that rule unable to fire, same as any other
+    missing evidence.
     """
 
     if pii is None or aggregate is None:
@@ -609,15 +627,17 @@ def _refine_confidence(
     ):
         confidence = max(0.1, confidence - 0.3)
     if generic and pii.category is PIICategory.NAME:
-        confidence = _shape_verdict(confidence, aggregate)
+        confidence = _shape_verdict(confidence, aggregate, row_count)
     return PIIFlag(category=pii.category, confidence=round(confidence, 4))
 
 
-def _shape_verdict(confidence: float, aggregate: ColumnAggregate) -> float:
+def _shape_verdict(
+    confidence: float, aggregate: ColumnAggregate, row_count: int | None = None
+) -> float:
     """Map value-shape evidence to a generic-name confidence.
 
     Fail closed: whenever the evidence is missing or ambiguous the name-derived
-    confidence stands unchanged, which keeps the column blocked. Only the two
+    confidence stands unchanged, which keeps the column blocked. Only the
     provably non-person shapes de-rate, and a person-shaped distribution
     corroborates up to the exact-token level.
     """
@@ -640,4 +660,26 @@ def _shape_verdict(confidence: float, aggregate: ColumnAggregate) -> float:
     tokens = aggregate.avg_token_count
     if tokens is not None and tokens >= _LABEL_AVG_TOKENS:
         return _SHAPE_REFERENCE_CONFIDENCE
+    if _is_closed_enumeration(aggregate, row_count):
+        return _SHAPE_REFERENCE_CONFIDENCE
     return confidence
+
+
+def _is_closed_enumeration(aggregate: ColumnAggregate, row_count: int | None) -> bool:
+    """A small closed set of repeated values (day/month names, status codes,
+    plan tiers): distinct count small in absolute terms and, more importantly,
+    small as a fraction of non-null rows. The fraction is what keeps a
+    genuinely small table of distinct people from clearing here: few rows,
+    each a different name, is a small distinct count but a high fraction."""
+
+    distinct = aggregate.distinct_count
+    if distinct is None or distinct > _ENUM_MAX_DISTINCT or not row_count:
+        return False
+    non_null = (
+        round((1 - aggregate.null_fraction) * row_count)
+        if aggregate.null_fraction is not None
+        else row_count
+    )
+    if not non_null:
+        return False
+    return (distinct / non_null) <= _ENUM_MAX_DISTINCT_FRACTION

--- a/packages/dex-core/tests/explore/conftest.py
+++ b/packages/dex-core/tests/explore/conftest.py
@@ -105,6 +105,33 @@ def tpch_names_duckdb(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def date_dim_duckdb(tmp_path: Path) -> Path:
+    """Issue #167's exact shape: a conventional date dimension, 2000 rows, with
+    `day_name` (7 distinct) and `month_name` (12 distinct) columns -- single-token
+    Title Case, so neither the all-caps nor the long-label shape rule catches
+    them, but cardinality (tiny relative to row count) is conclusive."""
+
+    duckdb = pytest.importorskip("duckdb")
+    path = tmp_path / "date_dim.duckdb"
+    conn = duckdb.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE date_dim AS
+        SELECT
+            i AS date_key,
+            (['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday',
+              'Saturday', 'Sunday'])[(i % 7) + 1] AS day_name,
+            (['January', 'February', 'March', 'April', 'May', 'June', 'July',
+              'August', 'September', 'October', 'November', 'December'])
+              [(i % 12) + 1] AS month_name
+        FROM range(2000) t(i)
+        """
+    )
+    conn.close()
+    return path
+
+
+@pytest.fixture
 def blob_duckdb(tmp_path: Path) -> Path:
     """A table with an informative numeric column next to a `BLOB` column
     (serialized-state shape): the profile scan-pruning gap the blob-column

--- a/packages/dex-core/tests/explore/test_profile.py
+++ b/packages/dex-core/tests/explore/test_profile.py
@@ -211,6 +211,28 @@ def test_tpch_reference_names_derate_below_threshold_and_person_names_hold(
         assert set(col["pii"]) == {"category", "confidence"}
 
 
+def test_date_dim_enumerations_derate_below_threshold(date_dim_duckdb: Path, capsys):
+    """#167: a weekday-name/month-name column is a closed enumeration, not a
+    person, and value-shape profiling must clear it via cardinality since
+    neither the all-caps nor the long-label shape rule applies to single-token
+    Title Case values."""
+
+    payload = _run(
+        ["explore", "profile", "date_dim", "--path", str(date_dim_duckdb)], capsys
+    )
+    (dataset,) = payload["data"]["datasets"]
+    columns = {c["name"]: c for c in dataset["columns"]}
+    day_name = columns["day_name"]
+    month_name = columns["month_name"]
+
+    for col in (day_name, month_name):
+        assert col["pii"]["category"] == "name", "the flag is never removed"
+        assert col["pii"]["confidence"] < 0.5, "de-rated below the block threshold"
+    # De-rating never weakens min/max suppression: string columns stay hidden.
+    for col in (day_name, month_name):
+        assert col["min_value"] is None and col["max_value"] is None
+
+
 def test_single_first_names_keep_base_confidence(airbnb_duckdb: Path, capsys):
     """Single-token first names ('Grace', 'Alan') match no shape rule in either
     direction: ambiguity keeps the name-derived 0.6, which blocks."""
@@ -289,6 +311,43 @@ def test_shape_rules_move_generic_name_confidence(aggregate: dict, expected: flo
 
     refined = _refine_confidence(
         _generic_name_flag(), _aggregate(**aggregate), generic=True
+    )
+    assert refined.category == PIICategory.NAME, "the flag is never removed"
+    assert refined.confidence == expected
+
+
+@pytest.mark.parametrize(
+    ("aggregate", "row_count", "expected"),
+    [
+        # Weekday names: 7 distinct over thousands of rows, single-token Title
+        # Case -- neither existing rule (all-caps, long labels) catches this,
+        # but cardinality alone is conclusive (#167).
+        ({"person_shape_fraction": 0.0, "distinct_count": 7}, 5000, 0.3),
+        # Month names: 12 distinct.
+        ({"person_shape_fraction": 0.0, "distinct_count": 12}, 5000, 0.3),
+        # The absolute cap: an enumeration this large is no longer obviously
+        # closed, so it stays blocked even at a tiny fraction.
+        ({"person_shape_fraction": 0.0, "distinct_count": 33}, 100000, 0.6),
+        # The fraction guard: a genuinely small table of distinct people has a
+        # low absolute distinct count but a HIGH fraction, not a low one, so it
+        # must not clear here.
+        ({"person_shape_fraction": 0.0, "distinct_count": 7}, 7, 0.6),
+        ({"person_shape_fraction": 0.0, "distinct_count": 7}, 50, 0.6),
+        # No row count: the rule cannot fire, same as any other missing
+        # evidence, regardless of how small the absolute distinct count is.
+        ({"person_shape_fraction": 0.0, "distinct_count": 7}, None, 0.6),
+        # Person shape still wins at low cardinality: a handful of executives
+        # repeated across a huge fact table are still real names.
+        ({"person_shape_fraction": 0.6, "distinct_count": 7}, 5000, 0.75),
+    ],
+)
+def test_low_cardinality_enumeration_derates_generic_name(
+    aggregate: dict, row_count: int | None, expected: float
+):
+    from exmergo_dex_core.explore.profile import _refine_confidence
+
+    refined = _refine_confidence(
+        _generic_name_flag(), _aggregate(**aggregate), generic=True, row_count=row_count
     )
     assert refined.category == PIICategory.NAME, "the flag is never removed"
     assert refined.confidence == expected


### PR DESCRIPTION
Closes https://github.com/exmergo/dex/issues/167
PR description:

Fixes low-cardinality enumerations (weekday names, month names, status codes) keeping a blocking name PII flag through value-shape profiling.

A string column matching the generic *_name pattern starts at 0.6 confidence, above the query firewall's 0.5 blocking threshold
Existing value-shape rules only de-rate all-caps reference vocabularies or long multi-token labels; single-token Title Case enumerations (Monday, January) matched neither, so a date dimension's weekday/month columns stayed blocked on every re-profile
Added a third corroborating rule: distinct count small both in absolute terms (≤32) and as a fraction of non-null rows (≤1%) de-rates the same way the existing rules do
Guard on the guard, per the report: a genuinely small table of distinct people has a low absolute count but a high fraction, so it's correctly excluded; person-shape corroboration still takes priority over cardinality
The flag is never removed only where it lands relative to the blocking threshold
Tests: 7 new parametrized unit tests on _refine_confidence (weekday/month cases, absolute cap, fraction guard both directions, missing row-count, person-shape priority) + 1 end-to-end DuckDB test with a real date-dimension fixture
CHANGELOG.md updated under [Unreleased] / Fixed

<img width="1417" height="190" alt="image" src="https://github.com/user-attachments/assets/434442ab-e52f-4300-b620-0458bb4a3a8a" />

