### PR TITLE
SCRUM-1023-Declare a composite grain via unique_combination_of_columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,27 +13,27 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 - **A project can declare a composite grain via `unique_combination_of_columns`**
   ([#169]). `DeclaredKey.column` was a single string, so a project could only
-  ever declare that ONE column is unique -- never that a table's real key is
-  the COMBINATION of several. This wasn't merely insufficient: on a genuinely
+  ever declare that ONE column is unique, never that a table's real key is the
+  COMBINATION of several. This wasn't merely insufficient: on a genuinely
   composite-grained table, declaring one member column (the only thing the old
   format allowed) made dex hold it as a permanent contradiction, and a
   semantic model's declared primary entity could unconditionally override a
   correctly-measured composite grain with a wrong single column. Measured
   evidence from the report: 13 declared keys across a reporting layer moved 0
-  of 12 elected grains -- the channel only ever reached tables that already had
+  of 12 elected grains; the channel only ever reached tables that already had
   a correctly-measured single-column grain.
 
   A new `DeclaredCompositeKey` reads dbt's own `unique_combination_of_columns`
   test (both the dbt-core 1.9+ built-in and the `dbt_utils` macro compile to
   the same stripped-namespace test name) from the compiled manifest and from
-  raw schema YAML's model-level `tests:`/`data_tests:` block -- no new
+  raw schema YAML's model-level `tests:`/`data_tests:` block, with no new
   dex-specific schema. A resolved, column-existence-checked declared composite
   now wins over a measured or heuristic grain, *unless* the current grain is
   already a measurement-proven single column, in which case the proven single
   stays and a note records that a composite was also declared. Because the
   declared composite lands in `Dataset.grain` as a multi-column list, it flows
-  through `maintain grain`'s existing combination-check path automatically --
-  never the single-column path -- so it cannot reproduce the false
+  through `maintain grain`'s existing combination-check path automatically,
+  never the single-column path, so it cannot reproduce the false
   `key_lost_uniqueness` failure mode the old single-column declaration could.
 
 - **A storage backend dex does not ship can be selected from configuration**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **A project can declare a composite grain via `unique_combination_of_columns`**
+  ([#169]). `DeclaredKey.column` was a single string, so a project could only
+  ever declare that ONE column is unique -- never that a table's real key is
+  the COMBINATION of several. This wasn't merely insufficient: on a genuinely
+  composite-grained table, declaring one member column (the only thing the old
+  format allowed) made dex hold it as a permanent contradiction, and a
+  semantic model's declared primary entity could unconditionally override a
+  correctly-measured composite grain with a wrong single column. Measured
+  evidence from the report: 13 declared keys across a reporting layer moved 0
+  of 12 elected grains -- the channel only ever reached tables that already had
+  a correctly-measured single-column grain.
+
+  A new `DeclaredCompositeKey` reads dbt's own `unique_combination_of_columns`
+  test (both the dbt-core 1.9+ built-in and the `dbt_utils` macro compile to
+  the same stripped-namespace test name) from the compiled manifest and from
+  raw schema YAML's model-level `tests:`/`data_tests:` block -- no new
+  dex-specific schema. A resolved, column-existence-checked declared composite
+  now wins over a measured or heuristic grain, *unless* the current grain is
+  already a measurement-proven single column, in which case the proven single
+  stays and a note records that a composite was also declared. Because the
+  declared composite lands in `Dataset.grain` as a multi-column list, it flows
+  through `maintain grain`'s existing combination-check path automatically --
+  never the single-column path -- so it cannot reproduce the false
+  `key_lost_uniqueness` failure mode the old single-column declaration could.
+
 - **A storage backend dex does not ship can be selected from configuration**
   ([#157]). `.dex/config.yml` gains a `cache` block, and it is the schema change
   worth reading first:

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -717,6 +717,23 @@ class DeclaredKey(BaseModel):
     source: str
 
 
+class DeclaredCompositeKey(BaseModel):
+    """A model-level ``unique_combination_of_columns`` test: the columns whose
+    COMBINATION is unique, never any one of them alone.
+
+    A distinct model from ``DeclaredKey`` rather than a widened ``column``:
+    this test has no ``not_null`` variant and a different multiplicity (it is
+    the model's own claim about several columns together, not one column's own
+    test), so overloading ``column`` to sometimes hold a list would blur two
+    different concepts into one field.
+    """
+
+    model: str
+    relation: str | None = None
+    columns: list[str]
+    source: str
+
+
 class ProjectDefinitions(BaseModel):
     """What the dbt project declares, loaded once for consumers that must keep
     working without one.
@@ -728,9 +745,11 @@ class ProjectDefinitions(BaseModel):
     names (model names and ``source.table``) to quote-stripped physical
     relations. ``primary_entities`` maps model names to their declared grain
     column; ``metric_models`` lists models reachable from any metric.
-    ``built_relation_names`` is bare table names (lowered) the project builds
-    or sources, from files/YAML alone (populated even with no compiled
-    manifest, unlike ``model_relations``) -- explore's orphan-relation
+    ``declared_composite_keys`` carries model-level ``unique_combination_of_
+    columns`` tests -- a grain declaration a column-level test structurally
+    cannot express. ``built_relation_names`` is bare table names (lowered) the
+    project builds or sources, from files/YAML alone (populated even with no
+    compiled manifest, unlike ``model_relations``) -- explore's orphan-relation
     down-ranking reads this. ``notes`` are analyst-readable caveats for the
     caller's envelope.
     """
@@ -743,6 +762,7 @@ class ProjectDefinitions(BaseModel):
     semantic_source: str | None = None
     foreign_keys: list[DeclaredForeignKey] = Field(default_factory=list)
     declared_keys: list[DeclaredKey] = Field(default_factory=list)
+    declared_composite_keys: list[DeclaredCompositeKey] = Field(default_factory=list)
     model_relations: dict[str, str] = Field(default_factory=dict)
     primary_entities: dict[str, str] = Field(default_factory=dict)
     metric_models: list[str] = Field(default_factory=list)
@@ -894,6 +914,7 @@ def _declared_from_manifest(manifest: dict[str, Any], defs: ProjectDefinitions) 
         return None
 
     keys: dict[tuple[str, str], DeclaredKey] = {}
+    composite_keys: dict[tuple[str, tuple[str, ...]], DeclaredCompositeKey] = {}
     for node in nodes.values():
         if not isinstance(node, dict) or node.get("resource_type") != "test":
             continue
@@ -902,10 +923,35 @@ def _declared_from_manifest(manifest: dict[str, Any], defs: ProjectDefinitions) 
             continue
         kwargs = meta.get("kwargs")
         kwargs = kwargs if isinstance(kwargs, dict) else {}
+        test_name = meta.get("name")
+        # A model-level composite-unique test carries no column_name at all
+        # (dbt-core's own built-in test and the dbt_utils macro both compile
+        # to this same stripped-namespace name), so it must be checked before
+        # the column_name gate below -- placed after, it would still hit that
+        # gate's `continue` and vanish, exactly today's silent-drop bug.
+        if test_name == "unique_combination_of_columns":
+            combo = kwargs.get("combination_of_columns")
+            if (
+                isinstance(combo, list)
+                and len(combo) >= 2
+                and all(isinstance(c, str) for c in combo)
+            ):
+                child = attached_name(node)
+                if child is not None:
+                    dedup_key = (child, tuple(sorted(c.lower() for c in combo)))
+                    composite_keys.setdefault(
+                        dedup_key,
+                        DeclaredCompositeKey(
+                            model=child,
+                            relation=relations.get(child),
+                            columns=list(combo),
+                            source="manifest",
+                        ),
+                    )
+            continue
         column = kwargs.get("column_name")
         if not isinstance(column, str) or not column:
             continue
-        test_name = meta.get("name")
         if test_name == "relationships":
             to_model = _parse_relation_ref(kwargs.get("to"))
             field = kwargs.get("field")
@@ -944,6 +990,7 @@ def _declared_from_manifest(manifest: dict[str, Any], defs: ProjectDefinitions) 
                 key.not_null = True
 
     defs.declared_keys = list(keys.values())
+    defs.declared_composite_keys = list(composite_keys.values())
     defs.model_relations.update(relations)
     defs.manifest_loaded = True
     defs.relationship_source = "manifest"
@@ -952,14 +999,49 @@ def _declared_from_manifest(manifest: dict[str, Any], defs: ProjectDefinitions) 
 def _declared_from_yaml(view: DbtProjectView, defs: ProjectDefinitions) -> None:
     """Column-level tests straight from schema YAML: model-level names only,
     no physical resolution. Model-level relationships tests (declared under the
-    model's ``tests:`` with a ``column_name`` kwarg) are a manifest-only shape."""
+    model's ``tests:`` with a ``column_name`` kwarg) are a manifest-only shape.
+
+    A ``unique_combination_of_columns`` test is itself a model-level construct
+    (it names no single column), so it is read from the model's own ``tests:``/
+    ``data_tests:`` block -- sibling to ``columns:``, never reached by the
+    column loop below.
+    """
 
     keys: dict[tuple[str, str], DeclaredKey] = {}
+    composite_keys: dict[tuple[str, tuple[str, ...]], DeclaredCompositeKey] = {}
     for parsed, _path in yaml_documents(view):
         for entry in parsed.get("models") or []:
             if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
                 continue
             model = entry["name"]
+            for test in entry.get("tests") or entry.get("data_tests") or []:
+                if not isinstance(test, dict):
+                    continue
+                combo_cfg = next(
+                    (
+                        cfg
+                        for name, cfg in test.items()
+                        if name == "unique_combination_of_columns"
+                        or name.endswith(".unique_combination_of_columns")
+                    ),
+                    None,
+                )
+                if combo_cfg is None:
+                    continue
+                combo_cfg = combo_cfg if isinstance(combo_cfg, dict) else {}
+                combo = combo_cfg.get("combination_of_columns")
+                if (
+                    isinstance(combo, list)
+                    and len(combo) >= 2
+                    and all(isinstance(c, str) for c in combo)
+                ):
+                    dedup_key = (model, tuple(sorted(c.lower() for c in combo)))
+                    composite_keys.setdefault(
+                        dedup_key,
+                        DeclaredCompositeKey(
+                            model=model, columns=list(combo), source="yaml"
+                        ),
+                    )
             for column in entry.get("columns") or []:
                 if not isinstance(column, dict) or not isinstance(
                     column.get("name"), str
@@ -1000,6 +1082,7 @@ def _declared_from_yaml(view: DbtProjectView, defs: ProjectDefinitions) -> None:
                             key.not_null = True
 
     defs.declared_keys = list(keys.values())
+    defs.declared_composite_keys = list(composite_keys.values())
     defs.relationship_source = "yaml"
     if defs.foreign_keys:
         defs.notes.append(

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -1507,14 +1507,22 @@ def _annotate_grain(
     With project definitions, the declared truth refines the heuristics: a
     semantic model's primary entity overrides the detected grain (noting any
     disagreement), and a profiled column contradicting its declared ``unique``
-    test gets a data-quality note. ``candidate_keys`` stays measurement-only:
-    an unmeasured declared key is a claim, and the cache is a drift baseline.
+    test gets a data-quality note. A declared composite key (a model-level
+    ``unique_combination_of_columns`` test -- the one grain shape measurement
+    alone can miss or a column-level test cannot express at all) overrides the
+    detected grain too, unless the detected grain is already a measurement-
+    proven single column, in which case the proven single wins and the
+    composite is only noted. ``candidate_keys`` stays measurement-only: an
+    unmeasured declared key is a claim, and the cache is a drift baseline.
     ``orphaned`` (map only) badges a relation no current model/source builds.
     """
 
     declared_grain: dict[str, str] = {}
     declared_unique: dict[str, set[str]] = {}
-    if defs is not None and (defs.primary_entities or defs.declared_keys):
+    declared_composite: dict[str, list[list[str]]] = {}
+    if defs is not None and (
+        defs.primary_entities or defs.declared_keys or defs.declared_composite_keys
+    ):
         identifiers = [d.identifier for d in datasets]
         for model, column in defs.primary_entities.items():
             ident, _ambiguous = rel_mod.resolve_declared(
@@ -1530,6 +1538,16 @@ def _annotate_grain(
             )
             if ident is not None:
                 declared_unique.setdefault(ident.lower(), set()).add(key.column.lower())
+        for composite in defs.declared_composite_keys:
+            ident, _ambiguous = rel_mod.resolve_declared(
+                composite.relation, composite.model, identifiers
+            )
+            if ident is None:
+                continue
+            bucket = declared_composite.setdefault(ident.lower(), [])
+            normalized = {c.lower() for c in composite.columns}
+            if not any({c.lower() for c in cols} == normalized for cols in bucket):
+                bucket.append(list(composite.columns))
 
     for ds in datasets:
         ds.candidate_keys = rel_mod.candidate_keys(ds)
@@ -1565,6 +1583,58 @@ def _annotate_grain(
                     f"{col.name} is declared unique in the dbt project but "
                     "profiling found duplicates"
                 )
+
+        composite_candidates = declared_composite.get(ds.identifier.lower())
+        if composite_candidates:
+            live = {c.name.lower(): c.name for c in ds.columns}
+            valid: list[list[str]] = []
+            for cols in composite_candidates:
+                resolved = [live.get(c.lower()) for c in cols]
+                if all(resolved):
+                    valid.append(resolved)
+                else:
+                    missing = [
+                        c for c, r in zip(cols, resolved, strict=True) if r is None
+                    ]
+                    ds.data_quality.append(
+                        f"declared composite key ({', '.join(cols)}) names "
+                        f"column(s) not in this profile ({', '.join(missing)}); "
+                        "not applied"
+                    )
+            if valid:
+                # detect_grain() only ever returns a single column drawn from
+                # candidate_keys()'s proven singles, EXCEPT the primary_entities
+                # override just above can also force ds.grain to an unproven
+                # single column -- this membership check catches both cases
+                # correctly: a freshly measured proven single passes it, an
+                # unproven declared one does not, and only the former should
+                # block a composite override.
+                proven_single = bool(
+                    ds.grain and len(ds.grain) == 1 and ds.grain in ds.candidate_keys
+                )
+                if proven_single:
+                    names = "; ".join(", ".join(c) for c in valid)
+                    ds.data_quality.append(
+                        f"a composite key ({names}) is also declared for this "
+                        f"table; the measured single-column grain {ds.grain[0]} "
+                        "took precedence"
+                    )
+                else:
+                    chosen = valid[0]
+                    if len(valid) > 1:
+                        others = "; ".join(", ".join(c) for c in valid[1:])
+                        ds.data_quality.append(
+                            f"{len(valid)} composite keys are declared for this "
+                            f"table; using {', '.join(chosen)} (also declared: "
+                            f"{others})"
+                        )
+                    if ds.grain and ds.grain != chosen:
+                        ds.data_quality.append(
+                            f"grain {', '.join(chosen)} comes from the project's "
+                            "declared composite key (heuristic suggested "
+                            f"{', '.join(ds.grain)})"
+                        )
+                    ds.grain = chosen
 
 
 def _relationship_notes(

--- a/packages/dex-core/tests/conftest.py
+++ b/packages/dex-core/tests/conftest.py
@@ -237,6 +237,7 @@ def write_manifest(
     relationship_tests: list[tuple[str, str, str, str]] = (),
     unique_tests: list[tuple[str, str]] = (),
     not_null_tests: list[tuple[str, str]] = (),
+    composite_unique_tests: list[tuple[str, list[str]]] = (),
     generated_at: str | None = None,
 ) -> Path:
     """Write a minimal compiled manifest.json shaped like dbt's.
@@ -246,6 +247,10 @@ def write_manifest(
     ``relationship_tests`` entries are ``(model, column, to, field)`` with
     ``to`` as the literal test argument (``"ref('x')"`` / ``"source('a','b')"``).
     ``unique_tests`` / ``not_null_tests`` entries are ``(model, column)``.
+    ``composite_unique_tests`` entries are ``(model, columns)``, compiled as a
+    model-level ``unique_combination_of_columns`` test node (no ``column_name``
+    kwarg at all -- both the dbt-core built-in and the dbt_utils macro compile
+    to this same shape).
     """
 
     uid_of = {name: f"model.dex_test.{name}" for name in models}
@@ -292,6 +297,12 @@ def write_manifest(
     for i, (model, column) in enumerate(not_null_tests):
         nodes[f"test.dex_test.not_null_{i}"] = test_node(
             f"not_null__{i}", {"column_name": column}, model
+        )
+    for i, (model, columns) in enumerate(composite_unique_tests):
+        nodes[f"test.dex_test.unique_combination_of_columns_{i}"] = test_node(
+            f"unique_combination_of_columns__{i}",
+            {"combination_of_columns": list(columns)},
+            model,
         )
 
     target = project / "target"

--- a/packages/dex-core/tests/explore/test_explore.py
+++ b/packages/dex-core/tests/explore/test_explore.py
@@ -13,10 +13,11 @@ from pathlib import Path
 import pytest
 
 from exmergo_dex_core import envelope as env
-from exmergo_dex_core.cache import Dataset, DexCache
+from exmergo_dex_core.cache import ColumnProfile, Dataset, DexCache
 from exmergo_dex_core.cli import main
 from exmergo_dex_core.config import DexConfig, save_config
-from exmergo_dex_core.explore.commands import _merged_hints
+from exmergo_dex_core.dbt_project import DeclaredCompositeKey, ProjectDefinitions
+from exmergo_dex_core.explore.commands import _annotate_grain, _merged_hints
 from exmergo_dex_core.storage import FilesystemStore
 
 
@@ -735,6 +736,161 @@ def test_map_notes_declared_unique_contradiction(tmp_path: Path, capsys):
     # Measurement-only: the contradicted declared key must not appear as a
     # candidate key just because the project claims it.
     assert ["status"] not in orders.candidate_keys
+
+
+# --- declared composite keys (#169): _annotate_grain unit tests --------------
+
+
+def _col(name: str, *, is_unique: bool | None = None, null_fraction: float = 0.0):
+    return ColumnProfile(
+        name=name, data_type="INTEGER", is_unique=is_unique, null_fraction=null_fraction
+    )
+
+
+def _composite_defs(*columns: str, model: str = "line_items") -> ProjectDefinitions:
+    return ProjectDefinitions(
+        present=True,
+        declared_composite_keys=[
+            DeclaredCompositeKey(model=model, columns=list(columns), source="yaml")
+        ],
+    )
+
+
+def test_declared_composite_fills_in_when_measurement_finds_no_grain():
+    """The gap the issue reports: measurement alone has nothing (no single
+    column is unique, no composite was probed), so declaration is the only
+    route to a grain at all."""
+
+    ds = Dataset(
+        identifier="db.main.line_items",
+        columns=[_col("order_id"), _col("line_number"), _col("amount")],
+    )
+    _annotate_grain([ds], _composite_defs("order_id", "line_number"))
+    assert ds.grain == ["order_id", "line_number"]
+    # candidate_keys stays measurement-only: nothing was measured here.
+    assert ds.candidate_keys == []
+
+
+def test_declared_composite_overrides_a_measured_composite_guess():
+    ds = Dataset(
+        identifier="db.main.line_items",
+        columns=[
+            _col("order_id"),
+            _col("line_number"),
+            _col("warehouse_id"),
+            _col("bin_id"),
+        ],
+        composite_keys=[["warehouse_id", "bin_id"]],
+    )
+    _annotate_grain([ds], _composite_defs("order_id", "line_number"))
+    assert ds.grain == ["order_id", "line_number"]
+    assert any("declared composite key" in n for n in ds.data_quality)
+
+
+def test_proven_single_column_wins_over_declared_composite():
+    """The override guard: a measurement-proven single-column grain is not
+    silently discarded just because a composite is also declared."""
+
+    ds = Dataset(
+        identifier="db.main.line_items",
+        columns=[
+            _col("id", is_unique=True, null_fraction=0.0),
+            _col("order_id"),
+            _col("line_number"),
+        ],
+    )
+    _annotate_grain([ds], _composite_defs("order_id", "line_number"))
+    assert ds.grain == ["id"]
+    assert any("also declared for this table" in n for n in ds.data_quality)
+
+
+def test_declared_composite_with_missing_column_is_not_applied():
+    ds = Dataset(identifier="db.main.line_items", columns=[_col("order_id")])
+    _annotate_grain([ds], _composite_defs("order_id", "line_number"))
+    assert ds.grain is None
+    assert any("not applied" in n for n in ds.data_quality)
+
+
+def test_multiple_declared_composites_uses_first_and_notes_the_rest():
+    ds = Dataset(
+        identifier="db.main.line_items",
+        columns=[
+            _col("order_id"),
+            _col("line_number"),
+            _col("sku"),
+            _col("warehouse_id"),
+        ],
+    )
+    defs = ProjectDefinitions(
+        present=True,
+        declared_composite_keys=[
+            DeclaredCompositeKey(
+                model="line_items", columns=["order_id", "line_number"], source="yaml"
+            ),
+            DeclaredCompositeKey(
+                model="line_items", columns=["sku", "warehouse_id"], source="yaml"
+            ),
+        ],
+    )
+    _annotate_grain([ds], defs)
+    assert ds.grain == ["order_id", "line_number"]
+    assert any("2 composite keys are declared" in n for n in ds.data_quality)
+
+
+# --- declared composite keys: end-to-end plumbing -----------------------------
+
+
+def _composite_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """A line_items table where no single column is unique but (order_id,
+    line_number) is, plus a schema.yml declaring exactly that combination."""
+
+    duckdb = pytest.importorskip("duckdb")
+    db = tmp_path / "wh.duckdb"
+    conn = duckdb.connect(str(db))
+    conn.execute(
+        "CREATE TABLE line_items (order_id INTEGER, line_number INTEGER, amount DOUBLE)"
+    )
+    conn.execute(
+        "INSERT INTO line_items VALUES "
+        "(1, 1, 10.0), (1, 2, 20.0), (2, 1, 10.0), (2, 2, 20.0)"
+    )
+    conn.close()
+
+    repo = tmp_path / "repo"
+    (repo / "models").mkdir(parents=True)
+    (repo / "dbt_project.yml").write_text(
+        'name: dex_test\nversion: "1.0.0"\nmodel-paths: ["models"]\n',
+        encoding="utf-8",
+    )
+    (repo / "models" / "schema.yml").write_text(
+        "version: 2\n"
+        "models:\n"
+        "  - name: line_items\n"
+        "    tests:\n"
+        "      - unique_combination_of_columns:\n"
+        "          combination_of_columns: [order_id, line_number]\n",
+        encoding="utf-8",
+    )
+    return db, repo
+
+
+def test_map_declared_composite_key_is_elected_as_grain(tmp_path: Path, capsys):
+    db, repo = _composite_repo(tmp_path)
+    _run(
+        [
+            "explore",
+            "map",
+            "--use-project",
+            "--path",
+            str(db),
+            "--repo-root",
+            str(repo),
+        ],
+        capsys,
+    )
+    cache = FilesystemStore(repo).load_cache()
+    (line_items,) = [d for d in cache.datasets if d.identifier.endswith(".line_items")]
+    assert line_items.grain == ["order_id", "line_number"]
 
 
 def test_profile_gets_declared_grain_too(tmp_path: Path, capsys):

--- a/packages/dex-core/tests/maintain/test_grain.py
+++ b/packages/dex-core/tests/maintain/test_grain.py
@@ -316,6 +316,137 @@ def test_composite_grain_drift_end_to_end(dex, tmp_path):
     assert finding["data"]["row_count"] == 2001
 
 
+def _declared_composite_repo(root, db_path, *, declare_composite: bool) -> None:
+    """A line_items fact table (order_key, line_number, quantity), 500*4 rows,
+    plus a dbt project. ``declare_composite`` picks which #169 scenario to
+    build: the new composite declaration, or the OLD single-column mechanism
+    misapplied to one member of what is actually a composite key (the issue's
+    opening complaint) -- a regression proving that path still never reaches
+    grain_plan's single-column check set."""
+
+    (root / "models").mkdir(parents=True)
+    (root / "dbt_project.yml").write_text(
+        'name: dex_test\nversion: "1.0.0"\nmodel-paths: ["models"]\n',
+        encoding="utf-8",
+    )
+    if declare_composite:
+        test_block = (
+            "    tests:\n"
+            "      - unique_combination_of_columns:\n"
+            "          combination_of_columns: [order_key, line_number]\n"
+        )
+    else:
+        test_block = "    columns:\n      - name: order_key\n        tests: [unique]\n"
+    (root / "models" / "schema.yml").write_text(
+        f"version: 2\nmodels:\n  - name: line_items\n{test_block}",
+        encoding="utf-8",
+    )
+
+
+def test_declared_composite_key_drift_end_to_end(dex, tmp_path):
+    """#169: a declared composite key is elected as the grain (measurement
+    alone would also find this one, since the fixture has few candidate
+    pairs, but the point is the DECLARED path reaches maintain grain
+    correctly, not just measurement's), and a genuine later break is reported
+    as one combination-level finding -- exactly like the measurement-only
+    end-to-end test above, now driven by declaration."""
+
+    import duckdb
+
+    root = tmp_path / "composite"
+    db_path = root / "warehouse.duckdb"
+    root.mkdir()
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE line_items AS "
+        "SELECT o.range::INTEGER AS order_key, l.range::INTEGER AS line_number, "
+        "(l.range % 2)::INTEGER AS quantity "
+        "FROM range(1, 501) o, range(1, 5) l"
+    )
+    conn.close()
+    (root / ".dex").mkdir()
+    (root / ".dex" / "config.yml").write_text(
+        f"connector: duckdb\nduckdb:\n  path: {db_path}\n", encoding="utf-8"
+    )
+    _declared_composite_repo(root, db_path, declare_composite=True)
+
+    rc, _payload = dex("--repo-root", str(root), "explore", "map", "--use-project")
+    assert rc == 0
+    from exmergo_dex_core.storage import FilesystemStore
+
+    cache = FilesystemStore(root).load_cache()
+    (line_items,) = [d for d in cache.datasets if d.identifier.endswith(".line_items")]
+    assert line_items.grain == ["order_key", "line_number"]
+
+    rc, _payload = dex("--repo-root", str(root), "maintain", "snapshot")
+    assert rc == 0
+
+    conn = duckdb.connect(str(db_path))
+    conn.execute("INSERT INTO line_items VALUES (1, 1, 1)")
+    conn.close()
+
+    rc, payload = dex("--repo-root", str(root), "maintain", "grain")
+    assert rc == 0 and payload["status"] == "ok"
+    findings = [
+        f for f in payload["data"]["findings"] if f["code"] == "key_lost_uniqueness"
+    ]
+    assert len(findings) == 1
+    assert findings[0]["column"] == "order_key, line_number"
+    assert findings[0]["data"]["columns"] == ["order_key", "line_number"]
+
+
+def test_declaring_one_member_of_a_composite_key_never_fires_key_lost_uniqueness(
+    dex, tmp_path
+):
+    """The issue's opening complaint, pinned as a named regression: declaring
+    ONE column of what is actually a composite key as `unique` (the only thing
+    the old single-column mechanism could express) must never reach
+    grain_plan's single-column check set -- declared_keys was never wired to
+    it in the first place, so this was already safe; this test keeps it that
+    way on purpose."""
+
+    import duckdb
+
+    root = tmp_path / "composite"
+    db_path = root / "warehouse.duckdb"
+    root.mkdir()
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE line_items AS "
+        "SELECT o.range::INTEGER AS order_key, l.range::INTEGER AS line_number, "
+        "(l.range % 2)::INTEGER AS quantity "
+        "FROM range(1, 501) o, range(1, 5) l"
+    )
+    conn.close()
+    (root / ".dex").mkdir()
+    (root / ".dex" / "config.yml").write_text(
+        f"connector: duckdb\nduckdb:\n  path: {db_path}\n", encoding="utf-8"
+    )
+    _declared_composite_repo(root, db_path, declare_composite=False)
+
+    rc, _payload = dex("--repo-root", str(root), "explore", "map", "--use-project")
+    assert rc == 0
+    from exmergo_dex_core.storage import FilesystemStore
+
+    cache = FilesystemStore(root).load_cache()
+    (line_items,) = [d for d in cache.datasets if d.identifier.endswith(".line_items")]
+    # The wrong declaration was actually read (not silently ignored) and
+    # contradicted by measurement, exactly like any other declared-unique
+    # contradiction -- never mutating candidate_keys/grain.
+    assert any(
+        "order_key is declared unique" in n and "duplicates" in n
+        for n in line_items.data_quality
+    )
+    assert ["order_key"] not in line_items.candidate_keys
+
+    rc, _payload = dex("--repo-root", str(root), "maintain", "snapshot")
+    assert rc == 0
+
+    rc, payload = dex("--repo-root", str(root), "maintain", "grain")
+    assert rc == 0 and payload["status"] == "ok"
+    assert payload["data"]["finding_count"] == 0
+
+
 def test_grain_estimate_prices_composite_checks():
     from exmergo_dex_core.maintain.drift import GrainPlan, grain_estimate
 

--- a/packages/dex-core/tests/transform/test_dbt_project.py
+++ b/packages/dex-core/tests/transform/test_dbt_project.py
@@ -396,6 +396,71 @@ def test_definitions_manifest_foreign_keys_and_key_merge(dbt_project_dir: Path):
     assert defs.model_relations["stg_orders"] == "dev.main.stg_orders"
 
 
+def test_definitions_manifest_composite_unique_key(dbt_project_dir: Path):
+    """#169: a model-level unique_combination_of_columns test has no
+    column_name at all, so it must be read before (never gated behind) the
+    column_name check that every other test type shares."""
+
+    write_manifest(
+        dbt_project_dir,
+        models={"stg_customers": '"dev"."main"."stg_customers"'},
+        composite_unique_tests=[("stg_customers", ["id", "email"])],
+    )
+    defs = definitions(dbt_project_dir)
+    (composite,) = defs.declared_composite_keys
+    assert composite.model == "stg_customers"
+    assert composite.columns == ["id", "email"]
+    assert composite.relation == "dev.main.stg_customers"
+    assert composite.source == "manifest"
+    # No column_name means it must never leak into the single-column list.
+    assert defs.declared_keys == []
+
+
+def test_definitions_yaml_composite_unique_key(dbt_project_dir: Path):
+    """The model-level tests:/data_tests: block, sibling to columns:, was
+    never read at all before #169 -- a pure blind spot, not a parse failure."""
+
+    (dbt_project_dir / "models" / "staging" / "schema.yml").write_text(
+        "version: 2\n"
+        "models:\n"
+        "  - name: stg_customers\n"
+        "    tests:\n"
+        "      - unique_combination_of_columns:\n"
+        "          combination_of_columns: [id, email]\n"
+        "    columns:\n"
+        "      - name: id\n"
+        "        tests: [not_null]\n",
+        encoding="utf-8",
+    )
+    defs = definitions(dbt_project_dir)
+    assert defs.relationship_source == "yaml"
+    (composite,) = defs.declared_composite_keys
+    assert composite.model == "stg_customers"
+    assert composite.columns == ["id", "email"]
+    assert composite.source == "yaml"
+    # The column-level not_null test alongside it is unaffected.
+    (key,) = defs.declared_keys
+    assert (key.model, key.column) == ("stg_customers", "id")
+
+
+def test_definitions_yaml_namespaced_composite_unique_key(dbt_project_dir: Path):
+    """dbt_utils.unique_combination_of_columns (the pre-dbt-core-1.9 macro
+    spelling) is recognized the same as the bare built-in test name."""
+
+    (dbt_project_dir / "models" / "staging" / "schema.yml").write_text(
+        "version: 2\n"
+        "models:\n"
+        "  - name: stg_customers\n"
+        "    tests:\n"
+        "      - dbt_utils.unique_combination_of_columns:\n"
+        "          combination_of_columns: [id, email]\n",
+        encoding="utf-8",
+    )
+    defs = definitions(dbt_project_dir)
+    (composite,) = defs.declared_composite_keys
+    assert composite.columns == ["id", "email"]
+
+
 def test_definitions_manifest_source_parent_and_backtick_quoting(
     dbt_project_dir: Path,
 ):


### PR DESCRIPTION
Closes https://github.com/exmergo/dex/issues/169
Fixes DeclaredKey.column being a single string, so a project could never declare that a table's real key is the COMBINATION of several columns and worse, declaring one member column of a composite key made dex hold it as a permanent contradiction, while a semantic model's declared primary entity could silently override a correctly-measured composite grain with a wrong single column.

New DeclaredCompositeKey reads dbt's own unique_combination_of_columns test both the dbt-core 1.9+ built-in and the dbt_utils macro compile to the same stripped-namespace test name from the compiled manifest and from schema YAML's model-level tests:/data_tests: block (a blind spot that never existed before). No new dex-specific schema.
A resolved, column-existence-checked declared composite now overrides a measured/heuristic grain unless the current grain is already a measurement-proven single column, in which case the proven single wins and a note records the composite was also declared
Because the declared composite lands in Dataset.grain as a multi-column list, it automatically routes through maintain grain's existing combination-check path (never the single-column path), so it structurally cannot reproduce the false key_lost_uniqueness bug the old single-column declaration caused
Tests: 3 parsing tests (manifest, bare YAML, namespaced dbt_utils. YAML), 5 direct unit tests on the election logic, 1 integration test, 2 end-to-end maintain grain tests including a named regression pinning that declaring one column of a composite as unique (the issue's opening complaint) still never fires a false key_lost_uniqueness
CHANGELOG.md updated under [Unreleased] / Added

<img width="1427" height="230" alt="image" src="https://github.com/user-attachments/assets/7576b390-eae8-4418-81e7-38fb158d37cc" />


