### PR TITLE
Hotfix: [storage-conformance] now ships [sql] package; more durable storage-conformance tests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,36 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   a backend dex does not ship gets; the git half is added only when the baseline
   really is a file in the repo. Nothing changes for the filesystem backend.
 
+- **The shipped conformance suite could not be run by two of the backends it was
+  written for** ([#174]). Both defects were in how the suite is packaged and how it
+  drives a backend, not in the storage contract, so nothing changes about what a
+  store owes its callers. Both were reported by an implementer running a full-tier,
+  tenant-keyed backend against 1.4.2 from outside this repository, and both surfaced
+  as assertion failures attributed to that backend rather than as anything naming
+  the suite.
+
+  `[storage-conformance]` shipped only pytest, while the ten plan assertions build a
+  `TransformPlan`, which reaches the SQL guard and so the dialect engine. Anyone
+  implementing the full `Store` tier got ten failures on a clean install. The extra
+  now self-references `[sql]`, the same treatment every connector extra already had.
+  The explore tier still installs and runs with no dialect engine, and a packaging
+  test now holds that line rather than leaving it to `a_plan`'s lazy import alone.
+
+  The suite also drove all 34 assertions through one key and never reset, so a
+  backend where two instances built from one key see the same state, which is the
+  defining property of every durable backend, inherited the previous assertion's
+  writes and failed nine of them. Every assertion now gets its own key, unique to
+  the run, so a durable backend passes unmodified with no reset hook and no fixture
+  of its own. A backend that resets on every call is unaffected: it receives
+  different strings and nothing else changes. `make_store` now documents what the
+  suite guarantees about key reuse and, just as importantly, what it does not
+  require, since the old contract was silent in both directions.
+
+  Neither gap was visible in-repo, because every backend the contract had ever run
+  against reset itself. There is now an in-repo backend that does not, and the
+  out-of-tree packaging test exercises the full tier instead of only the explore
+  tier.
+
 ## [1.4.2] - 2026-07-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.4.3] - 2026-07-28
+
 ### Added
 
 - **A storage backend dex does not ship can be selected from configuration**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,9 +244,11 @@ class TestMyStore(ExploreStoreContract):
 ```
 
 pytest collects the inherited tests and runs the whole contract against your
-backend, isolation assertions included. `references/storage.md` covers the tiers,
-the contracts that are not obvious from the signatures, and which calls need
-nothing on the filesystem.
+backend, isolation assertions included. Every assertion gets its own key, so a
+backend whose instances share state per key, which is every durable one, needs no
+reset hook to keep one assertion's writes out of the next.
+`references/storage.md` covers the tiers, the contracts that are not obvious from
+the signatures, and which calls need nothing on the filesystem.
 
 Backends contributed here run the same suite: see
 `packages/dex-core/tests/storage/test_parity.py`, which is deliberately the same

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -126,14 +126,23 @@ cluster = ["scikit-learn>=1.4"]
 # to execute them. Named for what it is conformance *to*, matching every other
 # extra here: an install line has to answer "conformance to what?" on its own.
 # Contributor tooling rather than a capability, which is why [all] omits it.
-storage-conformance = ["pytest>=8"]
+#
+# It self-references [sql] for the same reason the connector extras do. The plan
+# tier's assertions build a `TransformPlan`, which reaches the SQL guard and so the
+# dialect engine, so an implementer of the full `Store` tier cannot run the suite
+# without it. Shipping only pytest sent them ten failures that read as bugs in their
+# own backend. The explore tier still runs without a dialect engine (`a_plan`
+# imports lazily and a packaging test installs no extra at all), so this is a floor
+# raised for the wider tiers rather than a new requirement on the narrow one.
+storage-conformance = ["pytest>=8", "exmergo-dex-core[sql]"]
 # One command for users who want every optional capability at once: every
 # connector, both semantic-layer backends, and clustering. Self-references the
 # other extras so their requirement lists stay defined in exactly one place, which
 # does mean this reference list is the part that rots, so a test asserts it covers
-# every extra. Excludes only dev, which is contributor tooling rather than a
-# capability. This is the heaviest install there is (six dbt adapters, MetricFlow,
-# and scikit-learn); the light default and the [duckdb] on-ramp are unchanged.
+# every extra. Excludes dev and storage-conformance, both contributor tooling rather
+# than a capability: nobody installing "everything dex can do" wants a test runner.
+# This is the heaviest install there is (six dbt adapters, MetricFlow, and
+# scikit-learn); the light default and the [duckdb] on-ramp are unchanged.
 all = [
   "exmergo-dex-core[bigquery,cluster,databricks,duckdb,postgres,redshift,semantic,semantic-api,snowflake,sql]",
 ]

--- a/packages/dex-core/src/exmergo_dex_core/storage/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/conformance.py
@@ -28,6 +28,11 @@ in one process must not be able to see each other's cache, ledgers, or plans.
 Whether ``key`` is a directory, a tenant id, or a table prefix is the backend's
 business.
 
+**The suite never hands the same key to two assertions**, so a backend whose
+instances share state per key, which is every durable one, starts each assertion on
+a clean slate and needs no reset hook. See :meth:`ExploreStoreContract.make_store`
+for the whole of what that guarantees and what it does not.
+
 **If your backend is meant to be named in configuration rather than handed to the
 engine as an instance**, mix :class:`StoreFactoryContract` in as well. It routes
 ``make_store`` through your own factory, so every assertion above then runs
@@ -36,14 +41,18 @@ meaning the backend is both correct and constructable rather than only the first
 
 This module imports pytest, so it is deliberately not imported by
 ``exmergo_dex_core.storage``: a bare ``import exmergo_dex_core`` must not require
-a test framework. Install the ``[storage-conformance]`` extra to get pytest
-alongside it.
+a test framework. Install the ``[storage-conformance]`` extra to get what running
+the suite needs: pytest, and the dialect engine the plan-tier assertions reach
+through :func:`a_plan`. The explore tier needs only pytest, and a packaging test
+keeps it that way.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from itertools import count
 from typing import Any
+from uuid import uuid4
 
 import pytest
 
@@ -58,6 +67,14 @@ __all__ = [
     "StoreContract",
     "StoreFactoryContract",
 ]
+
+#: Unique per process, so two runs of the suite against one durable backend do not
+#: land in the same namespace. A counter alone would be enough for a backend that
+#: only outlives an assertion; a backend that outlives the *process*, which is the
+#: interesting case, would inherit the previous run's writes from a key it could
+#: predict. Also keeps parallel workers apart, since each is its own process.
+_RUN_ID = uuid4().hex[:8]
+_KEY_SEQUENCE = count()
 
 
 def a_cache(identifier: str = "db.main.orders") -> DexCache:
@@ -125,7 +142,54 @@ def a_plan(plan_id: str, created_at: str, *, kind: Any | None = None) -> Any:
     )
 
 
-class ExploreStoreContract:
+class _KeyedContract:
+    """Gives every assertion its own keyspace, for both contract families.
+
+    A durable backend is one where two instances built from the same key see the
+    same state. That is not an implementation detail to be worked around, it is the
+    defining property of every hosted backend and the reason the seam exists. So the
+    suite cannot reuse a key: driving 34 assertions through one literal made each
+    inherit the previous one's writes, and the resulting failures ("a cache that was
+    just saved must load back") read as bugs in the backend rather than as pollution
+    from the harness.
+
+    Namespacing here rather than asking implementers for a reset hook keeps the
+    integration at one method, and costs a backend that *does* reset per call
+    nothing at all: it simply receives different strings.
+    """
+
+    #: Replaced per assertion by the autouse fixture below. The class-level default
+    #: keeps a contract instantiated by hand, outside pytest, usable; the meta-tests
+    #: in this repository's suite drive the assertions that way to check their
+    #: failure messages.
+    _namespace: str = _RUN_ID
+
+    @pytest.fixture(autouse=True)
+    def _namespaced_keys(self) -> None:
+        self._namespace = f"{_RUN_ID}-{next(_KEY_SEQUENCE):02d}"
+
+    def key_for(self, label: str) -> str:
+        """The key this assertion uses for ``label``, unique to it and to this run.
+
+        ``label`` survives into the key so a backend that files state under it (a
+        directory, a table prefix) stays readable while you are debugging a failure.
+        """
+
+        return f"{label}-{self._namespace}"
+
+    def store_for(self, label: str) -> Any:
+        return self.make_store(self.key_for(label))
+
+    # Declared so `store_for` has something to call and a type checker can see it.
+    # Both families override it: the tier contracts document it as the one hook an
+    # implementer provides, `StoreFactoryContract` routes it through the factory.
+    def make_store(self, key: str) -> Any:  # pragma: no cover - always overridden
+        raise NotImplementedError(
+            "a conformance subclass must implement make_store(key) -> Store"
+        )
+
+
+class ExploreStoreContract(_KeyedContract):
     """What every backend owes, whatever tier it implements.
 
     The exploration cache, the two ledgers, and the locators: the state an
@@ -141,6 +205,21 @@ class ExploreStoreContract:
         as a directory name, a database backend as a tenant identifier. It is
         called more than once per test class, so it must be cheap and must not
         assume it is building the only store in the process.
+
+        **The suite never reuses a key**, within a run or across runs. Every
+        assertion gets its own, so you do not need a reset hook, a truncate step, or
+        a fixture of your own to keep one assertion's writes out of the next.
+
+        What that leaves you free to do is the point: two calls with the *same* key
+        may return two views of one shared state. That is what a durable backend is,
+        and what a hosted deployment depends on. The suite requires the opposite only
+        for two *different* keys, which is what the isolation assertions check; it
+        assumes nothing at all about the same key twice.
+
+        Nothing is cleaned up when the run ends. A durable backend therefore
+        accumulates one namespace per run, which is yours to prune; the suite cannot
+        do it without a teardown hook that would be a second thing to implement, and
+        get wrong, for a guarantee it does not need.
         """
 
         raise NotImplementedError(
@@ -148,8 +227,10 @@ class ExploreStoreContract:
         )
 
     @pytest.fixture
-    def store(self) -> Any:
-        return self.make_store("primary")
+    def store(self, _namespaced_keys: None) -> Any:
+        # Depends on the keyspace rather than trusting autouse ordering: this is the
+        # fixture whose key must be namespaced, so the dependency is stated.
+        return self.store_for("primary")
 
     # --- documents ------------------------------------------------------------
 
@@ -374,7 +455,7 @@ class ExploreStoreContract:
     # --- isolation ------------------------------------------------------------
 
     def test_two_keys_do_not_share_a_cache(self, store):
-        one, two = self.make_store("tenant-one"), self.make_store("tenant-two")
+        one, two = self.store_for("tenant-one"), self.store_for("tenant-two")
         one.save_cache(a_cache("db.one.orders"))
         # The firewall resolves every table reference against the cache, so a
         # cache leaking across keys is a leak of what the other tenant may query,
@@ -394,7 +475,7 @@ class ExploreStoreContract:
         )
 
     def test_two_keys_do_not_share_a_spend_ledger(self, store):
-        one, two = self.make_store("tenant-one"), self.make_store("tenant-two")
+        one, two = self.store_for("tenant-one"), self.store_for("tenant-two")
         one.append_spend_log({"at": "2026-07-03T10:00:00+00:00", "billed_bytes": 500})
         # A shared ledger would charge one tenant's spend against another's
         # session ceiling, which reads as a budget bug and is a tenancy bug.
@@ -465,7 +546,7 @@ class MaintainStoreContract(ExploreStoreContract):
         )
 
     def test_two_keys_do_not_share_a_snapshot(self, store):
-        one, two = self.make_store("tenant-one"), self.make_store("tenant-two")
+        one, two = self.store_for("tenant-one"), self.store_for("tenant-two")
         one.save_snapshot(a_snapshot())
         assert two.load_snapshot() is None, (
             "two keys share a snapshot, so one tenant's drift baseline is another's. "
@@ -577,7 +658,7 @@ class StoreContract(MaintainStoreContract):
         )
 
     def test_two_keys_do_not_share_plans(self, store):
-        one, two = self.make_store("tenant-one"), self.make_store("tenant-two")
+        one, two = self.store_for("tenant-one"), self.store_for("tenant-two")
         one.save_plan(a_plan("pabc", "2026-07-03T10:00:00+00:00"))
         assert two.list_plans() == [], (
             "two keys share the plan store, so one tenant can read and apply "
@@ -585,7 +666,7 @@ class StoreContract(MaintainStoreContract):
         )
 
 
-class StoreFactoryContract:
+class StoreFactoryContract(_KeyedContract):
     """The construction half, for a backend dex builds rather than receives.
 
     Mix it in front of the contract for your tier, and the whole behavioral suite
@@ -638,7 +719,7 @@ class StoreFactoryContract:
         return self.build(self.context_for(key))
 
     def test_the_factory_builds_a_store_of_the_declared_tier(self):
-        built = self.build(self.context_for("primary"))
+        built = self.build(self.context_for(self.key_for("primary")))
         assert isinstance(built, self.tier), (
             f"the factory returned {type(built).__name__}, which does not satisfy "
             f"{self.tier.__name__}. A backend that passes the behavioral suite and "
@@ -651,8 +732,11 @@ class StoreFactoryContract:
         # The same property the keyed isolation assertions cover, checked at the
         # construction seam: a factory that ignores its context builds one shared
         # store for every tenant, and every later isolation guarantee is void.
-        one = self.build(self.context_for("tenant-one"))
-        two = self.build(self.context_for("tenant-two"))
+        #
+        # Through build() rather than store_for(), so what is under test is named
+        # even where the two are the same call.
+        one = self.build(self.context_for(self.key_for("tenant-one")))
+        two = self.build(self.context_for(self.key_for("tenant-two")))
         one.save_cache(a_cache("db.one.orders"))
         assert two.load_cache() is None, (
             "two contexts built stores that share a cache. The factory is probably "

--- a/packages/dex-core/tests/storage/test_conformance.py
+++ b/packages/dex-core/tests/storage/test_conformance.py
@@ -48,6 +48,7 @@ from exmergo_dex_core.storage.conformance import (
     ExploreStoreContract,
     StoreContract,
     StoreFactoryContract,
+    a_cache,
 )
 from exmergo_dex_core.transform.plans import PlanNotFoundError, TransformPlan
 
@@ -169,6 +170,26 @@ class DocumentStore:
         return f"docstore://{self.tenant}/plans/{plan_id}"
 
 
+class DurableDocumentStore(DocumentStore):
+    """The same backend, never reset: the shape every hosted deployment has.
+
+    One difference from :class:`DocumentStore`, and it is the entire point: this
+    registry is deliberately left out of ``_clean_registries``, so what one
+    assertion writes under a key is still there for the next one. That is what a
+    Postgres-backed or document-database-backed store does between requests, and
+    the suite has to accommodate it without asking for a reset hook.
+
+    It exists because the reset is what hid the defect. Every backend the contract
+    was ever run against reset itself (this module through the autouse fixture, the
+    out-of-tree backend by popping its own state), so a suite that drove all 34
+    assertions through one literal key looked correct here and gave a real
+    implementer nine failures phrased as bugs in their own backend. If key reuse
+    ever comes back, this class fails and the shipped backends do not.
+    """
+
+    _registry: ClassVar[dict[str, dict[str, object]]] = {}
+
+
 class ExploreOnlyStore:
     """The narrow tier, with the five plan members genuinely absent.
 
@@ -250,6 +271,10 @@ class ContextKeyedExploreStore(ExploreOnlyStore):
 
 @pytest.fixture(autouse=True)
 def _clean_registries():
+    # DurableDocumentStore is deliberately absent, and must stay absent: resetting
+    # it would turn the one backend here that models a hosted deployment back into
+    # one that quietly starts clean, which is exactly how the key-reuse defect went
+    # unnoticed. The hand-written flow tests below keep the reset they do want.
     DocumentStore.reset()
     ExploreOnlyStore.reset()
     yield
@@ -297,6 +322,56 @@ class TestContextKeyedExploreStoreConstruction(
 
     def context_for(self, key: str) -> StoreContext:
         return StoreContext(options={"tenant": key})
+
+
+# --- the same contract, run against a backend that never resets ----------------
+#
+# The contract classes above all get a clean registry per assertion from
+# _clean_registries. These two do not, so they are the only in-repo run that proves
+# what a hosted implementer actually needs: that the suite hands out a fresh key per
+# assertion, and that a backend sharing state across instances built from one key
+# therefore passes without a reset hook or a fixture of its own.
+
+
+class TestDurableDocumentStoreConformance(StoreContract):
+    def make_store(self, key: str) -> DurableDocumentStore:
+        return DurableDocumentStore(tenant=key)
+
+
+class TestDurableDocumentStoreConstruction(StoreFactoryContract, StoreContract):
+    """And through the construction seam, which is where key reuse bit hardest.
+
+    `test_two_contexts_build_stores_that_share_nothing` asserts a freshly built
+    store has no cache. Under a shared literal key an earlier assertion had already
+    put one there, so this composition passed only on the order pytest happened to
+    collect it in.
+    """
+
+    tier = Store
+
+    def build(self, context: StoreContext) -> DurableDocumentStore:
+        # No refusal path here: what a factory owes a context missing its
+        # coordinate is document_store_factory's job and is tested against it.
+        return DurableDocumentStore(tenant=str(context.options["tenant"]))
+
+    def context_for(self, key: str) -> StoreContext:
+        return StoreContext(options={"tenant": key})
+
+
+def test_the_durable_backend_really_does_share_state_across_instances():
+    """Guards the guard.
+
+    Everything the two classes above prove rests on this backend being durable. If
+    it ever starts resetting (added to `_clean_registries`, or given per-instance
+    state), those runs keep passing while testing nothing about a hosted backend,
+    which is the failure mode this whole change exists to close.
+    """
+
+    DurableDocumentStore("durability-check").save_cache(a_cache())
+    assert DurableDocumentStore("durability-check").load_cache() is not None, (
+        "DurableDocumentStore stopped sharing state per key, so the conformance "
+        "runs above no longer cover a backend that outlives one assertion"
+    )
 
 
 # --- the tiers are what they claim to be --------------------------------------

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -286,8 +286,8 @@ def test_the_all_extra_installs_every_optional_capability(wheel: str):
     dbt adapters and MetricFlow in one environment, it is also the only place a
     version conflict between them can surface at all.
 
-    `dev` and `conformance` are excluded deliberately: contributor tooling, not
-    capabilities. `storage-conformance` carries a test runner for people
+    `dev` and `storage-conformance` are excluded deliberately: contributor tooling,
+    not capabilities. `storage-conformance` carries a test runner for people
     implementing a storage backend, and nobody installing "everything dex can do"
     wants pytest.
     """
@@ -426,24 +426,158 @@ def test_the_wheel_ships_the_typed_marker(wheel: str):
     )
 
 
-OUTSIDE_BACKEND = '''
+# A full-tier backend, and a durable one: two instances built from the same key
+# share state, with nothing anywhere resetting it. Both properties are deliberate
+# and both were once absent, which is how a released version shipped a suite that
+# no full-tier or hosted implementer could get green.
+OUTSIDE_FULL_BACKEND = '''
 import json
 
 from exmergo_dex_core.cache import DexCache
 from exmergo_dex_core.storage import (
     Document,
-    ExploreStore,
+    Store,
     StoreContext,
     spend_total,
 )
 from exmergo_dex_core.storage.conformance import (
-    ExploreStoreContract,
+    StoreContract,
     StoreFactoryContract,
 )
+from exmergo_dex_core.transform.plans import PlanNotFoundError, TransformPlan
 
 
 class TinyStore:
-    """A backend written against the published protocol and nothing else."""
+    """A full `Store` backend written against the published protocol and nothing
+    else, keyed by tenant and durable: state lives in a process-wide registry, so
+    two instances built from one key see the same documents. That is what a hosted
+    backend does between requests, and nothing here resets it."""
+
+    _state: dict = {}
+
+    def __init__(self, key):
+        self.key = key
+        self._docs = self._state.setdefault(key, {})
+
+    def load_cache(self):
+        raw = self._docs.get("cache")
+        return None if raw is None else DexCache.model_validate_json(raw)
+
+    def save_cache(self, cache, *, now=None):
+        if now is not None:
+            cache.provenance.updated_at = now.isoformat()
+        self._docs["cache"] = cache.model_dump_json()
+        return self.locator(Document.CACHE)
+
+    def load_snapshot(self):
+        from exmergo_dex_core.maintain.snapshot import Snapshot
+
+        raw = self._docs.get("snapshot")
+        return None if raw is None else Snapshot.model_validate_json(raw)
+
+    def save_snapshot(self, snapshot):
+        self._docs["snapshot"] = snapshot.model_dump_json()
+        return self.locator(Document.SNAPSHOT)
+
+    def load_drift(self):
+        from exmergo_dex_core.maintain.drift import DriftReport
+
+        raw = self._docs.get("drift")
+        return None if raw is None else DriftReport.model_validate_json(raw)
+
+    def save_drift(self, report):
+        self._docs["drift"] = report.model_dump_json()
+        return self.locator(Document.DRIFT)
+
+    def append_query_log(self, entry):
+        self._docs.setdefault("q", []).append(json.dumps(entry))
+
+    def append_spend_log(self, entry):
+        self._docs.setdefault("s", []).append(json.dumps(entry))
+
+    def spend_since(self, cutoff_iso, *, field="billed_bytes", connector=None):
+        entries = [json.loads(r) for r in self._docs.setdefault("s", [])]
+        return spend_total(entries, cutoff_iso, field=field, connector=connector)
+
+    def _plans(self):
+        return self._docs.setdefault("plans", {})
+
+    def save_plan(self, plan):
+        self._plans()[plan.plan_id] = plan.model_dump_json()
+        return self.plan_locator(plan.plan_id)
+
+    def load_plan(self, plan_id):
+        raw = self._plans().get(plan_id)
+        if raw is None:
+            raise PlanNotFoundError("no plan " + plan_id + " for " + self.key)
+        return TransformPlan.model_validate_json(raw)
+
+    def list_plans(self):
+        plans = [TransformPlan.model_validate_json(r) for r in self._plans().values()]
+        return sorted(plans, key=lambda p: p.created_at, reverse=True)
+
+    def latest_plan(self, kind=None):
+        candidates = [
+            p
+            for p in self.list_plans()
+            if p.applied_at is None
+            and (kind is None or all(e.kind is kind for e in p.edits))
+        ]
+        return max(candidates, key=lambda p: p.created_at, default=None)
+
+    def locator(self, document):
+        return "tiny://" + self.key + "/" + document.value
+
+    def plan_locator(self, plan_id):
+        return "tiny://" + self.key + "/plans/" + plan_id
+
+
+def tiny_store_factory(context):
+    """How this backend would be named in configuration: keyed by its own
+    coordinate, with no repo root anywhere."""
+
+    tenant = context.options.get("tenant")
+    if not tenant:
+        raise ValueError("this backend needs cache.options.tenant")
+    return TinyStore(tenant)
+
+
+def test_the_published_protocol_is_satisfied():
+    assert isinstance(TinyStore("k"), Store)
+
+
+class TestTinyStore(StoreContract):
+    def make_store(self, key):
+        return TinyStore(key)
+
+
+class TestTinyStoreConstruction(StoreFactoryContract, StoreContract):
+    """The whole contract, run through the construction seam from outside."""
+
+    tier = Store
+
+    def build(self, context):
+        return tiny_store_factory(context)
+
+    def context_for(self, key):
+        return StoreContext(options={"tenant": key})
+'''
+
+
+# The narrow tier as its own file, because the point of the run below is an
+# environment with no dialect engine in it: a module importing the plan model at
+# top level, as the full-tier backend legitimately does, would not even collect
+# there. This is what an explore-only implementer actually writes.
+OUTSIDE_EXPLORE_BACKEND = '''
+import json
+
+from exmergo_dex_core.cache import DexCache
+from exmergo_dex_core.storage import Document, ExploreStore, Store, spend_total
+from exmergo_dex_core.storage.conformance import ExploreStoreContract
+
+
+class TinyExploreStore:
+    """The narrow tier, written from `ExploreStore` alone, and durable per key."""
 
     _state: dict = {}
 
@@ -472,38 +606,17 @@ class TinyStore:
         return spend_total(entries, cutoff_iso, field=field, connector=connector)
 
     def locator(self, document):
-        return "tiny://" + self.key + "/" + document.value
+        return "tiny-explore://" + self.key + "/" + document.value
 
 
-def tiny_store_factory(context):
-    """How this backend would be named in configuration: keyed by its own
-    coordinate, with no repo root anywhere."""
-
-    tenant = context.options.get("tenant")
-    if not tenant:
-        raise ValueError("this backend needs cache.options.tenant")
-    TinyStore._state.pop(tenant, None)
-    return TinyStore(tenant)
+def test_the_narrow_tier_is_complete_not_partial():
+    assert isinstance(TinyExploreStore("k"), ExploreStore)
+    assert not isinstance(TinyExploreStore("k"), Store)
 
 
-def test_the_published_protocol_is_satisfied():
-    assert isinstance(TinyStore("k"), ExploreStore)
-
-
-class TestTinyStore(ExploreStoreContract):
+class TestTinyExploreStore(ExploreStoreContract):
     def make_store(self, key):
-        TinyStore._state.pop(key, None)
-        return TinyStore(key)
-
-
-class TestTinyStoreConstruction(StoreFactoryContract, ExploreStoreContract):
-    """The whole contract, run through the construction seam from outside."""
-
-    def build(self, context):
-        return tiny_store_factory(context)
-
-    def context_for(self, key):
-        return StoreContext(options={"tenant": key})
+        return TinyExploreStore(key)
 '''
 
 
@@ -524,13 +637,20 @@ def test_a_backend_outside_the_distribution_passes_the_shipped_contract(
     backend defined there is built the way configuration would build it, through a
     factory and a `StoreContext` carrying no repo root at all.
 
+    It is the **full** tier, and durable, because the two ways this has actually
+    broken both needed exactly that to show up. The plan assertions reach the
+    dialect engine, so an extra shipping only pytest failed all ten of them; and a
+    backend that shares state per key inherits the previous assertion's writes
+    unless the suite hands out a fresh key each time. An explore-tier backend that
+    resets itself, which is what this test used to define, demonstrates neither.
+
     If this passes, an outside contributor can implement a storage backend from
     what is published, which is the entire point of publishing it. If it fails,
     they cannot, whatever the in-repo tests say.
     """
 
     suite = tmp_path / "test_outside_backend.py"
-    suite.write_text(OUTSIDE_BACKEND.lstrip(), encoding="utf-8")
+    suite.write_text(OUTSIDE_FULL_BACKEND.lstrip(), encoding="utf-8")
 
     done = subprocess.run(  # noqa: S603  (a fixed argv, no shell)
         [
@@ -540,6 +660,71 @@ def test_a_backend_outside_the_distribution_passes_the_shipped_contract(
             "--no-project",
             "--with",
             f"exmergo-dex-core[storage-conformance] @ {wheel}",
+            "pytest",
+            "-q",
+            str(suite),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert "passed" in done.stdout
+
+
+def test_the_explore_tier_contract_runs_with_no_dialect_engine(
+    wheel: str, tmp_path: Path
+):
+    """The narrow tier, in an environment that cannot parse SQL.
+
+    `[storage-conformance]` brings the dialect engine because the plan assertions
+    need it, and that is what makes this test necessary rather than redundant: with
+    the extra installed, nothing else would notice if `a_plan` stopped importing
+    lazily and every explore-tier implementer suddenly needed sqlglot to run a suite
+    that never touches a plan. So this installs the bare wheel plus a test runner,
+    nothing more, and runs an explore-tier backend against it.
+
+    The first assertion is that sqlglot is genuinely absent, for the same reason the
+    hosted-semantic test makes it: without it the rest of this passes for the wrong
+    reason the moment anything puts a dialect engine back in the environment.
+    """
+
+    suite = tmp_path / "test_outside_explore_backend.py"
+    suite.write_text(OUTSIDE_EXPLORE_BACKEND.lstrip(), encoding="utf-8")
+    spec = f"exmergo-dex-core @ {wheel}"
+
+    done = subprocess.run(  # noqa: S603  (a fixed argv, no shell)
+        [
+            _uv(),
+            "run",
+            "--isolated",
+            "--no-project",
+            "--with",
+            spec,
+            "--with",
+            "pytest>=8",
+            "python",
+            "-c",
+            "\ntry: import sqlglot; raise SystemExit('sqlglot must not be here')"
+            "\nexcept ImportError: print('absent')",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert "absent" in done.stdout
+
+    done = subprocess.run(  # noqa: S603  (a fixed argv, no shell)
+        [
+            _uv(),
+            "run",
+            "--isolated",
+            "--no-project",
+            "--with",
+            spec,
+            "--with",
+            "pytest>=8",
             "pytest",
             "-q",
             str(suite),

--- a/packages/dex-core/uv.lock
+++ b/packages/dex-core/uv.lock
@@ -854,6 +854,7 @@ sql = [
 ]
 storage-conformance = [
     { name = "pytest" },
+    { name = "sqlglot" },
 ]
 
 [package.metadata]
@@ -908,6 +909,7 @@ requires-dist = [
     { name = "sqlglot", marker = "extra == 'semantic'", specifier = ">=28.6,<31" },
     { name = "sqlglot", marker = "extra == 'snowflake'", specifier = ">=28.6,<31" },
     { name = "sqlglot", marker = "extra == 'sql'", specifier = ">=28.6,<31" },
+    { name = "sqlglot", marker = "extra == 'storage-conformance'", specifier = ">=28.6,<31" },
 ]
 provides-extras = ["all", "bigquery", "cluster", "databricks", "dev", "duckdb", "postgres", "redshift", "semantic", "semantic-api", "snowflake", "sql", "storage-conformance"]
 

--- a/references/storage.md
+++ b/references/storage.md
@@ -260,6 +260,28 @@ Whether the key is a directory, a tenant id, or a table prefix is your business.
 Two tenants leaking into each other is the failure this seam exists to prevent, so
 those assertions are the ones worth reading if any fail.
 
+The extra brings pytest and the dialect engine, because the plan-tier assertions
+build a `TransformPlan` and that reaches the SQL guard. Implementing only
+`ExploreStore` needs neither the plans nor the engine, and that install stays
+viable: nothing in the narrow tier touches SQL.
+
+### What the suite guarantees about the key
+
+**It never hands the same key to two assertions**, within a run or across runs. So
+you need no reset hook, no truncate step, and no fixture of your own to keep one
+assertion's writes out of the next.
+
+That matters because of what it leaves you free to do. Two calls to `make_store`
+with the *same* key may return two views of one shared state, which is exactly what
+a durable backend is and what a hosted deployment depends on. The contract
+constrains you in one direction only: two *different* keys must share nothing. It
+says nothing about the same key twice, and the suite never depends on an answer.
+
+Nothing is cleaned up when the run ends, so a durable backend accumulates one
+namespace per run. Pruning them is yours; the alternative was a teardown hook, which
+is a second thing to implement and get wrong for a guarantee the suite does not
+need.
+
 **If your backend is meant to be named in configuration**, mix in
 `StoreFactoryContract` as well. It routes `make_store` through your own factory, so
 everything above then runs against stores built the way dex builds them:

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.4.2"
+DEX_CORE_VERSION = "1.4.3"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.4.2"
+DEX_CORE_VERSION = "1.4.3"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.4.2"
+DEX_CORE_VERSION = "1.4.3"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
## What this changes

**The shipped conformance suite could not be run by two of the backends it was
  written for** ([#174]). Both defects were in how the suite is packaged and how it
  drives a backend, not in the storage contract, so nothing changes about what a
  store owes its callers. Both were reported by an implementer running a full-tier,
  tenant-keyed backend against 1.4.2 from outside this repository, and both surfaced
  as assertion failures attributed to that backend rather than as anything naming
  the suite.

  `[storage-conformance]` shipped only pytest, while the ten plan assertions build a
  `TransformPlan`, which reaches the SQL guard and so the dialect engine. Anyone
  implementing the full `Store` tier got ten failures on a clean install. The extra
  now self-references `[sql]`, the same treatment every connector extra already had.
  The explore tier still installs and runs with no dialect engine, and a packaging
  test now holds that line rather than leaving it to `a_plan`'s lazy import alone.

  The suite also drove all 34 assertions through one key and never reset, so a
  backend where two instances built from one key see the same state, which is the
  defining property of every durable backend, inherited the previous assertion's
  writes and failed nine of them. Every assertion now gets its own key, unique to
  the run, so a durable backend passes unmodified with no reset hook and no fixture
  of its own. A backend that resets on every call is unaffected: it receives
  different strings and nothing else changes. `make_store` now documents what the
  suite guarantees about key reuse and, just as importantly, what it does not
  require, since the old contract was silent in both directions.

  Neither gap was visible in-repo, because every backend the contract had ever run
  against reset itself. There is now an in-repo backend that does not, and the
  out-of-tree packaging test exercises the full tier instead of only the explore
  tier.

## Related issues

Closes #174