### PR TITLE
A refusal no longer reports a metered connector as free (when over budget)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A refusal no longer reports a metered connector as free** ([#162]). An
+  over-ceiling refusal on BigQuery returned an envelope whose `cost.paradigm`
+  said `free_local` while the error prose beside it correctly said
+  `(bytes_scanned)`. `free_local` is a positive claim that the connector bills
+  nothing, so a host branching on the structured field to ask "was this refusal
+  about money?" was told no, and a host that trusted the structured field over
+  the prose (the right instinct) got the wrong answer.
+
+  **This is a visible change to the envelope contract**, in three parts:
+
+  - `cost.paradigm` is now nullable, and `null` is what a command reports when
+    nothing selected a connector. It is no longer possible for an envelope to
+    claim `free_local` by omission.
+  - `cost.paradigm` names **the connector the command ran against**, not what
+    the command happened to cost. A repo-only command such as `transform plans`
+    in a BigQuery-configured project now reports `bytes_scanned` where it used
+    to report `free_local`. To ask whether a command actually spent anything,
+    read `data.spend` and `cost.estimate`, not the paradigm.
+  - A refusal now carries the whole cost block. An over-ceiling refusal, a
+    confirmed-but-unbudgeted refusal, and a mid-run budget exhaustion all report
+    the estimate and the ceiling that bound them alongside the paradigm, so the
+    two numbers the error prose names are readable as structured fields.
+
+  `free_local` consequently means DuckDB and nothing else.
+
 ## [1.4.3] - 2026-07-28
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -26,7 +26,7 @@ import sys
 from . import command_args
 from . import envelope as env
 from .engine import DexEngine
-from .guards.cost_guard import ConfirmationRequiredError
+from .guards.cost_guard import ConfirmationRequiredError, CostGuardError
 from .guards.dialect import DialectDependencyError
 from .guards.dialect import ensure_available as ensure_dialect_available
 from .results import BudgetExhaustedError
@@ -243,8 +243,19 @@ def dispatch(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
         # Partial completion: an error, but one that reports what the attempt
         # actually cost, because that is what a caller needs to size the re-run.
         return env.error(
-            env.redact(str(exc)), data={"spend": exc.spend} if exc.spend else {}
+            env.redact(str(exc)),
+            data={"spend": exc.spend} if exc.spend else {},
+            cost=exc.cost or env.Cost(),
         )
+    except CostGuardError as exc:
+        # An over-ceiling or no-ceiling refusal. It carries the gate's own cost,
+        # so the refusal reports the paradigm it was denominated in and the two
+        # numbers the prose names, rather than leaving a caller to parse them
+        # back out of the message. Caught here and not left to `main`'s
+        # catch-all for the reason this function exists: a refusal that escapes
+        # arrives with no cost at all, and an empty cost block on a spend
+        # refusal reads as a claim that nothing was going to be spent.
+        return env.error(env.redact(str(exc)), cost=exc.cost or env.Cost())
 
 
 def _run(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
@@ -325,9 +336,16 @@ def _run(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
 
 def main(argv: list[str] | None = None) -> int:
     from .command_args import repo_root
+    from .connect import paradigm_for
 
     parser = _build_parser()
     args = parser.parse_args(argv)
+    # The connector in play, for envelopes that never priced anything and so
+    # never stamped a paradigm of their own. Read off the engine as soon as it
+    # exists, because `close()` runs before the handlers below and drops the
+    # adapter; a name is enough, and unlike an adapter it survives a connection
+    # that could not be opened. Stays None when nothing selected a connector.
+    paradigm: env.Paradigm | None = None
     # Building the engine is inside the handler, not before it: it reads the
     # config file and constructs the configured storage backend, and both can
     # refuse. Every agent wrapper expects exactly one envelope on stdout, so a
@@ -350,6 +368,7 @@ def main(argv: list[str] | None = None) -> int:
             budget=getattr(args, "budget", None),
             confirmed=getattr(args, "confirm", False),
         )
+        paradigm = engine.paradigm
         try:
             envelope = dispatch(args, engine)
         finally:
@@ -359,7 +378,21 @@ def main(argv: list[str] | None = None) -> int:
         # loudly in tests and CI rather than shipping a leak.
         raise
     except Exception as exc:
+        # An engine that could not be built leaves the flag as the only evidence
+        # of a connector, which still beats saying nothing on a refusal a host
+        # has to decide whether to retry.
+        if paradigm is None and getattr(args, "connector", None):
+            paradigm = paradigm_for(args.connector)
         envelope = env.error(env.redact(str(exc)))
+
+    # Every command runs against a connector or against none, so every envelope
+    # can name the paradigm a later billed command would spend in. Filled only
+    # where nothing claimed one, so a deliberate label survives: `explore
+    # semantic query --api` sets `hosted` because dbt Cloud owns that spend, and
+    # a genuine "no connector resolved" stays null rather than borrowing
+    # `free_local`, which is DuckDB's answer and not a way to say nothing.
+    if envelope.cost.paradigm is None and paradigm is not None:
+        envelope.cost.paradigm = paradigm
 
     env.emit(envelope)
     return 0 if envelope.status != env.Status.ERROR else 1

--- a/packages/dex-core/src/exmergo_dex_core/command_args.py
+++ b/packages/dex-core/src/exmergo_dex_core/command_args.py
@@ -83,12 +83,13 @@ def preflight_cost(adapter: Adapter) -> Cost:
 
     The free metadata commands (``inventory``, ``connect test``, the free drift
     axes) still report a cost, because its paradigm tells a caller what the
-    *next* command will bill in. On a free connector there is no gate and the
-    answer is the free/local default.
+    *next* command will bill in. A free connector has no gate, so the paradigm
+    comes from the adapter itself rather than from a default: ``free_local`` is
+    DuckDB's own answer here, never a placeholder for not having asked.
     """
 
     gate = cost_gate(adapter)
-    return gate.cost() if gate is not None else Cost()
+    return gate.cost() if gate is not None else Cost(paradigm=adapter.paradigm)
 
 
 def billed_handshake(

--- a/packages/dex-core/src/exmergo_dex_core/engine.py
+++ b/packages/dex-core/src/exmergo_dex_core/engine.py
@@ -42,6 +42,7 @@ from typing import TYPE_CHECKING, Any
 from . import command_args, connect
 from .config import CacheConfig, DexConfig, load_config
 from .connect import ConnectionSource, SemanticSource
+from .envelope import Paradigm
 from .errors import RepoRootRequiredError, StoreRequiredError
 from .results import ConnectResult
 from .storage import ExploreStore, MemoryStore, Store, StoreContext, build_store
@@ -305,6 +306,25 @@ class DexEngine:
         """
 
         return self._declared is not None
+
+    @property
+    def paradigm(self) -> Paradigm | None:
+        """The cost paradigm of the connector in play, ``None`` when nothing
+        selected one.
+
+        Resolved from the connector's name rather than from an open adapter,
+        which is what lets a refusal name the paradigm even when the refusal
+        *was* the connection failing, and after the adapter has been closed.
+
+        The three-input test is the same one :meth:`_config_for_open` refuses
+        on, and for the same reason: ``DexConfig.connector`` has a default, so
+        reading it when nothing declared a config would answer ``free_local``
+        for a project that never chose DuckDB.
+        """
+
+        if self._declared is None and self.connector is None and self.path is None:
+            return None
+        return connect.paradigm_for(self.connector or self.config.connector)
 
     def project_dir(self) -> Path:
         """The dbt project directory: the config pin wins, discovery is the default."""

--- a/packages/dex-core/src/exmergo_dex_core/envelope.py
+++ b/packages/dex-core/src/exmergo_dex_core/envelope.py
@@ -33,7 +33,13 @@ class Status(str, Enum):
 
 
 class Paradigm(str, Enum):
-    """Cost paradigm of the active connector. DuckDB is free/local."""
+    """Cost paradigm of the active connector. DuckDB is free/local.
+
+    ``FREE_LOCAL`` is DuckDB's own paradigm and never a stand-in for "not
+    applicable": it is a positive claim that the connector in play bills
+    nothing. A command with no connector to describe reports no paradigm at all
+    (``Cost.paradigm is None``) rather than borrowing this one.
+    """
 
     FREE_LOCAL = "free_local"
     BYTES_SCANNED = "bytes_scanned"
@@ -52,9 +58,16 @@ class Cost(BaseModel):
     ``estimate`` and ``ceiling`` are paradigm-relative magnitudes (bytes, credits,
     DBUs, or a load score); the unit is carried by ``paradigm``. For DuckDB both
     are ``None`` because the work is free and only resource-bounded.
+
+    ``paradigm`` names **the connector this command ran against**, so a caller
+    reading a free metadata command still learns what a billed one will cost in.
+    It defaults to ``None``, meaning no connector was resolved, and that default
+    is load-bearing: a refusal built without a paradigm has to say nothing rather
+    than claim ``free_local``, which is a positive assertion a host branching on
+    this field would read as "this refusal was not about money".
     """
 
-    paradigm: Paradigm = Paradigm.FREE_LOCAL
+    paradigm: Paradigm | None = None
     estimate: float | None = None
     ceiling: float | None = None
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -1859,6 +1859,7 @@ def _budget_exhausted(
 
     gate = command_args.cost_gate(adapter)
     spend = gate.spend_summary() if gate is not None else None
+    cost = gate.cost() if gate is not None else None
     n = len(accumulated)
     if n == 0:
         return BudgetExhaustedError(
@@ -1866,6 +1867,7 @@ def _budget_exhausted(
             "profiling; no partial profiles were saved. Raise --budget or narrow "
             "scope, then re-run",
             spend=spend,
+            cost=cost,
         )
     cache_locator = store.locator(Document.CACHE)
     return BudgetExhaustedError(
@@ -1873,6 +1875,7 @@ def _budget_exhausted(
         f"profiles saved to {cache_locator}. Raise --budget or narrow scope, then "
         "re-run",
         spend=spend,
+        cost=cost,
     )
 
 

--- a/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
@@ -29,7 +29,18 @@ from ..results import ConfirmationRequest
 
 
 class CostGuardError(DexError):
-    """Base for every cost-guard refusal."""
+    """Base for every cost-guard refusal.
+
+    Every refusal carries the :class:`Cost` it refused on, so the transport layer
+    can report the paradigm, the estimate, and the ceiling that bound rather than
+    a message the caller has to parse. One attribute on the base rather than one
+    per subclass: the boundary reads ``exc.cost`` without knowing which refusal
+    it caught.
+    """
+
+    def __init__(self, message: str, *, cost: Cost | None = None):
+        super().__init__(message)
+        self.cost = cost
 
 
 class OverCeilingError(CostGuardError):
@@ -55,12 +66,16 @@ class ConfirmationRequiredError(CostGuardError):
     :class:`CeilingRequiredError`: confirmation cannot override either.
     """
 
+    # Narrower than the base's optional: this refusal is always raised from a
+    # priced gate, so callers read `exc.cost.estimate` without a None check.
+    cost: Cost
+
     def __init__(self, cost: Cost):
         super().__init__(
             "confirmation required: re-run with --confirm (and a --budget on "
-            "billed connectors) after reviewing the cost estimate"
+            "billed connectors) after reviewing the cost estimate",
+            cost=cost,
         )
-        self.cost = cost
         # Starts as just the cost, which is all the gate knows; the command layer
         # replaces it with the full agent-facing payload on the way out. Never
         # None, so a caller can always read it.
@@ -100,12 +115,14 @@ def preflight(
     if estimate is not None and ceiling is not None and estimate > ceiling:
         raise OverCeilingError(
             f"estimated cost {estimate} exceeds the ceiling {ceiling} "
-            f"({paradigm.value}); raise the budget or narrow the work"
+            f"({paradigm.value}); raise the budget or narrow the work",
+            cost=cost,
         )
     if paradigm is not Paradigm.FREE_LOCAL and ceiling is None:
         raise CeilingRequiredError(
             f"no ceiling set for a {paradigm.value} connector; pass --budget or "
-            "set one in .dex/config.yml"
+            "set one in .dex/config.yml",
+            cost=cost,
         )
     if not confirmed:
         raise ConfirmationRequiredError(cost)
@@ -182,14 +199,16 @@ class CostGate:
         if ceiling is not None and estimate > ceiling:
             raise OverCeilingError(
                 f"estimated cost {estimate} exceeds the ceiling {ceiling} "
-                f"({self.paradigm.value}); raise the budget or narrow the work"
+                f"({self.paradigm.value}); raise the budget or narrow the work",
+                cost=cost,
             )
         if not self.confirmed:
             raise ConfirmationRequiredError(cost)
         if self.paradigm is not Paradigm.FREE_LOCAL and ceiling is None:
             raise CeilingRequiredError(
                 f"no ceiling set for a {self.paradigm.value} connector; pass "
-                "--budget or set one in .dex/config.yml"
+                "--budget or set one in .dex/config.yml",
+                cost=cost,
             )
         return cost
 

--- a/packages/dex-core/src/exmergo_dex_core/results.py
+++ b/packages/dex-core/src/exmergo_dex_core/results.py
@@ -52,11 +52,23 @@ class BudgetExhaustedError(DexError):
     says how much finished and where it was saved, and ``spend`` carries what was
     actually billed. A caller raises the budget and re-runs; the saved partial
     profiles mean the re-run is cheaper than the first attempt.
+
+    ``cost`` is the preflight side of the same event: the paradigm and the
+    ceiling that stopped the run, which is what a caller sizes the re-run
+    against. Both, because "what it cost" and "what it was allowed to cost" are
+    different numbers here and the gap between them is the whole message.
     """
 
-    def __init__(self, message: str, *, spend: dict[str, Any] | None = None):
+    def __init__(
+        self,
+        message: str,
+        *,
+        spend: dict[str, Any] | None = None,
+        cost: Cost | None = None,
+    ):
         super().__init__(message)
         self.spend = spend
+        self.cost = cost
 
 
 class Result(BaseModel):

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -674,3 +674,79 @@ def test_duckdb_map_verify_stays_confirmation_free(duckdb_file: Path, capsys):
     assert payload["status"] == "ok"
     assert payload["cost"]["paradigm"] == "free_local"
     assert "phase" not in payload["data"]
+
+
+# --- what a refusal reports ------------------------------------------------------
+#
+# A refusal is the most consequential message the cost guard emits, and it used
+# to arrive with an empty cost block whose paradigm defaulted to `free_local`: a
+# spend refusal on a metered connector positively asserting that nothing was
+# going to be spent. These pin that every cost-guard refusal carries the gate's
+# own cost, so the structured field agrees with the prose beside it.
+
+
+def test_over_ceiling_refusal_reports_the_metered_paradigm(
+    fake_bq_client, route_adapter, tmp_path
+):
+    route_adapter(fake_bq_client)
+    envelope = _dispatch(
+        tmp_path,
+        subcommand="profile",
+        objects=["customers"],
+        confirm=True,
+        budget=float(MB),
+    )
+    assert envelope.status.value == "error"
+    assert envelope.cost.paradigm is Paradigm.BYTES_SCANNED
+    # The two numbers the prose names, structured: what was asked for and what
+    # was allowed. A caller sizes the re-run from these without parsing text.
+    assert envelope.cost.estimate == 30 * MB
+    assert envelope.cost.ceiling == MB
+    assert "exceeds the ceiling" in envelope.errors[0]
+    assert all(c.dry_run for c in fake_bq_client.query_calls)
+
+
+def test_no_ceiling_refusal_reports_the_metered_paradigm(
+    fake_bq_client, route_adapter, tmp_path
+):
+    # Confirmed but unbudgeted: nothing executes unbudgeted, and the refusal
+    # still has to say which unit the missing budget would have been in.
+    route_adapter(fake_bq_client)
+    envelope = _dispatch(
+        tmp_path, subcommand="profile", objects=["customers"], confirm=True
+    )
+    assert envelope.status.value == "error"
+    assert envelope.cost.paradigm is Paradigm.BYTES_SCANNED
+    assert envelope.cost.ceiling is None
+    assert "no ceiling set" in envelope.errors[0]
+
+
+def test_budget_exhaustion_carries_both_the_ceiling_and_the_spend(
+    fake_bq_client, route_adapter, tmp_path, monkeypatch
+):
+    """Partial completion reports what it cost *and* what it was allowed to cost.
+
+    The gap between the two is the whole message: a caller deciding how much to
+    raise the budget by needs both numbers.
+    """
+
+    from exmergo_dex_core.cli import dispatch
+    from exmergo_dex_core.explore import commands as cmds
+
+    def exhausted(args, engine):
+        adapter = engine._adapter("explore profile")
+        adapter.cost_gate.charge(4 * MB)
+        adapter.cost_gate.record_billed(5_000)
+        raise cmds._budget_exhausted(FilesystemStore(tmp_path), adapter, [], 3)
+
+    route_adapter(fake_bq_client)
+    monkeypatch.setattr(cmds, "cmd_profile", exhausted)
+    envelope = dispatch(
+        _args(tmp_path, subcommand="profile", confirm=True, budget=float(10 * MB)),
+        _engine(tmp_path, confirm=True, budget=float(10 * MB)),
+    )
+    assert envelope.status.value == "error"
+    assert envelope.cost.paradigm is Paradigm.BYTES_SCANNED
+    assert envelope.cost.estimate == 4 * MB
+    assert envelope.cost.ceiling == 10 * MB
+    assert envelope.data["spend"]["bytes_billed"] == 5_000

--- a/packages/dex-core/tests/test_cli_contract.py
+++ b/packages/dex-core/tests/test_cli_contract.py
@@ -244,3 +244,62 @@ def test_an_unresolvable_backend_still_emits_exactly_one_envelope(
     assert rc == 1
     assert payload["status"] == "error"
     assert "unknown cache backend" in payload["errors"][0]
+
+
+# --- the cost paradigm every envelope carries ------------------------------------
+#
+# `cost.paradigm` names the connector the command ran against, so a caller
+# reading a free command still learns what a billed one will cost in. It is
+# absent when nothing selected a connector. `free_local` is DuckDB's own answer
+# and never a stand-in for having nothing to say, which is the distinction a
+# host branching on this field to ask "was this refusal about money?" depends on.
+
+
+def test_a_duckdb_command_reports_free_local(duckdb_file: Path, capsys):
+    assert main(["connect", "test", "--path", str(duckdb_file)]) == 0
+    assert json.loads(capsys.readouterr().out)["cost"]["paradigm"] == "free_local"
+
+
+def test_a_repo_only_command_reports_the_configured_connector(tmp_path: Path, capsys):
+    """`transform plans` reads the plan store and touches no warehouse, but the
+    repo is configured for BigQuery, so the next billed command bills in bytes
+    and the envelope says so."""
+
+    from exmergo_dex_core.config import DexConfig, save_config
+
+    save_config(DexConfig(connector="bigquery"), tmp_path)
+    assert main(["--repo-root", str(tmp_path), "transform", "plans"]) == 0
+    assert json.loads(capsys.readouterr().out)["cost"]["paradigm"] == "bytes_scanned"
+
+
+def test_a_command_with_no_connector_claims_no_paradigm(tmp_path: Path, capsys):
+    # No config, no --connector, no --path: nothing chose a connector, so there
+    # is no paradigm to report and the envelope must not invent one.
+    assert main(["--repo-root", str(tmp_path), "connect", "test"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "error"
+    assert payload["cost"]["paradigm"] is None
+
+
+def test_a_refusal_before_the_engine_exists_reports_the_flagged_connector(
+    tmp_path: Path, capsys
+):
+    # The store refuses while the engine is being built, so there is no engine
+    # to ask. The flag is the only evidence of a connector left, and it is still
+    # better than telling a host the failed BigQuery run was free and local.
+    rc = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--connector",
+            "bigquery",
+            "--cache-backend",
+            "nope",
+            "connect",
+            "test",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["status"] == "error"
+    assert payload["cost"]["paradigm"] == "bytes_scanned"

--- a/packages/dex-core/tests/test_envelope.py
+++ b/packages/dex-core/tests/test_envelope.py
@@ -15,9 +15,26 @@ def test_envelope_round_trips_to_json():
     payload = json.loads(json.dumps(e.model_dump(mode="json")))
     assert payload["status"] == "ok"
     assert payload["data"] == {"hello": "world"}
-    assert payload["cost"]["paradigm"] == "free_local"
     assert payload["warnings"] == ["heads up"]
     assert payload["diffs"] == [] and payload["errors"] == []
+
+
+def test_an_unstamped_cost_claims_no_paradigm():
+    """The default has to be an absence, not `free_local`.
+
+    `free_local` is DuckDB's own paradigm, so defaulting to it makes every
+    envelope built without a cost assert that the connector bills nothing. On a
+    refusal that is the opposite of true, and it is the field a host reaches for
+    to ask whether the refusal was about money.
+    """
+
+    for envelope in (env.ok(), env.error("no"), env.needs_confirmation()):
+        assert envelope.cost.paradigm is None
+    assert json.loads(json.dumps(env.error("no").model_dump(mode="json")))["cost"] == {
+        "paradigm": None,
+        "estimate": None,
+        "ceiling": None,
+    }
 
 
 def test_not_implemented_is_a_valid_envelope():

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -195,6 +195,57 @@ def test_cost_guard_blocks_over_ceiling():
         cost_guard.preflight(estimate=10_000, ceiling=10)
 
 
+@pytest.mark.parametrize(
+    "paradigm",
+    [env.Paradigm.BYTES_SCANNED, env.Paradigm.COMPUTE_TIME, env.Paradigm.DB_LOAD],
+)
+def test_a_refusal_never_reports_a_metered_connector_as_free(paradigm, monkeypatch):
+    """The guard being right is not enough: the envelope has to say so.
+
+    Every other cost assertion in this family stops at the exception, which is
+    exactly how a metered over-ceiling refusal shipped for three releases
+    reporting `cost.paradigm: free_local` in the envelope beside prose that
+    named the real paradigm. `free_local` is a positive claim that the connector
+    bills nothing, so a host branching on the structured field to ask whether a
+    refusal was about money was told no. Assert it where the consumer reads it.
+    """
+
+    import argparse
+
+    from exmergo_dex_core import cli
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    gate = CostGate(
+        paradigm=paradigm,
+        ceiling=10.0,
+        session_ceiling=None,
+        session_spent=0.0,
+        confirmed=True,
+        connector="metered",
+    )
+
+    def refuse(estimate):
+        # The two refusals confirmation cannot override, rendered the way the
+        # CLI renders them: through dispatch, which is the only path from a
+        # raised guard error to something an agent reads.
+        def raiser(args, engine):
+            gate.preflight_command(estimate)
+            raise AssertionError("the gate admitted an unbudgeted or over-ceiling run")
+
+        monkeypatch.setattr(cli, "_run", raiser)
+        return cli.dispatch(argparse.Namespace(), None)
+
+    over_ceiling = refuse(10_000.0)
+    assert over_ceiling.status is env.Status.ERROR
+    assert over_ceiling.cost.paradigm is paradigm
+    assert over_ceiling.cost.estimate == 10_000.0 and over_ceiling.cost.ceiling == 10.0
+
+    gate.ceiling = None
+    no_ceiling = refuse(1.0)
+    assert no_ceiling.status is env.Status.ERROR
+    assert no_ceiling.cost.paradigm is paradigm
+
+
 def test_a_scope_flag_cannot_widen_the_committed_allowlist():
     """The source allowlist in .dex/config.yml is a committed cost boundary. A
     per-command flag scopes work inside it and can never reach outside it, on any

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -330,7 +330,11 @@ Every command prints one object of this shape (`exmergo_dex_core.envelope`):
 {
   "status": "ok | not_implemented | error | needs_confirmation",
   "data": {},
-  "cost": { "estimate": null, "ceiling": null, "paradigm": "free_local" },
+  "cost": {
+    "estimate": null,
+    "ceiling": null,
+    "paradigm": "bytes_scanned | compute_time | db_load | hosted | free_local | null"
+  },
   "warnings": [],
   "diffs": [],
   "errors": []
@@ -348,6 +352,14 @@ Rules the envelope enforces, all of them Tier-2 eval targets:
   backstop, actual spend is reported under `data.spend`, and every billed byte
   is appended to the `.dex/spend.jsonl` ledger, against which the optional
   `budget.session_ceiling` binds cumulatively per UTC day.
+- **`cost.paradigm` names the connector the command ran against**, not what the
+  command happened to cost. A free metadata command on BigQuery reports
+  `bytes_scanned` with a null estimate, so a caller learns what a billed command
+  will cost in before running one. `free_local` is DuckDB's own paradigm and a
+  positive claim that the connector bills nothing; when no connector was
+  resolved the field is `null` instead. A refusal carries the paradigm, the
+  estimate, and the ceiling that bound it, so "was this refused over money?" is
+  answerable from the structured fields without parsing the error prose.
 - **Diffs, not silent writes.** Proposed changes appear in `diffs`; being there
   does not apply them. The user applies through their normal review and PR flow.
 - **No secrets, no uncleared values.** `data` is scanned before printing


### PR DESCRIPTION
## What this changes

- **A refusal no longer reports a metered connector as free** ([#162]). An
  over-ceiling refusal on BigQuery returned an envelope whose `cost.paradigm`
  said `free_local` while the error prose beside it correctly said
  `(bytes_scanned)`. `free_local` is a positive claim that the connector bills
  nothing, so a host branching on the structured field to ask "was this refusal
  about money?" was told no, and a host that trusted the structured field over
  the prose (the right instinct) got the wrong answer.

  **This is a visible change to the envelope contract**, in three parts:

  - `cost.paradigm` is now nullable, and `null` is what a command reports when
    nothing selected a connector. It is no longer possible for an envelope to
    claim `free_local` by omission.
  - `cost.paradigm` names **the connector the command ran against**, not what
    the command happened to cost. A repo-only command such as `transform plans`
    in a BigQuery-configured project now reports `bytes_scanned` where it used
    to report `free_local`. To ask whether a command actually spent anything,
    read `data.spend` and `cost.estimate`, not the paradigm.
  - A refusal now carries the whole cost block. An over-ceiling refusal, a
    confirmed-but-unbudgeted refusal, and a mid-run budget exhaustion all report
    the estimate and the ceiling that bound them alongside the paradigm, so the
    two numbers the error prose names are readable as structured fields.

  `free_local` consequently means DuckDB and nothing else.

## Related issues

Closes #162