### PR TITLE
SCRUM-1006-Fix explore map carry-forward resurrecting relations deleted from the…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`explore map` no longer resurrects a relation deleted from the warehouse**
+  ([#149]). Carry-forward unions back any prior cached profile this run "did
+  not examine," correct when that means outside a narrower `--scope`/
+  `--dataset` (issue #111), but the same test also fired when an object was
+  simply dropped between two maps: the prior profile came back with its
+  original `profiled_at`, `maintain snapshot` pinned the ghost as a real
+  dataset, and the next `maintain check` reported it as a high-severity
+  `table_dropped` finding for something the operator deliberately removed.
+  With `orphan_relation` (#146) shipped, this actively worked against dex's
+  own remediation loop: classify an orphan, drop it, re-map, and the re-map
+  resurrected exactly what was just cleaned up.
+
+  Neither the cache nor any adapter records what scope built a prior run, so
+  "not examined" could not tell "out of scope" from "gone" apart. The fix
+  derives the schema/dataset namespaces this run's inventory actually
+  observed; an unexamined prior identifier is carried forward only when its
+  own namespace was never observed (genuinely out of scope, so #111 still
+  holds), and dropped, not carried, when the namespace was observed but the
+  object itself is missing from it. `explore map`'s envelope now reports a
+  `dropped_count` and a warning naming what was dropped. `explore
+  relationships` shares the same carry-forward function and gets the fix for
+  free; `explore profile` is unaffected, since neither does a full inventory
+  scan wide enough to know what "observed" means.
+
+  Known gap: if an entire schema is emptied out (every object in it dropped,
+  not just a few), it still looks identical to "never in scope" and
+  resurrects; narrower than the reported repro (a handful of relations gone
+  from otherwise-live schemas) and left for a future fix.
+
 ## [1.4.3] - 2026-07-28
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 from .. import command_args, dbt_project
 from .. import envelope as env
 from ..adapters import get_dialect
-from ..adapters.base import Adapter, ObjectMeta
+from ..adapters.base import Adapter, ObjectMeta, name_list
 
 # Aliased: `QueryResult` here is the explore record, and the adapter's
 # same-named row carrier is only a type hint on one shaping helper.
@@ -430,6 +430,11 @@ def relationships(
     # first (free and local on DuckDB), then infer across the full set.
     metas = inventory_mod.inventory(adapter)
     connector = adapter.name
+    # See map()'s identical computation: tells carry-forward "out of this
+    # run's scope" apart from "gone from the warehouse" (issue #149).
+    observed_namespaces = {
+        m.identifier.rpartition(".")[0].lower() for m in metas if "." in m.identifier
+    }
     # Skip re-scanning objects whose cached profile is still fresh (same
     # connector, schema unchanged, within the freshness window); only the stale
     # remainder is estimated, confirmed, and profiled below.
@@ -554,7 +559,9 @@ def relationships(
     # connector, same as the profiles below.
     reusable = prior if prior and prior.provenance.connector == connector else None
     examined = {d.identifier for d in datasets}
-    rels, carried_relationships = _carry_forward_relationships(reusable, examined, rels)
+    rels, carried_relationships = _carry_forward_relationships(
+        reusable, examined, rels, observed_namespaces=observed_namespaces
+    )
     notes = _relationship_notes(datasets, declared, inferred, defs)
     notes.extend(declared_notes)
     notes.extend(defs.notes)
@@ -765,6 +772,13 @@ def map(
 
     metas = inventory_mod.inventory(adapter)
     orphaned = _orphan_candidates(metas, defs)
+    # The schema/dataset namespaces this run's inventory actually saw, so
+    # carry-forward can tell "out of this run's scope" from "gone from the
+    # warehouse" (issue #149) -- an identifier whose own namespace is here but
+    # who is itself absent from metas was looked at and is not there.
+    observed_namespaces = {
+        m.identifier.rpartition(".")[0].lower() for m in metas if "." in m.identifier
+    }
     # First-pass rank on cheap signals (no connectivity yet) to choose what to
     # profile; re-ranked with connectivity once relationships are known.
     first_pass = rank_mod.rank(metas, None, hints, orphaned)
@@ -888,11 +902,15 @@ def map(
     reusable = prior if prior and prior.provenance.connector == adapter.name else None
     examined = {d.identifier for d in all_selected}
     relationship_set, carried_relationships = _carry_forward_relationships(
-        reusable, examined, relationship_set
+        reusable, examined, relationship_set, observed_namespaces=observed_namespaces
     )
     final_scores = rank_mod.rank(metas, relationship_set, hints, orphaned)
-    datasets, carried, out_of_scope = _compose_datasets(
-        metas, all_selected, final_scores, reusable
+    datasets, carried, out_of_scope, dropped = _compose_datasets(
+        metas,
+        all_selected,
+        final_scores,
+        reusable,
+        observed_namespaces=observed_namespaces,
     )
 
     cache = DexCache(datasets=datasets, relationships=relationship_set)
@@ -951,6 +969,12 @@ def map(
             f"carried forward {carried_relationships} prior relationship(s) "
             "with an endpoint this run did not profile or reuse fresh"
         )
+    if dropped:
+        warnings.append(
+            f"{len(dropped)} object(s) no longer in the warehouse were dropped "
+            "from the cache rather than resurrected as carried-forward "
+            f"profiles: {name_list(dropped)}"
+        )
     if folded_edges > 0:
         notes.append(
             f"folded {folded_edges} same-lineage duplicate relationship(s); "
@@ -976,6 +1000,7 @@ def map(
         skipped_count=skipped,
         carried_forward_count=carried,
         out_of_scope_carried_count=out_of_scope,
+        dropped_count=len(dropped),
         carried_relationship_count=carried_relationships,
         relationship_count=len(relationship_set),
         pii_column_count=sum(
@@ -1474,6 +1499,8 @@ def _carry_forward_relationships(
     prior: DexCache | None,
     examined: set[str],
     relationships: list[Relationship],
+    *,
+    observed_namespaces: set[str] | None = None,
 ) -> tuple[list[Relationship], int]:
     """Union back in any prior relationship this run could not possibly have
     regenerated or superseded: one with an endpoint outside ``examined`` (the
@@ -1486,16 +1513,30 @@ def _carry_forward_relationships(
     datasets (issue #111). Deduped against the newly built set by the same
     edge key `_merge_relationships` uses, so an edge both runs agree on is
     never doubled.
+
+    ``observed_namespaces`` (see `_compose_datasets`) excludes an edge whose
+    endpoint is gone from the warehouse rather than merely out of scope, so a
+    deleted relation's join does not resurrect either (issue #149).
     """
 
     if prior is None or not prior.relationships:
         return relationships, 0
     existing = {_relationship_edge_key(rel) for rel in relationships}
+
+    def dropped(identifier: str) -> bool:
+        return (
+            observed_namespaces is not None
+            and identifier not in examined
+            and identifier.rpartition(".")[0].lower() in observed_namespaces
+        )
+
     carried = [
         rel
         for rel in prior.relationships
         if (rel.from_dataset not in examined or rel.to_dataset not in examined)
         and _relationship_edge_key(rel) not in existing
+        and not dropped(rel.from_dataset)
+        and not dropped(rel.to_dataset)
     ]
     if not carried:
         return relationships, 0
@@ -1763,10 +1804,13 @@ def _compose_datasets(
     profiled: list[Dataset],
     scores: dict[str, float],
     prior: DexCache | None,
-) -> tuple[list[Dataset], int, int]:
+    *,
+    observed_namespaces: set[str] | None = None,
+) -> tuple[list[Dataset], int, int, list[str]]:
     """Merge this run's profiles over the full inventory. Returns the composed
     datasets, how many prior profiles were carried forward within this run's
-    inventory, and how many were carried forward from entirely outside it.
+    inventory, how many were carried forward from entirely outside it, and
+    which prior identifiers were dropped as gone rather than carried.
 
     An object not profiled this run reuses its prior profile wholesale (columns,
     keys, grain, notes, and its original ``profiled_at``, which marks the age)
@@ -1775,13 +1819,20 @@ def _compose_datasets(
     is internally consistent with its own notes and counts. Carried profiles do
     not feed relationship inference, which runs on this run's profiles only.
 
-    A prior dataset absent from ``metas`` entirely (a ``--scope``/``--dataset``
-    narrower than what built the prior cache) is carried forward untouched,
-    rank score included: this run's inventory never saw it, so it is not
-    stale, not superseded, and not this run's to drop from the cache (issue
-    #111). Its rank score is left alone rather than reset, since a score of
-    ``None`` would rank it last for no reason connectivity or naming ever
-    said was true; it just was not part of this run's ranking pass.
+    A prior dataset absent from ``metas`` entirely is either out of this run's
+    scope or gone from the warehouse, and ``observed_namespaces`` (the
+    schema/dataset prefixes this run's inventory actually saw, lowered) is
+    what tells the two apart: if the identifier's own namespace was never
+    observed, this run's inventory never looked there at all (a
+    ``--scope``/``--dataset`` narrower than what built the prior cache), so it
+    is carried forward untouched, rank score included, same as before (issue
+    #111) -- not stale, not superseded, not this run's to drop. If its
+    namespace WAS observed but the object itself is not in ``metas``, this
+    run did look and it is not there: dropped, not carried, so a deleted
+    relation cannot resurrect itself into the next baseline as a false
+    ``table_dropped`` (issue #149). ``observed_namespaces=None`` (no scope
+    information available) preserves the pre-#149 behavior of carrying
+    everything unexamined forward.
     """
 
     by_id = {d.identifier: d for d in profiled}
@@ -1811,12 +1862,17 @@ def _compose_datasets(
         datasets.append(ds)
 
     out_of_scope = 0
+    dropped: list[str] = []
     for identifier, previous in prior_by_id.items():
         if identifier in seen:
             continue
+        namespace = identifier.rpartition(".")[0].lower()
+        if observed_namespaces is not None and namespace in observed_namespaces:
+            dropped.append(identifier)
+            continue
         datasets.append(previous.model_copy(deep=True))
         out_of_scope += 1
-    return datasets, carried, out_of_scope
+    return datasets, carried, out_of_scope, dropped
 
 
 # Sentinel: preserve the prior cache's relationships (profile has no inference

--- a/packages/dex-core/src/exmergo_dex_core/explore/results.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/results.py
@@ -117,6 +117,7 @@ class MapResult(Result):
     skipped_count: int = 0
     carried_forward_count: int = 0
     out_of_scope_carried_count: int = 0
+    dropped_count: int = 0
     carried_relationship_count: int = 0
     relationship_count: int = 0
     pii_column_count: int = 0
@@ -133,6 +134,7 @@ class MapResult(Result):
             "skipped_count": self.skipped_count,
             "carried_forward_count": self.carried_forward_count,
             "out_of_scope_carried_count": self.out_of_scope_carried_count,
+            "dropped_count": self.dropped_count,
             "carried_relationship_count": self.carried_relationship_count,
             "relationship_count": self.relationship_count,
             "pii_column_count": self.pii_column_count,

--- a/packages/dex-core/tests/explore/test_explore.py
+++ b/packages/dex-core/tests/explore/test_explore.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 from exmergo_dex_core import envelope as env
-from exmergo_dex_core.cache import Dataset, DexCache
+from exmergo_dex_core.cache import Dataset, DexCache, Relationship
 from exmergo_dex_core.cli import main
 from exmergo_dex_core.config import DexConfig, save_config
 from exmergo_dex_core.explore.commands import _merged_hints
@@ -385,12 +385,13 @@ def test_compose_datasets_carries_forward_objects_outside_this_runs_scope():
     )
     # This run's inventory only saw the marts dataset (a narrower --scope).
     metas = [_stub_meta("db.marts.orders")]
-    datasets, carried, out_of_scope = _compose_datasets(metas, [], {}, prior)
+    datasets, carried, out_of_scope, dropped = _compose_datasets(metas, [], {}, prior)
 
     identifiers = {d.identifier for d in datasets}
     assert identifiers == {"db.shop.customers", "db.marts.orders"}
     assert carried == 1  # marts itself: in scope, not freshly profiled
     assert out_of_scope == 1  # customers: never even in this run's inventory
+    assert dropped == []
     carried_ds = next(d for d in datasets if d.identifier == "db.shop.customers")
     assert carried_ds.profiled_at == "2026-01-01T00:00:00+00:00"
     assert carried_ds.columns  # not degraded to an inventory-only stub
@@ -409,7 +410,7 @@ def test_compose_datasets_out_of_scope_dataset_keeps_its_own_rank_score():
     metas = [_stub_meta("db.marts.orders")]
     profiled = [_stub_dataset("db.marts.orders")]
 
-    datasets, _carried, out_of_scope = _compose_datasets(
+    datasets, _carried, out_of_scope, _dropped = _compose_datasets(
         metas, profiled, {"db.marts.orders": 0.5}, prior
     )
     assert out_of_scope == 1
@@ -421,10 +422,131 @@ def test_compose_datasets_without_a_prior_cache_reports_no_out_of_scope():
     from exmergo_dex_core.explore.commands import _compose_datasets
 
     metas = [_stub_meta("db.shop.customers")]
-    datasets, carried, out_of_scope = _compose_datasets(metas, [], {}, None)
+    datasets, carried, out_of_scope, dropped = _compose_datasets(metas, [], {}, None)
     assert [d.identifier for d in datasets] == ["db.shop.customers"]
     assert carried == 0
     assert out_of_scope == 0
+    assert dropped == []
+
+
+def test_compose_datasets_drops_object_gone_from_an_observed_namespace():
+    """#149: a prior dataset whose namespace this run's inventory DID look at,
+    but who is not itself in metas, is gone from the warehouse -- dropped, not
+    carried forward as a ghost that would later pin as a false table_dropped."""
+
+    from exmergo_dex_core.explore.commands import _compose_datasets
+
+    prior = DexCache(
+        datasets=[
+            _stub_dataset("db.marts.orders"),
+            _stub_dataset("db.marts.customers"),  # deleted from the warehouse
+        ]
+    )
+    # This run's inventory saw db.marts (orders survives), so the namespace
+    # was observed -- customers' absence is a deletion, not out of scope.
+    metas = [_stub_meta("db.marts.orders")]
+    datasets, _carried, out_of_scope, dropped = _compose_datasets(
+        metas, [], {}, prior, observed_namespaces={"db.marts"}
+    )
+
+    assert {d.identifier for d in datasets} == {"db.marts.orders"}
+    assert dropped == ["db.marts.customers"]
+    assert out_of_scope == 0
+
+
+def test_compose_datasets_still_carries_forward_a_truly_unscoped_namespace():
+    """The counterpart control: a prior dataset in a namespace this run's
+    inventory never touched at all stays carried forward untouched (issue
+    #111 preserved) even when observed_namespaces is passed."""
+
+    from exmergo_dex_core.explore.commands import _compose_datasets
+
+    prior = DexCache(datasets=[_stub_dataset("db.shop.customers")])
+    metas = [_stub_meta("db.marts.orders")]
+    datasets, _carried, out_of_scope, dropped = _compose_datasets(
+        metas, [], {}, prior, observed_namespaces={"db.marts"}
+    )
+
+    assert {d.identifier for d in datasets} == {
+        "db.marts.orders",
+        "db.shop.customers",
+    }
+    assert out_of_scope == 1
+    assert dropped == []
+
+
+def _stub_relationship(from_ds: str, to_ds: str) -> Relationship:
+    return Relationship(
+        from_dataset=from_ds, from_columns=["id"], to_dataset=to_ds, to_columns=["id"]
+    )
+
+
+def test_carry_forward_relationships_drops_edge_with_a_gone_endpoint():
+    """#149: an edge whose endpoint's namespace was observed this run but the
+    endpoint itself is gone from the warehouse must not resurrect either."""
+
+    from exmergo_dex_core.explore.commands import _carry_forward_relationships
+
+    prior = DexCache(
+        relationships=[_stub_relationship("db.marts.orders", "db.marts.customers")]
+    )
+    examined = {"db.marts.orders"}  # customers no longer profiled: it's gone
+    rels, carried = _carry_forward_relationships(
+        prior, examined, [], observed_namespaces={"db.marts"}
+    )
+    assert rels == []
+    assert carried == 0
+
+
+def test_map_drops_relation_deleted_from_the_warehouse_between_maps(
+    tmp_path: Path, capsys
+):
+    """#149: a relation dropped from the warehouse between two `explore map`
+    runs must not be resurrected as a carried-forward ghost -- that ghost is
+    what `maintain snapshot` would pin and `maintain check` would then report
+    as a false high-severity table_dropped for something the operator
+    deliberately removed."""
+
+    duckdb = pytest.importorskip("duckdb")
+    path = tmp_path / "warehouse.duckdb"
+    conn = duckdb.connect(str(path))
+    conn.execute("CREATE SCHEMA marts")
+    conn.execute("CREATE TABLE marts.orders (id INTEGER)")
+    conn.execute("CREATE TABLE marts.customers (id INTEGER)")
+    conn.close()
+
+    argv = ["explore", "map", "--path", str(path)]
+    _run(argv, capsys)
+
+    # The operator drops `customers` outside dex (a raw SQL statement,
+    # mirroring a dbt run-operation) -- `orders` in the same schema survives.
+    conn = duckdb.connect(str(path))
+    conn.execute("DROP TABLE marts.customers")
+    conn.close()
+
+    payload = _run(argv, capsys)
+    data = payload["data"]
+    assert data["dropped_count"] == 1
+    assert any("customers" in w for w in payload["warnings"])
+
+    cache = FilesystemStore(tmp_path).load_cache()
+    identifiers = {d.identifier for d in cache.datasets}
+    assert not any(i.endswith(".customers") for i in identifiers)
+    assert any(i.endswith(".orders") for i in identifiers)
+
+
+def test_carry_forward_relationships_still_carries_a_truly_unscoped_edge():
+    from exmergo_dex_core.explore.commands import _carry_forward_relationships
+
+    prior = DexCache(
+        relationships=[_stub_relationship("db.marts.orders", "db.shop.customers")]
+    )
+    examined = {"db.marts.orders"}
+    rels, carried = _carry_forward_relationships(
+        prior, examined, [], observed_namespaces={"db.marts"}
+    )
+    assert carried == 1
+    assert rels[0].to_dataset == "db.shop.customers"
 
 
 def test_map_reuses_fresh_cached_profiles(

--- a/packages/dex-core/tests/maintain/test_schema.py
+++ b/packages/dex-core/tests/maintain/test_schema.py
@@ -20,6 +20,29 @@ def test_clean_warehouse_reports_no_drift(maintain_repo):
     assert payload["data"]["axes_run"] == ["schema"]
 
 
+def test_dropped_relation_does_not_resurrect_as_a_false_table_dropped(maintain_repo):
+    """#149: explore map's carry-forward must not resurrect a relation
+    deleted from the warehouse; maintain snapshot then correctly excludes it
+    from the baseline too, so maintain check reports no false table_dropped
+    for something the operator deliberately removed (outside dex, mirroring
+    a dbt run-operation)."""
+
+    maintain_repo.snapshot()  # baseline: customers/orders/stg_orders all present
+
+    maintain_repo.sql("DROP TABLE customers")
+
+    # Re-map: the buggy carry-forward would resurrect `customers` here.
+    rc, payload = maintain_repo.dex("explore", "map")
+    assert rc == 0 and payload["status"] == "ok"
+    assert payload["data"]["dropped_count"] == 1
+
+    maintain_repo.snapshot()  # re-pin: must not include the resurrected ghost
+
+    _rc, payload = maintain_repo.dex("maintain", "schema")
+    by_code = _by_code(payload)
+    assert "table_dropped" not in by_code
+
+
 def test_schema_requires_a_snapshot(maintain_repo):
     rc, payload = maintain_repo.dex("maintain", "schema")
     assert rc == 1 and payload["status"] == "error"


### PR DESCRIPTION
Closes https://github.com/exmergo/dex/issues/149

Fixes explore map resurrecting a relation deleted from the warehouse via its carry-forward mechanism, which maintain snapshot then pins and maintain check reports as a false high-severity table_dropped.

Carry-forward's "not examined this run" test couldn't distinguish "outside --scope/--dataset" (issue #111, correct to carry forward) from "gone from the warehouse" (should be dropped, not resurrected)
Fix derives the schema/dataset namespaces this run's inventory actually observed; an unexamined prior identifier is only carried forward when its own namespace was never observed, and dropped when the namespace was observed but the object itself is missing
explore map's envelope now reports dropped_count and a warning naming what was dropped
explore relationships shares the same carry-forward function and gets the fix for free; explore profile is untouched (no full inventory scan, no reliable "observed" signal)
Now actively supports the orphan_relation (#146) remediation loop instead of undoing it: classify an orphan, drop it, re-map, and the re-map no longer resurrects what was just cleaned up
Known accepted gap: an entire schema emptied out (not just a few relations) still looks identical to "never in scope" and resurrects narrower than the reported repro, left for a future fix
Tests: 4 new unit tests (drop case + preserved-#111 control, at dataset and relationship level), 1 end-to-end explore map test, 1 full-loop regression proving no false table_dropped survives drop → remap → snapshot → check
CHANGELOG.md updated under [Unreleased] / Fixed
Before the fix : 
<img width="1542" height="337" alt="image" src="https://github.com/user-attachments/assets/8a1f7b9c-9e0d-401b-ae12-3f8065b29a6c" />
After the fix : 
<img width="1542" height="356" alt="image" src="https://github.com/user-attachments/assets/c18cf521-8803-4084-90df-28e93d6a3d95" />
