### PR TITLE
SCRUM-1024-A machine-readable `reason` on every error envelope, alongside `status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,45 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **A machine-readable `reason` on every error envelope, alongside `status`**
+  ([#170]). #155 gave every deliberate refusal a typed exception a library
+  consumer can catch, but a host driving the CLI still only ever saw
+  `status: error` and a prose string: `OverCeilingError` and a BigQuery
+  connection fault arrived in the identical shape. A host mapping the
+  envelope onto its own automation had to pattern-match error text to tell a
+  policy refusal from a transient fault, and got it wrong in the field: a
+  `connection refused` blip scored the same as a real policy violation and
+  was treated as a permanent stop rather than something to retry.
+
+  `reason` is one of seven values (`guard`, `prerequisite`, `connection`,
+  `configuration`, `request`, `execution_failure`, `internal`), derived
+  automatically from the caught exception's class, never invented per call
+  site: `guard` covers a cost/PII/firewall/safety policy declining
+  (`OverCeilingError`, `QueryRefusedError`, a production-target refusal);
+  `prerequisite` covers a named setup command that needs to run first, then
+  retry (`CacheRequiredError`, `NoBaselineError`, a missing optional extra);
+  `connection` covers an unreachable warehouse; `configuration` covers the
+  engine or repo being wired without something it needs; `request` covers
+  bad input to this specific call; `execution_failure` covers an operation
+  that ran (a `dbt build`) and failed partway; `internal` is reserved for
+  whatever is not a deliberate dex refusal at all. `reason` is `null` outside
+  `status: error`, same discipline as `cost.paradigm`'s null default (#162):
+  an envelope that was not a refusal makes no claim about why.
+
+  The prose messages are unchanged and stay the primary explanation for a
+  human; `reason` is an addition for a host that wants to branch on retry
+  semantics without regex-matching a string this project should stay free to
+  reword.
+
+  Classification itself is deliberately two-tiered: a small, always-available
+  set of families resolves without importing anything connector-specific,
+  and only a broader set (which pulls in sqlglot, scikit-learn, and the dbt
+  reader transitively) is attempted after. Reason: classifying a missing-extra
+  refusal is exactly the moment those imports are least likely to succeed,
+  and a `ModuleNotFoundError` while classifying an error must not crash the
+  process reporting it. A packaging test against a real isolated wheel
+  install with no connector extra pins this end to end.
+
 - **A project can declare a composite grain via `unique_combination_of_columns`**
   ([#169]). `DeclaredKey.column` was a single string, so a project could only
   ever declare that ONE column is unique, never that a table's real key is the

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -234,7 +234,7 @@ def dispatch(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     except DialectDependencyError as exc:
         # A missing extra, caught before the command imported anything that needed
         # it, so nothing has been opened or priced. The message names the install.
-        return env.error(str(exc))
+        return env.error_for(exc)
     except ConfirmationRequiredError as exc:
         return env.needs_confirmation(
             exc.request.data, cost=exc.request.cost, warnings=exc.request.warnings
@@ -242,7 +242,8 @@ def dispatch(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     except BudgetExhaustedError as exc:
         # Partial completion: an error, but one that reports what the attempt
         # actually cost, because that is what a caller needs to size the re-run.
-        return env.error(
+        return env.error_for(
+            exc,
             env.redact(str(exc)),
             data={"spend": exc.spend} if exc.spend else {},
             cost=exc.cost or env.Cost(),
@@ -255,7 +256,7 @@ def dispatch(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
         # catch-all for the reason this function exists: a refusal that escapes
         # arrives with no cost at all, and an empty cost block on a spend
         # refusal reads as a claim that nothing was going to be spent.
-        return env.error(env.redact(str(exc)), cost=exc.cost or env.Cost())
+        return env.error_for(exc, env.redact(str(exc)), cost=exc.cost or env.Cost())
 
 
 def _run(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
@@ -383,7 +384,7 @@ def main(argv: list[str] | None = None) -> int:
         # has to decide whether to retry.
         if paradigm is None and getattr(args, "connector", None):
             paradigm = paradigm_for(args.connector)
-        envelope = env.error(env.redact(str(exc)))
+        envelope = env.error_for(exc, env.redact(str(exc)))
 
     # Every command runs against a connector or against none, so every envelope
     # can name the paradigm a later billed command would spend in. Filled only

--- a/packages/dex-core/src/exmergo_dex_core/envelope.py
+++ b/packages/dex-core/src/exmergo_dex_core/envelope.py
@@ -72,6 +72,27 @@ class Cost(BaseModel):
     ceiling: float | None = None
 
 
+class Reason(str, Enum):
+    """Why an error envelope was refused, coarse enough for a host to branch
+    on retry/setup/stop without parsing prose. Derived from the exception's
+    class (see :func:`reason_for`), never invented per call site, so it stays
+    consistent with every refusal's typed exception as new ones are added.
+    Populated only when ``status`` is ``error``.
+    """
+
+    GUARD = "guard"  # a cost/PII/firewall/safety policy said no
+    PREREQUISITE = "prerequisite"  # run a named setup command first, then retry
+    CONNECTION = "connection"  # the warehouse/backend could not be reached
+    CONFIGURATION = (
+        "configuration"  # the engine/repo is wired without something it needs
+    )
+    REQUEST = "request"  # this call's input cannot be resolved or used
+    EXECUTION_FAILURE = (
+        "execution_failure"  # the operation ran (e.g. dbt build) and failed
+    )
+    INTERNAL = "internal"  # unclassified: not a deliberate dex refusal
+
+
 class Envelope(BaseModel):
     """The single object every command prints to stdout."""
 
@@ -82,6 +103,7 @@ class Envelope(BaseModel):
     # Reviewable diffs (propose-don't-impose). Nothing is applied just by being here.
     diffs: list[dict[str, Any]] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
+    reason: Reason | None = None
 
 
 # Keys whose presence anywhere in ``data`` indicates a credential or secret has
@@ -179,6 +201,143 @@ def not_implemented(command: str) -> Envelope:
 
 def error(message: str, **kwargs: Any) -> Envelope:
     return Envelope(status=Status.ERROR, errors=[message], **kwargs)
+
+
+_reason_overrides_cache: list[tuple[type[BaseException], Reason]] | None = None
+
+
+def _reason_overrides() -> list[tuple[type[BaseException], Reason]]:
+    """Built on first use, not at import time: the exception classes it
+    references live in modules that already import this one at their own top
+    level (``explore/commands.py``, ``transform/commands.py``,
+    ``transform/build.py``, ``connect.py``, ``guards/cost_guard.py``), so
+    importing them here at module load would be circular. By the time any
+    error envelope is built, every module is already loaded, so a call-time
+    import (the same lazy-import pattern ``cli.py``'s own ``_run`` already
+    uses for command modules) is safe. Cached after the first call so the
+    import cost is paid once, not on every error envelope.
+
+    Two tiers, not one: a handful of exception families live in modules with
+    no optional-dependency imports of their own and are always available; the
+    rest live behind connector extras (sqlglot, scikit-learn, the dbt reader)
+    that a bare or partial install may not have -- and importing THOSE must
+    not itself crash the very refusal (a missing extra) that names the gap.
+    """
+
+    global _reason_overrides_cache
+    if _reason_overrides_cache is not None:
+        return _reason_overrides_cache
+
+    # Always safe: no imports of their own (`errors.py`) or explicitly
+    # designed to import without the dialect engine (`guards/dialect.py` is
+    # the module that checks whether sqlglot is even installed).
+    from .errors import (
+        ConfigurationError,
+        ConnectorError,
+        DexError,
+        PrerequisiteError,
+        RequestError,
+    )
+    from .guards.dialect import DialectDependencyError
+
+    overrides: list[tuple[type[BaseException], Reason]] = [
+        (DialectDependencyError, Reason.PREREQUISITE),
+        (PrerequisiteError, Reason.PREREQUISITE),  # CacheRequiredError, NoBaselineError
+        (ConnectorError, Reason.CONNECTION),  # every *ConnectionError subclass
+        (ConfigurationError, Reason.CONFIGURATION),
+        (RequestError, Reason.REQUEST),
+        (DexError, Reason.REQUEST),  # generic fallback for any other deliberate refusal
+        (ValueError, Reason.REQUEST),  # the pre-typed-error convention: bad input
+    ]
+
+    # Everything else pulls in a connector extra transitively (sqlglot,
+    # scikit-learn, the dbt reader chain) that a bare or partial install may
+    # not have -- and a missing-extra refusal (DialectDependencyError,
+    # ClusterDependencyError) is exactly the scenario where that extra is
+    # absent. A ModuleNotFoundError here must not crash the one command
+    # reporting exactly that, so a failed optional import just keeps the
+    # safe subset above (an unlisted subclass still resolves through
+    # `DexError`/`ValueError`) instead of propagating.
+    try:
+        from .connect import CredentialDiscoveryError
+        from .dbt_project import DbtProjectError
+        from .explore.cluster import ClusterDependencyError, ClusterError
+        from .explore.semantic import SemanticBackendError, SemanticQueryRefusedError
+        from .guards.cost_guard import CostGuardError
+        from .guards.query_firewall import QueryRefusedError
+        from .guards.sql_guard import NotSelectOnlyError
+        from .results import BudgetExhaustedError
+        from .transform.build import DbtRunError, ProdTargetRefusedError
+        from .transform.commands import BuildFailedError, DbtParseError
+        from .transform.plans import PlanError
+        from .transform.scaffold import ScaffoldError
+        from .transform.validate import EditValidationError
+    except ImportError:
+        _reason_overrides_cache = overrides
+        return overrides
+
+    # Most-specific-first: a subclass here overrides its parent's bucket.
+    # Anything not listed falls through to the nearest listed ancestor via
+    # isinstance, so a new DexError subclass only needs an entry when its own
+    # reason diverges from its parent's.
+    _reason_overrides_cache = [
+        (SemanticQueryRefusedError, Reason.GUARD),  # policy, not backend failure
+        (ClusterDependencyError, Reason.PREREQUISITE),  # install the extra, retry
+        (DialectDependencyError, Reason.PREREQUISITE),
+        (PrerequisiteError, Reason.PREREQUISITE),
+        (CostGuardError, Reason.GUARD),  # OverCeilingError, CeilingRequiredError
+        (BudgetExhaustedError, Reason.GUARD),
+        (QueryRefusedError, Reason.GUARD),
+        (NotSelectOnlyError, Reason.GUARD),
+        (ProdTargetRefusedError, Reason.GUARD),
+        (ConnectorError, Reason.CONNECTION),
+        (CredentialDiscoveryError, Reason.CONFIGURATION),  # will not appear on a retry
+        (ConfigurationError, Reason.CONFIGURATION),
+        (DbtProjectError, Reason.CONFIGURATION),
+        (SemanticBackendError, Reason.CONFIGURATION),  # after SemanticQueryRefusedError
+        (BuildFailedError, Reason.EXECUTION_FAILURE),
+        (DbtRunError, Reason.EXECUTION_FAILURE),
+        (RequestError, Reason.REQUEST),
+        (DbtParseError, Reason.REQUEST),
+        (PlanError, Reason.REQUEST),  # PlanNotFoundError
+        (ScaffoldError, Reason.REQUEST),
+        (EditValidationError, Reason.REQUEST),
+        (ClusterError, Reason.REQUEST),  # after ClusterDependencyError
+        (DexError, Reason.REQUEST),
+        (ValueError, Reason.REQUEST),
+    ]
+    return _reason_overrides_cache
+
+
+def reason_for(exc: BaseException) -> Reason:
+    """Classify why a caught exception refused, from its class alone.
+
+    Fails toward the informative: an unrecognized ``DexError`` subclass or a
+    bare ``ValueError`` still reads as ``REQUEST`` (a deliberate refusal, bad
+    input assumed) rather than ``INTERNAL``, which is reserved for exceptions
+    that are not a deliberate dex refusal at all.
+    """
+
+    for exc_type, reason in _reason_overrides():
+        if isinstance(exc, exc_type):
+            return reason
+    return Reason.INTERNAL
+
+
+def error_for(
+    exc: BaseException, message: str | None = None, **kwargs: Any
+) -> Envelope:
+    """Build an error envelope from a caught exception: ``errors`` defaults to
+    ``str(exc)`` (override via ``message`` for call sites that add context or
+    redact), and ``reason`` is derived automatically via :func:`reason_for`.
+    """
+
+    return Envelope(
+        status=Status.ERROR,
+        errors=[message if message is not None else str(exc)],
+        reason=reason_for(exc),
+        **kwargs,
+    )
 
 
 def needs_confirmation(

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -731,7 +731,7 @@ def cmd_query(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     try:
         return to_envelope(query(engine, args.sql))
     except QueryRefusedError as exc:
-        return env.error(f"query refused: {exc}")
+        return env.error_for(exc, f"query refused: {exc}")
 
 
 def map(
@@ -1204,7 +1204,7 @@ def cmd_cluster(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
         cluster_mod.ClusterError,
         cluster_mod.ClusterDependencyError,
     ) as exc:
-        return env.error(str(exc))
+        return env.error_for(exc)
 
 
 # --- helpers -----------------------------------------------------------------

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/commands.py
@@ -106,4 +106,4 @@ def cmd_semantic(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
             )
         )
     except SemanticBackendError as exc:
-        return env.error(str(exc))
+        return env.error_for(exc)

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -560,7 +560,7 @@ def cmd_reconcile(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     try:
         result = reconcile(engine, drift_class)
     except (NoBaselineError, DbtProjectError) as exc:
-        return env.error(str(exc))
+        return env.error_for(exc)
     if not result.proposals:
         scope = f" for the '{drift_class}' axis" if drift_class else ""
         return to_envelope(result, hints={"hint": f"no drift{scope} to reconcile"})

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -158,7 +158,7 @@ def cmd_init(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
             layered_schemas=bool(getattr(args, "layered_schemas", False)),
         )
     except ValueError as exc:
-        return env.error(str(exc))
+        return env.error_for(exc)
     return to_envelope(
         result,
         hints={
@@ -242,9 +242,9 @@ def cmd_plan(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
         )
         return to_envelope(result, hints=_plan_hint(result))
     except DbtParseError as exc:
-        return env.error(str(exc), warnings=exc.warnings)
+        return env.error_for(exc, warnings=exc.warnings)
     except ValueError as exc:
-        return env.error(str(exc))
+        return env.error_for(exc)
 
 
 def macro(engine: DexEngine, name: str | None = None) -> MacroListResult | MacroResult:
@@ -304,7 +304,7 @@ def cmd_macro(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     try:
         result = macro(engine, getattr(args, "argument", None))
     except DbtParseError as exc:
-        return env.error(str(exc), warnings=exc.warnings)
+        return env.error_for(exc, warnings=exc.warnings)
     if isinstance(result, MacroListResult):
         return to_envelope(
             result, hints={"next": "scaffold one with `transform macro <name>`"}
@@ -371,7 +371,7 @@ def cmd_apply(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     try:
         return to_envelope(apply(engine, getattr(args, "argument", None)))
     except ValueError as exc:
-        return env.error(str(exc))
+        return env.error_for(exc)
 
 
 def plans(engine: DexEngine) -> PlanListResult:
@@ -535,8 +535,8 @@ def cmd_build(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
         data = exc.result.data()
         if exc.result.spend is not None:
             data["spend"] = exc.result.spend
-        return env.error(
-            str(exc),
+        return env.error_for(
+            exc,
             data=data,
             cost=exc.result.cost,
             warnings=exc.result.warnings,
@@ -575,7 +575,7 @@ def cmd_deps(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     try:
         return to_envelope(deps(engine))
     except BuildFailedError as exc:
-        return env.error(str(exc), data=exc.result.data(), warnings=exc.result.warnings)
+        return env.error_for(exc, data=exc.result.data(), warnings=exc.result.warnings)
 
 
 def semantic_define(
@@ -647,9 +647,9 @@ def _semantic_envelope(
             no_parse=bool(getattr(args, "no_parse", False)),
         )
     except DbtParseError as exc:
-        return env.error(str(exc), warnings=exc.warnings)
+        return env.error_for(exc, warnings=exc.warnings)
     except ValueError as exc:
-        return env.error(str(exc))
+        return env.error_for(exc)
     return to_envelope(result, hints=_plan_hint(result))
 
 

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -17,7 +17,7 @@ from exmergo_dex_core.adapters.bigquery import BigQueryAdapter
 from exmergo_dex_core.cache import ColumnProfile, Dataset, DexCache, PIIFlag
 from exmergo_dex_core.config import BigQueryTarget, DexConfig
 from exmergo_dex_core.engine import DexEngine
-from exmergo_dex_core.envelope import Paradigm
+from exmergo_dex_core.envelope import Paradigm, Reason
 from exmergo_dex_core.explore import commands as explore_cmds
 from exmergo_dex_core.guards.cost_guard import CostGate
 from exmergo_dex_core.storage import FilesystemStore
@@ -704,6 +704,8 @@ def test_over_ceiling_refusal_reports_the_metered_paradigm(
     assert envelope.cost.ceiling == MB
     assert "exceeds the ceiling" in envelope.errors[0]
     assert all(c.dry_run for c in fake_bq_client.query_calls)
+    # #170: a machine-readable reason alongside the prose.
+    assert envelope.reason is Reason.GUARD
 
 
 def test_no_ceiling_refusal_reports_the_metered_paradigm(
@@ -719,6 +721,8 @@ def test_no_ceiling_refusal_reports_the_metered_paradigm(
     assert envelope.cost.paradigm is Paradigm.BYTES_SCANNED
     assert envelope.cost.ceiling is None
     assert "no ceiling set" in envelope.errors[0]
+    # #170: a machine-readable reason alongside the prose.
+    assert envelope.reason is Reason.GUARD
 
 
 def test_budget_exhaustion_carries_both_the_ceiling_and_the_spend(

--- a/packages/dex-core/tests/explore/test_cluster.py
+++ b/packages/dex-core/tests/explore/test_cluster.py
@@ -166,6 +166,8 @@ def test_cluster_without_cache_is_refused_with_the_fix(
     payload = _cluster(clusterable_duckdb, repo, capsys=capsys, expect_error=True)
     assert "explore map" in payload["errors"][0]
     assert not (repo / ".dex").exists(), "a refused gate writes nothing"
+    # #170: a machine-readable reason alongside the prose.
+    assert payload["reason"] == "prerequisite"
 
 
 def test_missing_cluster_extra_is_a_clean_error(

--- a/packages/dex-core/tests/maintain/test_check.py
+++ b/packages/dex-core/tests/maintain/test_check.py
@@ -11,6 +11,8 @@ def test_check_requires_a_snapshot(maintain_repo):
     rc, payload = maintain_repo.dex("maintain", "check")
     assert rc == 1 and payload["status"] == "error"
     assert "maintain snapshot" in payload["errors"][0]
+    # #170: a machine-readable reason alongside the prose.
+    assert payload["reason"] == "prerequisite"
 
 
 def test_clean_world_reports_every_axis_clean(maintain_repo):

--- a/packages/dex-core/tests/test_cli_contract.py
+++ b/packages/dex-core/tests/test_cli_contract.py
@@ -50,7 +50,15 @@ def test_every_command_emits_one_valid_envelope(argv, capsys):
     assert out.count("\n") == 1, "exactly one line on stdout"
     payload = json.loads(out)
     assert payload["status"] in _VALID_STATUSES
-    assert set(payload) == {"status", "data", "cost", "warnings", "diffs", "errors"}
+    assert set(payload) == {
+        "status",
+        "data",
+        "cost",
+        "warnings",
+        "diffs",
+        "errors",
+        "reason",
+    }
     assert rc in (0, 1)
 
 

--- a/packages/dex-core/tests/test_envelope.py
+++ b/packages/dex-core/tests/test_envelope.py
@@ -100,3 +100,83 @@ def test_emit_writes_single_json_line(capsys):
 
 def test_redact_masks_dsn_password():
     assert "hunter2" not in env.redact("postgres://user:hunter2@host:5432/db")
+
+
+# --- reason_for / error_for: a machine-readable refusal reason (#170) --------
+
+
+def test_reason_for_classifies_representative_families():
+    from exmergo_dex_core.dbt_project import DbtProjectError
+    from exmergo_dex_core.errors import ConnectorError, RequestError
+    from exmergo_dex_core.guards.cost_guard import OverCeilingError
+    from exmergo_dex_core.maintain.commands import NoBaselineError
+
+    assert env.reason_for(OverCeilingError("x")) is env.Reason.GUARD
+    assert env.reason_for(NoBaselineError("x")) is env.Reason.PREREQUISITE
+    assert env.reason_for(ConnectorError("x")) is env.Reason.CONNECTION
+    assert env.reason_for(DbtProjectError("x")) is env.Reason.CONFIGURATION
+    assert env.reason_for(RequestError("x")) is env.Reason.REQUEST
+    assert env.reason_for(ValueError("x")) is env.Reason.REQUEST
+    assert env.reason_for(RuntimeError("x")) is env.Reason.INTERNAL
+
+
+def test_reason_for_execution_failure():
+    from exmergo_dex_core.transform.build import DbtRunError
+
+    assert (
+        env.reason_for(DbtRunError("dbt build failed")) is env.Reason.EXECUTION_FAILURE
+    )
+
+
+def test_reason_for_subclass_precedence():
+    """A more specific bucket must win over its parent's default, proving the
+    override ordering (not just isinstance against the wrong ancestor)."""
+
+    from exmergo_dex_core.explore.cluster import ClusterDependencyError, ClusterError
+    from exmergo_dex_core.explore.semantic import (
+        SemanticBackendError,
+        SemanticQueryRefusedError,
+    )
+
+    # SemanticQueryRefusedError IS-A SemanticBackendError, but is policy
+    # (GUARD), not a backend failure (CONFIGURATION, its parent's bucket).
+    assert env.reason_for(SemanticQueryRefusedError("x")) is env.Reason.GUARD
+    assert env.reason_for(SemanticBackendError("x")) is env.Reason.CONFIGURATION
+
+    # ClusterDependencyError IS-A ClusterError, but a missing extra is a setup
+    # step (PREREQUISITE), not the bare-input REQUEST its parent defaults to.
+    assert env.reason_for(ClusterDependencyError("x")) is env.Reason.PREREQUISITE
+    assert env.reason_for(ClusterError("x")) is env.Reason.REQUEST
+
+
+def test_error_for_defaults_message_to_str_and_derives_reason():
+    from exmergo_dex_core.errors import RequestError
+
+    envelope = env.error_for(RequestError("bad thing"))
+    assert envelope.status is env.Status.ERROR
+    assert envelope.errors == ["bad thing"]
+    assert envelope.reason is env.Reason.REQUEST
+
+
+def test_error_for_message_override():
+    from exmergo_dex_core.guards.query_firewall import QueryRefusedError
+
+    exc = QueryRefusedError("nope")
+    envelope = env.error_for(exc, f"query refused: {exc}")
+    assert envelope.errors == ["query refused: nope"]
+    assert envelope.reason is env.Reason.GUARD
+
+
+def test_error_for_passes_through_kwargs():
+    from exmergo_dex_core.errors import RequestError
+
+    envelope = env.error_for(
+        RequestError("x"), cost=env.Cost(paradigm=env.Paradigm.BYTES_SCANNED)
+    )
+    assert envelope.cost.paradigm is env.Paradigm.BYTES_SCANNED
+
+
+def test_reason_is_none_outside_error_status():
+    assert env.ok().reason is None
+    assert env.needs_confirmation().reason is None
+    assert env.not_implemented("x").reason is None

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -182,6 +182,11 @@ def test_an_install_that_cannot_parse_sql_refuses_and_names_the_fix(wheel: str):
     assert "No module named" not in message, (
         f"the refusal must name the extra, not the missing module: {message}"
     )
+    # #170: classifying *why* the refusal happened must not itself import
+    # something this bare install lacks (a prior bug: reason_for's own
+    # lazy imports of connector-extra-dependent modules crashed the process
+    # instead of degrading, so the envelope above never got printed at all).
+    assert envelope["reason"] == "prerequisite", envelope
 
     # And the guard is reached before anything is opened or priced, so asking is
     # free: `ensure_available` must not need the thing whose absence it reports.


### PR DESCRIPTION
Closes https://github.com/exmergo/dex/issues/170
Adds a closed Reason enum (guard, prerequisite, connection, configuration, request, execution_failure, internal) and a reason field on Envelope, populated only when status == "error".
reason_for(exc) classifies via isinstance against #155's existing exception hierarchy (most-specific-first); error_for(exc, message=None, **kwargs) is the new envelope constructor wired into all 17 existing env.error(...) call sites across cli.py, explore/commands.py, explore/semantic/commands.py, maintain/commands.py, and transform/commands.py.
Classification is two-tiered: a small always-safe set (from errors.py and guards/dialect.py, both import-light) resolves first, then a broader set that pulls in sqlglot/scikit-learn/dbt is attempted behind a try/except ImportError — so classifying a missing-extra refusal can't itself crash the process on that same missing extra. Caught by the project's own isolated-wheel packaging test.
Prose error messages are unchanged; reason is additive, for hosts that want to branch on retry/setup/stop semantics without parsing strings.
BEFORE the fix : 
<img width="1536" height="272" alt="image" src="https://github.com/user-attachments/assets/90848e94-d40d-422b-8c7f-51b82427192a" />
AFTER fixing : 
<img width="1526" height="272" alt="image" src="https://github.com/user-attachments/assets/e66c4f95-abf3-4e5a-b9b4-7bc2b7c70ae0" />
