### PR TITLE
`SpendLock` for concurrent cost guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,12 @@ them.
    handshake and instead states, explicitly and on every result, that the cost
    guard is unavailable and spend is governed by the dbt Cloud environment, not
    by dex. The local backend (`--local`) executes through dex's own connector and
-   keeps the full cost-before-spend handshake.
+   keeps the full cost-before-spend handshake. `budget.session_ceiling` binds
+   across commands that overlap in time as well as across commands that follow
+   one another: an admitted command books its estimate against the day's
+   headroom before it runs, so issuing several billed commands at once cannot
+   spend the same budget twice. If a cache backend cannot serialize that, every
+   billed command says so.
 5. Nothing reaches agent context except through the sanitized envelope.
    Credentials never; data values only from profiled, PII-cleared columns,
    bounded and capped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,87 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`budget.session_ceiling` now binds under concurrency** ([#159]). The cost
+  gate read the day's spend once, when it was built, and every ceiling decision
+  for the life of that gate derived from that one reading. Two billed commands
+  overlapping in time were therefore admitted against the same headroom. Nothing
+  looked wrong afterwards: every ledger entry was well-formed and true, and only
+  the aggregate was over budget.
+
+  Re-verified live at 1.5.0 on BigQuery before this was scoped. A sequential
+  pair refused exactly as designed; the same pair issued concurrently both ran,
+  and the ledger finished **15.3% over** a seeded `session_ceiling`. Two further
+  findings came out of that run. Inspecting the executed jobs showed the
+  **server-side backstop was raced too**: each command's first statement carried
+  the whole daily ceiling as its `maximum_bytes_billed`, so the warehouse-side
+  bound on the pair was twice the ceiling. And `data.spend.session_spent_today`
+  **under-reported**, because each command added its own spend to a stale
+  reading, so two concurrent commands reporting 25.2 MB and 21.0 MB had in fact
+  spent 46.1 MB between them.
+
+  The fix is not a fresher read, which is the shape the defect first suggests: a
+  read followed by a decision leaves a window in which two commands read the
+  same number and both decide yes, however recent the number is. An admitted
+  command now **books its estimate against the day's headroom before it runs**
+  and releases the unspent part when it settles, both inside a lock the store
+  provides. A refusal books nothing, so the unconfirmed handshake that begins
+  every billed command stays a pure read. `transform build` reserves too, which
+  matters most there: dbt executes the statements, so nothing reached the ledger
+  until the run finished and a build's headroom looked free for as long as it
+  ran.
+
+  The server-side cap is bounded by the booking as well as by the ceiling, which
+  is what closes the warehouse-side half. Two commands admitted together now
+  carry caps that sum to at most the ceiling, verified on the live jobs, where
+  before both carried the whole of it. A command whose estimate drifts past what
+  it booked is re-admitted against a live reading rather than spending into
+  headroom another command holds, so drift is still allowed to use budget that
+  is genuinely free and no longer able to use budget that is not.
+
+  Ledger entries gain an `entry` kind (`reservation`, `settlement`, `release`)
+  and a `reservation_id`. A release is negative, so **a day that has finished
+  sums to actual spend exactly as before**, and no consumer summing settled
+  spend sees a different number; a day with commands still running sums to
+  actual spend plus the headroom they hold, which is the number a concurrent
+  command has to see. `spend_since` is unchanged, so every storage backend
+  written before this keeps working untouched.
+
+  A process killed outright cannot release, and its reservation then stands
+  until the UTC rollover. That is deliberate and it is the safe direction for a
+  spend guard. Every softer exit releases: the settlement funnel, the engine
+  rebuilding a gate, and engine shutdown, which the CLI calls from a `finally`.
+
+### Added
+
+- **`SpendLock`, an optional storage capability** ([#159]). A store that
+  implements `spend_lock` lets dex make the spend admission atomic. Both shipped
+  backends implement it, so the CLI and the default library path are safe by
+  default rather than safe by documentation: the filesystem backend takes an
+  advisory lock on `.dex/spend.lock` (plus a per-path in-process lock, since a
+  POSIX lock belongs to the open file description and would not keep two threads
+  apart), and the memory backend takes a re-entrant lock.
+
+  It sits beside the tiers rather than inside them, and a backend without one
+  still runs: dex reserves regardless, which narrows the race from the duration
+  of a warehouse query to the microseconds around the ledger read, and **every
+  billed command warns that the cumulative ceiling is advisory on that
+  backend**. A warning rather than a refusal, matching the call already made for
+  a `session_ceiling` nobody set.
+
+  This reverses a decision recorded on the protocol, which said it would not
+  grow a member for atomicity because an optional member no implementer can rely
+  on is worse than a stated bound. That holds for a member dex would use
+  silently; it does not hold for one dex detects and reports, because a caller
+  is then never told a ceiling bound when it did not.
+
+  `SpendLockContract` ships in the conformance suite alongside the tier
+  contracts. It checks that the lock excludes, that it is re-entrant for one
+  holder, and that it is scoped to the ledger rather than to the backend, the
+  last being the failure a single-tenant test cannot see: a global mutex passes
+  the first two and serializes every tenant in a deployment.
+
 ## [1.5.0] - 2026-08-01
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,6 +250,13 @@ reset hook to keep one assertion's writes out of the next.
 `references/storage.md` covers the tiers, the contracts that are not obvious from
 the signatures, and which calls need nothing on the filesystem.
 
+If your backend can be reached by more than one command at a time, also
+implement `spend_lock` and mix in `SpendLockContract`. It is the one optional
+capability whose absence costs correctness: without it two overlapping billed
+commands are admitted against the same headroom and `budget.session_ceiling`
+does not bind. dex says so on every billed result rather than assuming it, so a
+backend without one is honest rather than silently broken.
+
 Backends contributed here run the same suite: see
 `packages/dex-core/tests/storage/test_parity.py`, which is deliberately the same
 three lines a third party writes.

--- a/packages/dex-core/src/exmergo_dex_core/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/__init__.py
@@ -94,6 +94,8 @@ _EXPORTS = {
     "SemanticQueryRefusedError": "explore.semantic",
     "SemanticSource": "connect",
     "Snapshot": "maintain.snapshot",
+    "SpendLock": "storage",
+    "SpendLockTimeoutError": "guards.cost_guard",
     "Store": "storage",
     "StoreContext": "storage",
     "StoreFactory": "storage",
@@ -133,6 +135,7 @@ if TYPE_CHECKING:  # what a type checker and an IDE see; never run
         ConfirmationRequiredError,
         CostGuardError,
         OverCeilingError,
+        SpendLockTimeoutError,
     )
     from .guards.dialect import DialectDependencyError
     from .guards.query_firewall import QueryRefusedError
@@ -150,6 +153,7 @@ if TYPE_CHECKING:  # what a type checker and an IDE see; never run
         FilesystemStore,
         MaintainStore,
         MemoryStore,
+        SpendLock,
         Store,
         StoreContext,
         StoreFactory,
@@ -208,6 +212,8 @@ __all__ = [
     "SemanticQueryRefusedError",
     "SemanticSource",
     "Snapshot",
+    "SpendLock",
+    "SpendLockTimeoutError",
     "Store",
     "StoreContext",
     "StoreFactory",

--- a/packages/dex-core/src/exmergo_dex_core/command_args.py
+++ b/packages/dex-core/src/exmergo_dex_core/command_args.py
@@ -255,10 +255,17 @@ def stamp_spend(result: Result, adapter: Adapter) -> Result:
     result already carrying a cost (a phase checkpoint priced its own ask) keeps
     it; only the spend summary is refreshed. Free connectors have no gate and so
     report no spend at all, rather than a row of zeroes.
+
+    This is the settlement funnel for every billed command that returns a
+    result, so it is where the gate releases the headroom it booked to be
+    admitted. Settling before reading the summary is what makes
+    ``session_spent_today`` the day's total rather than this command's share of
+    it.
     """
 
     gate = cost_gate(adapter)
     if gate is not None:
+        gate.settle()
         if result.cost.estimate is None:
             result.cost = gate.cost()
         spend = gate.spend_summary()

--- a/packages/dex-core/src/exmergo_dex_core/connect.py
+++ b/packages/dex-core/src/exmergo_dex_core/connect.py
@@ -222,20 +222,29 @@ def new_cost_gate(
 
     Kept here, alongside credential discovery, on purpose: a host that supplies
     its own connection must never be the thing that supplies the guard.
+
+    The day's spend is passed as a reader rather than a number, so the gate
+    re-reads it when it admits work instead of deciding the whole command from
+    one reading taken here. The lock comes from the store when the store has
+    one; without it the gate still reserves and says on every billed result that
+    the cumulative ceiling is advisory.
     """
 
     paradigm = paradigm_for(connector)
+    field = ledger_field(paradigm)
+    lock = getattr(store, "spend_lock", None)
     return CostGate(
         paradigm=paradigm,
         ceiling=budget if budget is not None else config.budget.ceiling,
         session_ceiling=config.budget.session_ceiling,
-        session_spent=store.spend_since(
-            utc_day_start(), field=ledger_field(paradigm), connector=connector
+        session_spent=lambda: store.spend_since(
+            utc_day_start(), field=field, connector=connector
         ),
         confirmed=confirmed,
         connector=connector,
         command=command,
         record=store.append_spend_log,
+        lock=lock if callable(lock) else None,
     )
 
 

--- a/packages/dex-core/src/exmergo_dex_core/engine.py
+++ b/packages/dex-core/src/exmergo_dex_core/engine.py
@@ -248,6 +248,11 @@ class DexEngine:
         a second one to replace it would re-read the whole spend ledger for the
         same answer, and the CLI's one-command-per-process shape means that
         wasted read would land on every single invocation.
+
+        A rebuild settles the outgoing gate first. It has normally settled
+        itself already, on its own way out; this covers the command that raised
+        past that point, so the headroom it booked is released by the next
+        command rather than held until the UTC rollover.
         """
 
         budget = self.budget if budget is None else budget
@@ -271,7 +276,9 @@ class DexEngine:
             return self._adapter_instance
 
         adapter = self._adapter_instance
-        if command_args.cost_gate(adapter) is not None:
+        outgoing = command_args.cost_gate(adapter)
+        if outgoing is not None:
+            outgoing.settle()
             adapter.cost_gate = connect.new_cost_gate(
                 adapter.name,
                 self.config,
@@ -630,11 +637,25 @@ class DexEngine:
     # --- lifecycle ------------------------------------------------------------
 
     def close(self) -> None:
-        """Close the held connection. Idempotent."""
+        """Close the held connection, releasing any held spend headroom first.
+
+        Idempotent. The CLI closes from a ``finally``, so this is the funnel that
+        catches a command interrupted partway: without it, a gate that had been
+        admitted but never settled would hold its estimate against the day's
+        cumulative ceiling until the UTC rollover. Releasing must not be able to
+        stop the connection closing, so a store that cannot be reached at this
+        point loses the release rather than leaking the connection.
+        """
 
         adapter = self._adapter_instance
         self._adapter_instance = None
-        if adapter is not None:
+        if adapter is None:
+            return
+        gate = command_args.cost_gate(adapter)
+        try:
+            if gate is not None:
+                gate.settle()
+        finally:
             adapter.close()
 
     def __enter__(self) -> DexEngine:

--- a/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
@@ -15,12 +15,22 @@ numeric budget is optional, but the confirm handshake still runs so the gating
 path is exercised on every connector. Billed paradigms require both a ceiling and
 confirmation. DuckDB resource bounds (memory, threads, read-only) are enforced by
 the adapter, not here.
+
+**The cumulative ceiling is settled against the ledger, so admitting a command
+has to be atomic with booking its headroom.** Reading the day's spend and then
+deciding leaves a window in which a second command reads the same number and
+decides the same way, and both are then legal individually and wrong together.
+So an admitted command writes a reservation at its estimate before it runs and
+releases it when it settles, both under the store's spend lock. See
+:meth:`CostGate.settle` for what an interrupted command leaves behind.
 """
 
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Callable
+import uuid
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager, nullcontext
 from datetime import UTC, datetime
 
 from ..envelope import Cost, Paradigm
@@ -49,6 +59,16 @@ class OverCeilingError(CostGuardError):
 
 class CeilingRequiredError(CostGuardError):
     """A billed paradigm was invoked with no ceiling; nothing runs without one."""
+
+
+class SpendLockTimeoutError(CostGuardError):
+    """The spend-admission lock could not be taken, so nothing was admitted.
+
+    A refusal rather than a proceed-anyway, because the lock is the thing that
+    makes the cumulative ceiling bind: running without it is the defect this
+    guard exists to close. It is also the recoverable kind of refusal, since
+    whatever holds the lock is a billed command that will finish.
+    """
 
 
 class ConfirmationRequiredError(CostGuardError):
@@ -155,6 +175,38 @@ def no_session_ceiling_warning(
     ]
 
 
+def unserialized_ledger_warning(
+    paradigm: Paradigm, session_ceiling: float | None, serialized: bool
+) -> list[str]:
+    """The warning a billed command carries when its store cannot serialize the
+    spend admission.
+
+    Only when a cumulative ceiling is actually set: with none, there is nothing
+    for the lock to protect and :func:`no_session_ceiling_warning` is already
+    saying the more useful thing. Both shipped backends implement the lock, so
+    this is silent unless a host selected a backend of its own.
+
+    A warning rather than a refusal, which is the same call made for an unset
+    cumulative ceiling: refusing would break a host whose backend predates the
+    capability, and the reservation still narrows the race from the length of a
+    warehouse query to the microseconds around the ledger read.
+
+    Module level beside its siblings for the reason this file already documents:
+    ``transform build`` prices itself outside the gate and has to reach the same
+    sentence.
+    """
+
+    if paradigm is Paradigm.FREE_LOCAL or session_ceiling is None or serialized:
+        return []
+    return [
+        "the cumulative spend ceiling is advisory on this cache backend: it "
+        "does not implement the optional spend lock, so two overlapping billed "
+        "commands can be admitted against the same headroom and the day's total "
+        "can exceed budget.session_ceiling. Select a backend that implements it "
+        "(both backends dex ships do), or run billed commands one at a time"
+    ]
+
+
 def preflight(
     estimate: float | None,
     ceiling: float | None,
@@ -199,6 +251,13 @@ class CostGate:
     without a ceiling. Billed bytes are appended to the ``.dex/spend.jsonl``
     ledger through ``record`` (functional DI), and the session ceiling is
     settled against spend already in that ledger.
+
+    Three functional dependencies rather than a store, because the gate needs
+    three verbs and a store is sixteen: ``read_session_spent`` for the day's
+    total, ``record`` to append, ``lock`` to make the pair of them atomic. A
+    caller with no ledger (DuckDB, and any gate built directly) passes a plain
+    float for the first and omits the other two, which is why those paths need
+    no store at all.
     """
 
     def __init__(
@@ -207,23 +266,113 @@ class CostGate:
         paradigm: Paradigm,
         ceiling: float | None,
         session_ceiling: float | None,
-        session_spent: float,
+        session_spent: float | Callable[[], float],
         confirmed: bool,
         connector: str,
         command: str | None = None,
         record: Callable[[dict], None] | None = None,
+        lock: Callable[[], AbstractContextManager[None]] | None = None,
     ):
         self.paradigm = paradigm
         self.ceiling = ceiling
         self.session_ceiling = session_ceiling
-        self.session_spent = session_spent
         self.confirmed = confirmed
         self.connector = connector
         self.command = command
         self._record = record
+        self._lock = lock
         self._estimated = 0.0
         self._billed = 0.0
         self._command_estimate: float | None = None
+        # What this gate has itself appended to the ledger, netted. Subtracted
+        # from every live reading so `session_spent` keeps meaning what it meant
+        # when it was a constructor argument: the day's spend belonging to OTHER
+        # commands. Without it a gate would read its own reservation back and
+        # charge itself for it twice, and every ceiling below would tighten by
+        # its own estimate.
+        self._ledger_written = 0.0
+        self._reserved = 0.0
+        self._settled = False
+        self._reservation_id = uuid.uuid4().hex[:16]
+        self._read_session_spent: Callable[[], float] = (
+            session_spent
+            if callable(session_spent)
+            else (lambda fixed=float(session_spent): fixed)
+        )
+        self.session_spent = self._read_session_spent()
+
+    @property
+    def serialized(self) -> bool:
+        """Whether the spend admission is safe from being raced.
+
+        True with a lock, and also true with no ledger writer at all: a gate that
+        appends nowhere shares no ledger, so there is nothing for a concurrent
+        command to race it on. The second case is every free path and every gate
+        built without a store, and folding it in here is what keeps those from
+        warning about a ledger they do not have.
+        """
+
+        return self._lock is not None or self._record is None
+
+    @contextmanager
+    def _admission(self) -> Iterator[None]:
+        """The critical section around read, decide, and book.
+
+        Held for the decision only, never across a warehouse query: a lock that
+        spans execution would serialize commands that have no reason to wait for
+        each other, and would ask a hosted backend to hold one for minutes.
+        """
+
+        try:
+            with self._lock() if self._lock is not None else nullcontext():
+                self._refresh()
+                yield
+        except TimeoutError as exc:
+            raise SpendLockTimeoutError(
+                f"could not take the spend lock ({exc}); another billed command "
+                "is being admitted. Nothing ran, so re-issuing the same command "
+                "is safe",
+                cost=Cost(
+                    paradigm=self.paradigm,
+                    estimate=self._command_estimate,
+                    ceiling=self.ceiling,
+                ),
+            ) from exc
+
+    def _refresh(self) -> None:
+        self.session_spent = self._read_session_spent() - self._ledger_written
+
+    def _append(self, kind: str, amount: float, **extra) -> None:
+        if self._record is None:
+            return
+        self._record(
+            {
+                "at": datetime.now(UTC).isoformat(),
+                "connector": self.connector,
+                "command": self.command,
+                "entry": kind,
+                "reservation_id": self._reservation_id,
+                self.ledger_field(): amount,
+                **extra,
+            }
+        )
+        self._ledger_written += amount
+
+    def _reserve_to(self, target: float) -> None:
+        """Hold ``target`` of the day's headroom, topping up what is held.
+
+        Only with a cumulative ceiling set: a reservation exists to be seen by a
+        concurrent command settling against ``session_ceiling``, so with none
+        there is nothing it could protect, and writing one anyway would put a
+        number in the ledger that no ceiling reads. That keeps the ledger
+        byte-identical for every project that never set a daily cap.
+        """
+
+        if self.session_ceiling is None or self.paradigm is Paradigm.FREE_LOCAL:
+            return
+        if target > self._reserved:
+            self._append("reservation", target - self._reserved)
+            self._reserved = target
 
     def effective_ceiling(self) -> float | None:
         """The binding ceiling: the per-command budget or what remains of the
@@ -249,25 +398,35 @@ class CostGate:
         over-ceiling estimate still refuses first (confirmation cannot
         override it), and a confirmed run without a ceiling still refuses:
         nothing executes unbudgeted.
+
+        The whole check runs inside the admission section, against a reading
+        taken there rather than at construction, and an admitted command books
+        its estimate before the section ends. **A refusal books nothing**: every
+        branch below leaves through the exception, so an unconfirmed handshake
+        (much the most common outcome, since it is how every billed command
+        starts) touches the ledger not at all.
         """
 
         self._command_estimate = estimate
-        ceiling = self.effective_ceiling()
-        cost = Cost(paradigm=self.paradigm, estimate=estimate, ceiling=ceiling)
-        if ceiling is not None and estimate > ceiling:
-            raise OverCeilingError(
-                f"estimated cost {estimate} exceeds the ceiling {ceiling} "
-                f"({self.paradigm.value}); raise the budget or narrow the work",
-                cost=cost,
-            )
-        if not self.confirmed:
-            raise ConfirmationRequiredError(cost)
-        if self.paradigm is not Paradigm.FREE_LOCAL and ceiling is None:
-            raise CeilingRequiredError(
-                f"no ceiling set for a {self.paradigm.value} connector; pass "
-                "--budget or set one in .dex/config.yml",
-                cost=cost,
-            )
+        with self._admission():
+            ceiling = self.effective_ceiling()
+            cost = Cost(paradigm=self.paradigm, estimate=estimate, ceiling=ceiling)
+            if ceiling is not None and estimate > ceiling:
+                raise OverCeilingError(
+                    f"estimated cost {estimate} exceeds the ceiling {ceiling} "
+                    f"({self.paradigm.value}); raise the budget or narrow the "
+                    "work",
+                    cost=cost,
+                )
+            if not self.confirmed:
+                raise ConfirmationRequiredError(cost)
+            if self.paradigm is not Paradigm.FREE_LOCAL and ceiling is None:
+                raise CeilingRequiredError(
+                    f"no ceiling set for a {self.paradigm.value} connector; pass "
+                    "--budget or set one in .dex/config.yml",
+                    cost=cost,
+                )
+            self._reserve_to(estimate)
         return cost
 
     def preflight_phase(self, estimate: float) -> Cost:
@@ -280,26 +439,52 @@ class CostGate:
         budget directly from it. Raises :class:`ConfirmationRequiredError`
         rather than :class:`OverCeilingError` because a bigger budget on
         re-run can cover it; ``needs_confirmation`` is the recovery channel.
+
+        An admitted phase extends the reservation rather than adding a second
+        one, because the command holds one hold for its whole life and the
+        phase raises what that hold is worth.
         """
 
-        ceiling = self.effective_ceiling()
-        needed = self._estimated + estimate
-        cost = Cost(paradigm=self.paradigm, estimate=needed, ceiling=ceiling)
-        if ceiling is not None and needed > ceiling:
-            raise ConfirmationRequiredError(cost)
+        with self._admission():
+            ceiling = self.effective_ceiling()
+            needed = self._estimated + estimate
+            cost = Cost(paradigm=self.paradigm, estimate=needed, ceiling=ceiling)
+            if ceiling is not None and needed > ceiling:
+                raise ConfirmationRequiredError(cost)
+            self._reserve_to(needed)
         return cost
 
     def charge(self, estimate: float) -> None:
         """Gate one statement on the confirmed run. Accumulates estimates so a
-        sequence of statements is bounded as a whole, not just individually."""
+        sequence of statements is bounded as a whole, not just individually.
 
-        preflight(
-            self._estimated + estimate,
-            self.effective_ceiling(),
-            paradigm=self.paradigm,
-            confirmed=self.confirmed,
-        )
-        self._estimated += estimate
+        A statement inside what the command already booked takes the cheap local
+        path: the headroom is held, so no reading can change whether it fits.
+        **An estimate that drifts past the booking is re-admitted** against a
+        live reading instead, because past that point the command is asking for
+        headroom it never reserved, and the frozen reading it was admitted on
+        cannot see what a concurrent command has taken since. Only the drift pays
+        for the lock, and drift is the exception rather than the rule.
+        """
+
+        needed = self._estimated + estimate
+        if self._reserved and needed > self._reserved:
+            with self._admission():
+                preflight(
+                    needed,
+                    self.effective_ceiling(),
+                    paradigm=self.paradigm,
+                    confirmed=self.confirmed,
+                )
+                self._reserve_to(needed)
+        else:
+            preflight(
+                needed,
+                self.effective_ceiling(),
+                paradigm=self.paradigm,
+                confirmed=self.confirmed,
+            )
+        self._estimated = needed
 
     def try_charge(self, estimate: float) -> bool:
         """Non-raising :meth:`charge` for optional spend (e.g. distinct-count
@@ -315,9 +500,20 @@ class CostGate:
         """The server-side cap for the next statement, in the paradigm's unit
         (bytes for ``maximum_bytes_billed``, seconds for a statement timeout):
         what remains of the effective ceiling after everything already charged.
+
+        Bounded by the booking as well as by the ceiling, when there is one. The
+        two differ exactly when another command is holding headroom, and handing
+        the warehouse the wider of them is how the backstop that is supposed to
+        bind when an estimate is wrong ends up permitting the pair to overspend
+        together. :meth:`charge` widens the booking when the estimate genuinely
+        drifts, so this tightens the cap without capping honest work.
         """
 
         ceiling = self.effective_ceiling()
+        if self._reserved:
+            ceiling = (
+                self._reserved if ceiling is None else min(ceiling, self._reserved)
+            )
         if ceiling is None:
             return None
         return max(int(ceiling - self._billed), 0)
@@ -335,31 +531,65 @@ class CostGate:
         so anything the caller would wrongly assume is enforced belongs here.
         """
 
-        return no_session_ceiling_warning(self.paradigm, self.session_ceiling)
+        return [
+            *no_session_ceiling_warning(self.paradigm, self.session_ceiling),
+            *unserialized_ledger_warning(
+                self.paradigm, self.session_ceiling, self.serialized
+            ),
+        ]
 
     def record_billed(
         self, billed: float, *, job_id: str | None = None, statement: str = ""
     ) -> None:
         """Account one executed statement's actual spend and append it to the
         ledger. Statements are stored as a hash, never as text, so the ledger
-        can hold no values."""
+        can hold no values.
+
+        Deliberately outside the admission lock. This is a pure append with
+        nothing read back, so it races nothing, and taking the lock here would
+        hold it once per statement on a path that runs while the warehouse is
+        working.
+        """
 
         self._billed += billed
-        if self._record is not None:
-            self._record(
-                {
-                    "at": datetime.now(UTC).isoformat(),
-                    "connector": self.connector,
-                    "command": self.command,
-                    self.ledger_field(): billed,
-                    "job_id": job_id,
-                    "statement_sha256": hashlib.sha256(
-                        statement.encode("utf-8")
-                    ).hexdigest()[:16]
-                    if statement
-                    else None,
-                }
-            )
+        self._append(
+            "settlement",
+            billed,
+            job_id=job_id,
+            statement_sha256=hashlib.sha256(statement.encode("utf-8")).hexdigest()[:16]
+            if statement
+            else None,
+        )
+
+    def settle(self) -> None:
+        """Release the unspent hold and re-read the day, once per command.
+
+        Called from the command layer's settlement funnel, from the engine when
+        it rebuilds a gate, and from engine shutdown, so an interrupted command
+        releases as reliably as a completed one. Idempotent, because those three
+        overlap by design rather than by accident.
+
+        **A process killed outright leaves its reservation standing**, and it
+        holds the estimate against the day's headroom until the UTC rollover.
+        That is the safe direction for a spend guard and it is why there is no
+        expiry: expiring a hold would mean teaching every backend's
+        ``spend_since`` to tell the entry kinds apart and reason about time,
+        which is a protocol change for a case the three funnels already cover.
+        """
+
+        if self._settled:
+            return
+        self._settled = True
+        # Entering the section re-reads the day, which is what makes
+        # `spend_summary` report the true total rather than this command's view
+        # of it. Releasing after that needs no second read: the release lowers
+        # the live total and this gate's own written total by the same amount,
+        # so the difference between them, which is what `session_spent` holds,
+        # does not move.
+        with self._admission():
+            if self._reserved:
+                self._append("release", -self._reserved)
+                self._reserved = 0.0
 
     def cost(self) -> Cost:
         """The preflight cost to stamp into the envelope: the whole-command
@@ -380,7 +610,15 @@ class CostGate:
     def spend_summary(self) -> dict:
         """Actual spend for the envelope's ``data`` (the ``cost`` field stays a
         preflight estimate by contract). Key names deliberately avoid every
-        envelope-sanitizer pattern and carry the paradigm's unit."""
+        envelope-sanitizer pattern and carry the paradigm's unit.
+
+        ``session_spent_today`` is the day's total across every command, not
+        this one's contribution to it, which is why it is read after
+        :meth:`settle`: the sum of what other commands have settled plus what
+        this one just did. Two commands running at once used to report their own
+        spend under a name that promised the day's, so a caller reading either
+        one saw a fraction of the truth.
+        """
 
         return {
             spend_field(self.paradigm): self._billed,

--- a/packages/dex-core/src/exmergo_dex_core/storage/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/__init__.py
@@ -5,9 +5,12 @@
 only what its host uses; the sibling modules are the backends. Callers receive a
 store; only the entry point picks which one.
 
-It also holds the separate, optional construction contract
-(:class:`~.base.StoreFactory` over a :class:`~.base.StoreContext`), for a backend
-that is named somewhere rather than handed to the engine as an instance.
+It also holds two separate, optional contracts that sit alongside the tiers
+rather than inside them: :class:`~.base.SpendLock`, which lets the cost gate make
+the spend admission atomic so the cumulative ceiling binds under concurrency, and
+the construction contract (:class:`~.base.StoreFactory` over a
+:class:`~.base.StoreContext`), for a backend that is named somewhere rather than
+handed to the engine as an instance.
 ``resolver`` is what turns such a name into a store, as an open registry: a
 shipped name, a dotted path, or an entry point an installed distribution
 registered.
@@ -21,6 +24,7 @@ from .base import (
     Document,
     ExploreStore,
     MaintainStore,
+    SpendLock,
     Store,
     StoreContext,
     StoreFactory,
@@ -37,6 +41,7 @@ __all__ = [
     "FilesystemStore",
     "MaintainStore",
     "MemoryStore",
+    "SpendLock",
     "Store",
     "StoreContext",
     "StoreFactory",

--- a/packages/dex-core/src/exmergo_dex_core/storage/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/base.py
@@ -21,6 +21,12 @@ two shipped backends. :mod:`~.conformance` ships the executable copy of those
 rules: subclass ``StoreContract``, hand it a factory, and the whole contract runs
 against your backend. ``references/storage.md`` is the prose version.
 
+**Serializing the spend admission is a separate, optional capability**,
+:class:`SpendLock`, and a backend serving concurrent requests wants it: without
+one the cumulative session ceiling does not bind across overlapping billed
+commands, and dex warns on every such command rather than letting the ceiling
+look enforced.
+
 **Constructing one is a separate contract**, :class:`StoreFactory` over a
 :class:`StoreContext`, and it is optional. A host that passes its own instance to
 the engine never needs it; it exists so a backend can also be *named* somewhere
@@ -37,6 +43,7 @@ surface would double the contract for no caller that exists.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -158,6 +165,16 @@ class ExploreStore(Protocol):
         The ledger is the audit trail for warehouse spend and the substrate for
         the cumulative session budget: byte counts, job ids, and statement
         hashes only, never SQL values or credentials.
+
+        **A backend stores entries; it does not interpret them.** Entries carry
+        an ``entry`` kind (``reservation``, ``settlement``, ``release``) and a
+        ``reservation_id`` tying the three together, because the cumulative
+        ceiling holds headroom for a command that has been admitted but has not
+        finished paying. A release carries a negative magnitude, which is the
+        one thing worth knowing here: **a backend must not assume the magnitude
+        is positive**, and one that clamps or filters would leak held headroom
+        for the rest of the UTC day. Sum what you are given, the way
+        :func:`spend_total` does.
         """
         ...
 
@@ -191,17 +208,28 @@ class ExploreStore(Protocol):
         ledger line means one spend record is lost, and refusing to run every
         subsequent billed command because of one bad line is the worse failure.
 
-        **Concurrency.** The cost gate calls this and then calls
-        :meth:`append_spend_log`, and that read-then-write is not atomic at the
-        protocol level. The cumulative session ceiling therefore binds exactly
-        when commands are serialized, which is the CLI's one-command-per-process
-        shape, and under genuinely concurrent commands the overshoot is bounded
-        by the sum of the concurrent estimates. A backend that can make the pair
-        atomic for one key (a transaction, a conditional write) should, and a
-        multi-tenant backend serving concurrent requests per tenant is where that
-        stops being optional. The protocol does not grow a member for it, because
-        an optional member no implementer can rely on is worse than a stated
-        bound.
+        **What the total means depends on when you read it.** The cost gate
+        books a reservation at the estimate when it admits a command and
+        releases it when the command settles, so a day already finished sums to
+        actual spend, exactly as it always has, while a day with commands still
+        running sums to actual spend plus the headroom those commands hold. The
+        second is not an accounting error; it is the number a concurrent command
+        has to see for the ceiling to bind.
+
+        **Concurrency, and how a backend opts into the guarantee.** The gate
+        reads this and then appends, and that read-then-write has to be atomic
+        for the cumulative ceiling to bind. Implement :class:`SpendLock` and the
+        gate serializes the pair through it. Without one the gate still reserves,
+        which narrows the window from the duration of a warehouse query to the
+        few microseconds between the read and the append, and it **warns on
+        every billed command** that the cumulative ceiling is not enforced on
+        this backend. A guard that is narrower than it looks is worse than one
+        that is absent, so the narrowing is reported rather than assumed.
+
+        The capability is deliberately separate from the tiers: a store is
+        useful without it, and the reason an optional member is tolerable here
+        is that dex detects its absence and says so, rather than relying on
+        every implementer to have read a paragraph.
         """
         ...
 
@@ -259,6 +287,38 @@ class Store(MaintainStore, Protocol):
         ...
 
     def plan_locator(self, plan_id: str) -> str: ...
+
+
+@runtime_checkable
+class SpendLock(Protocol):
+    """Optional: serialize the spend admission so the cumulative ceiling binds.
+
+    One method, on top of any tier. A store that has it lets the cost gate make
+    "read the day's spend, decide, book the headroom" one indivisible step, which
+    is what stops two concurrent billed commands being admitted against the same
+    headroom. A store without it still works, and every billed command run
+    against it warns that the cumulative ceiling is advisory there.
+
+    **The scope to lock is the ledger this store reads, and nothing wider.** The
+    gate holds it for the few microseconds around the decision and never across
+    a warehouse query, so locking the whole backend would serialize commands that
+    have no reason to wait for each other. Two stores keyed differently must not
+    contend: that is the same isolation the tier contracts already require, and a
+    lock is the one place it is easy to forget, since a single global mutex looks
+    correct in a single-tenant test.
+
+    It must be **reentrant for one holder**. The gate settles from more than one
+    funnel and a settle inside an already-held section is expected rather than a
+    deadlock to design around.
+
+    Raise the builtin :class:`TimeoutError` when ``timeout`` elapses. The gate
+    turns that into a named refusal carrying the cost; the builtin is what the
+    protocol asks for so a backend needs no import from dex to satisfy it.
+    """
+
+    def spend_lock(self, *, timeout: float = 30.0) -> AbstractContextManager[None]:
+        """Hold the spend-admission lock for this store's ledger."""
+        ...
 
 
 @dataclass(frozen=True)
@@ -332,6 +392,11 @@ def spend_total(
     the ledger is stored. String comparison on ``at`` is correct because every
     stamp is written by dex in the same UTC ISO format. Malformed entries are
     skipped rather than poisoning the budget check.
+
+    A plain sum, negatives included: a release is a reservation entry with the
+    sign flipped, so the three entry kinds net out to actual spend with no
+    branch on kind here. That is why adding reservations did not change what any
+    existing backend's ``spend_since`` returns for a settled day.
     """
 
     total = 0.0

--- a/packages/dex-core/src/exmergo_dex_core/storage/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/conformance.py
@@ -39,6 +39,14 @@ engine as an instance**, mix :class:`StoreFactoryContract` in as well. It routes
 against a store built the way dex would build it, and "the suite is green" keeps
 meaning the backend is both correct and constructable rather than only the first.
 
+**If your backend serves concurrent requests**, mix :class:`SpendLockContract` in
+too. It is the only optional capability here, and skipping it costs correctness
+rather than convenience: without a lock two overlapping billed commands are
+admitted against the same headroom and the cumulative session ceiling does not
+bind. dex reports that on every billed result rather than assuming it, so a
+backend without one is honest rather than silently broken, but a hosted backend
+wants the lock.
+
 This module imports pytest, so it is deliberately not imported by
 ``exmergo_dex_core.storage``: a bare ``import exmergo_dex_core`` must not require
 a test framework. Install the ``[storage-conformance]`` extra to get what running
@@ -49,6 +57,8 @@ keeps it that way.
 
 from __future__ import annotations
 
+import threading
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from itertools import count
 from typing import Any
@@ -59,11 +69,12 @@ import pytest
 from ..cache import CacheProvenance, Dataset, DexCache
 from ..maintain.drift import AxisResult, DriftFinding, DriftReport
 from ..maintain.snapshot import Snapshot, WarehouseBaseline
-from .base import Document, ExploreStore, StoreContext
+from .base import Document, ExploreStore, SpendLock, StoreContext
 
 __all__ = [
     "ExploreStoreContract",
     "MaintainStoreContract",
+    "SpendLockContract",
     "StoreContract",
     "StoreFactoryContract",
 ]
@@ -664,6 +675,167 @@ class StoreContract(MaintainStoreContract):
             "two keys share the plan store, so one tenant can read and apply "
             f"another's proposed dbt changes. Got {two.list_plans()!r}"
         )
+
+
+class SpendLockContract(_KeyedContract):
+    """The optional capability that makes the cumulative spend ceiling bind.
+
+    Mix it in alongside the contract for your tier::
+
+        class TestMyStore(SpendLockContract, ExploreStoreContract):
+            def make_store(self, key):
+                return MyStore(tenant=key)
+
+    The cost gate reads the day's spend, decides whether the command fits under
+    ``budget.session_ceiling``, and books the headroom, all inside one
+    ``spend_lock``. Without it two commands read the same total and both decide
+    yes, which is legal for each and wrong for the pair.
+
+    Three properties, and the third is the one most likely to be missed. **It
+    must exclude**, so a second holder waits. **It must be re-entrant for one
+    holder**, because the gate settles from more than one funnel and a settle
+    inside a held section is expected rather than a deadlock to design around.
+    And **it must be scoped to the ledger this store reads, not to the backend**,
+    so two tenants never wait on each other; a single global mutex passes the
+    first two assertions and quietly serializes an entire deployment.
+
+    Only threads are exercised here, because that is the population a suite can
+    portably create. A backend spanning processes or hosts has to reach for
+    whatever its own substrate offers (an advisory file lock, a transaction, a
+    conditional write) and this contract cannot see the difference. That gap is
+    real, and it is why the two shipped backends carry cross-process assertions
+    of their own in dex's suite rather than relying on this class.
+    """
+
+    #: How long an assertion waits for something it expects to *happen* before
+    #: calling the backend broken. Generous on purpose: a slow CI box must not
+    #: read as a failure.
+    lock_timeout: float = 10.0
+
+    #: How long an assertion waits to be satisfied that something did *not*
+    #: happen. Short, and it can be: a lock that fails to exclude admits its
+    #: second holder in microseconds, so the only reason to wait at all is
+    #: thread scheduling. The assertions that use it first wait out
+    #: :attr:`lock_timeout` for the contending thread to reach the lock, so a
+    #: slow machine delays the probe rather than passing it vacuously.
+    overlap_probe: float = 0.5
+
+    @contextmanager
+    def _held(self, store) -> Any:
+        """Hold ``store``'s spend lock on another thread for the block's duration.
+
+        A separate thread because the point is always what a *different* holder
+        sees, and a re-entrant lock would let the same thread straight back in.
+        Yields a handle whose ``release()`` drops the lock early, for the
+        assertions that then check the waiter got through.
+
+        **The holder outlasts anything that waits on it**, which is what keeps
+        these assertions from being decided by which of two equal timeouts fires
+        first. Holding for exactly ``lock_timeout`` while an assertion waits
+        ``lock_timeout`` for a contender makes the outcome a coin flip on a busy
+        machine, and a contract that reports a backend as broken once in a
+        hundred runs is one nobody trusts.
+        """
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def hold():
+            with store.spend_lock(timeout=self.lock_timeout):
+                entered.set()
+                release.wait(self.lock_timeout * 4)
+
+        holder = threading.Thread(target=hold, daemon=True)
+        holder.start()
+        try:
+            assert entered.wait(self.lock_timeout), (
+                "a thread could not take spend_lock on an idle store within "
+                f"{self.lock_timeout}s, so the lock never becomes available"
+            )
+            yield type("_Holder", (), {"release": staticmethod(release.set)})
+        finally:
+            release.set()
+            holder.join(self.lock_timeout)
+
+    def _contend(self, store, attempting, crossed) -> None:
+        """Start a thread that reaches for ``store``'s lock and reports both
+        that it tried and, when it succeeds, that it got in."""
+
+        def contend():
+            attempting.set()
+            with store.spend_lock(timeout=self.lock_timeout):
+                crossed.set()
+
+        threading.Thread(target=contend, daemon=True).start()
+
+    def test_the_store_declares_the_capability(self, store):
+        assert isinstance(store, SpendLock), (
+            f"{type(store).__name__} does not satisfy SpendLock, so mixing this "
+            "contract in asserts nothing. Add "
+            "spend_lock(self, *, timeout=...) returning a context manager"
+        )
+
+    def test_the_lock_excludes_a_second_holder(self, store):
+        attempting, crossed = threading.Event(), threading.Event()
+        with self._held(store) as holder:
+            self._contend(store, attempting, crossed)
+            # Wait for the contender to actually reach the lock before judging
+            # whether it got through, so a slow machine delays this rather than
+            # passing it without a contender having tried.
+            assert attempting.wait(self.lock_timeout), "the contender never started"
+            assert not crossed.wait(self.overlap_probe), (
+                "a second holder entered spend_lock while the first still held it, "
+                "so the lock does not exclude. The cost gate reads the day's spend "
+                "and books headroom inside this section, and two commands running "
+                "it at once are admitted against the same headroom"
+            )
+            holder.release()
+            assert crossed.wait(self.lock_timeout), (
+                "the second holder never acquired spend_lock after the first "
+                "released it, so the lock excludes permanently rather than "
+                "serializing. Check that the section releases on the way out"
+            )
+
+    def test_the_lock_is_reentrant_for_one_holder(self, store):
+        done = threading.Event()
+
+        def nest():
+            with (
+                store.spend_lock(timeout=self.lock_timeout),
+                store.spend_lock(timeout=self.lock_timeout),
+            ):
+                pass
+            done.set()
+
+        thread = threading.Thread(target=nest, daemon=True)
+        thread.start()
+        assert done.wait(self.lock_timeout), (
+            "taking spend_lock twice on one thread deadlocked. dex settles a gate "
+            "from more than one funnel and a settle inside a held section is "
+            "expected, so the lock has to be re-entrant for the holder"
+        )
+
+    def test_two_keys_do_not_wait_on_each_other(self):
+        """A lock scoped to the backend rather than to the ledger.
+
+        It excludes and it is re-entrant, so the two assertions above pass, and
+        it serializes every tenant in the deployment against every other. That is
+        a performance failure severe enough to be a correctness one under load,
+        and it is invisible in any single-tenant test.
+        """
+
+        one, two = self.store_for("tenant-one"), self.store_for("tenant-two")
+        attempting, crossed = threading.Event(), threading.Event()
+        with self._held(one):
+            self._contend(two, attempting, crossed)
+            # A lock scoped to one ledger lets this straight through while
+            # another ledger's is held; one scoped to the backend cannot let it
+            # through at all, so the generous wait costs nothing when it passes.
+            assert crossed.wait(self.lock_timeout), (
+                "one key's spend lock blocked another key's, so the lock is scoped "
+                "to the backend rather than to the ledger it protects. Every tenant "
+                "then waits on every other tenant's billed commands"
+            )
 
 
 class StoreFactoryContract(_KeyedContract):

--- a/packages/dex-core/src/exmergo_dex_core/storage/filesystem.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/filesystem.py
@@ -8,6 +8,7 @@ Layout (all non-secret, committed to the user's repo):
     .dex/drift.json     the last drift-detection report (see maintain/drift.py)
     .dex/queries.jsonl  the append-only `explore query` decision ledger
     .dex/spend.jsonl    the append-only billed-command ledger
+    .dex/spend.lock     an empty file; the spend-admission lock is held on it
     .dex/plans/*.json   the stored transform plans
 
 State on disk is what lets the CLI subcommands stay stateless: the agent
@@ -22,6 +23,10 @@ This module is the only place in the engine that knows these file names.
 from __future__ import annotations
 
 import json
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -41,7 +46,71 @@ SNAPSHOT_FILE = "snapshot.json"
 DRIFT_FILE = "drift.json"
 QUERIES_FILE = "queries.jsonl"
 SPEND_FILE = "spend.jsonl"
+SPEND_LOCK_FILE = "spend.lock"
 PLANS_DIR = "plans"
+
+# One re-entrant lock per resolved `.dex/` path, shared by every store instance
+# addressing it. The OS lock below is what serializes separate processes; this is
+# what serializes threads inside one, and it is not redundant with it: a POSIX
+# `flock` is held by the open file description, so two threads opening the same
+# lock file each get their own and neither waits for the other.
+_PROCESS_LOCKS: dict[str, threading.RLock] = {}
+_PROCESS_LOCKS_GUARD = threading.Lock()
+
+
+def _process_lock(key: str) -> threading.RLock:
+    with _PROCESS_LOCKS_GUARD:
+        lock = _PROCESS_LOCKS.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _PROCESS_LOCKS[key] = lock
+        return lock
+
+
+# Re-entrancy is tracked per thread rather than left to the RLock, because the OS
+# lock is not re-entrant the way the RLock is: a second `flock` from the same
+# process on a second descriptor for the same file blocks forever. So a nested
+# acquisition takes the fast path and touches no descriptor at all.
+_HELD = threading.local()
+
+
+def _held_depths() -> dict[str, int]:
+    depths = getattr(_HELD, "depths", None)
+    if depths is None:
+        depths = {}
+        _HELD.depths = depths
+    return depths
+
+
+try:  # POSIX
+    import fcntl
+
+    def _lock_descriptor(handle) -> bool:
+        """True when the exclusive lock was taken, False when someone holds it."""
+
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return False
+        return True
+
+    def _unlock_descriptor(handle) -> None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+except ImportError:  # Windows
+    import msvcrt
+
+    def _lock_descriptor(handle) -> bool:
+        try:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError:
+            return False
+        return True
+
+    def _unlock_descriptor(handle) -> None:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
 
 _DOCUMENT_FILES = {
     Document.CACHE: CACHE_FILE,
@@ -152,6 +221,59 @@ class FilesystemStore:
             except json.JSONDecodeError:
                 continue
         return spend_total(entries, cutoff_iso, field=field, connector=connector)
+
+    @contextmanager
+    def spend_lock(self, *, timeout: float = 30.0) -> Iterator[None]:
+        """Serialize the spend admission across every process holding this root.
+
+        Two locks, because the CLI runs one command per process while a host can
+        run several engines in one. An advisory `flock` on `.dex/spend.lock`
+        keeps processes apart; a per-path re-entrant lock keeps threads apart,
+        and it is genuinely needed rather than belt-and-braces, since a POSIX
+        lock belongs to the open file description and two threads opening the
+        same file would each get their own and neither would wait.
+
+        The lock file is created and never removed. Unlinking it is what would
+        break this: the lock is on the inode, so a holder and a waiter that
+        opened it either side of a delete would hold two different files and both
+        proceed. An empty file per repo is cheaper than that failure.
+        """
+
+        self.dex_dir.mkdir(parents=True, exist_ok=True)
+        path = self.dex_dir / SPEND_LOCK_FILE
+        key = str(path)
+        depths = _held_depths()
+        if depths.get(key, 0):
+            depths[key] += 1
+            try:
+                yield
+            finally:
+                depths[key] -= 1
+            return
+
+        deadline = time.monotonic() + timeout
+        if not _process_lock(key).acquire(timeout=max(timeout, 0.0)):
+            raise TimeoutError(
+                f"waited {timeout}s for the spend lock at {path} and another "
+                "thread still holds it"
+            )
+        try:
+            with path.open("a", encoding="utf-8") as handle:
+                while not _lock_descriptor(handle):
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            f"waited {timeout}s for the spend lock at {path} and "
+                            "another process still holds it"
+                        )
+                    time.sleep(0.01)
+                depths[key] = 1
+                try:
+                    yield
+                finally:
+                    depths[key] = 0
+                    _unlock_descriptor(handle)
+        finally:
+            _process_lock(key).release()
 
     # --- plans ----------------------------------------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/storage/memory.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/memory.py
@@ -17,6 +17,9 @@ Two properties are load-bearing:
 
 from __future__ import annotations
 
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -46,6 +49,7 @@ class MemoryStore:
         self._plans: dict[str, TransformPlan] = {}
         self._queries: list[dict] = []
         self._spend: list[dict] = []
+        self._spend_lock = threading.RLock()
 
     @classmethod
     def from_context(cls, context: StoreContext) -> MemoryStore:
@@ -110,6 +114,21 @@ class MemoryStore:
         connector: str | None = None,
     ) -> float:
         return spend_total(self._spend, cutoff_iso, field=field, connector=connector)
+
+    @contextmanager
+    def spend_lock(self, *, timeout: float = 30.0) -> Iterator[None]:
+        """Serialize the spend admission across threads sharing this instance.
+
+        The ledger lives in one process, so the whole population that could race
+        is the threads holding this object and a plain lock is genuinely atomic
+        rather than advisory. ``timeout`` is accepted and not enforced: honoring
+        it would mean reporting a lock contended by a section that only spans a
+        ledger read and a list append, which cannot outlast any sane timeout, and
+        a spurious refusal there would be worse than the wait.
+        """
+
+        with self._spend_lock:
+            yield
 
     # --- plans ----------------------------------------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -419,6 +419,7 @@ def build(
     from ..guards.cost_guard import (
         ConfirmationRequiredError,
         no_session_ceiling_warning,
+        unserialized_ledger_warning,
     )
 
     # `from .build import ...` rather than `from . import build`: the package
@@ -503,6 +504,11 @@ def build(
             notes=[
                 *price_notes,
                 *no_session_ceiling_warning(paradigm, config.budget.session_ceiling),
+                *unserialized_ledger_warning(
+                    paradigm,
+                    config.budget.session_ceiling,
+                    callable(getattr(store, "spend_lock", None)),
+                ),
             ],
         )
         raise
@@ -515,6 +521,7 @@ def build(
         store,
         extra_notes=[*price_notes, *dev_warnings],
         session_ceiling=config.budget.session_ceiling,
+        gate=command_args.cost_gate(adapter) if adapter is not None else None,
     )
 
 
@@ -767,6 +774,7 @@ def _shape_build_result(
     store: Store,
     extra_notes=(),
     session_ceiling: float | None = None,
+    gate=None,
 ) -> BuildResult:
     """Shape a finished dbt run per paradigm, and ledger what it actually cost.
 
@@ -779,11 +787,22 @@ def _shape_build_result(
     A failed run reports its spend too: dbt bills for the statements it ran
     before it stopped, and a caller sizing the re-run needs that number more
     than a successful one does.
+
+    dbt has returned by the time this runs, so the headroom the handshake booked
+    is released here, before the ledger is read back. A build is the longest
+    billed command dex has, which makes it both the one whose hold matters most
+    to a concurrent command and the one where reporting the day's total without
+    releasing first would overstate it by the whole estimate.
     """
 
     from ..envelope import Paradigm
-    from ..guards.cost_guard import no_session_ceiling_warning
+    from ..guards.cost_guard import (
+        no_session_ceiling_warning,
+        unserialized_ledger_warning,
+    )
 
+    if gate is not None:
+        gate.settle()
     messages = summary.pop("messages", [])
     notes = [*extra_notes, *summary.pop("notes", [])]
     spend: dict[str, float] | None = None
@@ -823,7 +842,15 @@ def _shape_build_result(
         if seconds:
             summary["seconds_billed"] = seconds
             spend = _record_build_spend(store, connector, seconds, paradigm)
-    notes = [*notes, *no_session_ceiling_warning(paradigm, session_ceiling)]
+    notes = [
+        *notes,
+        *no_session_ceiling_warning(paradigm, session_ceiling),
+        *unserialized_ledger_warning(
+            paradigm,
+            session_ceiling,
+            callable(getattr(store, "spend_lock", None)),
+        ),
+    ]
     if summary["success"]:
         return BuildResult(
             success=True,

--- a/packages/dex-core/tests/guards/test_cost_guard.py
+++ b/packages/dex-core/tests/guards/test_cost_guard.py
@@ -231,6 +231,285 @@ def test_a_free_gate_never_warns_about_a_cumulative_cap():
     assert _gate(paradigm=Paradigm.FREE_LOCAL, session_ceiling=None).warnings() == []
 
 
+def test_a_gate_whose_store_cannot_serialize_the_admission_warns():
+    """A ceiling that cannot bind under concurrency has to say so.
+
+    Both shipped backends implement the lock, so this reaches only a host that
+    selected a backend of its own. It warns rather than refusing, the same call
+    made for a missing cumulative cap: refusing would break a backend written
+    before the capability existed.
+    """
+
+    warning = _gate(
+        session_ceiling=10_000.0, record=lambda entry: None, lock=None
+    ).warnings()
+    assert len(warning) == 1
+    assert "spend lock" in warning[0]
+    assert "budget.session_ceiling" in warning[0]
+
+
+def test_a_gate_whose_store_serializes_the_admission_stays_quiet():
+    from contextlib import nullcontext
+
+    gate = _gate(session_ceiling=10_000.0, record=lambda entry: None, lock=nullcontext)
+    assert gate.serialized is True
+    assert gate.warnings() == []
+
+
+def test_a_gate_with_no_ledger_never_warns_about_serializing_one():
+    """Nothing is appended, so nothing can be raced.
+
+    This is every free path and every gate built without a store. Warning here
+    would report a hazard that does not exist, on the commands least able to act
+    on it.
+    """
+
+    assert _gate(session_ceiling=10_000.0, record=None).warnings() == []
+
+
+# --- reserving the headroom a command was admitted against -----------------------
+
+
+class _Ledger:
+    """The smallest thing that behaves like a shared spend ledger.
+
+    A list plus the two members the gate reaches for, so these assertions are
+    about the gate rather than about a backend. `FilesystemStore` is exercised
+    against the real thing in the concurrency suite.
+    """
+
+    def __init__(self) -> None:
+        self.entries: list[dict] = []
+
+    def append(self, entry: dict) -> None:
+        self.entries.append(dict(entry))
+
+    def total(self) -> float:
+        return sum(e.get("billed_bytes", 0.0) for e in self.entries)
+
+    def kinds(self) -> list[str]:
+        return [e["entry"] for e in self.entries]
+
+
+def _ledger_gate(ledger: _Ledger, **overrides) -> CostGate:
+    from contextlib import nullcontext
+
+    kwargs = {
+        "session_ceiling": 1_000.0,
+        "session_spent": ledger.total,
+        "record": ledger.append,
+        "lock": nullcontext,
+    }
+    kwargs.update(overrides)
+    return _gate(**kwargs)
+
+
+def test_an_admitted_command_books_its_estimate_before_it_runs():
+    """The hold is what a concurrent command settles against.
+
+    Without it the second command reads a ledger that will not show the first
+    one's spend until it finishes, and admits itself against headroom that is
+    already committed.
+    """
+
+    ledger = _Ledger()
+    _ledger_gate(ledger).preflight_command(600.0)
+    assert ledger.kinds() == ["reservation"]
+    assert ledger.total() == 600.0
+
+
+def test_a_refused_command_books_nothing():
+    """Every refusal leaves through the exception before the reservation.
+
+    The common case is the unconfirmed handshake, which is how every billed
+    command starts, so a gate that reserved on the way to asking would hold
+    headroom for work that was never authorized.
+    """
+
+    ledger = _Ledger()
+    with pytest.raises(ConfirmationRequiredError):
+        _ledger_gate(ledger, confirmed=False).preflight_command(10.0)
+    with pytest.raises(OverCeilingError):
+        _ledger_gate(ledger).preflight_command(5_000.0)
+    with pytest.raises(CeilingRequiredError):
+        _ledger_gate(ledger, ceiling=None, session_ceiling=None).preflight_command(10.0)
+    assert ledger.entries == []
+
+
+def test_a_second_gate_sees_the_first_ones_hold():
+    ledger = _Ledger()
+    _ledger_gate(ledger).preflight_command(600.0)
+    with pytest.raises(OverCeilingError):
+        _ledger_gate(ledger).preflight_command(600.0)
+
+
+def test_settling_releases_what_was_held_but_not_spent():
+    """The ledger nets back to actual spend, which is what makes this safe.
+
+    A day already finished sums to what it really cost, exactly as before
+    reservations existed, so nothing summing settled spend had to change.
+    """
+
+    ledger = _Ledger()
+    gate = _ledger_gate(ledger)
+    gate.preflight_command(600.0)
+    gate.record_billed(400.0)
+    gate.settle()
+    assert ledger.kinds() == ["reservation", "settlement", "release"]
+    assert ledger.total() == 400.0
+
+
+def test_the_freed_headroom_admits_the_next_command():
+    ledger = _Ledger()
+    first = _ledger_gate(ledger)
+    first.preflight_command(600.0)
+    first.record_billed(400.0)
+    first.settle()
+    # 1,000 ceiling less 400 actually spent, not less the 600 that was held.
+    assert _ledger_gate(ledger).preflight_command(600.0).ceiling == 600.0
+
+
+def test_a_gate_does_not_charge_itself_for_its_own_reservation():
+    """The invariant the whole design rests on.
+
+    A live reading includes this gate's own writes, so `session_spent` is that
+    reading net of them: the day's spend belonging to other commands. Without
+    the subtraction every ceiling after the reservation would tighten by the
+    gate's own estimate, and a command would refuse itself partway through.
+    """
+
+    ledger = _Ledger()
+    gate = _ledger_gate(ledger)
+    gate.preflight_command(600.0)
+    assert gate.session_spent == 0.0
+    assert gate.effective_ceiling() == 1_000.0
+    gate.record_billed(400.0)
+    gate._refresh()
+    assert gate.session_spent == 0.0
+
+
+def test_an_estimate_that_drifts_past_its_booking_is_re_admitted():
+    """The gap a live BigQuery run exposed after the reservation landed.
+
+    A command is bounded per statement by the ceiling rather than by its own
+    estimate, deliberately, so a drifting estimate stops mid-command instead of
+    overrunning. Under concurrency that bound was computed from the reading the
+    command was admitted on, which cannot see headroom a later command took. So
+    drift could spend into another command's hold even though every admission
+    was correct.
+    """
+
+    ledger = _Ledger()
+    gate = _ledger_gate(ledger)
+    gate.preflight_command(300.0)
+    gate.charge(200.0)
+    assert ledger.kinds() == ["reservation"]  # inside the booking: no re-admit
+
+    # Another command takes headroom after this one was admitted.
+    other = _ledger_gate(ledger)
+    other.preflight_command(600.0)
+
+    # Drifting past the 300 booked now has to fit what is genuinely left, and
+    # 300 + 600 already accounts for the whole 1,000 ceiling.
+    with pytest.raises(OverCeilingError):
+        gate.charge(400.0)
+    # The refused charge is not counted, so the command can still finish inside
+    # what it did book.
+    assert gate._estimated == 200.0
+    gate.charge(100.0)
+
+
+def test_the_server_side_cap_never_exceeds_what_was_booked():
+    """The backstop that binds when an estimate is wrong has to bind under
+    concurrency too, or two commands hand the warehouse caps that overlap."""
+
+    ledger = _Ledger()
+    gate = _ledger_gate(ledger)
+    gate.preflight_command(300.0)
+    assert gate.remaining_for_statement() == 300
+    gate.record_billed(100.0)
+    assert gate.remaining_for_statement() == 200
+
+
+def test_settling_is_idempotent():
+    """Three funnels settle a gate and they overlap by design, not by accident:
+    the command layer on its way out, the engine when it rebuilds a gate, and
+    engine shutdown."""
+
+    ledger = _Ledger()
+    gate = _ledger_gate(ledger)
+    gate.preflight_command(600.0)
+    gate.settle()
+    gate.settle()
+    gate.settle()
+    assert ledger.kinds().count("release") == 1
+
+
+def test_a_phase_extends_the_hold_rather_than_adding_a_second():
+    ledger = _Ledger()
+    gate = _ledger_gate(ledger)
+    gate.preflight_command(100.0)
+    gate.charge(100.0)
+    gate.preflight_phase(300.0)
+    assert ledger.kinds() == ["reservation", "reservation"]
+    assert ledger.total() == 400.0
+    gate.settle()
+    assert ledger.total() == 0.0
+
+
+def test_settlement_reports_the_days_total_not_this_commands_share():
+    """Two commands used to each report their own spend under a name that
+    promises the day's, so a caller reading either one saw a fraction of the
+    truth."""
+
+    ledger = _Ledger()
+    other = _ledger_gate(ledger)
+    other.preflight_command(300.0)
+    other.record_billed(300.0)
+    other.settle()
+
+    gate = _ledger_gate(ledger)
+    gate.preflight_command(200.0)
+    gate.record_billed(200.0)
+    gate.settle()
+    assert gate.spend_summary() == {
+        "bytes_billed": 200.0,
+        "session_spent_today": 500.0,
+    }
+
+
+def test_nothing_is_reserved_without_a_cumulative_ceiling_to_protect():
+    """A reservation exists to be seen by a command settling against
+    `session_ceiling`. With none set nothing reads it, so the ledger stays
+    byte-identical for every project that never configured a daily cap."""
+
+    ledger = _Ledger()
+    gate = _ledger_gate(ledger, session_ceiling=None)
+    gate.preflight_command(600.0)
+    gate.record_billed(400.0)
+    gate.settle()
+    assert ledger.kinds() == ["settlement"]
+
+
+def test_a_contended_lock_refuses_rather_than_running_unguarded():
+    """Proceeding without the lock is the defect this guard closes, so a lock
+    that cannot be taken is a refusal. It is the recoverable kind: whatever
+    holds it is a billed command that will finish."""
+
+    from exmergo_dex_core.guards.cost_guard import SpendLockTimeoutError
+
+    def contended():
+        raise TimeoutError("waited 30.0s for the spend lock")
+
+    ledger = _Ledger()
+    gate = _ledger_gate(ledger, lock=contended)
+    with pytest.raises(SpendLockTimeoutError) as exc_info:
+        gate.preflight_command(10.0)
+    assert "re-issuing the same command is safe" in str(exc_info.value)
+    assert exc_info.value.cost.paradigm is Paradigm.BYTES_SCANNED
+    assert ledger.entries == []
+
+
 def test_the_ledger_and_envelope_spellings_stay_distinct():
     """`billed_bytes` goes to the ledger, `bytes_billed` to the envelope.
 

--- a/packages/dex-core/tests/guards/test_cost_guard_concurrency.py
+++ b/packages/dex-core/tests/guards/test_cost_guard_concurrency.py
@@ -1,0 +1,296 @@
+"""The cumulative ceiling under concurrency: two commands, one budget.
+
+The rest of the cost-guard suite drives one gate at a time, which is the shape
+in which the guard always worked. What it could not catch is that every ceiling
+decision used to derive from a reading taken once at construction, so two
+commands overlapping in time were admitted against the same headroom. Both were
+legal individually and wrong together, and nothing said so: the ledger afterwards
+was well-formed and every entry in it was true.
+
+Two populations can race, and they need different tests. Threads sharing a
+process are what an embedding host produces; separate processes are what the CLI
+produces, one per subcommand, and that is the shape the defect was reported in.
+Neither is covered by the other, since an in-process lock says nothing about two
+processes and a file lock says nothing about two threads holding one descriptor.
+
+Deliberately stdlib only: `threading` and `subprocess`, no new dependency and no
+parallel-test plugin. The child below drives the real `FilesystemStore` against a
+real `.dex/` directory rather than a fake, because the file lock is the part
+under test.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.config import Budget, DexConfig
+from exmergo_dex_core.connect import new_cost_gate
+from exmergo_dex_core.guards.cost_guard import (
+    CostGuardError,
+    OverCeilingError,
+    utc_day_start,
+)
+from exmergo_dex_core.storage import FilesystemStore, MemoryStore
+
+CEILING = 1_000.0
+ESTIMATE = 600.0  # two of these do not fit under CEILING; exactly one does
+ACTUAL = 500.0
+
+
+def _config() -> DexConfig:
+    return DexConfig(
+        connector="bigquery",
+        budget=Budget(ceiling=CEILING, session_ceiling=CEILING),
+    )
+
+
+def _new_gate(store, index: int):
+    """Built through `new_cost_gate` rather than by hand, so these exercise the
+    wiring a real command gets (the reader closure, the record hook, and the
+    store's own lock) rather than a gate assembled the way a test finds
+    convenient."""
+
+    return new_cost_gate(
+        "bigquery",
+        _config(),
+        store,
+        confirmed=True,
+        command=f"explore profile {index}",
+    )
+
+
+def _run_one(gate, results: list) -> None:
+    """One whole billed command from admission onwards: admit, spend, settle."""
+
+    try:
+        gate.preflight_command(ESTIMATE)
+    except CostGuardError as exc:
+        results.append(("refused", type(exc).__name__))
+        return
+    try:
+        gate.record_billed(ACTUAL, statement="select 1")
+        results.append(("admitted", gate.spend_summary()))
+    finally:
+        gate.settle()
+
+
+def _ledger_total(root: Path) -> float:
+    path = root / ".dex" / "spend.jsonl"
+    if not path.is_file():
+        return 0.0
+    return sum(
+        json.loads(line).get("billed_bytes", 0.0)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    )
+
+
+# --- threads sharing one store ---------------------------------------------------
+
+
+@pytest.mark.parametrize("store_factory", ["filesystem", "memory"])
+def test_concurrent_threads_cannot_both_pass_one_session_ceiling(
+    tmp_path, store_factory
+):
+    """The acceptance test, in its in-process shape.
+
+    Both shipped backends, because the guarantee is the store's to provide and
+    a host picks the store.
+
+    **The barrier sits between building the gates and admitting through them**,
+    which is the thing worth being deliberate about. Ten commands issued at the
+    same moment all read a ledger that is still empty, and under the old design
+    that reading was the whole basis for every later decision, so all ten
+    admitted. Letting the threads construct their own gates instead would make
+    the overlap a function of scheduler luck, and a test that passes on the
+    broken code some of the time is worse than no test.
+    """
+
+    store = (
+        FilesystemStore(tmp_path) if store_factory == "filesystem" else MemoryStore()
+    )
+    results: list = []
+    gates = [_new_gate(store, index) for index in range(10)]
+    ready = threading.Barrier(len(gates))
+
+    def start(gate) -> None:
+        ready.wait()  # release them together, so they genuinely overlap
+        _run_one(gate, results)
+
+    threads = [threading.Thread(target=start, args=(gate,)) for gate in gates]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    admitted = [r for r in results if r[0] == "admitted"]
+    assert len(admitted) == 1, f"exactly one command fits under the ceiling: {results}"
+    assert len(results) == 10
+
+    settled = (
+        _ledger_total(tmp_path)
+        if store_factory == "filesystem"
+        else store.spend_since(utc_day_start(), connector="bigquery")
+    )
+    assert settled == ACTUAL
+    assert settled <= CEILING
+
+
+def test_a_second_thread_sees_the_first_ones_hold_while_it_is_still_running(tmp_path):
+    """The property reservations exist for.
+
+    A command that has been admitted but has not finished contributes nothing to
+    the ledger under the old design, so its headroom looks free for as long as it
+    runs. On a `transform build` that is minutes.
+    """
+
+    store = FilesystemStore(tmp_path)
+    first = new_cost_gate(
+        "bigquery", _config(), store, confirmed=True, command="transform build"
+    )
+    first.preflight_command(ESTIMATE)
+
+    second = new_cost_gate(
+        "bigquery", _config(), store, confirmed=True, command="explore profile"
+    )
+    with pytest.raises(OverCeilingError):
+        second.preflight_command(ESTIMATE)
+
+    # ...and the headroom comes back when the long command finishes.
+    first.record_billed(ACTUAL, statement="select 1")
+    first.settle()
+    third = new_cost_gate(
+        "bigquery", _config(), store, confirmed=True, command="explore profile"
+    )
+    assert third.preflight_command(400.0).ceiling == CEILING - ACTUAL
+
+
+# --- separate processes, which is what the CLI actually produces -----------------
+
+
+# Numbers arrive through argv rather than being interpolated into the source, so
+# this stays readable as the Python it is and the ceiling cannot drift from the
+# one the parent asserts against.
+_CHILD = """
+import json, os, sys, time
+from exmergo_dex_core.config import Budget, DexConfig
+from exmergo_dex_core.connect import new_cost_gate
+from exmergo_dex_core.guards.cost_guard import CostGuardError
+from exmergo_dex_core.storage import FilesystemStore
+
+root, ready, go, ceiling, estimate, actual = sys.argv[1:7]
+gate = new_cost_gate(
+    "bigquery",
+    DexConfig(
+        connector="bigquery",
+        budget=Budget(ceiling=float(ceiling), session_ceiling=float(ceiling)),
+    ),
+    FilesystemStore(root),
+    confirmed=True,
+    command="explore profile",
+)
+
+# Announce readiness, then spin until the parent drops the go file, so every
+# child reaches its admission inside the same few milliseconds. Sleeping a fixed
+# amount instead would make the overlap a function of process startup time, which
+# is exactly the thing that varies most between a laptop and CI.
+open(ready, "w").close()
+while not os.path.exists(go):
+    time.sleep(0.001)
+
+try:
+    gate.preflight_command(float(estimate))
+except CostGuardError as exc:
+    print(json.dumps({"outcome": "refused", "error": type(exc).__name__}))
+    sys.exit(0)
+try:
+    gate.record_billed(float(actual), statement="select 1")
+    print(json.dumps({"outcome": "admitted"}))
+finally:
+    gate.settle()
+"""
+
+
+def test_concurrent_processes_cannot_both_pass_one_session_ceiling(tmp_path):
+    """The acceptance test, in the shape the defect was reported in.
+
+    The CLI is one command per process, so the ledger on disk is the only thing
+    two commands share and the file lock is the only thing that can serialize
+    them. This is the assertion an in-process test cannot make: a `threading`
+    lock would pass it while the CLI stayed broken.
+    """
+
+    root = tmp_path / "repo"
+    (root / ".dex").mkdir(parents=True)
+    go = tmp_path / "go"
+    children = []
+    for index in range(6):
+        ready = tmp_path / f"ready-{index}"
+        children.append(
+            (
+                ready,
+                subprocess.Popen(  # noqa: S603
+                    [
+                        sys.executable,
+                        "-c",
+                        _CHILD,
+                        str(root),
+                        str(ready),
+                        str(go),
+                        str(CEILING),
+                        str(ESTIMATE),
+                        str(ACTUAL),
+                    ],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                ),
+            )
+        )
+
+    for ready, child in children:
+        for _ in range(3_000):
+            if ready.exists():
+                break
+            if child.poll() is not None:
+                break
+            threading.Event().wait(0.01)
+    go.touch()
+
+    outcomes = []
+    for _, child in children:
+        stdout, stderr = child.communicate(timeout=120)
+        assert child.returncode == 0, stderr
+        outcomes.append(json.loads(stdout.strip())["outcome"])
+
+    assert outcomes.count("admitted") == 1, outcomes
+    assert _ledger_total(root) == ACTUAL
+
+
+def test_an_unreleased_reservation_holds_its_estimate_rather_than_freeing_it(tmp_path):
+    """A process killed outright cannot release, and the guard errs closed.
+
+    The wrong direction here would be to expire a stale hold, which would mean
+    teaching every backend's `spend_since` to tell the entry kinds apart and
+    reason about time. Holding costs an over-conservative day; freeing costs the
+    overspend this whole change exists to prevent.
+    """
+
+    store = FilesystemStore(tmp_path)
+    abandoned = new_cost_gate(
+        "bigquery", _config(), store, confirmed=True, command="explore profile"
+    )
+    abandoned.preflight_command(ESTIMATE)
+    del abandoned  # no settle: the process died here
+
+    survivor = new_cost_gate(
+        "bigquery", _config(), store, confirmed=True, command="explore profile"
+    )
+    with pytest.raises(OverCeilingError):
+        survivor.preflight_command(ESTIMATE)

--- a/packages/dex-core/tests/storage/test_conformance.py
+++ b/packages/dex-core/tests/storage/test_conformance.py
@@ -24,6 +24,7 @@ Three shapes matter here and are not covered anywhere else:
 from __future__ import annotations
 
 import json
+import threading
 from datetime import datetime
 from pathlib import Path
 from typing import ClassVar
@@ -46,6 +47,7 @@ from exmergo_dex_core.storage import (
 )
 from exmergo_dex_core.storage.conformance import (
     ExploreStoreContract,
+    SpendLockContract,
     StoreContract,
     StoreFactoryContract,
     a_cache,
@@ -449,6 +451,58 @@ def test_a_factory_that_undershoots_its_declared_tier_names_the_tier():
     message = str(failure.value)
     assert "ExploreOnlyStore" in message and "Store" in message
     assert "unusable from configuration" in message
+
+
+def test_a_lock_that_does_not_exclude_fails_with_what_it_costs():
+    """The optional capability's worst failure, and the one easiest to ship.
+
+    A `spend_lock` returning `nullcontext` satisfies the type, satisfies the
+    re-entrancy assertion, and never blocks anything. Everything downstream then
+    looks correct, because each command in isolation is correct; what fails is
+    that the ceiling stopped binding across them. So the message has to say what
+    the lock was for rather than that two threads overlapped.
+    """
+
+    from contextlib import nullcontext
+
+    class UnlockedStore(ExploreOnlyStore):
+        def spend_lock(self, *, timeout: float = 30.0):
+            return nullcontext()
+
+    contract = SpendLockContract()
+    contract.make_store = lambda key: UnlockedStore(key)  # type: ignore[method-assign]
+    contract.lock_timeout = 2.0
+
+    with pytest.raises(AssertionError) as failure:
+        contract.test_the_lock_excludes_a_second_holder(contract.make_store("broken"))
+
+    message = str(failure.value)
+    assert "does not exclude" in message
+    assert "admitted against the same headroom" in message
+
+
+def test_a_backend_wide_lock_fails_by_naming_the_scope_it_should_have():
+    """The subtler failure: a lock that works and is scoped to the whole backend.
+
+    It excludes, it is re-entrant, and it makes every tenant wait on every other
+    tenant's billed commands. No single-tenant test can see it, which is why the
+    contract carries a two-key assertion at all.
+    """
+
+    shared = threading.RLock()
+
+    class GloballyLockedStore(ExploreOnlyStore):
+        def spend_lock(self, *, timeout: float = 30.0):
+            return shared
+
+    contract = SpendLockContract()
+    contract.make_store = lambda key: GloballyLockedStore(key)  # type: ignore[method-assign]
+    contract.lock_timeout = 2.0
+
+    with pytest.raises(AssertionError) as failure:
+        contract.test_two_keys_do_not_wait_on_each_other()
+
+    assert "scoped to the backend rather than to the ledger" in str(failure.value)
 
 
 def test_a_full_backend_satisfies_every_tier():

--- a/packages/dex-core/tests/storage/test_filesystem.py
+++ b/packages/dex-core/tests/storage/test_filesystem.py
@@ -9,6 +9,7 @@ poisoning the session budget.
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -137,3 +138,80 @@ def test_locators_are_absolute_paths_under_the_repo_root(tmp_path: Path):
     assert Path(store.plan_locator("pabc")) == (
         tmp_path / DEX_DIR / PLANS_DIR / "pabc.json"
     )
+
+
+# --- the spend lock, in the shape only this backend has -------------------------
+
+_LOCK_CHILD = """
+import sys, time
+from exmergo_dex_core.storage import FilesystemStore
+
+store = FilesystemStore(sys.argv[1])
+with store.spend_lock():
+    print("held", flush=True)
+    time.sleep(float(sys.argv[2]))
+"""
+
+
+def test_the_spend_lock_excludes_another_process(tmp_path: Path):
+    """The property the conformance contract cannot portably assert.
+
+    A `threading.Lock` satisfies every assertion the shipped contract makes and
+    would leave the CLI exactly as broken as it was, because the CLI is one
+    command per process and the ledger on disk is all two commands share. So the
+    cross-process half is pinned here, against the real file.
+    """
+
+    import subprocess
+    import sys as _sys
+
+    store = FilesystemStore(tmp_path)
+    child = subprocess.Popen(  # noqa: S603
+        [_sys.executable, "-c", _LOCK_CHILD, str(tmp_path), "0.5"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout.readline().strip() == "held"
+        started = time.monotonic()
+        with store.spend_lock():
+            waited = time.monotonic() - started
+    finally:
+        child.wait(timeout=30)
+    assert waited > 0.2, (
+        f"took the lock after {waited:.3f}s while another process held it, so "
+        "two CLI commands can be admitted against the same headroom"
+    )
+
+
+def test_a_contended_lock_gives_up_rather_than_waiting_forever(tmp_path: Path):
+    import subprocess
+    import sys as _sys
+
+    store = FilesystemStore(tmp_path)
+    child = subprocess.Popen(  # noqa: S603
+        [_sys.executable, "-c", _LOCK_CHILD, str(tmp_path), "2"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout.readline().strip() == "held"
+        with (
+            pytest.raises(TimeoutError) as refusal,
+            store.spend_lock(timeout=0.05),
+        ):
+            pass
+    finally:
+        child.wait(timeout=30)
+    # The builtin, not a dex type: the protocol asks for it so a backend needs no
+    # import from dex to satisfy the contract. The gate names it on the way out.
+    assert "spend lock" in str(refusal.value)
+
+
+def test_the_lock_file_sits_beside_the_ledger_it_protects(tmp_path: Path):
+    store = FilesystemStore(tmp_path)
+    with store.spend_lock():
+        pass
+    assert (tmp_path / DEX_DIR / "spend.lock").is_file()
+    # Empty, and it stays that way: the lock is the inode, not the contents.
+    assert (tmp_path / DEX_DIR / "spend.lock").read_text(encoding="utf-8") == ""

--- a/packages/dex-core/tests/storage/test_parity.py
+++ b/packages/dex-core/tests/storage/test_parity.py
@@ -17,10 +17,10 @@ from pathlib import Path
 import pytest
 
 from exmergo_dex_core.storage import FilesystemStore, MemoryStore
-from exmergo_dex_core.storage.conformance import StoreContract
+from exmergo_dex_core.storage.conformance import SpendLockContract, StoreContract
 
 
-class TestFilesystemStore(StoreContract):
+class TestFilesystemStore(SpendLockContract, StoreContract):
     @pytest.fixture(autouse=True)
     def _root(self, tmp_path: Path):
         # One root per test, with the key as a subdirectory: two keys are two
@@ -31,7 +31,7 @@ class TestFilesystemStore(StoreContract):
         return FilesystemStore(self.root / key)
 
 
-class TestMemoryStore(StoreContract):
+class TestMemoryStore(SpendLockContract, StoreContract):
     def make_store(self, key: str) -> MemoryStore:
         # Nothing to key on: a MemoryStore's state is the instance, so a distinct
         # instance is a distinct key by construction.

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -432,15 +432,18 @@ def test_the_wheel_ships_the_typed_marker(wheel: str):
 # no full-tier or hosted implementer could get green.
 OUTSIDE_FULL_BACKEND = '''
 import json
+import threading
 
 from exmergo_dex_core.cache import DexCache
 from exmergo_dex_core.storage import (
     Document,
+    SpendLock,
     Store,
     StoreContext,
     spend_total,
 )
 from exmergo_dex_core.storage.conformance import (
+    SpendLockContract,
     StoreContract,
     StoreFactoryContract,
 )
@@ -455,9 +458,20 @@ class TinyStore:
 
     _state: dict = {}
 
+    _locks: dict = {}
+    _locks_guard = threading.Lock()
+
     def __init__(self, key):
         self.key = key
         self._docs = self._state.setdefault(key, {})
+
+    def spend_lock(self, *, timeout=30.0):
+        # Per key, not per backend: two tenants must not wait on each other. A
+        # single module-level lock passes the exclusion assertions and quietly
+        # serializes every tenant in the deployment.
+        with self._locks_guard:
+            lock = self._locks.setdefault(self.key, threading.RLock())
+        return lock
 
     def load_cache(self):
         raw = self._docs.get("cache")
@@ -544,9 +558,10 @@ def tiny_store_factory(context):
 
 def test_the_published_protocol_is_satisfied():
     assert isinstance(TinyStore("k"), Store)
+    assert isinstance(TinyStore("k"), SpendLock)
 
 
-class TestTinyStore(StoreContract):
+class TestTinyStore(SpendLockContract, StoreContract):
     def make_store(self, key):
         return TinyStore(key)
 

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -246,6 +246,105 @@ def test_a_refusal_never_reports_a_metered_connector_as_free(paradigm, monkeypat
     assert no_ceiling.cost.paradigm is paradigm
 
 
+@pytest.mark.parametrize("backend", ["filesystem", "memory"])
+def test_two_concurrent_billed_commands_cannot_both_pass_one_session_ceiling(
+    tmp_path, backend
+):
+    """The cumulative ceiling binds across commands, not only within one.
+
+    The guard used to read the day's spend once when a gate was built and decide
+    the whole command from that reading, so two commands overlapping in time were
+    admitted against the same headroom. Reproduced live on BigQuery: a sequential
+    pair refused as designed, the same pair issued concurrently both ran, and the
+    ledger finished 15.3% over a seeded `session_ceiling`. Nothing looked wrong
+    afterwards, because every entry in that ledger was true.
+
+    Here rather than only in the cost-guard suite because a ceiling that reports
+    a number which did not bind is a safety regression, not a bug: it is the
+    control the published cost claim rests on.
+    """
+
+    import threading
+
+    from exmergo_dex_core.config import Budget, DexConfig
+    from exmergo_dex_core.connect import new_cost_gate
+    from exmergo_dex_core.guards.cost_guard import CostGuardError, utc_day_start
+
+    store = FilesystemStore(tmp_path) if backend == "filesystem" else MemoryStore()
+    config = DexConfig(
+        connector="bigquery", budget=Budget(ceiling=1_000.0, session_ceiling=1_000.0)
+    )
+    # Every gate is built before any of them admits, which is what makes this an
+    # honest test of the race rather than of thread scheduling: all four read the
+    # same empty ledger, and under the old design that reading was the whole basis
+    # for every decision that followed.
+    gates = [
+        new_cost_gate(
+            "bigquery", config, store, confirmed=True, command="explore profile"
+        )
+        for _ in range(4)
+    ]
+    admitted: list[bool] = []
+    ready = threading.Barrier(len(gates))
+
+    def run(gate):
+        ready.wait()
+        try:
+            gate.preflight_command(600.0)
+        except CostGuardError:
+            return
+        try:
+            gate.record_billed(500.0, statement="select 1")
+            admitted.append(True)
+        finally:
+            gate.settle()
+
+    threads = [threading.Thread(target=run, args=(g,)) for g in gates]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(admitted) == 1
+    settled = store.spend_since(
+        utc_day_start(), field="billed_bytes", connector="bigquery"
+    )
+    assert settled <= 1_000.0
+
+
+def test_every_shipped_store_can_serialize_the_spend_admission(tmp_path):
+    """A ceiling dex cannot enforce has to be one dex reports it cannot enforce.
+
+    Both shipped backends carry the lock, so the CLI and the default library path
+    are safe by default rather than safe by documentation. A backend without one
+    still runs, and every billed command against it says the cumulative ceiling is
+    advisory there, which is the same rule the rest of the guard follows: a
+    control that is narrower than it looks is worse than one that is absent.
+    """
+
+    from exmergo_dex_core.guards.cost_guard import CostGate
+    from exmergo_dex_core.storage import SpendLock
+
+    for store in (FilesystemStore(tmp_path), MemoryStore()):
+        assert isinstance(store, SpendLock), type(store).__name__
+
+    def gate(lock):
+        return CostGate(
+            paradigm=env.Paradigm.BYTES_SCANNED,
+            ceiling=10.0,
+            session_ceiling=1_000.0,
+            session_spent=0.0,
+            confirmed=True,
+            connector="bigquery",
+            record=lambda entry: None,
+            lock=lock,
+        )
+
+    assert gate(FilesystemStore(tmp_path).spend_lock).warnings() == []
+    unguarded = gate(None).warnings()
+    assert len(unguarded) == 1 and "spend lock" in unguarded[0]
+
+
 def test_a_scope_flag_cannot_widen_the_committed_allowlist():
     """The source allowlist in .dex/config.yml is a committed cost boundary. A
     per-command flag scopes work inside it and can never reach outside it, on any

--- a/packages/dex-core/tests/transform/test_build.py
+++ b/packages/dex-core/tests/transform/test_build.py
@@ -691,6 +691,8 @@ def _install_fake_pricing(
     ceiling: float | None,
     describe=None,
     notes: list[str] = (),
+    store=None,
+    session_ceiling: float | None = None,
 ):
     """Make ``cmd_build`` price a billed build without a real warehouse.
 
@@ -701,7 +703,7 @@ def _install_fake_pricing(
     """
 
     from exmergo_dex_core.engine import DexEngine
-    from exmergo_dex_core.guards.cost_guard import CostGate
+    from exmergo_dex_core.guards.cost_guard import CostGate, ledger_field, utc_day_start
     from exmergo_dex_core.transform import dev_target
 
     build_module = importlib.import_module("exmergo_dex_core.transform.build")
@@ -710,14 +712,30 @@ def _install_fake_pricing(
         def __init__(self):
             self.paradigm = paradigm
             self.name = connector
+            # With a store, the gate is wired the way `new_cost_gate` wires a
+            # real one (live reader, record hook, the store's own lock) so the
+            # reservation a build holds while dbt runs is exercised. Without one
+            # it stays the plain snapshot gate the pricing tests want.
             self.cost_gate = CostGate(
                 paradigm=paradigm,
                 ceiling=ceiling,
-                session_ceiling=None,
-                session_spent=0.0,
+                session_ceiling=session_ceiling,
+                session_spent=(
+                    0.0
+                    if store is None
+                    else (
+                        lambda: store.spend_since(
+                            utc_day_start(),
+                            field=ledger_field(paradigm),
+                            connector=connector,
+                        )
+                    )
+                ),
                 confirmed=confirmed,
                 connector=connector,
                 command="transform build",
+                record=None if store is None else store.append_spend_log,
+                lock=None if store is None else store.spend_lock,
             )
             self.closed = False
 
@@ -1433,3 +1451,113 @@ def test_a_billed_build_under_a_cumulative_cap_stays_quiet(
     )
     assert rc == 0, envelope
     assert [w for w in envelope["warnings"] if "budget.session_ceiling" in w] == []
+
+
+def test_a_running_build_holds_its_headroom_and_gives_it_back(
+    bigquery_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """The case the reservation exists for, on the command where it matters most.
+
+    A build is the longest billed command dex has, and it settles outside the
+    cost gate entirely: dbt executes the statements, so nothing reaches the
+    ledger until the run finishes. For as long as it runs, its headroom used to
+    look free, and a concurrent `explore profile` was admitted against a daily
+    budget the build had already committed.
+
+    The probe fires from inside the fake dbt runner, which is exactly the window
+    a real build is open for.
+    """
+
+    import json as json_mod
+
+    from exmergo_dex_core.config import Budget, DexConfig
+    from exmergo_dex_core.connect import new_cost_gate
+    from exmergo_dex_core.envelope import Paradigm
+    from exmergo_dex_core.guards.cost_guard import OverCeilingError, utc_day_start
+    from exmergo_dex_core.storage import FilesystemStore
+
+    store = FilesystemStore(tmp_path)
+    config = DexConfig(
+        connector="bigquery",
+        budget=Budget(ceiling=100_000_000.0, session_ceiling=8_000_000.0),
+    )
+    _install_fake_pricing(
+        monkeypatch,
+        connector="bigquery",
+        paradigm=Paradigm.BYTES_SCANNED,
+        estimate=5_000_000.0,
+        per_node={"stg_customers": 5_000_000.0},
+        confirmed=True,
+        ceiling=100_000_000,
+        store=store,
+        session_ceiling=8_000_000.0,
+    )
+
+    refused: list[bool] = []
+
+    def probe_while_dbt_runs():
+        # A second command arriving mid-build. 5 MB is held of an 8 MB day, so a
+        # 5 MB scan no longer fits, and before reservations it would have.
+        concurrent = new_cost_gate(
+            "bigquery", config, store, confirmed=True, command="explore profile"
+        )
+        try:
+            concurrent.preflight_command(5_000_000.0)
+        except OverCeilingError:
+            refused.append(True)
+        finally:
+            concurrent.settle()
+
+    target_dir = bigquery_project_dir / "target"
+    run_results = json_mod.dumps(
+        {
+            "results": [
+                {
+                    "unique_id": "model.dex_test.stg_customers",
+                    "status": "success",
+                    "execution_time": 1.0,
+                    "adapter_response": {"bytes_billed": 3_000_000},
+                }
+            ]
+        }
+    )
+    build_module = importlib.import_module("exmergo_dex_core.transform.build")
+    import subprocess as _subprocess
+
+    def fake(timeout: float, cwd, env=None):
+        def run(argv: list[str]):
+            probe_while_dbt_runs()
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "run_results.json").write_text(run_results, encoding="utf-8")
+            return _subprocess.CompletedProcess(args=argv, returncode=0, stdout="")
+
+        return run
+
+    monkeypatch.setattr(build_module, "_default_runner", fake)
+
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--connector",
+            "bigquery",
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+            "--budget",
+            "100000000",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+    assert refused == [True], "a concurrent command was admitted against held headroom"
+
+    # ...and the hold is given back once dbt returns, so the day settles to what
+    # the build really cost rather than to what it was quoted.
+    assert (
+        store.spend_since(utc_day_start(), field="billed_bytes", connector="bigquery")
+        == 3_000_000
+    )
+    assert envelope["data"]["spend"]["session_spent_today"] == 3_000_000

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -372,6 +372,23 @@ Rules the envelope enforces, all of them Tier-2 eval targets:
   plus `session_spent_today`, which is what the next command's cumulative
   ceiling will start from. A failed build reports it too: dbt bills for the
   statements it ran before it stopped.
+- **The cumulative ceiling binds across commands that overlap in time**, not
+  only across commands that follow one another. An admitted command books its
+  estimate against the day's headroom before it runs and releases the unspent
+  part when it settles, so a second command issued while the first is still
+  running is measured against what is genuinely left, and the server-side cap
+  each statement carries is bounded by that booking rather than by the whole
+  ceiling. Three consequences a caller can see:
+  - `cost.ceiling` on a refusal reflects headroom another command is holding, so
+    two runs of the same command can be refused against different numbers.
+  - `session_spent_today` counts headroom held by commands still in flight, so
+    while another billed command is running it reads higher than settled spend
+    and can briefly exceed `session_ceiling` without anything having overspent.
+    Run commands one at a time and it is exactly settled spend.
+  - A command killed outright leaves its estimate booked until the UTC rollover.
+    Every softer exit, including an interrupt, releases. This errs conservative
+    on purpose: the alternative is a hold that expires while its command is
+    still spending.
 - **A billed command with no cumulative ceiling warns.** `budget.ceiling` is
   *refused* when missing, because nothing runs unbudgeted;
   `budget.session_ceiling` is only warned about, because refusing would break

--- a/references/storage.md
+++ b/references/storage.md
@@ -54,6 +54,12 @@ at runtime. Passing an explore-only store to a transform command refuses with a
 message naming the tier and the missing members, rather than failing on a missing
 attribute several frames down.
 
+Two capabilities sit alongside the tiers rather than inside them, and both are
+optional: `SpendLock`, so the cumulative spend ceiling binds when two commands
+overlap, and the construction contract, so your backend can be named in
+configuration. A backend is a complete backend without either, and the first is
+one every concurrent host wants.
+
 ## Writing one
 
 ```python
@@ -98,6 +104,56 @@ engine = DexEngine(connector="bigquery", config=cfg, store=MyStore(tenant))
 Use `spend_total` rather than reimplementing the ledger arithmetic. It is exported
 for exactly this reason: every backend then answers the session-budget question
 identically, which is a property you want in a guard.
+
+## Serializing the spend admission
+
+One optional capability, and the only place in this seam where skipping something
+costs correctness rather than convenience. If your backend can be reached by more
+than one command at a time, implement it.
+
+```python
+from contextlib import contextmanager
+
+
+class MyStore:
+    @contextmanager
+    def spend_lock(self, *, timeout: float = 30.0):
+        with self._lock_for(self.tenant, timeout=timeout):
+            yield
+```
+
+**What dex does with it.** The cost gate reads the day's spend, decides whether
+the command fits under `budget.session_ceiling`, and books that much headroom in
+the ledger, all inside one `spend_lock`. It is held for the decision only, never
+across a warehouse query, so it costs microseconds and never serializes work that
+has no reason to wait.
+
+**Three properties, and the third is the one most often missed.**
+
+- **It excludes.** A second holder waits.
+- **It is re-entrant for one holder.** dex settles a gate from more than one
+  funnel, so a settle inside a section already held is expected rather than a
+  deadlock to design around.
+- **It is scoped to the ledger this store reads, not to the backend.** A single
+  global mutex satisfies the first two and quietly serializes every tenant in the
+  deployment against every other. That is the same isolation the tier contracts
+  already require, and a lock is the easy place to forget it, because a
+  single-tenant test cannot see the difference.
+
+Raise the builtin `TimeoutError` when `timeout` elapses; dex turns it into a
+named refusal carrying the cost. The builtin is what the protocol asks for so
+your backend needs no import from dex to satisfy it.
+
+**Without it your backend still works.** dex books the headroom regardless, which
+narrows the race from the duration of a warehouse query to the microseconds
+around the ledger read, and every billed command carries a warning that the
+cumulative ceiling is advisory. That is a warning rather than a refusal on
+purpose, matching the call already made for a `session_ceiling` nobody set:
+refusing would break a backend written before this existed. It is not a reason to
+skip the lock on anything serving concurrent requests.
+
+`SpendLockContract` in the conformance suite is the executable version of all of
+the above.
 
 ## Constructing one
 
@@ -221,13 +277,36 @@ permissive, which makes it worth stating plainly: key stores exactly as you key
 principals. A host that splits stores for some other reason, one per repo root
 say, has split the budget too and will not be told.
 
-**The ledger read-then-write is not atomic at the protocol level.** The cost gate
-calls `spend_since` and then `append_spend_log`. The cumulative session ceiling
-therefore binds exactly when commands are serialized, which is the CLI's
-one-command-per-process shape; under genuinely concurrent commands the overshoot
-is bounded by the sum of the concurrent estimates. A backend that can make the
-pair atomic for one key should, and a multi-tenant backend serving concurrent
-requests per tenant is where that stops being optional.
+**The ledger read-then-write has to be atomic for the cumulative ceiling to
+bind**, and `SpendLock` below is how a backend provides it. The cost gate reads
+`spend_since`, decides whether the command fits under `budget.session_ceiling`,
+and appends, and two commands running that sequence at once read the same total
+and both decide yes. Implement the lock and dex serializes the sequence through
+it. Without one dex still books the headroom, which narrows the window from the
+length of a warehouse query to the microseconds around the read, and warns on
+every billed command that the ceiling is advisory on this backend.
+
+**Entries are stored, not interpreted.** Each carries an `entry` kind
+(`reservation`, `settlement`, `release`) and a `reservation_id` tying the three
+together, because the ceiling has to hold headroom for a command that has been
+admitted and has not finished paying. A release carries a **negative**
+magnitude, and that is the one thing to know here: a backend that clamps or
+filters on sign would leak held headroom for the rest of the UTC day. Sum what
+you are given.
+
+Two properties follow, and neither required a change to any backend written
+before reservations existed:
+
+- **A day that has finished sums to actual spend**, exactly as it always did, so
+  nothing summing settled spend saw a different number.
+- **A day with commands still running sums to actual spend plus the headroom
+  they hold.** That is not an accounting error; it is the number a concurrent
+  command has to see.
+
+A process killed outright cannot release, so its reservation stands until the
+UTC rollover. That is deliberate, and it is the safe direction: the alternative
+is expiring a hold, which would mean teaching every backend's `spend_since` to
+tell the entry kinds apart and reason about time.
 
 **The protocol is synchronous.** A backend whose client is async wraps it, running
 the coroutine to completion inside the method. Every caller in the engine is
@@ -305,6 +384,27 @@ This is why construction is not a second, unchecked obligation: with it, "the
 conformance suite is green" still means your backend is both correct and
 constructable. Without it, the suite proves behavior only, and a backend can pass
 every assertion here and still fail the moment configuration names it.
+
+**If your backend serves concurrent requests**, mix in `SpendLockContract` the
+same way, and it checks all three properties from
+[Serializing the spend admission](#serializing-the-spend-admission), including
+the scope one:
+
+```python
+from exmergo_dex_core.storage.conformance import ExploreStoreContract, SpendLockContract
+
+
+class TestMyStore(SpendLockContract, ExploreStoreContract):
+    def make_store(self, key):
+        return MyStore(tenant=key)
+```
+
+It exercises threads, because that is the population a suite can portably create.
+If your backend spans processes or hosts, the lock has to reach whatever your own
+substrate offers (an advisory file lock, a transaction, a conditional write) and
+this contract cannot tell the difference. That gap is real, and it is why the two
+shipped backends carry cross-process assertions of their own rather than treating
+a green contract as the whole answer.
 
 ## Which calls need nothing on the filesystem
 


### PR DESCRIPTION
Closes #159

## What this changes

`budget.session_ceiling` did not bind under concurrency. The cost gate read the
day's spend once, as a constructor argument, and every ceiling decision for the
life of that gate derived from that one reading, so two billed commands
overlapping in time were admitted against the same headroom. Every individual
command was legal, only the aggregate was not, and nothing said so: the ledger
afterwards was well-formed and every entry in it was true.

## Reproduced live at 1.5.0 before scoping

BigQuery, `session_ceiling: 40000000`, two
`explore profile` commands estimated at 34,685,000 and 31,457,280 bytes. Only one
fits.

Sequential: the first admits and settles at 20,971,520; the second sees
`ceiling: 19028480` and refuses. Concurrent, same seeded ledger: both were handed
the full 40,000,000 and both ran, leaving the ledger at 46,137,344, **15.3% over**.

Two findings beyond the issue text came out of that run.

**The server-side backstop was raced too**, confirmed against the jobs
themselves. `bq show -j` on the four executed jobs showed each command's first
statement carrying `maximum_bytes_billed=40000000`, the whole daily ceiling, so
the warehouse-side bound on the pair was twice the ceiling. The cap winds down
correctly *within* a command (29.5M, then 25.3M, as `_billed` accumulates) and
not at all across commands.

**`data.spend.session_spent_today` under-reported.** The two commands reported
25,165,824 and 20,971,520 against a real day total of 46,137,344, because each
added its own spend to a stale reading. A host reading either envelope saw less
than half the truth.

Snowflake reproduced the same wrong admission on the compute-time paradigm. Its
ledger did not exceed the ceiling, and that is worth stating precisely rather
than reading as a pass: the heuristic over-forecasts by roughly 5x on that
workload, so the overshoot was absorbed by conservatism rather than prevented by
the guard.

The reachability half of the issue ("a remedy that exists in the tree is not a
remedy that runs") was closed by #157 in 1.4.3, so the work here is making the
shipped default safe rather than making the seam reachable.

## The fix

**Not a fresher read.** A read followed by a decision leaves a window in which
two commands read the same number and both decide yes, however recent the number
is. Refreshing at admission would have narrowed the window and left the defect.

An admitted command now **books its estimate against the day's headroom before it
runs** and releases the unspent part when it settles, both inside a lock the
store provides. The check order is untouched: over-ceiling refuses first, an
unconfirmed call asks even with no ceiling, a confirmed call with no ceiling
refuses. **A refusal books nothing**, so the unconfirmed handshake that begins
every billed command stays a pure read.

### The invariant that kept the blast radius small

A live reading includes the gate's own writes, so the gate tracks what it has
appended and defines

```
session_spent = read() - what this gate wrote
```

which is the day's spend belonging to *other* commands, exactly what
`session_spent` meant when it was a constructor argument. So `effective_ceiling`,
`charge`, `remaining_for_statement` and all five adapters keep their meanings,
and `spend_summary`'s expression is unchanged and now reports the truth because
it is read after settlement. **The entire existing suite passed with no edits**,
which is the check that this sits in the right place.

`spend_total` is untouched, so a settled day still sums to actual spend and
**every third-party backend keeps working with no change**.

### The two live findings, closed

The server-side cap is now bounded by the booking as well as by the ceiling.
Verified on the jobs: a concurrent pair under a 90,000,000 ceiling carried caps
of 31,457,280 and 40,790,764, summing to 72.2M, where before both carried the
whole ceiling.

That exposed a residual the plan had not anticipated. A command is bounded per
statement by the ceiling rather than by its own estimate, deliberately, so a
drifting estimate stops mid-command instead of overrunning. Under concurrency
that bound came from the reading the command was admitted on, which cannot see
headroom a later command took. So **drift is now re-admitted** against a live
reading: it may still use budget that is genuinely free and can no longer use
budget another command is holding. Only the drift pays for the lock.

### Where settlement happens

Three funnels, overlapping by design so an interrupted command releases as
reliably as a completed one: `stamp_spend`, the engine rebuilding a gate, and
`engine.close()`, which the CLI calls from a `finally`. `settle()` is idempotent.

`transform build` reserves too, and it matters most there: dbt executes the
statements, so nothing reaches the ledger until the run finishes and a build's
headroom used to look free for as long as it ran.

## The ledger

Entries gain an `entry` kind (`reservation`, `settlement`, `release`) and a
`reservation_id`. A release is negative, so a finished day sums to actual spend
exactly as before, and a day with commands still running sums to actual spend
plus the headroom they hold, which is the number a concurrent command has to see.

**Nothing is reserved when no `session_ceiling` is set**, since a reservation
exists to be seen by a command settling against one. The ledger stays
byte-identical for every project that never configured a daily cap.

A process killed outright cannot release, so its reservation stands until the UTC
rollover. Deliberate, and the safe direction: expiring a hold would mean teaching
every backend's `spend_since` to tell entry kinds apart and reason about time,
which is a protocol change for a case the three funnels already cover.

## `SpendLock`

A new optional storage capability, beside the tiers rather than inside them.
`FilesystemStore` takes an advisory `flock` on `.dex/spend.lock` plus a per-path
in-process lock (not belt-and-braces: a POSIX lock belongs to the open file
description, so two threads opening the same file would each get their own).
`MemoryStore` takes a re-entrant lock. Both shipped backends have it, so the CLI
and the default library path are safe by default rather than by documentation.

A backend without one still runs. dex reserves regardless, which narrows the race
from the duration of a warehouse query to the microseconds around the read, and
every billed command warns that the cumulative ceiling is advisory there. A
warning rather than a refusal, matching the call already made for a
`session_ceiling` nobody set.

**This reverses a decision written on the protocol**, which said it would not grow
a member for atomicity because "an optional member no implementer can rely on is
worse than a stated bound". That holds for a member dex uses silently. It does not
hold for one dex detects and reports, because a caller is then never told a
ceiling bound when it did not.
