### PR TITLE
Tier the project seam, and ship a conformance contract for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **The project seam is tiered, and load-bearing** ([#171]). `ProjectAdapter` had
+  exactly one reference in the distribution, its own `class` statement, and
+  `DbtProject` was never constructed anywhere, tests included, while every
+  project-reading consumer went to `dbt_project` directly. It is now three nested
+  protocols in `adapters/project.py`:
+  `ExploreProject` (`definitions()`), `MaintainProject` (adding
+  `transform_layer()` and `semantic_layer()`), and `EditableProject` (adding
+  `write_edits()`), with `tier_of()` reporting the highest tier an object
+  satisfies. `DbtProject` implements all three by delegating to the functions
+  that already existed, and explore's one project read now goes through it, so
+  the seam carries a real read path instead of describing one.
+
+  Tier 2 is two methods rather than one returning a union, because
+  `maintain.snapshot` already exposes exactly those two and `maintain.commands`
+  already calls them; a union would have to be unpacked at every call site.
+  Declining `EditableProject` is a supported answer: a project reduced from a
+  running graph cannot receive an edit, and a tier is checkable where a
+  `writeback: no` flag would be a claim the engine has to trust.
+
+- **A conformance contract for project formats** ([#171]).
+  `exmergo_dex_core.adapters.conformance` ships the seam's rules as assertions, so
+  a format outside this distribution runs them in its own suite, the way
+  `storage.conformance` already does for backends. Install
+  `exmergo-dex-core[project-conformance]`, which needs only pytest: nothing in the
+  contract reaches the dialect engine, and a packaging test keeps it that way.
+  `references/project.md` covers the tiers and what the construction contract
+  still leaves open.
+
+### Fixed
+
+- **`definitions()` no longer raises on a project file that is not valid YAML**
+  ([#171]). Its docstring promises that no project, an ambiguous choice, or an
+  unreadable project yields the empty view and never an exception, and explore
+  depends on that: exploration runs against warehouses with no project at all. But
+  `load` parses `dbt_project.yml` with `yaml.safe_load`, so a malformed project
+  file arrived as `yaml.YAMLError` while only `DbtProjectError` was caught, and
+  `explore --use-project` raised out of a read that is meant to degrade. The three
+  profile readers in the same module already pair the two exceptions; this is that
+  pairing on the read path. Found by the first run of the new conformance suite
+  against the shipped format.
+
 ## [1.5.1] - 2026-08-03
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,6 +261,46 @@ Backends contributed here run the same suite: see
 `packages/dex-core/tests/storage/test_parity.py`, which is deliberately the same
 three lines a third party writes.
 
+## Writing a project format
+
+The source of truth lives behind a tiered protocol in `adapters/project.py`, and
+that contract is public too. The usual reason to write one is that your models are
+not a dbt project: an orchestrated asset graph, SQLMesh, or a semantic layer that
+owns its own definitions still knows which tables it builds, at what grain, and how
+they relate.
+
+Implement the tier your format can answer (`ExploreProject` is one method;
+`MaintainProject` adds the two snapshot layers; `EditableProject` adds the write
+path), then prove it with the suite dex ships:
+
+```
+pip install "exmergo-dex-core[project-conformance]"
+```
+
+```python
+from exmergo_dex_core.adapters.conformance import ExploreProjectContract
+
+
+class TestMyProject(ExploreProjectContract):
+    def make_project(self):
+        return MyProject(nothing_declared())
+```
+
+The assertion worth the most is behavioural rather than structural: `definitions()`
+must not raise, on an absent project, an ambiguous one, or a source that will not
+parse. Explore runs against warehouses with no project at all, so a format that
+raises there turns an ordinary state into an outage. Override
+`make_unreadable_project()` to get those assertions running against your format
+instead of skipped.
+
+Declining `EditableProject` is a supported answer, not a gap. A project reduced from
+a running graph cannot receive an edit, because its source of truth is the code that
+produced the graph. `references/project.md` covers the tiers, the rules that are not
+obvious from the signatures, and what the construction contract still leaves open.
+
+Formats contributed here run the same suite: see
+`packages/dex-core/tests/adapters/test_project_parity.py`.
+
 ## Linting and formatting (Ruff)
 
 We use [Ruff](https://docs.astral.sh/ruff/) as both the linter and the

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -135,6 +135,16 @@ cluster = ["scikit-learn>=1.4"]
 # imports lazily and a packaging test installs no extra at all), so this is a floor
 # raised for the wider tiers rather than a new requirement on the narrow one.
 storage-conformance = ["pytest>=8", "exmergo-dex-core[sql]"]
+# The project conformance contract (`exmergo_dex_core.adapters.conformance`), for
+# anyone implementing a project format outside this distribution. Named on the same
+# rule as the extra above: an install line answers "conformance to what?" alone.
+#
+# Unlike [storage-conformance] this needs no dialect engine, and that is a property
+# worth keeping rather than a coincidence: the contract reads a project and asserts
+# on `ProjectDefinitions`, so nothing in it reaches the SQL guard. A packaging test
+# holds it true, because the cheapest way for this to acquire a heavier floor is for
+# an assertion to start building something that parses SQL.
+project-conformance = ["pytest>=8"]
 # One command for users who want every optional capability at once: every
 # connector, both semantic-layer backends, and clustering. Self-references the
 # other extras so their requirement lists stay defined in exactly one place, which

--- a/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
@@ -1,0 +1,299 @@
+"""The executable contract a project format has to satisfy, shipped for reuse.
+
+The rules a format owes its callers are stated on the protocol members in
+:mod:`.project`. This module is the same rules as assertions, packaged so a format
+living outside this distribution can run them in its own test suite:
+
+    from exmergo_dex_core.adapters.conformance import ExploreProjectContract
+
+    class TestMyProject(ExploreProjectContract):
+        def make_project(self):
+            return MyProject(nothing_declared())
+
+That is the whole integration. pytest collects the inherited ``test_*`` methods and
+runs the contract against your format.
+
+**Pick the class that matches the tier you implement**, mirroring the protocols
+exactly: :class:`ExploreProjectContract` for a format that can state what it
+declares, :class:`MaintainProjectContract` when it can also produce the two
+snapshot layers. Subclassing a wider contract than your format implements is how
+you find out you have not finished, so the narrow class is a feature rather than a
+convenience.
+
+**A project is a source, not a sink, and that shapes this suite.** The storage
+contract can write through the protocol and read back, so it needs no fixtures from
+the implementer. Nothing here can put a declaration *into* your format, so the
+assertions that check content arrive have to be handed a project already in a known
+state. That is what the hooks are for, and why the content half is a separate
+mix-in: a format is worth reading before it is worth trusting to round-trip a key.
+
+**The assertion that matters most is behavioural, not structural.**
+``definitions()`` must not raise -- not on an absent project, not on an ambiguous
+one, not on a source it cannot parse. Exploration runs against warehouses with no
+project at all, so absence is an ordinary state, and a format that raises turns it
+into an outage. A contract asserting only shapes cannot catch that, which is why
+:meth:`ExploreProjectContract.make_unreadable_project` exists and why it is worth
+overriding even though it defaults to skipping.
+
+**If your format can be handed a declaration to read**, mix
+:class:`DeclaringProjectContract` in as well. It checks that a declared key and a
+declared join actually reach the engine, which is the whole reason a project is
+read on the explore path: those two arrive through ``definitions()`` and through no
+other channel.
+
+This module imports pytest, so it is deliberately not imported by
+:mod:`exmergo_dex_core.adapters`: a bare ``import exmergo_dex_core`` must not
+require a test framework. Install the ``[project-conformance]`` extra to get what
+running the suite needs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ..dbt_project import ProjectDefinitions
+from .project import ExploreProject, tier_of
+
+if TYPE_CHECKING:
+    from ..maintain.snapshot import SemanticLayer, TransformLayer
+
+__all__ = [
+    "DeclaringProjectContract",
+    "ExploreProjectContract",
+    "MaintainProjectContract",
+]
+
+
+class ExploreProjectContract:
+    """Tier 1. Subclass and implement :meth:`make_project`.
+
+    Every assertion here is format-independent: it asks what dex may assume about
+    any project it is handed, never what a particular format looks like.
+    """
+
+    def make_project(self) -> ExploreProject:
+        """A project of your format with nothing declared in it.
+
+        The empty case rather than the interesting one, because it is the case dex
+        actually meets most often: a repo with no project, a warehouse explored
+        bare. If your format cannot represent "nothing declared", that is worth
+        knowing before you go further -- dex reaches this state on every explore
+        run that does not ask for a project.
+        """
+
+        raise NotImplementedError
+
+    def make_unreadable_project(self) -> ExploreProject | None:
+        """A project whose source your format cannot parse, or ``None``.
+
+        Override this. It is the hook behind the contract's most valuable
+        assertion, and it defaults to ``None`` -- which skips those assertions with
+        a message saying so -- only because a format may genuinely have no
+        unparseable state: one reduced from an object already in memory cannot be
+        malformed the way a file can.
+
+        A default that skips is a compromise, and it is the right one here: making
+        it mandatory would lock out a format for which the state does not exist,
+        and the skip is explicit in the report rather than silent.
+        """
+
+        return None
+
+    # --- what dex may assume of any project -----------------------------------
+
+    def test_satisfies_the_explore_tier(self) -> None:
+        assert tier_of(self.make_project()) >= 1
+
+    def test_names_its_format_and_not_the_instance(self) -> None:
+        """``name`` identifies the format, so two instances agree on it.
+
+        A name that varies per instance is a name a registry cannot resolve, and
+        the mistake is easy to make by deriving it from a path or an id.
+        """
+
+        first = self.make_project()
+        second = self.make_project()
+        assert first.name
+        assert first.name == second.name
+
+    def test_an_empty_project_declares_nothing_without_raising(self) -> None:
+        definitions = self.make_project().definitions()
+
+        assert isinstance(definitions, ProjectDefinitions)
+        assert definitions.declared_keys == []
+        assert definitions.declared_composite_keys == []
+        assert definitions.foreign_keys == []
+
+    def test_definitions_is_repeatable(self) -> None:
+        """Two reads of an unchanged project agree.
+
+        Not a caching requirement -- a format may re-read its source every call.
+        What it rules out is a read that consumes something, which is a real
+        failure mode for a format reduced from a stream or an iterator, and one
+        that surfaces as a second command mysteriously seeing less than the first.
+        """
+
+        project = self.make_project()
+
+        assert project.definitions() == project.definitions()
+
+    def test_an_unreadable_project_does_not_raise(self) -> None:
+        project = self.make_unreadable_project()
+        if project is None:
+            pytest.skip(
+                "make_unreadable_project() returned None: this format declares it "
+                "has no unparseable state"
+            )
+
+        definitions = project.definitions()
+
+        assert isinstance(definitions, ProjectDefinitions)
+
+    def test_an_unreadable_project_says_why_rather_than_going_quiet(self) -> None:
+        """Degrading quietly is not the same as degrading silently.
+
+        An empty result with no note is indistinguishable from a project that
+        genuinely declares nothing, so the operator cannot tell a typo in their
+        source from a correct empty read. ``notes`` is where that difference goes.
+        """
+
+        project = self.make_unreadable_project()
+        if project is None:
+            pytest.skip(
+                "make_unreadable_project() returned None: this format declares it "
+                "has no unparseable state"
+            )
+
+        assert project.definitions().notes
+
+
+class DeclaringProjectContract:
+    """Opt-in: the declarations dex reads a project *for* actually arrive.
+
+    Mix in beside the contract for your tier::
+
+        class TestMyProject(DeclaringProjectContract, ExploreProjectContract):
+            def make_project(self): ...
+            def a_project_declaring_a_unique_key(self): ...
+            def a_project_declaring_a_join(self): ...
+
+    Separate from the tier contract because the two answer different questions. The
+    tier contract asks whether dex can safely call your format at all; this asks
+    whether reading it was worth doing.
+    """
+
+    def a_project_declaring_a_unique_key(self) -> tuple[ExploreProject, str, str]:
+        """A project declaring one single-column unique key.
+
+        Returns ``(project, model, column)`` -- the project, and what dex should
+        see in it. Naming the expectation here rather than fixing it in the suite
+        keeps your format's own vocabulary out of the assertion: whatever you call
+        the model, the contract checks that dex learns that name.
+        """
+
+        raise NotImplementedError
+
+    def a_project_declaring_a_join(
+        self,
+    ) -> tuple[ExploreProject, str, str, str, str]:
+        """A project declaring one single-column join between two models.
+
+        Returns ``(project, model, column, to_model, to_column)``.
+        """
+
+        raise NotImplementedError
+
+    def test_a_declared_unique_key_reaches_the_engine(self) -> None:
+        project, model, column = self.a_project_declaring_a_unique_key()
+
+        declared = project.definitions().declared_keys
+        matching = [k for k in declared if k.model == model and k.column == column]
+
+        assert matching, f"expected a declared key on {model}.{column}, got {declared}"
+        assert matching[0].unique, (
+            "a key declared unique must arrive with unique=True; a grain that "
+            "arrives without it is read as an ordinary column"
+        )
+
+    def test_a_declared_join_carries_both_sides(self) -> None:
+        """Both ends, because a half-read join is worse than an unread one.
+
+        A join naming the wrong side sends the relationship detector looking for a
+        key that is not there, and the finding it produces reads like a data
+        problem rather than a misread declaration.
+        """
+
+        project, model, column, to_model, to_column = self.a_project_declaring_a_join()
+
+        declared = project.definitions().foreign_keys
+        matching = [
+            fk
+            for fk in declared
+            if fk.model == model
+            and fk.column == column
+            and fk.to_model == to_model
+            and fk.to_column == to_column
+        ]
+
+        assert matching, (
+            f"expected a declared join {model}.{column} -> {to_model}.{to_column}, "
+            f"got {declared}"
+        )
+
+
+class MaintainProjectContract(ExploreProjectContract):
+    """Tier 2. Inherits every tier-1 assertion.
+
+    The layers are what a snapshot is taken of, so a format reaching this tier can
+    be a drift baseline. What is asserted here is deliberately thin: the layers'
+    contents are the format's business, and the one cross-tier rule worth holding
+    is that the two channels agree about which models exist.
+    """
+
+    def test_satisfies_the_maintain_tier(self) -> None:
+        assert tier_of(self.make_project()) >= 2
+
+    def test_both_layers_are_produced_with_nothing_declared(self) -> None:
+        """Tier 2 is reached with nothing declared, not only with content.
+
+        A format that only produces layers once something is declared cannot be
+        snapshotted on its first run, which is the run that establishes the
+        baseline every later drift report compares against.
+
+        Note what is *not* asserted: that the layers are empty. A project can build
+        models while declaring nothing about them -- that is the ordinary state of
+        an uninstrumented project -- so emptiness here would be a claim about the
+        fixture rather than about the format. What has to hold is that both
+        channels answer at all.
+        """
+
+        project = self.make_project()
+
+        transform: TransformLayer = project.transform_layer()
+        semantic: SemanticLayer = project.semantic_layer()
+
+        assert isinstance(transform.models, list)
+        assert isinstance(transform.model_refs, dict)
+        assert semantic.semantic_models == []
+        assert semantic.metrics == []
+
+    def test_the_two_channels_agree_about_which_models_exist(self) -> None:
+        """A model in the transform layer is a model ``definitions()`` built.
+
+        The layers and the definitions are read by different commands, and a
+        format producing them from two different traversals can disagree. Drift
+        then reports a model as added or orphaned on the strength of which channel
+        happened to be read.
+        """
+
+        project = self.make_project()
+
+        layer_models = set(project.transform_layer().models)
+        built = {name.lower() for name in project.definitions().built_relation_names}
+
+        assert {m.lower() for m in layer_models} <= built or not built, (
+            f"transform_layer() reports models {sorted(layer_models)} that "
+            f"definitions() does not list as built: {sorted(built)}"
+        )

--- a/packages/dex-core/src/exmergo_dex_core/adapters/project.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/project.py
@@ -1,24 +1,153 @@
 """The project adapter seam: how dex stays open to more model formats over time.
 
 The source of truth is a *project*, and today the only project format is dbt. This
-thin protocol is the extension point: `DbtProject` is the one implementation now,
-and future source formats (SQLMesh, Cube) become new implementations of the same
-protocol without touching the engine that reasons over a project. This is
-deliberately thin. dex does not build a neutral internal model behind it; the
-protocol is shaped by what dbt already provides, and other formats adapt to it.
+is the extension point: `DbtProject` is the one implementation now, and future
+source formats (SQLMesh, Cube, an orchestrated asset graph) become new
+implementations of the same protocol without touching the engine that reasons over
+a project.
+
+**Why tiers rather than one protocol.** A project is read through channels with
+different consumers and different requirements, and a single-method seam cannot
+carry that whichever method it names: pin it to the compiled view and the declared
+keys never arrive, because those reach dex only through ``definitions()``; pin it
+to the declarations and the per-layer snapshot has nowhere to come from. So the
+seam is tiered, the way `storage.base` is::
+
+    ExploreProject     definitions()                  -- what the project declares
+    MaintainProject      + transform_layer()          -- what it looks like right now
+                         + semantic_layer()
+    EditableProject      + write_edits()              -- what may be written back
+
+Each tier is a superset of the one above, and a format implements the tiers it can
+serve. The two read tiers are named for the channels that consume them, exactly as
+``ExploreStore`` and ``MaintainStore`` are. The write tier is named for the
+capability rather than left as an unqualified ``Project``, because unlike ``Store``
+that noun is already taken in this ecosystem: dbt ships two classes called
+``Project``, and a reader holding both open should not have to disambiguate.
+
+**Why tiers rather than a capability flag.** A flag is a claim the engine has to
+interpret, trust, and branch on, and nothing stops a format from setting it wrong.
+A tier is checkable: ``isinstance(project, EditableProject)`` is either true or it
+is not, and a format that cannot receive edits cannot accidentally claim it can.
+The declaration and the enforcement become the same object.
+
+That matters most for the write path. ``maintain reconcile``'s two mechanical write
+paths already gate on the ``models/staging/stg_<table>.*`` scaffold convention and
+fail closed to advisory, so a generated or derived project tree is safe from them
+today -- but safe by naming coincidence rather than by contract, and a format whose
+layer directories happened to use that vocabulary would not be. Declining a tier
+makes it structural.
+
+**Non-goal: this does not describe how a project is constructed.** Locating and
+building one is a separate contract, deliberately left open here: the formats
+disagree about what keys them (a directory, a graph already in memory, a service),
+and that disagreement does not resolve by picking whichever the first format used.
+``StoreContext`` is the shape that question took for storage.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from .. import dbt_project
+from ..maintain import snapshot
+
+if TYPE_CHECKING:
+    from ..dbt_project import DbtProjectView, ProjectDefinitions
+    from ..maintain.snapshot import SemanticLayer, TransformLayer
+
+__all__ = [
+    "DbtProject",
+    "EditableProject",
+    "ExploreProject",
+    "MaintainProject",
+    "ProjectAdapter",
+    "tier_of",
+]
+
+
+@runtime_checkable
+class ExploreProject(Protocol):
+    """Tier 1: a project that can state what it declares.
+
+    The narrowest useful tier, and the one every format must reach to be worth
+    reading at all: declared keys, declared joins, and metric models arrive here
+    and nowhere else.
+
+    ``name`` is a stable identifier for the project *format*, not for the instance
+    -- ``"dbt"``, ``"sqlmesh"``. It is what a registry would resolve.
+    """
+
+    #: Stable format name, e.g. "dbt".
+    name: str
+
+    def definitions(self) -> ProjectDefinitions:
+        """What the project declares: keys, joins, relations, metric models.
+
+        **This must not raise.** No project, an ambiguous choice, or an unreadable
+        project yields the empty view (with a note where there is something
+        actionable to say), never an exception -- the promise
+        ``dbt_project.definitions`` already makes in its own docstring, made part
+        of the contract here. Explore runs on raw warehouses where absence is the
+        normal case, so a format that raises turns an ordinary condition into an
+        outage.
+
+        This is the tier's real contract, and it is behavioural rather than
+        structural, which is why a conformance suite asserting only shapes will not
+        catch a format that gets it wrong.
+        """
+        ...
+
+
+@runtime_checkable
+class MaintainProject(ExploreProject, Protocol):
+    """Tier 2: adds the snapshot channel that makes drift detectable.
+
+    Two methods rather than one returning a union, because these are the two
+    functions `maintain.snapshot` already exposes and `maintain.commands` already
+    calls: a union return would have to be unpacked at every one of those call
+    sites. A format reaching only tier 1 still contributes declared keys and
+    joins; it simply cannot be a drift baseline.
+
+    Unlike tier 1 these presume a project that loads. ``maintain`` already treats
+    an unreadable project as a handled state and carries a note saying so, so the
+    absence is reported by the caller rather than papered over with an empty layer
+    here -- an empty layer compared against an empty layer reads as "no drift"
+    rather than "this could not be checked".
+    """
+
+    def transform_layer(self) -> TransformLayer: ...
+
+    def semantic_layer(self) -> SemanticLayer: ...
+
+
+@runtime_checkable
+class EditableProject(MaintainProject, Protocol):
+    """Tier 3: the write path.
+
+    Implemented only by formats whose source of truth can actually receive an edit.
+    A project reduced from a running graph cannot: its source of truth is the code
+    that produced the graph, and writing into the reduction would edit an artifact
+    that is regenerated from something else on the next run.
+
+    Declining this tier is the honest answer for such a format, and the reason the
+    tiers exist rather than a ``writeback`` flag.
+    """
+
+    def write_edits(self, edits: Any) -> Any:
+        """Write proposed edits back into the project as reviewable diffs."""
+        ...
 
 
 @runtime_checkable
 class ProjectAdapter(Protocol):
-    """A project that dex can read as the source of truth and edit as diffs."""
+    """The pre-tier seam, kept so an existing importer keeps working.
+
+    Superseded by the tiers above, which say the same thing with the write path
+    separable. Nothing in this distribution references it; it is retained rather
+    than removed because it has been public since v1.
+    """
 
     #: Stable format name, e.g. "dbt".
     name: str
@@ -32,21 +161,64 @@ class ProjectAdapter(Protocol):
         ...
 
 
-class DbtProject:
-    """The dbt implementation of the project seam: the only one in v1.
+def tier_of(project: object) -> int:
+    """The highest tier ``project`` satisfies, or 0 for none.
 
-    Delegates to `dbt_project`, which reads `manifest.json` plus the source files
-    and writes edits back. Holds the project directory (class DI) so callers do not
-    thread it through every call.
+    Checked structurally rather than declared, so a format cannot claim a tier it
+    does not implement. Note the ordering: the tiers are nested, so the test has to
+    run from the most specific down.
+    """
+
+    if isinstance(project, EditableProject):
+        return 3
+    if isinstance(project, MaintainProject):
+        return 2
+    if isinstance(project, ExploreProject):
+        return 1
+    return 0
+
+
+class DbtProject:
+    """The dbt implementation of the project seam.
+
+    Every member delegates to `dbt_project` or `maintain.snapshot`, which is the
+    point: the tiers describe what the engine already does with a project rather
+    than asking dbt to be read differently.
+
+    Holds the search surface (class DI) so callers do not thread it through every
+    call. ``repo_root`` is where dex was pointed; ``project_dir`` pins one project
+    within it and stays optional, because ``None`` is how ``definitions()`` is
+    reached when ``dbt_project_dir`` is unset and discovery has to run.
     """
 
     name = "dbt"
 
-    def __init__(self, project_dir: Path | str = "."):
-        self.project_dir = Path(project_dir)
+    def __init__(
+        self,
+        repo_root: Path | str = ".",
+        project_dir: Path | str | None = None,
+    ):
+        self.repo_root = Path(repo_root)
+        self.project_dir = Path(project_dir) if project_dir is not None else None
 
-    def load(self) -> Any:
-        return dbt_project.load(self.project_dir)
+    def definitions(self) -> ProjectDefinitions:
+        return dbt_project.definitions(self.repo_root, self.project_dir)
+
+    def load(self) -> DbtProjectView:
+        """Load the project into an in-memory view.
+
+        Raises ``DbtProjectError`` when there is no project to load, which is what
+        every caller of ``dbt_project.load`` already expects. Tier 1 is the channel
+        with the never-raises promise.
+        """
+
+        return dbt_project.load(self.project_dir or self.repo_root)
+
+    def transform_layer(self) -> TransformLayer:
+        return snapshot.transform_layer(self.load())
+
+    def semantic_layer(self) -> SemanticLayer:
+        return snapshot.semantic_layer(self.load())
 
     def write_edits(self, edits: Any) -> Any:
-        return dbt_project.write_edits(edits, self.project_dir)
+        return dbt_project.write_edits(edits, self.project_dir or self.repo_root)

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -803,7 +803,14 @@ def definitions(
 
     try:
         view = load(project)
-    except DbtProjectError as exc:
+    except (DbtProjectError, yaml.YAMLError) as exc:
+        # `yaml.YAMLError` alongside `DbtProjectError` for the same reason the
+        # three profile readers above pair them: `load` parses dbt_project.yml, so
+        # a project file that is not valid YAML surfaces as a parser error rather
+        # than ours. Catching only `DbtProjectError` here let that one case escape
+        # the promise this function's docstring makes -- an unreadable project is
+        # supposed to yield the empty view with a note, and instead `explore
+        # --use-project` raised out of a read that is meant to degrade.
         return ProjectDefinitions(
             notes=[
                 f"dbt project at '{project}' could not be read ({exc}); "

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -33,6 +33,7 @@ from ..adapters.base import Adapter, ObjectMeta, name_list
 # Aliased: `QueryResult` here is the explore record, and the adapter's
 # same-named row carrier is only a type hint on one shaping helper.
 from ..adapters.base import QueryResult as AdapterQueryResult  # noqa: F401
+from ..adapters.project import DbtProject
 from ..cache import (
     Dataset,
     DexCache,
@@ -1462,7 +1463,11 @@ def _project_definitions(
             )
         return defs
     pin = Path(repo_root) / config.dbt_project_dir if config.dbt_project_dir else None
-    return dbt_project.definitions(repo_root, pin)
+    # Through the seam rather than the module: this is the one project read on the
+    # explore path, so routing it here is what makes `ExploreProject` load-bearing
+    # instead of a protocol nothing satisfies. `DbtProject.definitions` delegates
+    # to the same function this line used to call, so the read is unchanged.
+    return DbtProject(repo_root, pin).definitions()
 
 
 def _relationship_edge_key(rel: Relationship) -> tuple:

--- a/packages/dex-core/tests/adapters/test_project_parity.py
+++ b/packages/dex-core/tests/adapters/test_project_parity.py
@@ -1,0 +1,132 @@
+"""One contract, every project format: the assertions each format owes its callers.
+
+The contract itself lives in `exmergo_dex_core.adapters.conformance`, shipped in the
+wheel so a format outside this distribution runs exactly these assertions. This file
+is the in-repo consumer of it, and it is deliberately the same few lines a third
+party writes: if driving the shipped contract were awkward here, it would be awkward
+there.
+
+Format-specific behavior lives in tests/transform/test_dbt_project.py. What is here
+is only "does the one shipped format satisfy the seam", plus the control below that
+keeps the seam load-bearing rather than merely defined.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exmergo_dex_core.adapters.conformance import (
+    DeclaringProjectContract,
+    MaintainProjectContract,
+)
+from exmergo_dex_core.adapters.project import DbtProject
+from exmergo_dex_core.explore import commands as explore_commands
+
+_PROJECT_YML = (
+    'name: dex_test\nversion: "1.0.0"\nprofile: dex_test\nmodel-paths: ["models"]\n'
+)
+
+
+def _project(root: Path, schema: str | None = None) -> Path:
+    """A minimal dbt project, optionally carrying one schema.yml."""
+
+    project = root / "analytics"
+    (project / "models").mkdir(parents=True, exist_ok=True)
+    (project / "dbt_project.yml").write_text(_PROJECT_YML, encoding="utf-8")
+    (project / "models" / "stg_customers.sql").write_text(
+        "select 1 as id\n", encoding="utf-8"
+    )
+    if schema is not None:
+        (project / "models" / "schema.yml").write_text(schema, encoding="utf-8")
+    return project
+
+
+class TestDbtProject(DeclaringProjectContract, MaintainProjectContract):
+    @pytest.fixture(autouse=True)
+    def _root(self, tmp_path: Path):
+        # One root per assertion: a project is read from disk, so two assertions
+        # writing different schema.yml files must not share a directory.
+        self.root = tmp_path
+
+    def make_project(self) -> DbtProject:
+        project = _project(self.root)
+        return DbtProject(self.root, project)
+
+    def make_unreadable_project(self) -> DbtProject:
+        # A dbt_project.yml that is not parseable YAML. dbt is a filesystem format,
+        # so this state is real for it, which is why the hook is overridden rather
+        # than left to skip.
+        project = self.root / "broken"
+        project.mkdir()
+        (project / "dbt_project.yml").write_text("name: [unclosed\n", encoding="utf-8")
+        return DbtProject(self.root, project)
+
+    def a_project_declaring_a_unique_key(self) -> tuple[DbtProject, str, str]:
+        project = _project(
+            self.root,
+            "version: 2\n"
+            "models:\n"
+            "  - name: stg_customers\n"
+            "    columns:\n"
+            "      - name: id\n"
+            "        tests: [unique]\n",
+        )
+        return DbtProject(self.root, project), "stg_customers", "id"
+
+    def a_project_declaring_a_join(self) -> tuple[DbtProject, str, str, str, str]:
+        project = _project(
+            self.root,
+            "version: 2\n"
+            "models:\n"
+            "  - name: stg_orders\n"
+            "    columns:\n"
+            "      - name: customer_id\n"
+            "        tests:\n"
+            "          - relationships:\n"
+            "              to: ref('stg_customers')\n"
+            "              field: id\n",
+        )
+        return (
+            DbtProject(self.root, project),
+            "stg_orders",
+            "customer_id",
+            "stg_customers",
+            "id",
+        )
+
+
+def test_explore_reads_the_project_through_the_seam(monkeypatch, tmp_path: Path):
+    """The control: explore's project read goes through `DbtProject`, not around it.
+
+    Every other assertion in this file would pass just as well if
+    `_project_definitions` called `dbt_project.definitions` directly, because
+    `DbtProject.definitions` delegates to it -- the results are identical by
+    construction. That is exactly what makes this test necessary: without it "the
+    suite is green" would not distinguish a seam that is load-bearing from one that
+    is merely defined, which is the state this whole protocol exists to leave.
+    """
+
+    project = _project(tmp_path)
+    calls: list[tuple[Path, Path | None]] = []
+    real = DbtProject.definitions
+
+    def recording(self: DbtProject):
+        calls.append((self.repo_root, self.project_dir))
+        return real(self)
+
+    monkeypatch.setattr(DbtProject, "definitions", recording)
+
+    engine = SimpleNamespace(
+        config=SimpleNamespace(dbt_project_dir="analytics"),
+        repo_root=str(tmp_path),
+    )
+    defs = explore_commands._project_definitions(engine, use_project=True)
+
+    assert calls == [(Path(tmp_path), project)], (
+        "explore did not read the project through DbtProject; the seam is defined "
+        "but not load-bearing"
+    )
+    assert defs.present

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -291,10 +291,10 @@ def test_the_all_extra_installs_every_optional_capability(wheel: str):
     dbt adapters and MetricFlow in one environment, it is also the only place a
     version conflict between them can surface at all.
 
-    `dev` and `storage-conformance` are excluded deliberately: contributor tooling,
-    not capabilities. `storage-conformance` carries a test runner for people
-    implementing a storage backend, and nobody installing "everything dex can do"
-    wants pytest.
+    `dev` and the two `*-conformance` extras are excluded deliberately: contributor
+    tooling, not capabilities. They carry a test runner for people implementing a
+    storage backend or a project format, and nobody installing "everything dex can
+    do" wants pytest.
     """
 
     extras = _project_metadata()["optional-dependencies"]
@@ -302,7 +302,7 @@ def test_the_all_extra_installs_every_optional_capability(wheel: str):
     referenced = set(
         extras["all"][0].removeprefix("exmergo-dex-core[").removesuffix("]").split(",")
     )
-    tooling = {"all", "dev", "storage-conformance"}
+    tooling = {"all", "dev", "storage-conformance", "project-conformance"}
     assert referenced == set(extras) - tooling, (
         f"[all] does not cover {sorted(set(extras) - tooling - referenced)}"
     )

--- a/packages/dex-core/tests/transform/test_dbt_project.py
+++ b/packages/dex-core/tests/transform/test_dbt_project.py
@@ -536,6 +536,27 @@ def test_definitions_degrades_without_a_project(tmp_path: Path):
     assert defs.notes == []
 
 
+def test_definitions_degrades_on_an_unparseable_project_file(tmp_path: Path):
+    """A dbt_project.yml that is not valid YAML degrades rather than raising.
+
+    `load` parses it with `yaml.safe_load`, so this case arrives as `yaml.YAMLError`
+    rather than `DbtProjectError`, and catching only the latter let it escape the
+    promise the docstring makes two lines up from the `try`. The three profile
+    readers in this module already pair the two exceptions; this is the same pairing
+    on the read path that explore depends on.
+    """
+
+    project = tmp_path / "analytics"
+    project.mkdir()
+    (project / "dbt_project.yml").write_text("name: [unclosed\n", encoding="utf-8")
+
+    defs = definitions(tmp_path, project)
+
+    assert defs.present is False
+    assert defs.declared_keys == [] and defs.foreign_keys == []
+    assert any("could not be read" in note for note in defs.notes)
+
+
 def test_definitions_degrades_on_multiple_projects(tmp_path: Path):
     for name in ("one", "two"):
         child = tmp_path / name

--- a/packages/dex-core/uv.lock
+++ b/packages/dex-core/uv.lock
@@ -831,6 +831,9 @@ postgres = [
     { name = "psycopg", extra = ["binary"] },
     { name = "sqlglot" },
 ]
+project-conformance = [
+    { name = "pytest" },
+]
 redshift = [
     { name = "boto3" },
     { name = "dbt-redshift" },
@@ -889,6 +892,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest", marker = "extra == 'project-conformance'", specifier = ">=8" },
     { name = "pytest", marker = "extra == 'storage-conformance'", specifier = ">=8" },
     { name = "pyyaml", specifier = ">=6" },
     { name = "redshift-connector", marker = "extra == 'all'", specifier = ">=2.1" },
@@ -911,7 +915,7 @@ requires-dist = [
     { name = "sqlglot", marker = "extra == 'sql'", specifier = ">=28.6,<31" },
     { name = "sqlglot", marker = "extra == 'storage-conformance'", specifier = ">=28.6,<31" },
 ]
-provides-extras = ["all", "bigquery", "cluster", "databricks", "dev", "duckdb", "postgres", "redshift", "semantic", "semantic-api", "snowflake", "sql", "storage-conformance"]
+provides-extras = ["all", "bigquery", "cluster", "databricks", "dev", "duckdb", "postgres", "project-conformance", "redshift", "semantic", "semantic-api", "snowflake", "sql", "storage-conformance"]
 
 [[package]]
 name = "fastjsonschema"
@@ -3062,7 +3066,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -3144,7 +3148,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -3207,8 +3211,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/references/project.md
+++ b/references/project.md
@@ -1,0 +1,169 @@
+# Projects: where dex reads the source of truth
+
+A **project** is what declares intent: which models exist, what grain each is
+unique at, which columns join to which, what the metrics mean. dex reads it and
+reasons over it; the warehouse is what dex measures against it.
+
+Today one format ships. `DbtProject` reads a dbt project: model SQL, `schema.yml`,
+the semantic manifest, and the compiled `manifest.json` when there is one. [`dbt-project.md`](dbt-project.md) covers what dex reads out of it and what it
+writes back.
+
+This document is about the seam underneath that: what a *second* format has to
+satisfy, and what dex promises to do with it.
+
+## Why you would write your own
+
+One reason, and it is a real one: your models are not a dbt project.
+
+A host that builds its transformation graph in something else (an orchestrator's
+asset graph, SQLMesh, a semantic layer that owns its own definitions) still has
+everything dex needs to be useful. It knows which tables it builds, at what grain,
+and how they relate. What it does not have is a `dbt_project.yml`, and generating a
+fake one to satisfy dex means maintaining a translation nobody reads and dex cannot
+check.
+
+The seam exists so that translation can be code you own instead.
+
+## The three tiers
+
+The contract is three nested protocols in `adapters/project.py`. Implement the one
+that matches what your format can actually answer, and stop there: a narrower
+implementation is complete rather than partial.
+
+| tier | protocol | adds | what it buys |
+|---|---|---|---|
+| 1 | `ExploreProject` | `definitions()` | declared keys, joins and metric models reach `explore` |
+| 2 | `MaintainProject` | `transform_layer()`, `semantic_layer()` | the format can be a drift baseline |
+| 3 | `EditableProject` | `write_edits()` | `transform` and `reconcile` may write back |
+
+`tier_of(project)` reports the highest tier an object satisfies, checked with
+`isinstance` rather than declared, so a format cannot claim a tier it has not
+implemented.
+
+**Tier 1 is where the value is concentrated, and it is easy to underestimate.**
+Declared keys and declared joins reach dex through `definitions()` and through no
+other channel: not through the layers, not through a content hash. A format that
+implements only tier 1 has already delivered the part of a project that changes what
+`explore` concludes.
+
+**Tier 3 is the one to decline on purpose.** A project reduced from a running graph
+cannot receive an edit: its source of truth is the code that produced the graph, so
+writing into the reduction would edit an artifact that is regenerated on the next
+run. Declining the tier is the honest answer, and it is why the tiers exist rather
+than a `writeback: no` flag. A flag is a claim the engine has to trust, while a tier
+is checkable.
+
+That distinction has teeth today. `maintain reconcile`'s two mechanical write paths
+gate on the `models/staging/stg_<table>.*` scaffold convention and fail closed to
+advisory, so a generated tree is already safe from them, but safe because its naming
+happens not to collide rather than because it declared anything. A format whose
+layer directories used that vocabulary would not be.
+
+## The one rule that is not visible in the signatures
+
+**`definitions()` must not raise.** Not on a project that is absent, not on an
+ambiguous choice between two, not on a source that will not parse.
+
+Exploration runs against warehouses with no project at all, so absence is an
+ordinary state rather than an error, and a format that raises turns a normal
+condition into an outage in the middle of a command that had nothing to do with the
+project. The empty result is the correct answer; a note saying why is how the
+operator tells "nothing declared" apart from "your source has a typo in it".
+
+This is the assertion a second implementation is most likely to get wrong, and a
+contract that only checked shapes would not catch it. It is also not hypothetical:
+the shipped dbt format violated it until recently, because a `dbt_project.yml` that
+is not valid YAML surfaced as `yaml.YAMLError` while only `DbtProjectError` was
+caught. The conformance suite below is what found that.
+
+Tier 2 is different, deliberately. `transform_layer()` and `semantic_layer()`
+presume a project that loads, because `maintain` already treats an unreadable
+project as a handled state and carries a note saying so. Returning empty layers
+instead would be worse than raising: an empty layer compared against an empty layer
+reads as "no drift" rather than "this could not be checked".
+
+## Writing one
+
+```python
+from exmergo_dex_core.dbt_project import ProjectDefinitions
+
+
+class MyProject:
+    name = "my_format"
+
+    def __init__(self, graph):
+        self._graph = graph
+
+    def definitions(self) -> ProjectDefinitions:
+        defs = ProjectDefinitions(present=True)
+        defs.built_relation_names = sorted(self._graph.models)
+        # ...declared keys, joins, metric models
+        return defs
+```
+
+`ProjectDefinitions` is the engine's existing model, not a new neutral one. That is
+deliberate: it is already what `definitions()` returns and already what every
+consumer reads, so a second format reuses the vocabulary rather than introducing a
+parallel one that has to be mapped at every call site.
+
+Where your format's shape and this model's shape disagree, say so in `notes` rather
+than inventing a value. A fabricated field is indistinguishable from a measured one
+by the time a finding is shown to a human.
+
+## Proving it works
+
+```
+pip install "exmergo-dex-core[project-conformance]"
+```
+
+```python
+from exmergo_dex_core.adapters.conformance import ExploreProjectContract
+
+
+class TestMyProject(ExploreProjectContract):
+    def make_project(self):
+        return MyProject(nothing_declared())
+```
+
+pytest collects the inherited assertions and runs the contract against your format.
+Use `MaintainProjectContract` instead if you reach tier 2.
+
+Two hooks are worth overriding beyond `make_project`:
+
+- **`make_unreadable_project()`** returns a project whose source your format cannot
+  parse. It defaults to `None`, which skips the never-raises assertions with a
+  message saying so. That is a compromise, because a format reduced from an
+  in-memory object may genuinely have no unparseable state. If yours does have one, override
+  it: those are the assertions worth the most.
+- **`DeclaringProjectContract`**, mixed in beside your tier contract, checks that a
+  declared key and a declared join actually arrive. It is separate because the two
+  contracts answer different questions: whether dex can safely call your format, and
+  whether reading it was worth doing.
+
+The suite needs only pytest: no dialect engine, no connector. A packaging test keeps
+it that way.
+
+Formats contributed here run the same suite: see
+`packages/dex-core/tests/adapters/test_project_parity.py`, which is deliberately the
+same few lines a third party writes.
+
+## What the tiers do not settle
+
+**How a project gets constructed is a separate question, and it is still open.**
+
+The tiers describe what dex may ask of a project it already holds. They say nothing
+about how it came to hold one, and that gap is deliberate rather than an oversight:
+the formats disagree about what keys them. A dbt project is keyed by a directory. A
+project reduced from a graph already in memory has no directory and no repository. A
+hosted one has service coordinates and neither.
+
+Storage answered the equivalent question with `StoreContext` plus a resolver, after
+finding that a constructor argument alone was unreachable for a host that talks to
+dex as a subprocess. Whether the same answer is right here has not been decided, and
+picking one now on the strength of the only format that exists would be picking the
+directory-shaped one.
+
+Until it is settled, dex constructs `DbtProject` itself at the one place `explore`
+reads a project, exactly as it constructed `dbt_project` calls before. A second
+format is readable through these tiers; naming one in configuration is what the
+construction contract still owes.

--- a/ruff.toml
+++ b/ruff.toml
@@ -35,6 +35,9 @@ ignore = ["UP042"]
 # the package (so a backend outside this distribution can run it), so it is
 # written in the pytest idiom like any other test file (S101).
 "packages/dex-core/src/exmergo_dex_core/storage/conformance.py" = ["S101"]
+# The project conformance contract ships for the same reason and in the same
+# idiom (S101).
+"packages/dex-core/src/exmergo_dex_core/adapters/conformance.py" = ["S101"]
 # The skill wrappers shell out to the pinned dex CLI by design; the command is
 # a fixed path plus an argv passthrough, not untrusted input (S603).
 "skills/**/scripts/run.py" = ["S603"]


### PR DESCRIPTION
Closes nothing on its own; this is the prototype #171 asks for, and the decision that issue wants is still yours to make.

#171 asked which of two contract shapes to prototype. We said on the issue we would bring a third that contains both, tiered like `ExploreStore` / `MaintainStore` / `Store`. This is that, built against 1.5.1.

It is deliberately scoped so that **none of the three questions we asked on the issue has to be answered for it to land**, and none of the three answers you offered there is foreclosed by it. In particular it does not touch construction: dex builds `DbtProject` itself, at the one place explore reads a project, exactly as it called `dbt_project` before.

## What it does

`adapters/project.py` becomes three nested protocols:

| tier | protocol | adds |
|---|---|---|
| 1 | `ExploreProject` | `definitions() -> ProjectDefinitions` |
| 2 | `MaintainProject` | `transform_layer()`, `semantic_layer()` |
| 3 | `EditableProject` | `write_edits()`, unchanged from today |

`tier_of(project)` reports the highest tier an object satisfies, by `isinstance` rather than declaration, so a format cannot claim a tier it has not implemented. `DbtProject` implements all three, every member delegating to a function that already existed.

**One line makes it load-bearing.** `explore/commands.py:1465`:

```diff
-    return dbt_project.definitions(repo_root, pin)
+    return DbtProject(repo_root, pin).definitions()
```

That is the whole rewiring. `DbtProject` is now constructed for the first time, and tier 1 sits on the real explore read path. `maintain` still calls `snapshot.transform_layer(view)` directly at its six call sites: tier 2 is implemented and contract-tested, but not rewired, because rewiring it is a bigger change than this PR should carry and the methods being present is what makes the tier real.

Two corrections to what we said on the issue, both found by building it:

**Tier 2 is two methods, not one `fingerprint()` returning a union.** Our comment on #171 proposed `fingerprint() -> TransformLayer | SemanticLayer`. That was wrong for your tree: `maintain.snapshot` already exposes exactly `transform_layer(view)` and `semantic_layer(view)`, and `maintain.commands` already calls both. A union return would have to be unpacked at every one of those call sites for no gain.

**The tiers are not named `Project` at the top.** `ExploreStore`/`MaintainStore`/`Store` was the model, but dbt itself ships two classes called `Project` (`dbt.config.project`, `dbt.contracts.project`), so the unqualified noun would collide for anyone reading both. Hence `EditableProject` for the write tier, named for the capability.

## The contract found a real bug on the first run

`adapters/conformance.py` ships the seam's rules as assertions, the way `storage/conformance.py` does. Its most important assertion is behavioural, and it is the one we flagged on the issue as the property a second implementation is most likely to get wrong: **`definitions()` must not raise.**

It went red against the shipped dbt format.

`load` parses `dbt_project.yml` with `yaml.safe_load`, so a project file that is not valid YAML arrives as `yaml.YAMLError`, and `definitions()` caught only `DbtProjectError`. The docstring two lines above the `try` promises that an unreadable project yields the empty view and never an exception; `explore --use-project` raised out of it instead.

The fix is to pair the two exceptions, which is what the three profile readers in that same module already do (`dbt_project.py:321`, `:356`, `:386`). It is a one-line change plus a regression test, and it is in this PR because shipping a contract whose reference implementation fails it is not an option.

**One adjacent instance we did not touch:** `_duckdb_dev_path`'s `try` block at `dbt_project.py:415` is byte-identical to the one at `:317` but also catches only `DbtProjectError`. It is not on the project-seam read path, so it is out of scope here rather than forgotten.

## Re-measured at 1.5.1, with the rule stated

The counts in #171 hold, and one moved:

- `ProjectAdapter`: still **one** reference before this PR, its own `class` statement. Nothing referenced it, tests included.
- `DbtProject`: **never constructed** anywhere, tests included.
- Modules referencing `dbt_project` directly: **19 → 20**.

That last one needs its rule, because the two rules disagree. Under *"module references `dbt_project`"* it is 20 at 1.5.1. The newcomer is `envelope.py:263`, which imports `DbtProjectError` to classify a refusal reason: under *"module reads a project through it"* it is still 19. It arrived with the `reason` work in 1.5.1, so it is not a project read routing around the seam, and we are not counting it as one.

`definitions()` itself is unmoved at `dbt_project.py:773`, still one caller (`_project_definitions`, `explore/commands.py:1433`, ending `:1465`), reached from `:279`/`:416`/`:759`.

## Deliberately not here

- **The construction contract.** The currency question, the first of the three we asked on the issue and the one we most wanted the call on, is still open and this PR does not pre-empt it. `references/project.md` states it as open and says why picking now would mean picking the directory-shaped answer on the strength of the only format that exists.
- **Tier 3's shape.** `write_edits(edits) -> Any` is moved, not redesigned.
- **`definitions()` taking a view.** Its four disk touches (`discover_projects`, `load`, `_read_semantic_manifest`, and `_flag_stale_manifest`'s `rglob` + `stat` walk) are a separate and larger argument.
- **Anything in `maintain/`.** No call site there changes.

## Proving it out of tree

`ProjectContract` is the piece we said we would want landed even if everything else came out smaller, because it is what makes #144's criterion checkable by you without running our code. We are wiring our own Dagster format up against it next, from a separate distribution depending only on the published wheel.

The extra needs **only pytest**: nothing in the contract reaches the dialect engine, and `test_packaging.py` holds that true. That is a difference from `[storage-conformance]`, and worth keeping rather than a coincidence.

## Checks

- Full suite on this branch: same result as `v1.5.1` before it, plus 13 new tests.
- `ruff check` and `ruff format --check` clean across the repo (162 files).
- `scripts/check_no_em_dashes.py` clean on every prose file touched.
- The behavioural assertion and the regression test were both confirmed red without the `dbt_project.py` fix and green with it.
- One pre-existing failure is unrelated and present on `v1.5.1` too: `test_dev_target.py::test_retargeted_dev_database_is_refused_naming_both_values` asserts `analytics/profiles.yml` while the message is built with a native separator, so it fails on Windows only. Happy to send that separately if it is not already known.

If the answer to #171 is that the seam is set aside or retired, this closes without hard feelings and we document the gap on our side.
