### PR TITLE
fix(transform): compare resolved DuckDB paths in dev-target preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **transform dev-target preflight compares resolved DuckDB paths** ([#234]).
+  Relative and absolute spellings of the same warehouse file (e.g. `warehouse.duckdb`
+  vs `./warehouse.duckdb`) are no longer treated as configuration drift.
+
+
 - **A crowded low-cardinality dimension no longer pushes the true grain out
   of the composite-key probe** ([#168]). `_probe_composite_keys` ranks
   candidate 2-column keys by smallest distinct-count product and probes only

--- a/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
@@ -99,7 +99,6 @@ def _resolve_declared_path(declared: str, base_dir: Path) -> Path:
         return path if path.is_absolute() else (base_dir / path).absolute()
 
 
-
 def check(
     project_dir: Path | str,
     target: str,

--- a/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
@@ -87,6 +87,19 @@ _DRIFT_FIELDS: dict[str, tuple[tuple[str, str, str], ...]] = {
 _CASE_FOLDING = {"snowflake"}
 
 
+def _resolve_declared_path(declared: str, base_dir: Path) -> Path:
+    """Expand user, make absolute against ``base_dir``, and resolve symlinks."""
+    path = Path(declared).expanduser()
+    if not path.is_absolute():
+        path = base_dir / path
+    try:
+        return path.resolve()
+    except OSError:
+        # Unresolvable symlink / missing parent: still normalize as absolute.
+        return path if path.is_absolute() else (base_dir / path).absolute()
+
+
+
 def check(
     project_dir: Path | str,
     target: str,
@@ -146,6 +159,10 @@ def _assert_no_drift(
         return
     fold = config.connector in _CASE_FOLDING
     divergent = []
+    # Config paths resolve against the repo root (committed target); profile
+    # paths resolve against the dbt project dir (dbt's cwd).
+    config_base = Path(repo_root)
+    profile_base = project
     for attribute, config_key, profile_key in _DRIFT_FIELDS.get(config.connector, ()):
         # An unset config field was never a claim about the dev target, so it
         # cannot have drifted away from one.
@@ -154,6 +171,17 @@ def _assert_no_drift(
         want = getattr(target_config, attribute, None)
         got = profile.get(profile_key)
         if want is None or got is None:
+            continue
+        if config.connector == "duckdb" and attribute == "path":
+            want_resolved = _resolve_declared_path(str(want), config_base)
+            got_resolved = _resolve_declared_path(str(got), profile_base)
+            if want_resolved == got_resolved:
+                continue
+            divergent.append(
+                f"  {config_key}: {want} (resolves to {want_resolved})\n"
+                f"  {PROFILES_FILE} {target}.{profile_key}: {got} "
+                f"(resolves to {got_resolved})"
+            )
             continue
         if (str(want).upper() == got.upper()) if fold else (str(want) == got):
             continue

--- a/packages/dex-core/tests/transform/test_dev_target.py
+++ b/packages/dex-core/tests/transform/test_dev_target.py
@@ -1243,3 +1243,25 @@ def test_an_explicit_config_reaches_the_probe_instead_of_one_on_disk(
 
     assert calls[0]["config"] is config
     assert calls[0]["config"].snowflake.dev_database == "DBT_DEV"
+
+
+def test_duckdb_equivalent_path_spellings_are_accepted(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    """Relative, ./prefixed, and absolute paths to the same file are not drift."""
+    from exmergo_dex_core.config import DuckDBTarget
+
+    warehouse = dbt_project_dir / "warehouse.duckdb"
+    warehouse.write_text("", encoding="utf-8")
+    # profiles.yml already points at ./warehouse.duckdb in fixtures in many cases;
+    # write an explicit matching profile path.
+    profiles = dbt_project_dir / "profiles.yml"
+    profiles.write_text(
+        "test:\n  target: dev\n  outputs:\n    dev:\n      type: duckdb\n"
+        "      path: ./warehouse.duckdb\n",
+        encoding="utf-8",
+    )
+    for declared in ("warehouse.duckdb", "./warehouse.duckdb", str(warehouse.resolve())):
+        config = DexConfig(connector="duckdb", duckdb=DuckDBTarget(path=declared))
+        # should not raise
+        dev_target.check(dbt_project_dir, "dev", config, dbt_project_dir)

--- a/packages/dex-core/tests/transform/test_dev_target.py
+++ b/packages/dex-core/tests/transform/test_dev_target.py
@@ -1261,7 +1261,11 @@ def test_duckdb_equivalent_path_spellings_are_accepted(
         "      path: ./warehouse.duckdb\n",
         encoding="utf-8",
     )
-    for declared in ("warehouse.duckdb", "./warehouse.duckdb", str(warehouse.resolve())):
+    for declared in (
+        "warehouse.duckdb",
+        "./warehouse.duckdb",
+        str(warehouse.resolve()),
+    ):
         config = DexConfig(connector="duckdb", duckdb=DuckDBTarget(path=declared))
         # should not raise
         dev_target.check(dbt_project_dir, "dev", config, dbt_project_dir)


### PR DESCRIPTION
## Summary
Dev-target preflight compared DuckDB paths as raw strings, so `warehouse.duckdb`, `./warehouse.duckdb`, and absolute paths to the same file were treated as drift.

## Changes
- Resolve config path against the repo root and profile path against the dbt project dir (expanduser + absolute + resolve).
- Accept equivalent spellings / symlinks; keep refusal for real mismatches with resolved paths in the message.
- Unit test for equivalent spellings.

Closes #196