### PR TITLE
feat(transform): allow transform init into the current directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **transform init**: allow initializing into the current directory ([#235]).
+
 ## [1.5.2] - 2026-08-05
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -194,6 +194,12 @@ def _build_parser() -> argparse.ArgumentParser:
                     sp.add_argument(
                         "--layered-schemas", action="store_true", default=False
                     )
+                    sp.add_argument(
+                        "--in-place",
+                        action="store_true",
+                        default=False,
+                        help="scaffold into the current directory instead of <name>/",
+                    )
                 if group == "transform" and name == "plan":
                     # The agent-authored edits payload: a JSON file, or - for stdin.
                     sp.add_argument("--edits-file", default=None)

--- a/packages/dex-core/src/exmergo_dex_core/engine.py
+++ b/packages/dex-core/src/exmergo_dex_core/engine.py
@@ -578,6 +578,7 @@ class DexEngine:
         connector: str | None = None,
         path: str | None = None,
         layered_schemas: bool = False,
+        in_place: bool = False,
     ) -> InitResult:
         from .transform import commands as transform
 
@@ -587,6 +588,7 @@ class DexEngine:
             connector=connector,
             path=path,
             layered_schemas=layered_schemas,
+            in_place=in_place,
         )
 
     def plan(

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -84,6 +84,7 @@ def init_project(
     connector: str | None = None,
     path: str | None = None,
     layered_schemas: bool = False,
+    in_place: bool = False,
 ) -> InitResult:
     """Bootstrap a dbt project in the repo, rendering profiles from dex config.
 
@@ -120,6 +121,7 @@ def init_project(
         path=path,
         repo_root=repo_root,
         layered_schemas=layered_schemas,
+        in_place=in_place,
     )
 
     # The renderers persisted the resolved dev namespaces into .dex/config.yml,
@@ -156,6 +158,7 @@ def cmd_init(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
             connector=getattr(args, "connector", None),
             path=getattr(args, "path", None),
             layered_schemas=bool(getattr(args, "layered_schemas", False)),
+            in_place=bool(getattr(args, "in_place", False)),
         )
     except ValueError as exc:
         return env.error_for(exc)

--- a/packages/dex-core/src/exmergo_dex_core/transform/init.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/init.py
@@ -88,6 +88,7 @@ def init_project(
     path: str | None = None,
     repo_root: Path | str = ".",
     layered_schemas: bool = False,
+    in_place: bool = False,
 ) -> InitResult:
     """Render a fresh dbt project skeleton and record the choices in config.
 
@@ -118,7 +119,13 @@ def init_project(
             "duckdb|bigquery|snowflake|databricks|postgres|redshift`"
         )
 
+    # ``.`` or --in-place scaffolds at the run root using the directory name.
+    if name.strip() in {".", "./"}:
+        in_place = True
+        name = root.resolve().name
     project_name = sanitize_project_name(name)
+    project_prefix = "" if in_place else f"{project_name}/"
+    project_dir = "." if in_place else project_name
     existing = discover_projects(root)
     if existing:
         raise InitError(
@@ -131,18 +138,18 @@ def init_project(
     profiles_text = render_profile(project_name, path, config, root)
 
     files: dict[str, str] = {
-        f"{project_name}/{PROJECT_FILE}": _project_yaml(
+        f"{project_prefix}{PROJECT_FILE}": _project_yaml(
             project_name, layered_schemas=layered_schemas
         ),
-        f"{project_name}/{PROFILES_FILE}": profiles_text,
-        f"{project_name}/models/staging/.gitkeep": "",
-        f"{project_name}/models/marts/.gitkeep": "",
+        f"{project_prefix}{PROFILES_FILE}": profiles_text,
+        f"{project_prefix}models/staging/.gitkeep": "",
+        f"{project_prefix}models/marts/.gitkeep": "",
     }
     if layered_schemas:
         from .scaffold import macro_edit
 
-        files[f"{project_name}/models/intermediate/.gitkeep"] = ""
-        files[f"{project_name}/macros/generate_schema_name.sql"] = macro_edit(
+        files[f"{project_prefix}models/intermediate/.gitkeep"] = ""
+        files[f"{project_prefix}macros/generate_schema_name.sql"] = macro_edit(
             "generate_schema_name", "macros"
         ).new_content
     collisions = sorted(rel for rel in files if (root / rel).exists())
@@ -154,7 +161,7 @@ def init_project(
         )
 
     config.connector = connector
-    config.dbt_project_dir = project_name
+    config.dbt_project_dir = project_dir
     config.dbt_target = "dev"
 
     config_rel = f"{DEX_DIR}/{CONFIG_FILE}"
@@ -176,7 +183,7 @@ def init_project(
     created = list(files) + ([config_rel] if old_config is None else [])
     return InitResult(
         project_name=project_name,
-        project_dir=project_name,
+        project_dir=project_dir,
         connector=connector,
         created=created,
         diffs=diffs,


### PR DESCRIPTION
## Summary
`transform init` always wrote into a `<name>/` subdirectory, so root-level dbt layouts required manual moves.

## Changes
- Accept `.` as the project name (use directory basename, sanitize).
- Add `--in-place` to scaffold at the run root.
- Point `dbt_project_dir` at `.` in that mode; keep additive refusal when a project already exists.

Closes #200