### PR TITLE
A crowded low-cardinality dimension no longer pushes the true grain out of the composite-key probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   The cap (`_COMPOSITE_PAIR_CAP`) is raised from 3 to 5 for headroom, and a
   pair that shares a column with an already-kept pair is now dropped as a
   near-duplicate when its product is within `_COMPOSITE_REDUNDANCY_RATIO`
-  (3.0x) of the kept pair's — the same idea tried with interchangeable
+  (3.0x) of the kept pair's: the same idea tried with interchangeable
   filler, not a genuinely different candidate. A pair whose product diverges
   meaningfully still gets its own slot even if it reuses a column, which is
   what lets the true grain through. Each additional slot is still a real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A crowded low-cardinality dimension no longer pushes the true grain out
+  of the composite-key probe** ([#168]). `_probe_composite_keys` ranks
+  candidate 2-column keys by smallest distinct-count product and probes only
+  the top few, because each probe is a real two-column `DISTINCT` scan. When
+  one dimension column happened to pair cheaply with several other columns,
+  every one of those pairs ranked ahead of the true grain purely because they
+  shared that same attractive anchor, even though they were really the same
+  hypothesis ("does this dimension have *a* partner?") tried with different
+  filler. The true grain, which can legitimately score worse on raw product,
+  never got probed, and a wrong (or no) grain was recorded instead, so
+  `maintain grain` went on monitoring the wrong composite indefinitely.
+
+  The cap (`_COMPOSITE_PAIR_CAP`) is raised from 3 to 5 for headroom, and a
+  pair that shares a column with an already-kept pair is now dropped as a
+  near-duplicate when its product is within `_COMPOSITE_REDUNDANCY_RATIO`
+  (3.0x) of the kept pair's — the same idea tried with interchangeable
+  filler, not a genuinely different candidate. A pair whose product diverges
+  meaningfully still gets its own slot even if it reuses a column, which is
+  what lets the true grain through. Each additional slot is still a real
+  scan, but the batch stays one statement, and a metered adapter that cannot
+  cover the wider batch within the confirmed budget already degrades to
+  "grain unknown" via `distinct_combination_counts`'s existing contract, so
+  this does not bypass cost guards.
+
 ## [1.5.2] - 2026-08-05
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -37,7 +37,17 @@ _EXACT_DISTINCT_CAP = 8
 # Composite-key probes are capped much tighter than single-column escalation:
 # each pair costs a full two-column DISTINCT scan (not one cheap aggregate),
 # and the ranking puts a real grain in the first slots when one exists.
-_COMPOSITE_PAIR_CAP = 3
+_COMPOSITE_PAIR_CAP = 5
+
+# A later pair that shares a column with an already-kept pair is treated as
+# the same hypothesis tried with different filler ("does this dimension have
+# *a* partner?") when its product is within this multiple of the kept pair's
+# -- not a genuinely different candidate. Keeping the ratio bounded (rather
+# than 1:1) is what stops several near-identical junk pairs from each
+# consuming a cap slot; a pair whose product diverges meaningfully (a real
+# competing hypothesis, not filler) still gets its own slot even if it
+# reuses a column.
+_COMPOSITE_REDUNDANCY_RATIO = 3.0
 
 # Name patterns mapped to a PII category and a base confidence. Matched on the
 # snake-normalized column name (camelCase is split first, so "firstName" matches
@@ -539,10 +549,14 @@ def _probe_composite_keys(
     id-shaped members first (real grains are key-shaped), smallest product
     next (a minimal grain sits just above the row count; a pair of two
     near-unique columns lands near rows squared and is analytically useless
-    even when technically unique). Bounded to ``_COMPOSITE_PAIR_CAP`` pairs in
-    one batched adapter call; a pair is proven when its exact combination
-    count equals the row count. Adapters without
-    ``distinct_combination_counts`` degrade to no composite keys.
+    even when technically unique). Before the cut, pairs that share a column
+    with an already-kept pair and score within ``_COMPOSITE_REDUNDANCY_RATIO``
+    of it are dropped as the same hypothesis tried with different filler, so
+    the cap is spent on genuinely distinct candidates rather than several
+    near-identical pairs anchored on one popular column. Bounded to
+    ``_COMPOSITE_PAIR_CAP`` pairs in one batched adapter call; a pair is
+    proven when its exact combination count equals the row count. Adapters
+    without ``distinct_combination_counts`` degrade to no composite keys.
     """
 
     if not row_count:
@@ -585,7 +599,20 @@ def _probe_composite_keys(
         return []
 
     ranked.sort()
-    chosen = [list(pair) for _ids, _product, pair in ranked[:_COMPOSITE_PAIR_CAP]]
+    deduped: list[tuple[int, int, tuple[str, str]]] = []
+    best_product_for: dict[str, int] = {}
+    for ids, product, pair in ranked:
+        if any(
+            col in best_product_for
+            and product <= best_product_for[col] * _COMPOSITE_REDUNDANCY_RATIO
+            for col in pair
+        ):
+            continue  # near-duplicate: same anchor, interchangeable filler
+        deduped.append((ids, product, pair))
+        for col in pair:
+            best_product_for.setdefault(col, product)
+
+    chosen = [list(pair) for _ids, _product, pair in deduped[:_COMPOSITE_PAIR_CAP]]
     exact = combo_counts(identifier, chosen)
     return [combo for combo in chosen if exact.get(tuple(combo)) == row_count]
 

--- a/packages/dex-core/tests/explore/test_profile.py
+++ b/packages/dex-core/tests/explore/test_profile.py
@@ -1215,12 +1215,44 @@ def test_composite_probe_is_bounded_and_targeted():
 def test_composite_probe_caps_the_pair_count():
     from exmergo_dex_core.explore import profile as profile_mod
 
-    # Five interchangeable mid-cardinality columns: every pair survives the
-    # product test, so only the cap keeps the probe bounded.
-    adapter = _StubAdapter(rows=1000, approx={f"c{i}_id": 100 + i for i in range(5)})
+    # Twelve columns with geometrically spread cardinalities: every pair
+    # survives the product test, and their products are spread widely enough
+    # that redundancy dedup (#168) leaves dozens of genuinely distinct
+    # candidates -- so the cap, not the dedup, is what keeps the probe
+    # bounded here.
+    approx = {}
+    for i in range(6):
+        approx[f"a{i}_id"] = 32 * (2**i)
+        approx[f"b{i}_id"] = 64 * (2**i)
+    adapter = _StubAdapter(rows=1000, approx=approx)
     profile_mod.profile(adapter, ["db.s.t"])
     assert len(adapter.combo_calls) == 1
-    assert len(adapter.combo_calls[0]) == 3
+    assert len(adapter.combo_calls[0]) == 5  # _COMPOSITE_PAIR_CAP
+
+
+def test_composite_probe_dedups_same_anchor_pairs_so_the_true_grain_survives():
+    """#168: several pairs crossing one low-cardinality dimension with
+    different, equally uninteresting partners must not consume the entire
+    cap and crowd out the true grain, which can legitimately score worse on
+    raw distinct-count product than that junk cluster."""
+
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    # dim's five (dim, j_i) pairings all score identically (product == row
+    # count) and are near-duplicates of each other -- only one should survive
+    # as dim's representative. (date, dim) scores 5x worse but is a
+    # genuinely different hypothesis and must still get a slot.
+    approx = {"dim": 10, "date": 500, **{f"j{i}": 100 for i in range(1, 6)}}
+    adapter = _StubAdapter(rows=1000, approx=approx, combos={("date", "dim"): 1000})
+    datasets = profile_mod.profile(adapter, ["db.s.t"])
+
+    assert len(adapter.combo_calls) == 1
+    probed = adapter.combo_calls[0]
+    assert ["date", "dim"] in probed
+    dim_pairs = [pair for pair in probed if "dim" in pair]
+    assert len(dim_pairs) == 2, probed  # (date, dim) plus one junk representative
+
+    assert datasets[0].composite_keys == [["date", "dim"]]
 
 
 def test_composite_probe_skipped_when_single_key_exists():


### PR DESCRIPTION
Closes : https://github.com/exmergo/dex/issues/168

_probe_composite_keys (explore/profile.py) raises _COMPOSITE_PAIR_CAP from 3 to 5, and adds a new _COMPOSITE_REDUNDANCY_RATIO = 3.0 dedup pass before the cut: a pair sharing a column with an already-kept pair is dropped as a near-duplicate ("same dimension, different filler") only when its product is within 3x of the kept pair's a genuinely different hypothesis still gets its own slot even if it reuses that column.
Fixes the crowding case from the issue: several junk pairs anchored on one low-cardinality dimension no longer consume the entire cap and starve out the true grain, which can legitimately score worse on raw distinct-count product.
No change to cost-guard behavior: each extra slot is still a real scan batched into one statement, and a metered adapter that can't cover the wider batch already degrades to "grain unknown" via distinct_combination_counts's existing contract.

The issue : 
<img width="1644" height="150" alt="image" src="https://github.com/user-attachments/assets/2cda6336-26c6-42e3-915f-a2fbd62f72fa" />

After fix: 
<img width="1627" height="137" alt="image" src="https://github.com/user-attachments/assets/8fb10ab5-da60-4241-b826-f360bcc70941" />
