### PR TITLE
SCRUM-1053 explore profile: report the value domain of a low-cardinality non-PII column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,38 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **`explore profile` reports the value domain of a low-cardinality non-PII
+  column** ([#203]). `ColumnProfile.min_value`/`max_value` are suppressed for
+  every string column, PII or not, because a string extreme is itself a raw
+  value. On a raw source table (the norm: mostly string-typed columns), a
+  caller learned `env_tier` had 4 distinct values and had no way to learn
+  what they were, short of a raw SQL client, exactly the one place the PII
+  policy and query firewall do not apply.
+
+  A column now reports its `value_domain` (distinct values by frequency,
+  capped, with an `elided` count when the cap binds) when it carries no PII
+  flag at all, at any confidence, its distinct count clears both an absolute
+  cap (25) and a row-relative fraction (10% of non-null rows, so a tiny
+  table's near-key column does not qualify on the absolute count alone), and
+  it is not a candidate key (single-column or a proven composite member). A
+  flagged column reports no domain at any confidence or cardinality, full
+  stop; detection, confidence, and the block threshold are unchanged.
+
+  Eligibility is decided from the approximate pre-scan distinct count (cost
+  control: an obviously-too-wide column is never even queried), but the
+  reported domain is built from the exact count the new probe itself
+  returns: when the approximation under-estimated and the true count is
+  still within the fraction bar, the result is capped with an honest
+  `elided` count rather than dropped; only a true count that breaks the
+  fraction bar (a near-key the approximation missed) is dropped entirely.
+
+  New adapter capability (`value_domain_counts`), implemented for DuckDB and
+  BigQuery this pass; other connectors don't implement it yet and degrade to
+  reporting no domain, identical to how an adapter that predates this
+  feature behaves. On BigQuery it is spent only inside the already-confirmed
+  budget, floored at the per-query minimum like every other optional
+  escalation, and `profile_estimate` reserves for it up front.
+
 - **transform init**: allow initializing into the current directory ([#235]).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,12 +36,20 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   `elided` count rather than dropped; only a true count that breaks the
   fraction bar (a near-key the approximation missed) is dropped entirely.
 
-  New adapter capability (`value_domain_counts`), implemented for DuckDB and
-  BigQuery this pass; other connectors don't implement it yet and degrade to
-  reporting no domain, identical to how an adapter that predates this
-  feature behaves. On BigQuery it is spent only inside the already-confirmed
-  budget, floored at the per-query minimum like every other optional
-  escalation, and `profile_estimate` reserves for it up front.
+  New adapter capability (`value_domain_counts`), implemented across every
+  connector (DuckDB, BigQuery, Snowflake, Databricks, Redshift, Postgres),
+  matching the existing `exact_distinct_counts`/`distinct_combination_counts`
+  precedent. Every metered connector spends it only inside the
+  already-confirmed budget, floored like every other optional escalation,
+  and degrades to reporting no domain (plus a table note) rather than
+  self-escalating when the remaining budget can't cover it. The reported
+  order is re-sorted by the engine rather than trusted from the adapter, since
+  not every dialect's array-aggregate reliably preserves an inner subquery's
+  `ORDER BY` once collected into one value. Redshift's implementation reads
+  back multiple tagged rows instead of one struct-shaped row (its
+  semi-structured `SUPER` type is treated as degraded elsewhere in that
+  adapter already), trading the column's native value type for a text cast
+  that lets heterogeneous columns batch into one `UNION ALL` statement.
 
 - **transform init**: allow initializing into the current directory ([#235]).
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/base.py
@@ -88,6 +88,20 @@ class ColumnAggregate:
 
 
 @dataclass(frozen=True)
+class ValueDomainSample:
+    """One column's raw value-domain probe result. ``values`` is already
+    capped and ordered by frequency descending; ``total_distinct`` is the
+    *exact* distinct-group count (never the approximate estimate), so the
+    caller can compute an accurate elided count and, if the exact count
+    turns out to exceed the cap after all (an approximate pre-check
+    under-estimated), drop the domain rather than report a partial one.
+    """
+
+    values: list[tuple[object, int]]
+    total_distinct: int
+
+
+@dataclass(frozen=True)
 class QueryResult:
     """The result of one firewall-approved agent query, columnar.
 
@@ -335,6 +349,20 @@ class Adapter(Protocol):
         bounded and deliberate; a metered adapter that cannot cover the scan
         within the confirmed budget returns ``{}`` and explains itself through
         a table note instead of self-escalating."""
+        ...
+
+    def value_domain_counts(
+        self, identifier: str, columns: list[str], *, limit: int
+    ) -> dict[str, ValueDomainSample]:
+        """Top ``limit`` values by frequency for each named column, plus each
+        column's exact distinct-group count, batched into as few statements
+        as possible. The engine calls this only for columns already screened
+        as non-PII and low-cardinality, so the spend is bounded and
+        deliberate; a metered adapter that cannot cover the scan within the
+        confirmed budget returns ``{}`` and explains itself through a table
+        note, same as ``distinct_combination_counts``. Optional: an adapter
+        that does not implement it simply reports no value domain, exactly
+        like an adapter that predates this capability."""
         ...
 
     def run_query(

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -28,6 +28,7 @@ from .base import (
     ColumnMeta,
     ObjectMeta,
     QueryResult,
+    ValueDomainSample,
     blame,
     distinct_combination_sql,
     is_blob_type,
@@ -589,6 +590,52 @@ class BigQueryAdapter:
             tuple(combo): int(rows[0][f"d_{i}"]) for i, combo in enumerate(combinations)
         }
 
+    def value_domain_counts(
+        self, identifier: str, columns: list[str], *, limit: int
+    ) -> dict[str, ValueDomainSample]:
+        """Top ``limit`` values by frequency per column, spent only within
+        the already-confirmed budget: when the remaining budget cannot cover
+        the extra scan, return nothing and report no value domain. A metered
+        adapter never self-escalates past its ceiling.
+
+        Charged at the floored bytes, not the raw dry-run number: this is one
+        billed query like any other, so it bills (and must be budgeted
+        against) at least the per-query minimum (issue #107)."""
+
+        if self._unqueryable(identifier) or not columns:
+            return {}
+        table = self._quote(identifier)
+        parts = []
+        for i, name in enumerate(columns):
+            qcol = _quote_ident(name)
+            parts.append(
+                "(SELECT ARRAY_AGG(STRUCT(v AS v, c AS c) ORDER BY c DESC, v "  # noqa: S608
+                f"LIMIT {limit}) FROM (SELECT {qcol} AS v, COUNT(*) AS c "
+                f"FROM {table} WHERE {qcol} IS NOT NULL GROUP BY {qcol}) ) AS d_{i}"
+            )
+            parts.append(
+                f"(SELECT COUNT(*) FROM (SELECT DISTINCT {qcol} FROM {table} "  # noqa: S608
+                f"WHERE {qcol} IS NOT NULL)) AS n_{i}"
+            )
+        sql = assert_select_only(f"SELECT {', '.join(parts)}", dialect=self.dialect)
+        floored = max(self._dry_run(sql), float(_MIN_BILLED_BYTES))
+        if not self.cost_gate.try_charge(floored):
+            self._note(
+                identifier,
+                "value-domain probe skipped: the remaining budget could not "
+                "cover the extra scan; no value domain reported",
+            )
+            return {}
+        _job, iterator = self._run(sql)
+        rows = list(iterator)
+        return {
+            name: ValueDomainSample(
+                values=[(entry["v"], entry["c"]) for entry in rows[0][f"d_{i}"]],
+                total_distinct=int(rows[0][f"n_{i}"]),
+            )
+            for i, name in enumerate(columns)
+        }
+
     # --- estimation (free dry-runs; feeds the confirm handshake) --------------
 
     def profile_estimate(
@@ -659,6 +706,7 @@ class BigQueryAdapter:
                     )
             if scan_columns and meta.row_count != 0:
                 total += float(_MIN_BILLED_BYTES)  # exact_distinct_counts
+                total += float(_MIN_BILLED_BYTES)  # value_domain_counts
                 if len(scan_columns) >= 2:
                     total += float(_MIN_BILLED_BYTES)  # distinct_combination_counts
             per_table[identifier] = total

--- a/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
@@ -42,6 +42,7 @@ from .base import (
     ColumnMeta,
     ObjectMeta,
     QueryResult,
+    ValueDomainSample,
     blame,
     distinct_combination_sql,
     is_blob_type,
@@ -1031,6 +1032,57 @@ class DatabricksAdapter:
             tuple(combo): int(values[f"d_{i}"]) for i, combo in enumerate(combinations)
         }
 
+    def value_domain_counts(
+        self, identifier: str, columns: list[str], *, limit: int
+    ) -> dict[str, ValueDomainSample]:
+        """Top ``limit`` values by frequency per column, plus each column's
+        exact distinct-group count, spent only within the already-confirmed
+        budget: when the remaining budget cannot cover the extra scan,
+        return nothing and report no value domain. A metered adapter never
+        self-escalates past its ceiling. The array-of-structs this collects
+        need not preserve frequency order itself (the engine re-sorts): the
+        subquery's own ``ORDER BY ... LIMIT`` is what selects the right top
+        values, not the order they land in `collect_list`.
+        """
+
+        if not columns:
+            return {}
+        self._ensure_detail(identifier)
+        meta, _ = self.table_metadata(identifier)
+        estimate = self._statement_seconds(meta.byte_size)
+        if not self.cost_gate.try_charge(estimate):
+            self._note(
+                identifier,
+                "value-domain probe skipped: the remaining budget could not "
+                "cover the extra scan; no value domain reported",
+            )
+            return {}
+        table = self._quote(identifier)
+        parts = []
+        for i, name in enumerate(columns):
+            qcol = _quote_ident(name)
+            parts.append(
+                "(SELECT collect_list(struct(v AS v, c AS c)) FROM "  # noqa: S608
+                f"(SELECT {qcol} AS v, COUNT(*) AS c FROM {table} "
+                f"WHERE {qcol} IS NOT NULL GROUP BY {qcol} ORDER BY c DESC, v "
+                f"LIMIT {limit}) AS q_{i}) AS d_{i}"
+            )
+            parts.append(
+                f"(SELECT COUNT(*) FROM (SELECT DISTINCT {qcol} FROM {table} "  # noqa: S608
+                f"WHERE {qcol} IS NOT NULL) AS n_{i}) AS n_{i}"
+            )
+        sql = assert_select_only(f"SELECT {', '.join(parts)}", dialect=self.dialect)
+        rows, labels = self._run(sql)
+        values = dict(zip(labels, rows[0], strict=True))
+        result = {}
+        for i, name in enumerate(columns):
+            domain = values[f"d_{i}"] or []
+            result[name] = ValueDomainSample(
+                values=[(_field(entry, "v"), _field(entry, "c")) for entry in domain],
+                total_distinct=int(values[f"n_{i}"]),
+            )
+        return result
+
     # --- execution (the single billed door) --------------------------------------
 
     def run_query(
@@ -1185,3 +1237,12 @@ def _quote_ident(name: str) -> str:
 
     escaped = name.replace("`", "``")
     return f"`{escaped}`"
+
+
+def _field(entry: object, key: str) -> object:
+    """Read one field off a returned STRUCT row, which the connector may
+    hand back as either a mapping or an attribute-bearing Row object."""
+
+    if isinstance(entry, dict):
+        return entry[key]
+    return getattr(entry, key)

--- a/packages/dex-core/src/exmergo_dex_core/adapters/duckdb.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/duckdb.py
@@ -20,6 +20,7 @@ from .base import (
     ColumnMeta,
     ObjectMeta,
     QueryResult,
+    ValueDomainSample,
     distinct_combination_sql,
     json_safe,
     shape_stat_expressions,
@@ -309,6 +310,43 @@ class DuckDBAdapter:
         values = dict(zip(labels, row, strict=True))
         return {
             tuple(combo): int(values[f"d_{i}"]) for i, combo in enumerate(combinations)
+        }
+
+    def value_domain_counts(
+        self, identifier: str, columns: list[str], *, limit: int
+    ) -> dict[str, ValueDomainSample]:
+        """Top ``limit`` values by frequency per column, plus each column's
+        exact distinct-group count, all in one statement: two scalar
+        subqueries per column (the capped frequency list as a single
+        list-of-structs value, and the true distinct count so the caller can
+        tell an elided domain from a complete one)."""
+
+        if not columns:
+            return {}
+        table = self._quote(identifier)
+        parts = []
+        for i, name in enumerate(columns):
+            qcol = _quote_ident(name)
+            parts.append(
+                "(SELECT list(struct_pack(v := v, c := c)) FROM "  # noqa: S608
+                f"(SELECT {qcol} AS v, COUNT(*) AS c FROM {table} "
+                f"WHERE {qcol} IS NOT NULL GROUP BY {qcol} ORDER BY c DESC, v "
+                f"LIMIT {limit}) AS q_{i}) AS d_{i}"
+            )
+            parts.append(
+                f"(SELECT COUNT(*) FROM (SELECT DISTINCT {qcol} FROM {table} "  # noqa: S608
+                f"WHERE {qcol} IS NOT NULL) AS n_{i}) AS n_{i}"
+            )
+        sql = f"SELECT {', '.join(parts)}"
+        row = self._run_select(assert_select_only(sql, dialect=self.dialect))[0]
+        labels = [d[0] for d in self._conn.description]
+        values = dict(zip(labels, row, strict=True))
+        return {
+            name: ValueDomainSample(
+                values=[(entry["v"], entry["c"]) for entry in values[f"d_{i}"]],
+                total_distinct=int(values[f"n_{i}"]),
+            )
+            for i, name in enumerate(columns)
         }
 
     def _build_aggregate_sql(

--- a/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
@@ -48,6 +48,7 @@ from .base import (
     ColumnMeta,
     ObjectMeta,
     QueryResult,
+    ValueDomainSample,
     blame,
     distinct_combination_sql,
     is_blob_type,
@@ -836,6 +837,55 @@ class PostgresAdapter:
         return {
             tuple(combo): int(values[f"d_{i}"]) for i, combo in enumerate(combinations)
         }
+
+    def value_domain_counts(
+        self, identifier: str, columns: list[str], *, limit: int
+    ) -> dict[str, ValueDomainSample]:
+        """Top ``limit`` values by frequency per column, plus each column's
+        exact distinct-group count, spent only within the already-confirmed
+        budget: when the remaining budget cannot cover the extra scan,
+        return nothing and report no value domain. A metered adapter never
+        self-escalates past its ceiling.
+        """
+
+        if not columns:
+            return {}
+        meta, _ = self.table_metadata(identifier)
+        estimate = self._scan_seconds(meta.byte_size)
+        if not self.cost_gate.try_charge(estimate):
+            self._note(
+                identifier,
+                "value-domain probe skipped: the remaining budget could not "
+                "cover the extra scan; no value domain reported",
+            )
+            return {}
+        table = self._quote(identifier)
+        parts = []
+        for i, name in enumerate(columns):
+            qcol = _quote_ident(name)
+            parts.append(
+                "(SELECT json_agg(json_build_object('v', v, 'c', c)) FROM "  # noqa: S608
+                f"(SELECT {qcol} AS v, COUNT(*) AS c FROM {table} "
+                f"WHERE {qcol} IS NOT NULL GROUP BY {qcol} ORDER BY c DESC, v "
+                f"LIMIT {limit}) AS q_{i}) AS d_{i}"
+            )
+            parts.append(
+                f"(SELECT COUNT(*) FROM (SELECT DISTINCT {qcol} FROM {table} "  # noqa: S608
+                f"WHERE {qcol} IS NOT NULL) AS n_{i}) AS n_{i}"
+            )
+        sql = assert_select_only(f"SELECT {', '.join(parts)}", dialect=self.dialect)
+        rows, labels = self._run(sql)
+        values = dict(zip(labels, rows[0], strict=True))
+        result = {}
+        for i, name in enumerate(columns):
+            domain = values[f"d_{i}"]
+            if isinstance(domain, str):
+                domain = json.loads(domain)
+            result[name] = ValueDomainSample(
+                values=[(entry["v"], entry["c"]) for entry in (domain or [])],
+                total_distinct=int(values[f"n_{i}"]),
+            )
+        return result
 
     # --- execution (the single billed door) --------------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
@@ -53,6 +53,7 @@ from .base import (
     ColumnMeta,
     ObjectMeta,
     QueryResult,
+    ValueDomainSample,
     blame,
     distinct_combination_sql,
     is_blob_type,
@@ -927,6 +928,71 @@ class RedshiftAdapter:
         values = dict(zip(labels, rows[0], strict=True))
         return {
             tuple(combo): int(values[f"d_{i}"]) for i, combo in enumerate(combinations)
+        }
+
+    def value_domain_counts(
+        self, identifier: str, columns: list[str], *, limit: int
+    ) -> dict[str, ValueDomainSample]:
+        """Top ``limit`` values by frequency per column, plus each column's
+        exact distinct-group count, spent only within the already-confirmed
+        budget: when the remaining budget cannot cover the extra scan,
+        return nothing and report no value domain. A metered adapter never
+        self-escalates past its ceiling.
+
+        Unlike the other adapters' single-row batching, this reads back
+        multiple rows tagged by a column index, one row per top value plus a
+        sentinel row (``v IS NULL``) carrying the exact distinct-group count:
+        Redshift's struct/array support is the least reliable of every
+        dialect here (its semi-structured SUPER type is treated as degraded
+        elsewhere in this adapter), so this avoids depending on it at all.
+        The tradeoff is losing the column's native type for the reported
+        value (cast to text so heterogeneous columns can UNION into one
+        statement), which is acceptable for a name/label domain.
+        """
+
+        if not columns:
+            return {}
+        meta, _ = self.table_metadata(identifier)
+        estimate = self._scan_seconds(meta.byte_size) + self._wake_floor()
+        if not self.cost_gate.try_charge(estimate):
+            self._note(
+                identifier,
+                "value-domain probe skipped: the remaining budget could not "
+                "cover the extra scan; no value domain reported",
+            )
+            return {}
+        self._consume_wake_floor()
+        table = self._quote(identifier)
+        branches = []
+        for i, name in enumerate(columns):
+            qcol = _quote_ident(name)
+            branches.append(
+                f"SELECT {i} AS col, CAST(v AS VARCHAR) AS v, c AS c FROM "  # noqa: S608
+                f"(SELECT {qcol} AS v, COUNT(*) AS c FROM {table} "
+                f"WHERE {qcol} IS NOT NULL GROUP BY {qcol} ORDER BY c DESC, v "
+                f"LIMIT {limit}) AS q_{i}"
+            )
+            branches.append(
+                f"SELECT {i} AS col, CAST(NULL AS VARCHAR) AS v, COUNT(*) AS c "  # noqa: S608
+                f"FROM (SELECT DISTINCT {qcol} FROM {table} "
+                f"WHERE {qcol} IS NOT NULL) AS n_{i}"
+            )
+        sql = assert_select_only(" UNION ALL ".join(branches), dialect=self.dialect)
+        rows, labels = self._run(sql)
+        by_column: dict[int, list[tuple]] = {i: [] for i in range(len(columns))}
+        totals: dict[int, int] = {}
+        for row in rows:
+            values = dict(zip(labels, row, strict=True))
+            col_index = int(values["col"])
+            if values["v"] is None:
+                totals[col_index] = int(values["c"])
+            else:
+                by_column[col_index].append((values["v"], int(values["c"])))
+        return {
+            name: ValueDomainSample(
+                values=by_column[i], total_distinct=totals.get(i, len(by_column[i]))
+            )
+            for i, name in enumerate(columns)
         }
 
     # --- execution (the single billed door) --------------------------------------

--- a/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
@@ -40,6 +40,7 @@ from .base import (
     ColumnMeta,
     ObjectMeta,
     QueryResult,
+    ValueDomainSample,
     blame,
     distinct_combination_sql,
     is_blob_type,
@@ -920,6 +921,56 @@ class SnowflakeAdapter:
         return {
             tuple(combo): int(values[f"d_{i}"]) for i, combo in enumerate(combinations)
         }
+
+    def value_domain_counts(
+        self, identifier: str, columns: list[str], *, limit: int
+    ) -> dict[str, ValueDomainSample]:
+        """Top ``limit`` values by frequency per column, plus each column's
+        exact distinct-group count, spent only within the already-confirmed
+        budget: when the remaining budget cannot cover the extra scan,
+        return nothing and report no value domain. A metered adapter never
+        self-escalates past its ceiling.
+        """
+
+        if not columns:
+            return {}
+        meta, _ = self.table_metadata(identifier)
+        estimate = self._scan_seconds(meta.byte_size)
+        if not self.cost_gate.try_charge(estimate):
+            self._note(
+                identifier,
+                "value-domain probe skipped: the remaining budget could not "
+                "cover the extra scan; no value domain reported",
+            )
+            return {}
+        table = self._quote(identifier)
+        parts = []
+        for i, name in enumerate(columns):
+            qcol = _quote_ident(name)
+            parts.append(
+                "(SELECT ARRAY_AGG(OBJECT_CONSTRUCT('v', v, 'c', c)) "  # noqa: S608
+                "WITHIN GROUP (ORDER BY c DESC, v) FROM "
+                f"(SELECT {qcol} AS v, COUNT(*) AS c FROM {table} "
+                f"WHERE {qcol} IS NOT NULL GROUP BY {qcol} ORDER BY c DESC, v "
+                f"LIMIT {limit}) AS q_{i}) AS d_{i}"
+            )
+            parts.append(
+                f"(SELECT COUNT(*) FROM (SELECT DISTINCT {qcol} FROM {table} "  # noqa: S608
+                f"WHERE {qcol} IS NOT NULL) AS n_{i}) AS n_{i}"
+            )
+        sql = assert_select_only(f"SELECT {', '.join(parts)}", dialect=self.dialect)
+        rows, labels = self._run(sql)
+        values = dict(zip(labels, rows[0], strict=True))
+        result = {}
+        for i, name in enumerate(columns):
+            domain = values[f"d_{i}"]
+            if isinstance(domain, str):
+                domain = json.loads(domain)
+            result[name] = ValueDomainSample(
+                values=[(entry["v"], entry["c"]) for entry in (domain or [])],
+                total_distinct=int(values[f"n_{i}"]),
+            )
+        return result
 
     # --- execution (the single billed door) --------------------------------------
 

--- a/packages/dex-core/src/exmergo_dex_core/cache.py
+++ b/packages/dex-core/src/exmergo_dex_core/cache.py
@@ -49,6 +49,26 @@ class PIIFlag(BaseModel):
     confidence: float = Field(ge=0.0, le=1.0)
 
 
+class ValueCount(BaseModel):
+    """One distinct value's frequency, part of a reported value domain."""
+
+    value: object
+    count: int
+
+
+class ValueDomain(BaseModel):
+    """A column's value domain: distinct values by frequency, capped.
+
+    ``elided`` is the number of additional distinct values beyond the cap
+    (0 when the column's full domain fit). Never populated for a PII-flagged
+    column, at any confidence -- see `_probe_value_domains` in
+    `explore/profile.py`.
+    """
+
+    values: list[ValueCount]
+    elided: int = 0
+
+
 class ColumnProfile(BaseModel):
     """Aggregate-derived understanding of one column, built from SQL aggregates and
     never from raw rows in context."""
@@ -68,6 +88,7 @@ class ColumnProfile(BaseModel):
     #: detector, cleared this column. None when no override applied or the
     #: detector matched nothing.
     pii_overridden: PIICategory | None = None
+    value_domain: ValueDomain | None = None
 
 
 class Dataset(BaseModel):

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -701,8 +701,13 @@ def _probe_value_domains(
             # this is really a near-key column, so report no domain at all
             # rather than a capped slice of one.
             continue
+        # Sorted here, not trusted from the adapter: not every dialect's
+        # array-aggregate reliably preserves the inner subquery's ORDER BY
+        # once it's collected into a single value, so frequency order is
+        # guaranteed at this one point instead of per-dialect.
+        ordered = sorted(sample.values, key=lambda pair: pair[1], reverse=True)
         domains[name] = ValueDomain(
-            values=[ValueCount(value=json_safe(v), count=c) for v, c in sample.values],
+            values=[ValueCount(value=json_safe(v), count=c) for v, c in ordered],
             elided=max(0, sample.total_distinct - len(sample.values)),
         )
     return domains

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -16,7 +16,14 @@ from dataclasses import replace
 from datetime import UTC, datetime
 
 from ..adapters.base import Adapter, ColumnAggregate, is_blob_type, json_safe
-from ..cache import ColumnProfile, Dataset, PIICategory, PIIFlag
+from ..cache import (
+    ColumnProfile,
+    Dataset,
+    PIICategory,
+    PIIFlag,
+    ValueCount,
+    ValueDomain,
+)
 from ..config import PIIOverrideMatcher
 from ..progress import ProgressReporter
 
@@ -48,6 +55,15 @@ _COMPOSITE_PAIR_CAP = 5
 # competing hypothesis, not filler) still gets its own slot even if it
 # reuses a column.
 _COMPOSITE_REDUNDANCY_RATIO = 3.0
+
+# A column's value domain is reported only when its distinct count clears
+# BOTH bars: small absolutely (this cap) and small relative to the table
+# (the fraction below), so a tiny table's near-key column does not qualify
+# on the absolute count alone. Deliberately conservative -- this codebase's
+# general posture is to under-report rather than over-report, and a false
+# negative here just costs one more `explore query`.
+_VALUE_DOMAIN_CAP = 25
+_VALUE_DOMAIN_MAX_FRACTION = 0.10
 
 # Name patterns mapped to a PII category and a base confidence. Matched on the
 # snake-normalized column name (camelCase is split first, so "firstName" matches
@@ -414,6 +430,9 @@ def profile(
         composite_keys = _probe_composite_keys(
             adapter, identifier, meta.row_count, aggregates
         )
+        value_domains = _probe_value_domains(
+            adapter, identifier, meta.row_count, aggregates, prelim_pii, composite_keys
+        )
 
         profiles: list[ColumnProfile] = []
         data_quality: list[str] = []
@@ -458,6 +477,7 @@ def profile(
                     max_value=json_safe(agg.max_value) if agg else None,
                     pii=pii,
                     pii_overridden=overridden.get(col.name),
+                    value_domain=value_domains.get(col.name),
                 )
             )
 
@@ -615,6 +635,77 @@ def _probe_composite_keys(
     chosen = [list(pair) for _ids, _product, pair in deduped[:_COMPOSITE_PAIR_CAP]]
     exact = combo_counts(identifier, chosen)
     return [combo for combo in chosen if exact.get(tuple(combo)) == row_count]
+
+
+def _probe_value_domains(
+    adapter: Adapter,
+    identifier: str,
+    row_count: int | None,
+    aggregates: dict[str, ColumnAggregate],
+    prelim_pii: dict[str, PIIFlag | None],
+    composite_keys: list[list[str]],
+) -> dict[str, ValueDomain]:
+    """Report the value domain of a column with no PII flag at any
+    confidence, a distinct count that clears both the absolute cap and the
+    row-relative fraction, and that is not a candidate key -- so a caller
+    can write a correct CASE expression without a raw SQL client, the one
+    place the PII policy and query firewall don't apply.
+
+    Eligibility is decided from the approximate pre-scan distinct count (cost
+    control: an obviously-too-wide column is never even queried), but the
+    reported domain is built from the exact count the probe itself returns.
+    When HLL under-estimated and the true count is still within the
+    row-relative fraction, the result is capped to the top values by
+    frequency with the remainder counted as ``elided`` rather than dropped;
+    only a true count that breaks the fraction bar (a near-key column the
+    approximation missed) is dropped entirely.
+
+    ``prelim_pii``, not the post-``_refine_confidence`` flag: refinement
+    only adjusts confidence, never presence, so the two are equivalent for
+    an any-confidence presence check, and ``prelim_pii`` is already computed
+    before the aggregate scan even runs.
+    """
+
+    domain_fn = getattr(adapter, "value_domain_counts", None)
+    if domain_fn is None or not row_count:
+        return {}
+
+    composite_members = {c for pair in composite_keys for c in pair}
+    eligible = []
+    for name, agg in aggregates.items():
+        if prelim_pii.get(name) is not None:
+            continue  # flagged at any confidence: never a domain
+        if name in composite_members:
+            continue
+        if agg.is_unique and agg.null_fraction in (0.0, None):
+            continue  # single-column key
+        if not agg.distinct_count or agg.distinct_count > _VALUE_DOMAIN_CAP:
+            continue
+        non_null = row_count * (1 - (agg.null_fraction or 0.0))
+        if non_null <= 0 or agg.distinct_count > non_null * _VALUE_DOMAIN_MAX_FRACTION:
+            continue
+        eligible.append(name)
+    if not eligible:
+        return {}
+
+    samples = domain_fn(identifier, eligible, limit=_VALUE_DOMAIN_CAP)
+    domains: dict[str, ValueDomain] = {}
+    for name, sample in samples.items():
+        agg = aggregates[name]
+        non_null = row_count * (1 - (agg.null_fraction or 0.0))
+        if (
+            non_null <= 0
+            or sample.total_distinct > non_null * _VALUE_DOMAIN_MAX_FRACTION
+        ):
+            # The approximate pre-check under-estimated the true fraction:
+            # this is really a near-key column, so report no domain at all
+            # rather than a capped slice of one.
+            continue
+        domains[name] = ValueDomain(
+            values=[ValueCount(value=json_safe(v), count=c) for v, c in sample.values],
+            elided=max(0, sample.total_distinct - len(sample.values)),
+        )
+    return domains
 
 
 def _refine_confidence(

--- a/packages/dex-core/tests/adapters/test_connect_bigquery.py
+++ b/packages/dex-core/tests/adapters/test_connect_bigquery.py
@@ -200,11 +200,12 @@ def test_profile_estimate_floors_each_batch_at_the_billing_minimum(fake_bq_clien
     adapter = make_adapter(fake_bq_client)
     total, per_table = adapter.profile_estimate(["test-proj.shop.customers"])
     # One batch over one table (the raw 5000-byte scan floors to the minimum)
-    # plus a floor reserved for each of the two possible escalation queries
-    # (customers has 2 non-blob columns and 100 rows, so both are possible):
-    # 10 MB aggregate + 10 MB near-unique reserve + 10 MB composite reserve.
-    assert per_table["test-proj.shop.customers"] == 30 * MB
-    assert total == 30 * MB
+    # plus a floor reserved for each of the three possible escalation queries
+    # (customers has 2 non-blob columns and 100 rows, so all three are
+    # possible): 10 MB aggregate + 10 MB near-unique reserve + 10 MB
+    # value-domain reserve + 10 MB composite reserve.
+    assert per_table["test-proj.shop.customers"] == 40 * MB
+    assert total == 40 * MB
 
 
 def test_every_executed_job_carries_maximum_bytes_billed(fake_bq_client):
@@ -438,21 +439,22 @@ def test_profile_estimate_sums_free_dry_runs(fake_bq_client):
         ["test-proj.shop.customers", "test-proj.shop.events", "test-proj.logs.requests"]
     )
     # Each queryable table is one below-floor batch (floors to the minimum)
-    # plus a floor reserved for each of its two possible escalation queries
-    # (both tables have >= 2 non-blob columns and > 0 rows): 30 MB apiece.
-    assert per_table["test-proj.shop.customers"] == 30 * MB
-    assert per_table["test-proj.shop.events"] == 30 * MB
+    # plus a floor reserved for each of its three possible escalation queries
+    # (both tables have >= 2 non-blob columns and > 0 rows): 40 MB apiece.
+    assert per_table["test-proj.shop.customers"] == 40 * MB
+    assert per_table["test-proj.shop.events"] == 40 * MB
     assert per_table["test-proj.logs.requests"] == 0.0  # unqueryable, skipped
-    assert total == 60 * MB
+    assert total == 80 * MB
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
 
-def test_profile_estimate_reserves_only_the_near_unique_floor_for_one_column(
+def test_profile_estimate_skips_only_the_composite_reserve_for_one_column(
     fake_bq_client,
 ):
     """A composite-key probe needs at least 2 columns to form a combination;
     a single-column table can never trigger one, so the estimate must not
-    reserve for it (issue #107)."""
+    reserve for it (issue #107) -- but the near-unique and value-domain
+    reserves apply to a single column just as well, so both still count."""
 
     from fakes.bigquery import FakeBigQueryClient, FakeTable
 
@@ -471,9 +473,9 @@ def test_profile_estimate_reserves_only_the_near_unique_floor_for_one_column(
     )
     adapter = make_adapter(client)
     total, per_table = adapter.profile_estimate(["test-proj.shop.single_col"])
-    # 10 MB aggregate + 10 MB near-unique reserve only (no composite reserve).
-    assert per_table["test-proj.shop.single_col"] == 20 * MB
-    assert total == 20 * MB
+    # 10 MB aggregate + 10 MB near-unique + 10 MB value-domain (no composite).
+    assert per_table["test-proj.shop.single_col"] == 30 * MB
+    assert total == 30 * MB
 
 
 def test_profile_estimate_skips_the_reserve_for_a_provably_empty_table(fake_bq_client):
@@ -536,8 +538,8 @@ def test_profile_estimate_still_reserves_for_a_view_with_unknown_row_count(
     adapter = make_adapter(client)
     total, per_table = adapter.profile_estimate(["test-proj.shop.a_view"])
     # Full reserve still applies despite the unknown (None) row count.
-    assert per_table["test-proj.shop.a_view"] == 30 * MB
-    assert total == 30 * MB
+    assert per_table["test-proj.shop.a_view"] == 40 * MB
+    assert total == 40 * MB
 
 
 def _blob_fake_client():
@@ -618,6 +620,47 @@ def test_distinct_combination_counts_degrade_when_budget_cannot_cover(fake_bq_cl
     assert result == {}
     assert any(
         "composite-key probe skipped" in note
+        for note in adapter.table_notes("test-proj.shop.customers")
+    )
+    assert all(c.dry_run for c in fake_bq_client.query_calls)
+
+
+def test_value_domain_counts_batch_into_one_guarded_statement(fake_bq_client):
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    fake_bq_client.row_resolver = lambda sql: [
+        {
+            "d_0": [{"v": "prod", "c": 60}, {"v": "dev", "c": 40}],
+            "n_0": 2,
+            "d_1": [{"v": "x", "c": 100}],
+            "n_1": 1,
+        }
+    ]
+    adapter = make_adapter(fake_bq_client)
+    result = adapter.value_domain_counts(
+        "test-proj.shop.customers", ["env_tier", "flag"], limit=25
+    )
+    assert result["env_tier"].values == [("prod", 60), ("dev", 40)]
+    assert result["env_tier"].total_distinct == 2
+    assert result["flag"].values == [("x", 100)]
+    assert result["flag"].total_distinct == 1
+    billed = [c for c in fake_bq_client.query_calls if not c.dry_run]
+    assert len(billed) == 1
+    sql = billed[0].sql
+    assert "ARRAY_AGG" in sql
+    assert assert_select_only(sql, dialect="bigquery") == sql
+    assert adapter.value_domain_counts("test-proj.shop.customers", [], limit=25) == {}
+
+
+def test_value_domain_counts_degrade_when_budget_cannot_cover(fake_bq_client):
+    adapter = make_adapter(fake_bq_client, ceiling=100 * MB)
+    adapter.cost_gate.charge(100 * MB - 1_000)
+    result = adapter.value_domain_counts(
+        "test-proj.shop.customers", ["env_tier"], limit=25
+    )
+    assert result == {}
+    assert any(
+        "value-domain probe skipped" in note
         for note in adapter.table_notes("test-proj.shop.customers")
     )
     assert all(c.dry_run for c in fake_bq_client.query_calls)

--- a/packages/dex-core/tests/adapters/test_connect_databricks.py
+++ b/packages/dex-core/tests/adapters/test_connect_databricks.py
@@ -630,6 +630,45 @@ def test_distinct_combination_counts_degrade_when_budget_cannot_cover(
     assert data_statements(fake_databricks) == []
 
 
+def test_value_domain_counts_batch_into_one_guarded_statement(fake_databricks):
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    warm(fake_databricks)
+    fake_databricks.connection.row_resolver = lambda sql: [
+        {
+            "d_0": [{"v": "prod", "c": 60}, {"v": "dev", "c": 40}],
+            "n_0": 2,
+            "d_1": [{"v": "x", "c": 100}],
+            "n_1": 1,
+        }
+    ]
+    adapter = make_adapter(fake_databricks, ceiling=100_000.0)
+    result = adapter.value_domain_counts(
+        "shop.core.customers", ["env_tier", "flag"], limit=25
+    )
+    assert result["env_tier"].values == [("prod", 60), ("dev", 40)]
+    assert result["env_tier"].total_distinct == 2
+    assert result["flag"].values == [("x", 100)]
+    stmts = data_statements(fake_databricks)
+    assert len(stmts) == 1
+    assert "collect_list" in stmts[0].sql
+    assert assert_select_only(stmts[0].sql, dialect="databricks") == stmts[0].sql
+    assert adapter.value_domain_counts("shop.core.customers", [], limit=25) == {}
+
+
+def test_value_domain_counts_degrade_when_budget_cannot_cover(fake_databricks):
+    warm(fake_databricks)
+    adapter = make_adapter(fake_databricks, ceiling=100.0)
+    adapter.cost_gate.charge(99.5)
+    result = adapter.value_domain_counts("shop.core.customers", ["env_tier"], limit=25)
+    assert result == {}
+    assert any(
+        "value-domain probe skipped" in note
+        for note in adapter.table_notes("shop.core.customers")
+    )
+    assert data_statements(fake_databricks) == []
+
+
 # --- factory, dialect, and warehouse pin forms ----------------------------------------
 
 

--- a/packages/dex-core/tests/adapters/test_connect_postgres.py
+++ b/packages/dex-core/tests/adapters/test_connect_postgres.py
@@ -590,6 +590,44 @@ def test_distinct_combination_counts_batch_into_one_guarded_statement(
     assert adapter.distinct_combination_counts("dexdb.shop.customers", []) == {}
 
 
+def test_value_domain_counts_batch_into_one_guarded_statement(fake_pg_connection):
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    fake_pg_connection.row_resolver = lambda sql: FakeResult(
+        rows=[
+            {
+                "d_0": [{"v": "prod", "c": 60}, {"v": "dev", "c": 40}],
+                "n_0": 2,
+                "d_1": [{"v": "x", "c": 100}],
+                "n_1": 1,
+            }
+        ],
+        seconds=0.5,
+    )
+    adapter = make_adapter(fake_pg_connection)
+    result = adapter.value_domain_counts(
+        "dexdb.shop.customers", ["env_tier", "flag"], limit=25
+    )
+    assert result["env_tier"].values == [("prod", 60), ("dev", 40)]
+    assert result["env_tier"].total_distinct == 2
+    assert result["flag"].values == [("x", 100)]
+    stmts = fake_pg_connection.data_statements
+    assert len(stmts) == 1
+    sql = stmts[0].sql
+    assert "json_agg" in sql
+    assert assert_select_only(sql, dialect="postgres") == sql
+    assert adapter.value_domain_counts("dexdb.shop.customers", [], limit=25) == {}
+
+
+def test_value_domain_counts_skipped_when_budget_cannot_cover(fake_pg_connection):
+    adapter = make_adapter(fake_pg_connection, ceiling=1.0)
+    result = adapter.value_domain_counts("dexdb.shop.customers", ["env_tier"], limit=25)
+    assert result == {}
+    assert fake_pg_connection.data_statements == []
+    notes = adapter.table_notes("dexdb.shop.customers")
+    assert any("value-domain probe skipped" in note for note in notes)
+
+
 def test_composite_probe_skipped_when_budget_cannot_cover(fake_pg_connection):
     adapter = make_adapter(fake_pg_connection, ceiling=1.0)
     result = adapter.distinct_combination_counts(

--- a/packages/dex-core/tests/adapters/test_connect_redshift.py
+++ b/packages/dex-core/tests/adapters/test_connect_redshift.py
@@ -791,6 +791,90 @@ def test_composite_probe_skipped_when_budget_cannot_cover(fake_redshift_connecti
     )
 
 
+def test_value_domain_counts_batch_into_one_guarded_statement(
+    fake_redshift_connection,
+):
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    fake_redshift_connection.row_resolver = lambda sql: FakeResult(
+        rows=[
+            {"col": 0, "v": "prod", "c": 60},
+            {"col": 0, "v": "dev", "c": 40},
+            {"col": 0, "v": None, "c": 2},
+            {"col": 1, "v": "x", "c": 100},
+            {"col": 1, "v": None, "c": 1},
+        ],
+        seconds=0.5,
+    )
+    adapter = make_adapter(fake_redshift_connection, ceiling=100_000.0)
+    result = adapter.value_domain_counts(
+        "dexdb.shop.customers", ["env_tier", "flag"], limit=25
+    )
+    assert result["env_tier"].values == [("prod", 60), ("dev", 40)]
+    assert result["env_tier"].total_distinct == 2
+    assert result["flag"].values == [("x", 100)]
+    assert result["flag"].total_distinct == 1
+    stmts = fake_redshift_connection.data_statements
+    assert len(stmts) == 1
+    sql = stmts[0].sql
+    assert "UNION ALL" in sql
+    assert assert_select_only(sql, dialect="redshift") == sql
+    assert adapter.value_domain_counts("dexdb.shop.customers", [], limit=25) == {}
+
+
+def test_value_domain_counts_skipped_when_budget_cannot_cover(
+    fake_redshift_connection,
+):
+    adapter = make_adapter(fake_redshift_connection, ceiling=1.0)
+    result = adapter.value_domain_counts("dexdb.shop.customers", ["env_tier"], limit=25)
+    assert result == {}
+    assert fake_redshift_connection.data_statements == []
+    assert any(
+        "value-domain probe skipped" in note
+        for note in adapter.table_notes("dexdb.shop.customers")
+    )
+
+
+def test_value_domain_counts_carries_the_wake_floor_when_it_bills_first(
+    fake_redshift_connection,
+):
+    """Like the exact-distinct escalation, the value-domain probe can be a
+    command's first billed statement, so the pending wake minimum rides its
+    charge (and stays pending on refusal). One probe over customers estimates
+    scan (100s) + floor (60s)."""
+
+    def resolve(sql):
+        if "UNION ALL" in sql:
+            return FakeResult(
+                rows=[{"col": 0, "v": "x", "c": 1}, {"col": 0, "v": None, "c": 1}],
+                seconds=0.1,
+            )
+        return FakeResult(rows=[{"n": 1}], seconds=0.1)
+
+    fake_redshift_connection.row_resolver = resolve
+
+    # Covers the scan but not scan + floor: the probe must refuse rather than
+    # under-charge its way in, and the floor stays pending.
+    strict = make_adapter(fake_redshift_connection, ceiling=155.0)
+    assert (
+        strict.value_domain_counts("dexdb.shop.customers", ["env_tier"], limit=25) == {}
+    )
+    assert fake_redshift_connection.data_statements == []
+    assert strict._wake_floor_pending is True
+
+    # Once charged, the floor is consumed: probe (100 + 60) plus a follow-up
+    # query (100, floorless) fit a 270s ceiling only if the second statement
+    # does not carry the floor again.
+    adapter = make_adapter(fake_redshift_connection, ceiling=270.0)
+    result = adapter.value_domain_counts("dexdb.shop.customers", ["env_tier"], limit=25)
+    assert result["env_tier"].values == [("x", 1)]
+    adapter.run_query(
+        "SELECT count(*) AS n FROM dexdb.shop.customers",
+        max_rows=10,
+        timeout_seconds=30.0,
+    )
+
+
 def test_composite_probe_carries_the_wake_floor_when_it_bills_first(
     fake_redshift_connection,
 ):

--- a/packages/dex-core/tests/adapters/test_connect_snowflake.py
+++ b/packages/dex-core/tests/adapters/test_connect_snowflake.py
@@ -560,6 +560,45 @@ def test_distinct_combination_counts_degrade_when_budget_cannot_cover(
     assert data_statements(fake_sf_connection) == []
 
 
+def test_value_domain_counts_batch_into_one_guarded_statement(fake_sf_connection):
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    fake_sf_connection.row_resolver = lambda sql: [
+        {
+            "d_0": [{"v": "prod", "c": 60}, {"v": "dev", "c": 40}],
+            "n_0": 2,
+            "d_1": [{"v": "x", "c": 100}],
+            "n_1": 1,
+        }
+    ]
+    adapter = make_adapter(fake_sf_connection, ceiling=100_000.0)
+    result = adapter.value_domain_counts(
+        "SHOP.PUBLIC.CUSTOMERS", ["ENV_TIER", "FLAG"], limit=25
+    )
+    assert result["ENV_TIER"].values == [("prod", 60), ("dev", 40)]
+    assert result["ENV_TIER"].total_distinct == 2
+    assert result["FLAG"].values == [("x", 100)]
+    stmts = data_statements(fake_sf_connection)
+    assert len(stmts) == 1
+    assert "ARRAY_AGG" in stmts[0].sql
+    assert assert_select_only(stmts[0].sql, dialect="snowflake") == stmts[0].sql
+    assert adapter.value_domain_counts("SHOP.PUBLIC.CUSTOMERS", [], limit=25) == {}
+
+
+def test_value_domain_counts_degrade_when_budget_cannot_cover(fake_sf_connection):
+    adapter = make_adapter(fake_sf_connection, ceiling=100.0)
+    adapter.cost_gate.charge(99.5)
+    result = adapter.value_domain_counts(
+        "SHOP.PUBLIC.CUSTOMERS", ["ENV_TIER"], limit=25
+    )
+    assert result == {}
+    assert any(
+        "value-domain probe skipped" in note
+        for note in adapter.table_notes("SHOP.PUBLIC.CUSTOMERS")
+    )
+    assert data_statements(fake_sf_connection) == []
+
+
 # --- factory and dialect --------------------------------------------------------
 
 

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -60,6 +60,28 @@ def _near_unique_not_proven_resolver(sql: str):
     return [values]
 
 
+def _domain_eligible_resolver(sql: str):
+    """Like `_near_unique_not_proven_resolver`, but every filler column
+    (customers.plan_tier, orders.customer_id, orders.total) is also given a
+    small, domain-eligible cardinality instead of the generic 40. Their
+    value-domain probes are a genuinely different query shape -- a capped
+    frequency list, not the scalar the other escalations return under the
+    same `d_i`/`n_i` aliases -- so they are answered separately (keyed off
+    `ARRAY_AGG`, the marker unique to that statement) rather than sharing
+    the generic per-index values. This makes profiling this fixture's
+    tables actually spend the new reserve instead of leaving it as unused
+    padding, which is what the beyond-budget verify-checkpoint tests need."""
+
+    values = _near_unique_not_proven_resolver(sql)[0]
+    values["nd_1"] = 5  # orders.customer_id (customers.email stays PII-excluded
+    values["nd_2"] = 5  # regardless); customers.plan_tier / orders.total
+    if "ARRAY_AGG" in sql:
+        for i in range(3):
+            values[f"d_{i}"] = [{"v": f"v{j}", "c": 1} for j in range(5)]
+            values[f"n_{i}"] = 5
+    return [values]
+
+
 def _adapter(fake_bq_client, *, confirmed: bool, budget: float | None, record=None):
     gate = CostGate(
         paradigm=Paradigm.BYTES_SCANNED,
@@ -145,10 +167,10 @@ def test_unconfirmed_profile_returns_needs_confirmation(
     assert envelope.status.value == "needs_confirmation"
     assert envelope.cost.paradigm is Paradigm.BYTES_SCANNED
     # The single below-floor batch floors to the per-query minimum, plus a
-    # floor reserved for each of the two possible escalation queries (2
-    # columns, 100 rows): 10 + 10 + 10 = 30 MB.
-    assert envelope.cost.estimate == 30 * MB
-    assert envelope.data["per_table_bytes"] == {"test-proj.shop.customers": 30 * MB}
+    # floor reserved for each of the three possible escalation queries (2
+    # columns, 100 rows): 10 + 10 + 10 + 10 = 40 MB.
+    assert envelope.cost.estimate == 40 * MB
+    assert envelope.data["per_table_bytes"] == {"test-proj.shop.customers": 40 * MB}
     assert "--confirm" in envelope.data["hint"]
     # Nothing executed: only free metadata and dry-runs happened.
     assert all(c.dry_run for c in fake_bq_client.query_calls)
@@ -169,7 +191,7 @@ def test_confirmed_profile_runs_and_stamps_spend(
     )
     assert envelope.status.value == "ok"
     assert envelope.data["datasets"][0]["identifier"] == "test-proj.shop.customers"
-    assert envelope.cost.estimate == 30 * MB  # floored preflight estimate + reserve
+    assert envelope.cost.estimate == 40 * MB  # floored preflight estimate + reserve
     assert envelope.cost.ceiling == 100 * MB
     # The aggregate batch plus the exact-distinct escalation (optional spend
     # inside the confirmed budget): both scans land in the ledger.
@@ -184,9 +206,9 @@ def test_unconfirmed_map_estimates_selected_objects(
     envelope = _dispatch(tmp_path, subcommand="map")
     assert envelope.status.value == "needs_confirmation"
     # customers and events each floor to the per-query minimum plus a floor
-    # per possible escalation query (30 MB apiece); logs.requests needs a
+    # per possible escalation query (40 MB apiece); logs.requests needs a
     # partition filter, so it contributes zero.
-    assert envelope.cost.estimate == 2 * 30 * MB
+    assert envelope.cost.estimate == 2 * 40 * MB
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
 
@@ -246,7 +268,7 @@ def test_unconfirmed_map_excludes_fresh_cached_objects(
     assert envelope.status.value == "needs_confirmation"
     # Only events is priced now (customers is fresh-cached, requests is
     # partition-filtered to zero), so the estimate halves versus the no-cache run.
-    assert envelope.cost.estimate == 30 * MB
+    assert envelope.cost.estimate == 40 * MB
     assert "test-proj.shop.customers" not in envelope.data["per_table_bytes"]
     assert any("fresh-cached" in note for note in envelope.data["notes"])
     assert all(c.dry_run for c in fake_bq_client.query_calls)
@@ -475,6 +497,7 @@ def fk_bq_client():
             schema=[
                 bigquery.SchemaField("id", "INTEGER", mode="REQUIRED"),
                 bigquery.SchemaField("email", "STRING"),
+                bigquery.SchemaField("plan_tier", "STRING"),
             ],
             num_rows=100,
             num_bytes=5_000,
@@ -520,22 +543,25 @@ def test_verify_within_budget_runs_in_one_pass(fk_bq_client, route_adapter, tmp_
 def test_verify_beyond_budget_checkpoints_before_any_probe(
     fk_bq_client, route_adapter, tmp_path
 ):
-    # 60 MB matches profile_estimate()'s worst-case total exactly (two tables,
-    # each floored aggregate batch plus both possible escalation reserves: 30
-    # MB apiece), so the initial handshake just barely passes. A near-unique
-    # column that escalates without fully proving uniqueness (unlike the
-    # shared resolver's exact d_i == nd_i) leaves the composite-key probe
-    # un-short-circuited, so both escalations this fixture's estimate reserved
-    # for actually run and get charged -- leaving no headroom for the
-    # two-table verify probe, which floors to another 20 MB.
-    fk_bq_client.row_resolver = _near_unique_not_proven_resolver
+    # 80 MB is profile_estimate()'s worst-case total for two tables (each
+    # floored aggregate batch plus all three possible escalation reserves: 40
+    # MB apiece), so the initial handshake passes. A near-unique column that
+    # escalates without fully proving uniqueness (unlike the shared
+    # resolver's exact d_i == nd_i) leaves the composite-key probe
+    # un-short-circuited, and every filler column is domain-eligible, so
+    # every escalation this fixture's estimate reserved for actually runs and
+    # gets charged: 2 tables x (exact-distinct + combination) = 4 charges,
+    # plus 3 value-domain probes (customers.plan_tier, orders.customer_id,
+    # orders.total) = 7 charges x ~10 MB =~ 73 MB profiling, which alone
+    # already leaves no room for the two-table verify probe's 20 MB floor.
+    fk_bq_client.row_resolver = _domain_eligible_resolver
     route_adapter(fk_bq_client)
     envelope = _dispatch(
         tmp_path,
         subcommand="map",
         verify=True,
         confirm=True,
-        budget=float(60 * MB),
+        budget=float(80 * MB),
     )
     assert envelope.status.value == "needs_confirmation"
     assert envelope.data["phase"] == "verify"
@@ -545,7 +571,7 @@ def test_verify_beyond_budget_checkpoints_before_any_probe(
     assert "--budget" in envelope.data["hint"]
     # The raised estimate is the whole-command total the re-run needs.
     assert envelope.cost.estimate > envelope.cost.ceiling
-    assert envelope.cost.ceiling == 60 * MB
+    assert envelope.cost.ceiling == 80 * MB
     # No probe was billed; profiling spend is reported on the checkpoint.
     assert not _probe_executed(fk_bq_client)
     assert envelope.data["spend"]["bytes_billed"] > 0
@@ -561,14 +587,17 @@ def test_verify_beyond_budget_checkpoints_before_any_probe(
 def test_relationships_verify_beyond_budget_checkpoints(
     fk_bq_client, route_adapter, tmp_path
 ):
-    fk_bq_client.row_resolver = _near_unique_not_proven_resolver
+    # See test_verify_beyond_budget_checkpoints_before_any_probe: every
+    # filler column's value-domain probe is what actually spends the new
+    # reserve rather than leaving it as unused padding.
+    fk_bq_client.row_resolver = _domain_eligible_resolver
     route_adapter(fk_bq_client)
     envelope = _dispatch(
         tmp_path,
         subcommand="relationships",
         verify=True,
         confirm=True,
-        budget=float(60 * MB),
+        budget=float(80 * MB),
     )
     assert envelope.status.value == "needs_confirmation"
     assert envelope.data["phase"] == "verify"
@@ -700,7 +729,7 @@ def test_over_ceiling_refusal_reports_the_metered_paradigm(
     assert envelope.cost.paradigm is Paradigm.BYTES_SCANNED
     # The two numbers the prose names, structured: what was asked for and what
     # was allowed. A caller sizes the re-run from these without parsing text.
-    assert envelope.cost.estimate == 30 * MB
+    assert envelope.cost.estimate == 40 * MB
     assert envelope.cost.ceiling == MB
     assert "exceeds the ceiling" in envelope.errors[0]
     assert all(c.dry_run for c in fake_bq_client.query_calls)

--- a/packages/dex-core/tests/explore/test_profile.py
+++ b/packages/dex-core/tests/explore/test_profile.py
@@ -1074,13 +1074,16 @@ class _StubAdapter:
         approx: dict[str, int],
         nulls: dict[str, float] | None = None,
         combos: dict[tuple[str, ...], int] | None = None,
+        domains: dict[str, object] | None = None,
     ):
         self.rows = rows
         self.approx = approx
         self.nulls = nulls or {}
         self.combos = combos or {}
+        self.domains = domains or {}
         self.calls: list[list[str]] = []
         self.combo_calls: list[list[list[str]]] = []
+        self.domain_calls: list[list[str]] = []
 
     def table_metadata(self, identifier):
         from exmergo_dex_core.adapters.base import ColumnMeta, ObjectMeta
@@ -1126,6 +1129,10 @@ class _StubAdapter:
         return {
             tuple(c): self.combos.get(tuple(c), self.rows - 10) for c in combinations
         }
+
+    def value_domain_counts(self, identifier, columns, *, limit):
+        self.domain_calls.append(list(columns))
+        return {n: self.domains[n] for n in columns if n in self.domains}
 
 
 def test_escalation_policy_is_bounded_and_targeted():
@@ -1308,6 +1315,194 @@ def test_composite_grain_detected_end_to_end(composite_grain_duckdb: Path, capsy
     orders = ds["orders"]
     assert orders["grain"] == ["order_key"]
     assert orders["composite_keys"] == []
+
+
+# --- value-domain reporting (#203) -----------------------------------------------
+
+
+def test_value_domain_reported_for_eligible_low_cardinality_column():
+    """The issue's own acceptance case: a four-value non-PII string column
+    reports its domain with counts."""
+
+    from exmergo_dex_core.adapters.base import ValueDomainSample
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    adapter = _StubAdapter(
+        rows=1000,
+        approx={"env_tier": 4},
+        domains={
+            "env_tier": ValueDomainSample(
+                values=[("prod", 600), ("staging", 250), ("dev", 100), ("test", 50)],
+                total_distinct=4,
+            )
+        },
+    )
+    datasets = profile_mod.profile(adapter, ["db.s.t"])
+    col = datasets[0].columns[0]
+    assert adapter.domain_calls == [["env_tier"]]
+    assert col.value_domain is not None
+    assert [(v.value, v.count) for v in col.value_domain.values] == [
+        ("prod", 600),
+        ("staging", 250),
+        ("dev", 100),
+        ("test", 50),
+    ]
+    assert col.value_domain.elided == 0
+
+
+def test_value_domain_never_reported_for_pii_flagged_column_any_confidence():
+    """A flagged column reports no domain at any confidence or cardinality,
+    even if the adapter would have happily returned one. ``ssn`` (rather
+    than an email/name pattern) because the stub's columns are all typed
+    INTEGER, and the EMAIL/NAME categories are string-only -- GOVERNMENT_ID
+    flags on any type."""
+
+    from exmergo_dex_core.adapters.base import ValueDomainSample
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    adapter = _StubAdapter(
+        rows=1000,
+        approx={"ssn": 4},
+        domains={"ssn": ValueDomainSample(values=[(123, 500)], total_distinct=1)},
+    )
+    datasets = profile_mod.profile(adapter, ["db.s.t"])
+    assert adapter.domain_calls == []  # never even queried
+    assert datasets[0].columns[0].value_domain is None
+
+
+def test_value_domain_excluded_for_high_cardinality_column():
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    adapter = _StubAdapter(rows=1000, approx={"code": 30})  # over the cap of 25
+    datasets = profile_mod.profile(adapter, ["db.s.t"])
+    assert adapter.domain_calls == []
+    assert datasets[0].columns[0].value_domain is None
+
+
+def test_value_domain_excluded_when_fraction_exceeds_cutoff_on_small_table():
+    """The 'tiny table of distinct people' case: 20 distinct values clears
+    the absolute cap of 25, but on a 40-row table that's 50% of rows, far
+    past the 10% fraction cutoff -- a near-key, not a categorical dimension."""
+
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    adapter = _StubAdapter(rows=40, approx={"code": 20})
+    datasets = profile_mod.profile(adapter, ["db.s.t"])
+    assert adapter.domain_calls == []
+    assert datasets[0].columns[0].value_domain is None
+
+
+def test_value_domain_excluded_for_composite_key_member():
+    """`line_no` is well within the cap and fraction on its own, but it is a
+    proven composite-key member, so it must report no domain even though the
+    adapter would have returned one."""
+
+    from exmergo_dex_core.adapters.base import ValueDomainSample
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    adapter = _StubAdapter(
+        rows=1000,
+        approx={"order_key": 250, "line_no": 4, "qty": 30, "filler": 2},
+        combos={("order_key", "line_no"): 1000},
+        domains={
+            "line_no": ValueDomainSample(
+                values=[(1, 250), (2, 250), (3, 250), (4, 250)], total_distinct=4
+            )
+        },
+    )
+    datasets = profile_mod.profile(adapter, ["db.s.t"])
+    assert datasets[0].composite_keys == [["order_key", "line_no"]]
+    assert "line_no" not in adapter.domain_calls[0]
+    cols = {c.name: c for c in datasets[0].columns}
+    assert cols["line_no"].value_domain is None
+
+
+def test_value_domain_reports_elided_when_the_exact_count_exceeds_the_cap():
+    """HLL under-estimated: the approx distinct count (20) cleared the cap,
+    but the exact probe reveals 30 true values, still well within the 10%
+    fraction on this large table. Report the capped slice with an accurate
+    elided count instead of dropping it."""
+
+    from exmergo_dex_core.adapters.base import ValueDomainSample
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    adapter = _StubAdapter(
+        rows=10_000,
+        approx={"code": 20},
+        domains={
+            "code": ValueDomainSample(
+                values=[(f"v{i}", 100) for i in range(25)], total_distinct=30
+            )
+        },
+    )
+    datasets = profile_mod.profile(adapter, ["db.s.t"])
+    domain = datasets[0].columns[0].value_domain
+    assert domain is not None
+    assert len(domain.values) == 25
+    assert domain.elided == 5
+
+
+def test_value_domain_dropped_when_the_exact_fraction_breaks_the_safety_bar():
+    """The approx distinct count (20) passed the pre-scan fraction check on
+    this 250-row table (20/250 = 8%), but the exact probe reveals the true
+    count (30) actually breaks the 10% bar (30/250 = 12%) -- a near-key the
+    approximation missed. Report no domain at all, not a partial one."""
+
+    from exmergo_dex_core.adapters.base import ValueDomainSample
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    adapter = _StubAdapter(
+        rows=250,
+        approx={"code": 20},
+        domains={
+            "code": ValueDomainSample(
+                values=[(f"v{i}", 5) for i in range(25)], total_distinct=30
+            )
+        },
+    )
+    datasets = profile_mod.profile(adapter, ["db.s.t"])
+    assert datasets[0].columns[0].value_domain is None
+
+
+def test_adapter_without_value_domain_counts_degrades_gracefully():
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    adapter = _StubAdapter(rows=1000, approx={"env_tier": 4})
+    adapter.value_domain_counts = None  # shadow: adapter can't probe
+    datasets = profile_mod.profile(adapter, ["db.s.t"])
+    assert datasets[0].columns[0].value_domain is None
+
+
+def test_value_domain_detected_end_to_end(tmp_path: Path, capsys):
+    """The issue's own `raw_workspaces` shape: a low-cardinality non-PII
+    column reports its domain, a candidate key and a PII-flagged column
+    (even a low-cardinality one) do not."""
+
+    import duckdb
+
+    db_path = tmp_path / "raw.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE raw_workspaces (ws_id VARCHAR, env_tier VARCHAR, email VARCHAR)"
+    )
+    rows = [
+        (f"ws{i}", ["prod", "staging", "dev", "test"][i % 4], f"u{i}@x.com")
+        for i in range(100)
+    ]
+    conn.executemany("INSERT INTO raw_workspaces VALUES (?, ?, ?)", rows)
+    conn.close()
+
+    payload = _run(
+        ["explore", "profile", "raw_workspaces", "--path", str(db_path)], capsys
+    )
+    cols = {c["name"]: c for c in payload["data"]["datasets"][0]["columns"]}
+
+    assert cols["ws_id"]["value_domain"] is None  # candidate key
+    assert cols["email"]["value_domain"] is None  # PII, despite low cardinality
+    domain = cols["env_tier"]["value_domain"]
+    assert domain is not None
+    assert domain["elided"] == 0
+    assert {v["value"] for v in domain["values"]} == {"prod", "staging", "dev", "test"}
 
 
 def test_row_count_refreshes_after_the_aggregate_scan():

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -3051,7 +3051,10 @@ def fk_bq_client():
     client = FakeBigQueryClient(
         project="test-proj",
         tables=[
-            table("customers", [("id", "INTEGER"), ("email", "STRING")]),
+            table(
+                "customers",
+                [("id", "INTEGER"), ("email", "STRING"), ("plan_tier", "STRING")],
+            ),
             table(
                 "orders",
                 [("id", "INTEGER"), ("customer_id", "INTEGER"), ("total", "NUMERIC")],
@@ -3060,18 +3063,30 @@ def fk_bq_client():
     )
     # A near-unique column that escalates without fully proving uniqueness
     # (d_0 of 99, not 100) leaves the composite-key probe un-short-circuited, so
-    # both escalations the estimate reserved for actually run and get charged.
-    # That is what leaves no headroom for the verify probe below.
+    # every escalation the estimate reserved for actually runs and gets
+    # charged. plan_tier/customer_id/total are also domain-eligible (small
+    # cardinality, index 1/2), so the value-domain reserve is spent for real
+    # too, not left as unused padding -- together, that is what leaves no
+    # headroom for the verify probe below.
     values = {"n_total": 100, "nonnull_fk": 100, "orphans": 0}
     for i in range(10):
         values |= {
             f"nn_{i}": 100,
-            f"nd_{i}": 100 if i == 0 else 40,
+            f"nd_{i}": 100 if i == 0 else 5,
             f"mn_{i}": 1,
             f"mx_{i}": 100,
-            f"d_{i}": 99 if i == 0 else 40,
+            f"d_{i}": 99 if i == 0 else 5,
         }
-    client.row_resolver = lambda sql: [values]
+
+    def resolve(sql):
+        row = dict(values)
+        if "ARRAY_AGG" in sql:
+            for i in range(3):
+                row[f"d_{i}"] = [{"v": f"v{j}", "c": 1} for j in range(5)]
+                row[f"n_{i}"] = 5
+        return [row]
+
+    client.row_resolver = resolve
     return client
 
 
@@ -3089,8 +3104,11 @@ def test_api_verify_checkpoint_keeps_what_it_already_paid_for(
 
     import exmergo_dex_core.connect as connect_mod
 
+    # 80 MB is profile_estimate()'s worst-case total for two tables (each
+    # floored aggregate batch plus all three possible escalation reserves: 40
+    # MB apiece) -- the minimum that clears the confirm handshake at all.
     engine = _billed_engine(
-        fk_bq_client, tmp_path, confirmed=True, budget=float(60 * 1024 * 1024)
+        fk_bq_client, tmp_path, confirmed=True, budget=float(80 * 1024 * 1024)
     )
     monkeypatch.setattr(connect_mod, "open_adapter", engine._open_for_test)
     with engine:


### PR DESCRIPTION
Closes : https://github.com/exmergo/dex/issues/203
ColumnProfile gains a value_domain field (ValueDomain: capped values by frequency + elided count), populated by a new _probe_value_domains step in explore/profile.py.
Eligibility (all required): no PII flag at any confidence, distinct count ≤ 25 and ≤ 10% of non-null rows, not a candidate key (single-column or proven composite member).
New adapter capability value_domain_counts, implemented for DuckDB and BigQuery this pass (one batched statement: capped top-K by frequency + exact distinct-group count per column). Other connectors don't implement it yet and degrade to reporting no domain, same as any adapter that predates this feature.
Eligibility is decided from the approximate pre-scan distinct count (cost control); the reported domain is built from the exact count the probe returns if approximation under-estimated but the true count still clears the fraction bar, the result is capped with an honest elided count instead of being dropped; only a true count that breaks the fraction bar is dropped entirely.
BigQuery: cost-gated like every other optional escalation (dry-run, floor at the per-query minimum, try_charge, degrade to {} + a table note on insufficient budget); profile_estimate reserves for it up front.
before the fix : 
<img width="1340" height="180" alt="image" src="https://github.com/user-attachments/assets/ba88185e-a18d-492f-9e4b-0215694e1ce8" />
After fixing : 
<img width="1392" height="92" alt="image" src="https://github.com/user-attachments/assets/2cfed915-b3db-484a-8d8b-f3527f21a19f" />
