### PR TITLE
fix(transform): accept line-broken top-level dbt refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **`transform plan` accepts a line-broken top-level dbt `ref()`** ([#195]).
+  Placeholder-only Jinja lines remain intact after the model's first `SELECT` or
+  `WITH`, while standalone config headers before the query are still removed.
+
 - **transform dev-target preflight compares resolved DuckDB paths** ([#234]).
   Relative and absolute spellings of the same warehouse file (e.g. `warehouse.duckdb`
   vs `./warehouse.duckdb`) are no longer treated as configuration drift.

--- a/packages/dex-core/src/exmergo_dex_core/transform/validate.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/validate.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+import sqlglot
 import yaml
+from sqlglot.errors import TokenError
+from sqlglot.tokens import TokenType
 
 from ..errors import DexError
 from ..guards.sql_guard import assert_select_only
@@ -134,23 +137,41 @@ def strip_jinja(sql: str) -> str:
     """Reduce a dbt model to plain SQL for the SELECT-only check.
 
     Inline expressions (``{{ ref(...) }}``) become an identifier placeholder;
-    statement and comment blocks are removed. A line that was nothing but
-    jinja is dropped at the top level (a ``{{ config(...) }}`` header), but
-    inside parentheses it becomes a placeholder subquery, because there it is
-    a macro rendering a whole SELECT (``from ( {{ unpivot_json_object(...) }} )``)
-    and dropping it would leave unparseable SQL. Depth counting is naive about
-    parens inside string literals; a miscount only ever refuses, never admits.
+    statement and comment blocks are removed. Before the query starts, a
+    placeholder-only line is dropped at the top level (a ``{{ config(...) }}``
+    header). Once the first SQL ``SELECT`` or ``WITH`` token has started the
+    query, it is preserved as an identifier so a line-broken ``ref()`` remains
+    parseable. Inside parentheses it becomes a placeholder subquery, because
+    there it is a macro rendering a whole SELECT
+    (``from ( {{ unpivot_json_object(...) }} )``), and dropping it would leave
+    unparseable SQL. Depth counting is naive about parens inside string literals;
+    a miscount only ever refuses, never admits.
     """
 
     text = _JINJA_COMMENT.sub("", sql)
     text = _JINJA_STMT.sub("", text)
     text = _JINJA_EXPR.sub(_PLACEHOLDER, text)
+    # Token lines locate the query without mistaking keywords in comments or
+    # strings for its start.
+    try:
+        query_start_line = next(
+            (
+                token.line
+                for token in sqlglot.tokenize(text)
+                if token.token_type in (TokenType.SELECT, TokenType.WITH)
+            ),
+            None,
+        )
+    except TokenError:
+        query_start_line = None
     lines: list[str] = []
     depth = 0
-    for line in text.splitlines():
+    for line_number, line in enumerate(text.splitlines(), start=1):
         if line.strip() == _PLACEHOLDER:
             if depth > 0:
                 lines.append(line.replace(_PLACEHOLDER, f"select {_PLACEHOLDER}"))
+            elif query_start_line is not None and line_number >= query_start_line:
+                lines.append(line)
             continue
         depth += line.count("(") - line.count(")")
         lines.append(line)

--- a/packages/dex-core/tests/transform/test_validate.py
+++ b/packages/dex-core/tests/transform/test_validate.py
@@ -12,6 +12,14 @@ from exmergo_dex_core.transform.validate import (
 )
 
 
+def _model_sql(content: str) -> PlanEdit:
+    return PlanEdit(
+        path="model.sql",
+        new_content=content,
+        kind=EditKind.MODEL_SQL,
+    )
+
+
 def test_find_inlined_secret_flags_a_literal_value():
     assert find_inlined_secret("o:\n  password: hunter2\n") == "password"
 
@@ -77,3 +85,67 @@ def test_validate_profiles_yml_accepts_env_var_indirection():
         kind=EditKind.PROFILES_YML,
     )
     assert validate_edit(edit) == []
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "select a\nfrom\n  {{ ref('stg_accounts') }}\n",
+        (
+            "select a\n"
+            "from {{ ref('stg_accounts') }}\n"
+            "join\n"
+            "  {{ ref('stg_contacts') }}\n"
+            "  on stg_accounts.id = stg_contacts.account_id\n"
+        ),
+        (
+            "with accounts as (\n"
+            "  select a\n"
+            "  from\n"
+            "    {{ ref('stg_accounts') }}\n"
+            ")\n"
+            "select * from accounts\n"
+        ),
+    ],
+    ids=["top-level-from", "top-level-join", "cte"],
+)
+def test_validate_model_sql_keeps_jinja_references_after_query_start(sql: str):
+    assert validate_edit(_model_sql(sql)) == []
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "{{ config(materialized='view') }}",
+        "{{- config(materialized='view') -}}",
+    ],
+    ids=["plain", "whitespace-control"],
+)
+@pytest.mark.parametrize("gap", ["", "\n"], ids=["adjacent", "blank-line"])
+def test_validate_model_sql_drops_jinja_config_header(header: str, gap: str):
+    sql = f"{header}\n{gap}select a\nfrom source\n"
+    assert validate_edit(_model_sql(sql)) == []
+
+
+@pytest.mark.parametrize(
+    "comment",
+    [
+        "-- SELECT is only mentioned in this comment",
+        "/*\nWITH is only mentioned in this comment\n*/",
+    ],
+    ids=["line-comment", "block-comment"],
+)
+def test_validate_model_sql_finds_query_start_outside_comments(comment: str):
+    sql = f"{comment}\n{{{{ config(materialized='view') }}}}\nselect 1\n"
+    assert validate_edit(_model_sql(sql)) == []
+
+
+def test_validate_model_sql_finds_query_after_leading_inline_comment():
+    sql = "/* model note */ select a\nfrom\n  {{ ref('stg_accounts') }}\n"
+    assert validate_edit(_model_sql(sql)) == []
+
+
+def test_validate_model_sql_warns_when_model_is_entirely_jinja():
+    assert validate_edit(_model_sql("{{ generate_model() }}\n")) == [
+        "model.sql: model is entirely jinja; SELECT-only check skipped"
+    ]


### PR DESCRIPTION
## What this changes

- locate the model query boundary from real SQL `SELECT` and `WITH` tokens after Jinja replacement
- preserve placeholder-only Jinja lines after that boundary so line-broken top-level `ref()` calls remain valid after `FROM` and `JOIN`
- continue dropping standalone config headers before the query
- add regression coverage for top-level refs, CTEs, config variants, SQL comments, and entirely-Jinja models
- document the fix under `[Unreleased]`

Token-based boundary detection avoids treating keywords inside SQL comments or strings as the start of the query.

## Related issues

Closes #195.

## Checklist

- [x] Tests pass (`uv run pytest` in `packages/dex-core`): 1,818 passed, 61 skipped
- [x] Eval scoring-core tests pass (`uvx pytest evals`): 26 passed
- [x] The safety spine still holds (`uv run pytest -q tests/test_safety_spine.py`): 117 passed
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures

Additional checks:

- `uvx ruff@0.15.19 check --output-format=github .`
- `uvx ruff@0.15.19 format --check --diff .`
- `git diff --check`
- sqlglot 28.6 token API compatibility smoke test
