### PR TITLE
A pathless project format no longer has to invent provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,48 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 - **transform init**: allow initializing into the current directory ([#235]).
 
+- **`notes` on both maintain snapshot layers** ([#193]). `TransformLayer` and
+  `SemanticLayer` now carry `notes: list[str]`, matching the one
+  `ProjectDefinitions` has carried all along, and the four `maintain` commands
+  fold them into their warnings. Without it a project format producing a layer
+  that is faithful but narrower than a dbt project's had nowhere in the return
+  value to say so, and kept those caveats beside the bridge instead, where no
+  caller reading the snapshot ever saw them. That gap is what made the optional
+  `path` below only half a fix: a reader seeing no provenance still could not
+  tell "dex failed to record it" from "this format has no files", and the reason
+  is a property of the format rather than of the finding. A `file_count` of zero
+  beside a dozen models is the same problem one layer up.
+
+  Notes are collected from every layer a command read, baseline and current, then
+  deduplicated. Both sides, because the two provenance payloads read different
+  ones: `dangling_source` compares against the baseline's declared sources while
+  `definition_changed` reads the current project, so surfacing one side would
+  leave the other axis's limits unexplained. In practice the same format produces
+  both and says the same thing, which is what the deduplication is for. They are
+  reported at detection time as well as when a baseline is pinned, because a host
+  re-runs detection far more often than it re-pins.
+
+  Informational by design, and the boundary is worth stating because the next ask
+  will test it: no detector reads a note, notes take no part in any comparison so
+  a changed note is never drift, and dex does not branch on one. Anything dex has
+  to *decide* from belongs in a tier, which is checkable, rather than in prose the
+  engine would have to trust. That is the same reason the tiers exist instead of a
+  `writeback` flag.
+
+- **The project conformance contract asserts that a format's layers can be a
+  baseline** ([#193]). `MaintainProjectContract` gains one assertion: the two
+  layers survive a JSON round trip inside a `Snapshot`. That is precisely what
+  reaching tier 2 buys, since a store serializes the baseline and a later command
+  loads it back to diff against, and nothing checked it. The check is a real
+  serialization rather than a copy because that is where a value a format chose
+  can be accepted in Python and rejected on the way back, and the failure would
+  otherwise surface on the run after the one that caused it. No test in this
+  repository had ever round-tripped a populated layer through JSON: the storage
+  conformance fixture builds its snapshot with both layers unset, and the
+  in-memory backend copies rather than serializing. The contract still needs only
+  pytest. In-repo it now also runs against a pathless format, because the shipped
+  dbt format always has paths and would never exercise the freedom below.
+
 ### Fixed
 
 - **`transform plan` accepts a line-broken top-level dbt `ref()`** ([#195]).
@@ -64,6 +106,42 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   Relative and absolute spellings of the same warehouse file (e.g. `warehouse.duckdb`
   vs `./warehouse.duckdb`) are no longer treated as configuration drift.
 
+- **A project format with no files no longer has to invent provenance**
+  ([#193]). `SourceTable`, `SemanticModelDef` and `MetricDef` each required a
+  `path` with no default, so a format whose sources are declared in configuration
+  and whose semantic models and metrics are objects in a running graph had nothing
+  to supply and shipped the empty string. All three are now `str | None`.
+
+  The cost of the required field was never a broken read. Every consumer of those
+  three values is a provenance string in a finding payload, `declared_in` on
+  `dangling_source` and `path` on `definition_changed`, and dex opens neither. It
+  was that a `high` severity finding handed an analyst a file to go and check
+  which, for a pathless format, would not be there. That is the argument
+  `SemanticModelDef`'s own docstring already makes one field over, where a computed
+  expression maps to `None` because guessing columns out of expressions would turn
+  every refactor into a false dangling-ref finding.
+
+  The empty string was worse than a fabricated path in one specific way, and this
+  is why the change matters beyond the format that reported it: `""` was an
+  undocumented sentinel. A format author reading `path: str` had no way to tell
+  that the empty string was the sanctioned answer rather than a bug, so the next
+  implementer picks `"n/a"`, or a synthetic path that reads exactly like a real
+  one. `str | None = None` puts the answer in the signature, which is the same move
+  as a declinable tier over a capability flag: the declaration and the enforcement
+  become the same object.
+
+  Both payloads now **omit** the key rather than reporting a null. A null-valued
+  provenance key forces every reader to branch, and both branches fall back to the
+  identifier the finding already carries, while an absent key lets a
+  `.get(default)` do that on its own. Omission also cannot regress an existing
+  consumer, because the shipped dbt format always has a path and never produces
+  one; a null would be a new value shape in a key that is already there.
+
+  `SNAPSHOT_SCHEMA_VERSION` is deliberately unchanged. Widening a field is
+  backward compatible on read, so every existing baseline loads untouched, and the
+  only break is in the downgrade direction: an older engine reading a snapshot
+  that contains a null path. Such a snapshot can only have been written by a format
+  that older engine could not have served anyway.
 
 - **A crowded low-cardinality dimension no longer pushes the true grain out
   of the composite-key probe** ([#168]). `_probe_composite_keys` ranks

--- a/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
@@ -54,6 +54,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from ..dbt_project import ProjectDefinitions
+from ..maintain.snapshot import Snapshot
 from .project import ExploreProject, tier_of
 
 if TYPE_CHECKING:
@@ -297,3 +298,30 @@ class MaintainProjectContract(ExploreProjectContract):
             f"transform_layer() reports models {sorted(layer_models)} that "
             f"definitions() does not list as built: {sorted(built)}"
         )
+
+    def test_the_layers_survive_a_snapshot_round_trip(self) -> None:
+        """A tier-2 format's layers can be persisted as a baseline and read back.
+
+        This is what reaching tier 2 buys, so it is worth asserting rather than
+        assuming: the layers go into a `Snapshot`, a store serializes it, and a
+        later command loads it and diffs against it. A layer that cannot survive
+        that trip is not a baseline, and the failure would surface on the *next*
+        run rather than the one that produced it.
+
+        The assertion is equality after a JSON round trip specifically, not a
+        deep copy, because the in-memory store copies rather than serializing and
+        would hide the whole class of defect this catches: a value the format
+        chose that the model accepts in Python and rejects on the way back.
+        """
+
+        project = self.make_project()
+
+        snap = Snapshot(
+            created_at="2026-01-01T00:00:00+00:00",
+            transform_layer=project.transform_layer(),
+            semantic_layer=project.semantic_layer(),
+        )
+        restored = Snapshot.model_validate_json(snap.model_dump_json())
+
+        assert restored.transform_layer == snap.transform_layer
+        assert restored.semantic_layer == snap.semantic_layer

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -130,6 +130,7 @@ def snapshot(engine: DexEngine) -> SnapshotResult:
     warnings.extend(
         _cache_age_warnings(snap, config.profile_freshness_hours, now),
     )
+    warnings.extend(_layer_notes(transform_layer, semantic_layer))
     locator = store.save_snapshot(snap)
 
     return SnapshotResult(
@@ -218,7 +219,8 @@ def schema_drift(engine: DexEngine, objects: list[str] | None = None) -> DriftRe
         store,
         warnings=warnings
         + _column_detail_warnings(snap)
-        + _baseline_warnings(store, snap, engine.config.profile_freshness_hours),
+        + _baseline_warnings(store, snap, engine.config.profile_freshness_hours)
+        + _layer_notes(snap.transform_layer, current_transform),
     )
     result.cost = cost
     return result
@@ -320,6 +322,10 @@ def semantic_drift(engine: DexEngine, objects: list[str] | None = None) -> Drift
         )
     current_transform = snapshot_mod.transform_layer(view)
     current_semantic = snapshot_mod.semantic_layer(view)
+    # Extended here rather than at the two returns so the confirmation path
+    # carries them too: the free findings it returns are bounded by whatever the
+    # format could not supply, exactly as the settled ones are.
+    warnings.extend(_layer_notes(snap.semantic_layer, current_semantic))
     scope_names = list(objects or [])
 
     adapter = engine._adapter("maintain semantic")
@@ -411,6 +417,17 @@ def check(engine: DexEngine, objects: list[str] | None = None) -> DriftResult:
     except (DbtProjectError, ValueError) as exc:
         project_available = False
         warnings.append(f"semantic axis skipped (no dbt project: {exc})")
+    # All four layers: `check` sweeps every axis, so both the baseline's limits
+    # and the current read's bound what it reports. Added before the two returns
+    # so the confirmation path carries them as well.
+    warnings.extend(
+        _layer_notes(
+            snap.transform_layer,
+            snap.semantic_layer,
+            current_transform,
+            current_semantic,
+        )
+    )
 
     adapter = engine._adapter("maintain check")
     connector = adapter.name
@@ -769,6 +786,25 @@ def _cache_age_warnings(
         "the warehouse since then is not in it and will report as drift. Run "
         "`explore map` first, then `maintain snapshot`, to pin current state"
     ]
+
+
+def _layer_notes(*layers: object) -> list[str]:
+    """What the project format said it could not supply, from every layer read.
+
+    Both sides are collected, baseline and freshly read, because the two payload
+    sites read different ones: ``dangling_source`` compares against the
+    baseline's declared sources, while ``definition_changed`` reads the current
+    project. Surfacing one side would leave the other axis's limits unexplained.
+    In practice both come from the same format and say the same thing, so the
+    common case deduplicates to one line.
+    """
+
+    seen: list[str] = []
+    for layer in layers:
+        for note in getattr(layer, "notes", None) or []:
+            if note not in seen:
+                seen.append(note)
+    return seen
 
 
 def _adapter_notes(adapter, identifiers: list[str]) -> list[str]:

--- a/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
@@ -304,7 +304,12 @@ def schema_drift(
                             f"declared source {source.source_name}.{source.table} "
                             "has no matching warehouse object"
                         ),
-                        data={"declared_in": source.path},
+                        # The key is omitted rather than null when the format has
+                        # no file to name: a null provenance forces every reader
+                        # to branch, and both branches fall back to the
+                        # identifier above. An absent key lets `.get(default)`
+                        # do that on its own.
+                        data=({"declared_in": source.path} if source.path else {}),
                     )
                 )
     return findings
@@ -625,6 +630,7 @@ def semantic_free_drift(
     for key in sorted(base_defs.keys() & cur_defs.keys()):
         if base_defs[key].content_sha256 != cur_defs[key].content_sha256:
             kind, name = key
+            path = cur_defs[key].path
             findings.append(
                 DriftFinding(
                     axis="semantic",
@@ -634,7 +640,10 @@ def semantic_free_drift(
                         f"the definition of {kind.replace('_', ' ')} '{name}' "
                         "changed since the baseline"
                     ),
-                    data={"kind": kind, "name": name, "path": cur_defs[key].path},
+                    # `path` omitted rather than null where the definition has no
+                    # file; `kind` and `name` already identify it.
+                    data={"kind": kind, "name": name}
+                    | ({"path": path} if path else {}),
                 )
             )
 

--- a/packages/dex-core/src/exmergo_dex_core/maintain/snapshot.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/snapshot.py
@@ -73,13 +73,22 @@ class WarehouseBaseline(BaseModel):
 
 
 class SourceTable(BaseModel):
-    """One declared dbt source table: a contract the warehouse must keep honoring."""
+    """One declared source table: a contract the warehouse must keep honoring.
+
+    ``path`` is provenance for the ``dangling_source`` finding: the file an
+    analyst would open to fix the declaration. It is ``None`` for a project
+    format that declares its sources somewhere other than a file of their own,
+    and nothing ever opens it. Inventing a plausible path instead would attach a
+    file that is not there to a high-severity finding, which is the trap
+    :class:`SemanticModelDef` avoids one field over by mapping unresolvable
+    columns to ``None``.
+    """
 
     source_name: str
     schema_name: str | None = None
     table: str
     columns: list[str] = Field(default_factory=list)
-    path: str
+    path: str | None = None
 
 
 class TransformLayer(BaseModel):
@@ -90,6 +99,15 @@ class TransformLayer(BaseModel):
     ``ref()`` calls (source entries as ``source_name.table``), which is how a
     warehouse-level finding is traced to the models it lands on without
     re-reading the project at detection time.
+
+    ``notes`` is how a project format says what it could not supply, the way
+    ``ProjectDefinitions.notes`` does on the declarations channel. A format whose
+    layer is faithful but narrower than a dbt project's (no file hashes because it
+    has no files, say) records that here, and the maintain commands fold it into
+    their warnings. It is informational only: no detector reads it, and it is
+    excluded from every comparison, so a changed note is never drift. Anything dex
+    must *decide* from belongs in a project tier, which is checkable, rather than
+    in prose the engine would have to trust.
     """
 
     files: dict[str, str] = Field(default_factory=dict)
@@ -97,6 +115,7 @@ class TransformLayer(BaseModel):
     sources: list[SourceTable] = Field(default_factory=list)
     model_sources: dict[str, list[str]] = Field(default_factory=dict)
     model_refs: dict[str, list[str]] = Field(default_factory=dict)
+    notes: list[str] = Field(default_factory=list)
 
 
 class SemanticModelDef(BaseModel):
@@ -108,11 +127,13 @@ class SemanticModelDef(BaseModel):
     column (a bare-identifier ``expr``, or a name with no ``expr``, which dbt
     treats as the column itself); computed expressions map to ``None``.
     Guessing columns out of expressions would turn every refactor into a false
-    dangling-ref finding.
+    dangling-ref finding. ``path`` is ``None`` on the same principle: it is
+    provenance carried on the ``definition_changed`` finding, absent for a format
+    whose definitions are objects rather than files, and never opened.
     """
 
     name: str
-    path: str
+    path: str | None = None
     content_sha256: str
     model_ref: str | None = None
     entities: dict[str, str | None] = Field(default_factory=dict)
@@ -144,18 +165,31 @@ class SemanticModelDef(BaseModel):
 class MetricDef(BaseModel):
     """One metric: a content hash plus the measures and metrics it draws from,
     so warehouse drift can be traced through measures up to the metrics it
-    ultimately biases."""
+    ultimately biases.
+
+    ``path`` follows :class:`SemanticModelDef`: provenance for
+    ``definition_changed``, ``None`` where the definition has no file, never
+    opened."""
 
     name: str
-    path: str
+    path: str | None = None
     content_sha256: str
     input_measures: list[str] = Field(default_factory=list)
     input_metrics: list[str] = Field(default_factory=list)
 
 
 class SemanticLayer(BaseModel):
+    """The semantic layer's fingerprint: every named definition the project holds.
+
+    ``notes`` carries the same meaning as on :class:`TransformLayer`, and for the
+    same reason: this is a return type a non-dbt project format fills in, and a
+    layer that is narrower than a dbt one needs somewhere to say so that travels
+    with the value rather than sitting beside it.
+    """
+
     semantic_models: list[SemanticModelDef] = Field(default_factory=list)
     metrics: list[MetricDef] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
 
 
 class Snapshot(BaseModel):

--- a/packages/dex-core/tests/adapters/test_project_parity.py
+++ b/packages/dex-core/tests/adapters/test_project_parity.py
@@ -22,8 +22,16 @@ from exmergo_dex_core.adapters.conformance import (
     DeclaringProjectContract,
     MaintainProjectContract,
 )
-from exmergo_dex_core.adapters.project import DbtProject
+from exmergo_dex_core.adapters.project import DbtProject, tier_of
+from exmergo_dex_core.dbt_project import ProjectDefinitions
 from exmergo_dex_core.explore import commands as explore_commands
+from exmergo_dex_core.maintain.drift import schema_drift
+from exmergo_dex_core.maintain.snapshot import (
+    SemanticLayer,
+    Snapshot,
+    SourceTable,
+    TransformLayer,
+)
 
 _PROJECT_YML = (
     'name: dex_test\nversion: "1.0.0"\nprofile: dex_test\nmodel-paths: ["models"]\n'
@@ -96,6 +104,78 @@ class TestDbtProject(DeclaringProjectContract, MaintainProjectContract):
             "stg_customers",
             "id",
         )
+
+
+class _PathlessProject:
+    """A tier-2 format reduced from objects rather than files.
+
+    The stand-in for the class of format the seam exists for: its models,
+    sources, and definitions come from a graph held in memory, so there is no
+    file per declaration to name and no file hash to record. It is here because
+    the shipped dbt format will never exercise the optional `path` or the layer
+    `notes` -- it always has both -- so running the contract against dbt alone
+    would leave the pathless half of tier 2 unasserted.
+    """
+
+    name = "pathless"
+
+    _NOTE = "definitions are objects in a graph, so no file provenance exists"
+
+    def definitions(self) -> ProjectDefinitions:
+        return ProjectDefinitions(
+            present=True, built_relation_names=["orders"], notes=[self._NOTE]
+        )
+
+    def transform_layer(self) -> TransformLayer:
+        return TransformLayer(
+            models=["orders"],
+            sources=[SourceTable(source_name="raw", table="orders")],
+            notes=[self._NOTE],
+        )
+
+    def semantic_layer(self) -> SemanticLayer:
+        return SemanticLayer(notes=[self._NOTE])
+
+
+class TestPathlessProject(MaintainProjectContract):
+    """The shipped contract, run against a format that names no files."""
+
+    def make_project(self) -> _PathlessProject:
+        return _PathlessProject()
+
+
+def test_a_pathless_format_declines_the_write_tier():
+    """Tier 2 and not tier 3, which is the answer the tiers exist to let it give.
+
+    A reduction of a running graph cannot receive an edit, so declining
+    `EditableProject` is correct rather than partial. Asserted here because the
+    tier is what `reconcile`'s write guard is meant to read.
+    """
+
+    assert tier_of(_PathlessProject()) == 2
+
+
+def test_a_pathless_source_omits_provenance_from_a_dangling_finding():
+    """No path means no `declared_in` key, not a null one.
+
+    The finding stays actionable through `identifier`; a null-valued provenance
+    key would only force a reader to branch. Paired with
+    `tests/maintain/test_schema.py`, which asserts the dbt path still carries the
+    file it always had.
+    """
+
+    snap = Snapshot(
+        created_at="2026-01-01T00:00:00+00:00",
+        transform_layer=_PathlessProject().transform_layer(),
+    )
+
+    findings = schema_drift([], snap, None, None)
+
+    dangling = [f for f in findings if f.code == "dangling_source"]
+    assert len(dangling) == 1
+    assert dangling[0].identifier == "raw.orders"
+    assert dangling[0].severity == "high"
+    assert "declared_in" not in dangling[0].data
 
 
 def test_explore_reads_the_project_through_the_seam(monkeypatch, tmp_path: Path):

--- a/packages/dex-core/tests/maintain/test_schema.py
+++ b/packages/dex-core/tests/maintain/test_schema.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from exmergo_dex_core.maintain.snapshot import SourceTable, TransformLayer
 from exmergo_dex_core.storage import FilesystemStore
 
 
@@ -105,6 +106,42 @@ def test_dropped_source_table_is_flagged_dangling(maintain_repo):
     assert dangling["identifier"] == "main.orders"
     assert dangling["severity"] == "high"
     assert dangling["data"]["declared_in"] == "models/staging/_dex_sources.yml"
+
+
+def test_a_host_supplied_pathless_baseline_omits_declared_in_and_carries_its_note(
+    maintain_repo,
+):
+    """The same finding from a baseline a non-dbt format supplied.
+
+    This is the channel that makes an optional `path` reachable today: a host
+    builds the layers itself and persists them through the store, and
+    `dangling_source` reads the baseline's declared sources, so it fires with no
+    project on disk involved. The pair to
+    `test_dropped_source_table_is_flagged_dangling` above, which asserts the dbt
+    path still carries the file it always had.
+    """
+
+    maintain_repo.snapshot()
+    store = FilesystemStore(maintain_repo.root)
+    snap = store.load_snapshot()
+    snap.transform_layer = TransformLayer(
+        models=["stg_orders"],
+        sources=[SourceTable(source_name="main", table="orders")],
+        notes=["sources are declared in configuration, so no file declares them"],
+    )
+    store.save_snapshot(snap)
+
+    maintain_repo.sql("DROP TABLE orders")
+
+    _rc, payload = maintain_repo.dex("maintain", "schema")
+    dangling = _by_code(payload)["dangling_source"][0]
+    assert dangling["identifier"] == "main.orders"
+    assert dangling["severity"] == "high"
+    # Absent, not null: the identifier above is what makes it actionable.
+    assert "declared_in" not in dangling["data"]
+    assert any(
+        "declared in configuration" in warning for warning in payload["warnings"]
+    ), payload["warnings"]
 
 
 def test_new_table_is_reported_added(maintain_repo):

--- a/packages/dex-core/tests/maintain/test_semantic.py
+++ b/packages/dex-core/tests/maintain/test_semantic.py
@@ -11,6 +11,7 @@ from exmergo_dex_core.maintain.drift import (
     CardinalityCheck,
     cardinality_drift,
     cardinality_plan,
+    semantic_free_drift,
 )
 from exmergo_dex_core.maintain.snapshot import (
     SemanticLayer,
@@ -142,6 +143,9 @@ def test_definition_change_and_churn_are_reported(maintain_repo):
 
     changed_names = {f["data"]["name"] for f in by_code["definition_changed"]}
     assert changed_names == {"revenue"}
+    # The dbt path names the file, which is the non-degraded half of the pair
+    # asserted by test_a_pathless_definition_omits_its_provenance below.
+    assert by_code["definition_changed"][0]["data"]["path"] == SEMANTIC_PATH
     assert {f["data"]["name"] for f in by_code["definition_added"]} == {
         "orders_shipped"
     }
@@ -214,6 +218,36 @@ def test_new_categorical_value_is_a_cardinality_delta_never_a_value(maintain_rep
     # never reaches the envelope (or `.dex/`); naming it is a job for a
     # firewalled `explore query` if the user asks.
     assert "refunded" not in json.dumps(payload)
+
+
+def test_a_pathless_definition_omits_its_provenance():
+    """A definition with no file yields `definition_changed` without a `path`.
+
+    Direct rather than through the CLI because this payload reads the *current*
+    project, and `maintain semantic` refuses without a dbt project to read, so a
+    non-dbt format reaches this detector only as a caller. `kind` and `name`
+    still identify the definition, which is what makes the finding actionable
+    with the file gone.
+    """
+
+    baseline = SemanticLayer(
+        semantic_models=[
+            SemanticModelDef(name="orders", content_sha256="before"),
+        ],
+        notes=["definitions are objects, not files"],
+    )
+    current = SemanticLayer(
+        semantic_models=[
+            SemanticModelDef(name="orders", content_sha256="after"),
+        ]
+    )
+    snap = Snapshot(created_at="2024-01-01T00:00:00", semantic_layer=baseline)
+
+    findings = semantic_free_drift(None, current, [], snap)
+
+    changed = [f for f in findings if f.code == "definition_changed"]
+    assert len(changed) == 1
+    assert changed[0].data == {"kind": "semantic_model", "name": "orders"}
 
 
 def _snapshot_with_two_semantic_models() -> tuple[Snapshot, SemanticLayer]:

--- a/packages/dex-core/tests/maintain/test_snapshot.py
+++ b/packages/dex-core/tests/maintain/test_snapshot.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+from exmergo_dex_core.maintain.commands import _layer_notes
+from exmergo_dex_core.maintain.snapshot import TransformLayer
 from exmergo_dex_core.storage import FilesystemStore
 
 
@@ -52,6 +54,48 @@ def test_snapshot_pins_cache_and_fingerprints_layers(maintain_repo):
     assert snap.transform_layer.model_sources == {"stg_orders": ["main.orders"]}
     revenue = next(m for m in snap.semantic_layer.metrics if m.name == "revenue")
     assert revenue.input_measures == ["order_amount"]
+
+
+def test_layer_notes_are_collected_from_every_side_and_deduplicated():
+    """Both layers a command read, baseline and current, with repeats folded.
+
+    Both sides are collected because the two provenance payloads read different
+    ones: `dangling_source` compares against the baseline's declared sources
+    while `definition_changed` reads the current project. In practice the same
+    format produces both and says the same thing, so the repeat has to collapse
+    or every warning list carries it twice.
+    """
+
+    shared = "sources are declared in configuration"
+    baseline = TransformLayer(notes=[shared])
+    current = TransformLayer(notes=[shared, "no file hashes: there are no files"])
+
+    assert _layer_notes(baseline, current, None) == [
+        shared,
+        "no file hashes: there are no files",
+    ]
+
+
+def test_a_baseline_layer_note_surfaces_on_every_detection_run(maintain_repo):
+    """A note pinned into the baseline is reported by `check`, not only at pin time.
+
+    The baseline is what bounds what the schema axis can compare, and a host
+    re-runs detection far more often than it re-pins. A note that surfaced only
+    when the snapshot was taken would explain the limits of a run nobody was
+    reading and stay silent on the ones they were.
+    """
+
+    maintain_repo.snapshot()
+    store = FilesystemStore(maintain_repo.root)
+    snap = store.load_snapshot()
+    snap.transform_layer.notes = ["the transform layer is reduced from an asset graph"]
+    snap.semantic_layer.notes = ["metrics are Python objects, so none names a file"]
+    store.save_snapshot(snap)
+
+    rc, payload = maintain_repo.dex("maintain", "check")
+    assert rc == 0 and payload["status"] == "ok", payload
+    assert "the transform layer is reduced from an asset graph" in payload["warnings"]
+    assert "metrics are Python objects, so none names a file" in payload["warnings"]
 
 
 def test_snapshot_without_cache_is_metadata_only(dex, tmp_path: Path):

--- a/references/project.md
+++ b/references/project.md
@@ -110,6 +110,32 @@ Where your format's shape and this model's shape disagree, say so in `notes` rat
 than inventing a value. A fabricated field is indistinguishable from a measured one
 by the time a finding is shown to a human.
 
+That rule holds at tier 2 too, and two things make it possible to follow there.
+
+**The three `path` fields are optional.** `SourceTable`, `SemanticModelDef` and `MetricDef`
+each carry a `path`, and each accepts `None`. They are provenance and nothing else: the
+file an analyst would open, carried on the `dangling_source` and `definition_changed`
+findings, never opened by dex. A format whose sources are declared in configuration, or
+whose metrics are objects in a graph, leaves them unset, and the finding omits the key
+rather than reporting a null. Both findings still identify their subject by name, so
+nothing is lost but a shortcut. Supplying a plausible-looking path instead would attach
+a file that is not there to a high-severity finding, which is the same failure the
+`None` on `SemanticModelDef`'s column mappings exists to avoid.
+
+**`TransformLayer` and `SemanticLayer` carry `notes`.** Same meaning as on
+`ProjectDefinitions`: what your format could not supply. A layer that is faithful but
+narrower than a dbt project's has somewhere in the return value to say so, and the
+`maintain` commands fold those notes into their warnings, at detection time as well as
+when the baseline is pinned. Worth using for anything a reader would otherwise
+misread: a `file_count` of zero beside a dozen models is a shape nobody can interpret
+without one line of explanation.
+
+Notes are informational, deliberately. No detector reads them, they take no part in any
+comparison (so a changed note is never drift), and dex will not branch on one. Anything
+dex has to *decide* from belongs in a tier, which is checkable, rather than in prose the
+engine would have to trust. That is the same reason the tiers exist instead of a
+`writeback` flag.
+
 ## Proving it works
 
 ```
@@ -127,6 +153,14 @@ class TestMyProject(ExploreProjectContract):
 
 pytest collects the inherited assertions and runs the contract against your format.
 Use `MaintainProjectContract` instead if you reach tier 2.
+
+Tier 2's assertions are thin, because the layers' contents are your format's business.
+The one worth knowing about is that your layers **survive a JSON round trip inside a
+`Snapshot`**, since that is what reaching tier 2 buys: a store serializes the baseline
+and a later command loads it back to diff against. The check is deliberately a real
+serialization rather than a copy, because that is where a value your format chose can be
+accepted in Python and rejected on the way back, and the failure would otherwise surface
+on the run *after* the one that caused it.
 
 Two hooks are worth overriding beyond `make_project`:
 


### PR DESCRIPTION
Closes #193.

Filed by the consumer who built the second project format against the seam #192 shipped.
Their format is an asset graph: semantic models and metrics are Python objects with no
defining file, and warehouse sources are declared in configuration. `SourceTable`,
`SemanticModelDef` and `MetricDef` each required a `path` with no default, so they
shipped `path=""`, chosen over synthesizing something plausible because a synthesized
path cannot be told from a real one at the point it is read.

## Why this is a contract defect rather than an ergonomics ask

`references/project.md` tells a format author, in the section on writing one:

> Where your format's shape and this model's shape disagree, say so in `notes` rather
> than inventing a value. A fabricated field is indistinguishable from a measured one
> by the time a finding is shown to a human.

That instruction was impossible to follow at tier 2. `MaintainProject.transform_layer()`
and `semantic_layer()` return `TransformLayer` and `SemanticLayer`, which embed three
required `path` fields and carried no `notes` anywhere, so the only way to satisfy the
types was to invent a value. Both halves of #193 fall out of that one sentence, which is
why they ship together rather than separately.

## The value was already reaching an analyst

Worth stating plainly, because the obvious objection is that tier 2 has no production
call site: it does not, and it does not need one. The three models are reachable end to
end today through the storage seam. A host builds a `Snapshot` with its own
`TransformLayer`, persists it with `save_snapshot`, and `maintain schema` fires
`dangling_source` from the baseline's declared sources at severity `high`. The project
read on that path is optional and degrades with a warning, so a host with no dbt project
at all gets those findings through fully supported channels. Verified live against a
DuckDB warehouse while building this.

`SemanticModelDef.path` is the weaker case, since `definition_changed` reads the current
project and `maintain semantic` refuses without one. Fixed regardless: the field is on
the declared return type of a public protocol method shipped with a conformance suite
that invites outside implementations, and three annotations now is cheaper than a
breaking change after a second format has built against `path: str`.

## What changed

**`path` is `str | None` on all three models.** Every consumer of those values is a
provenance string in a finding payload, `declared_in` on `dangling_source` and `path` on
`definition_changed`, and dex opens neither. The cost of the required field was never a
broken read; it was a `high` severity finding handing an analyst a file to go and check
that would not be there. This is the argument `SemanticModelDef`'s own docstring already
makes one field over, where a computed expression maps to `None` because guessing columns
would turn every refactor into a false dangling-ref finding.

The empty string was worse than a fabricated path in one specific way, and this is the
part that matters beyond the format that reported it: `""` was an undocumented sentinel.
A format author reading `path: str` had no way to tell it was the sanctioned answer
rather than a bug, so the next implementer picks `"n/a"` or a synthetic path that reads
exactly like a real one.

**Both payloads omit the key rather than reporting a null.** A null-valued provenance
key forces every reader to branch and both branches fall back to the identifier the
finding already carries, while an absent key lets a `.get(default)` do that on its own.
Omission also cannot regress an existing consumer, because the shipped dbt format always
has a path and never produces one, whereas a null would be a new value shape in a key
that is already there.

**`notes: list[str]` on `TransformLayer` and `SemanticLayer`**, matching
`ProjectDefinitions`, folded into the four maintain commands' warnings. Notes are
collected from every layer a command read, baseline and current, then deduplicated: the
two payloads read different sides, since `dangling_source` compares against the
baseline's declared sources while `definition_changed` reads the current project, so
surfacing one side would leave the other axis's limits unexplained. They surface at
detection time as well as at pin time, because a host re-runs detection far more often
than it re-pins.

Notes are informational, and the boundary is written down because the next ask will test
it: no detector reads a note, notes take no part in any comparison so a changed note is
never drift, and dex does not branch on one. Anything dex has to *decide* from belongs in
a tier, which is checkable, rather than in prose the engine would have to trust.

**`SNAPSHOT_SCHEMA_VERSION` is unchanged, deliberately.** Widening a field is backward
compatible on read, so every existing baseline loads untouched. The only break is an
older engine reading a snapshot containing a null path, and such a snapshot can only have
been written by a format that older engine could not have served.

## One new conformance assertion, and it closes a real gap

`MaintainProjectContract` gains `test_the_layers_survive_a_snapshot_round_trip`: the two
layers go into a `Snapshot`, through `model_dump_json`, and back. That is precisely what
reaching tier 2 buys, and nothing checked it.

The check is a real serialization rather than a copy because that is where a value a
format chose can be accepted in Python and rejected on the way back, and the failure
would otherwise surface on the run after the one that caused it. **No test in this
repository had ever round-tripped a populated layer through JSON:** the storage
conformance fixture builds its snapshot with both layers unset, and the in-memory backend
copies rather than serializing.

The contract still needs only pytest, asserted directly.

## Tests

- A host-supplied pathless baseline through `FilesystemStore`, asserting `dangling_source`
  is `high`, carries its identifier, omits `declared_in`, and surfaces the layer note.
  Paired with the existing test that the dbt path still carries the file it always had.
- The same pair for `definition_changed`. Note this adds the **first** assertions on
  `SemanticModelDef.path` and `MetricDef.path` in either direction: no test set them and
  read them back, and none constructed `SourceTable` or `MetricDef` at all.
- `_layer_notes` dedup across sides, and a baseline note surfacing on `maintain check`
  rather than only at pin time.
- A `_PathlessProject` tier-2 format in `test_project_parity.py`, run against the shipped
  contract, because the dbt format always has paths and would never exercise the new
  freedom. It also asserts `tier_of() == 2`, declining the write tier, which is the answer
  the tiers exist to let such a format give.

No safety-spine addition: path provenance is not one of the five assertion families.

## Verification

1821 passed, 63 skipped. Spine green at 117. `ruff check` and `ruff format --check` clean.
Em-dash check clean. End to end on DuckDB with a host-built pathless baseline: the
`high` finding arrives with `data: {}` and the layer note in `warnings`, and `maintain
check` surfaces both layers' notes scoped to their own axes.

## What this surfaced, filed separately rather than folded in

1. **Tiers 2 and 3 have no production call site**, and `tier_of()` has no caller either.
   `maintain` still reads projects through `dbt_project.load` at five sites. This is
   #171's remaining half. Routing it is not the drop-in it looks like: `DbtProject`'s two
   layer accessors each call `self.load()`, which rglobs, reads and hashes every model and
   macro file and parses `manifest.json`, with no memoization anywhere in the package, so
   naive routing costs one extra full load on `snapshot`, `semantic` and `check`. And
   `reconcile` wants the view itself, which no tier exposes.
2. **`EditableProject.write_edits` cannot carry `confirmed`.** The real caller passes
   `confirmed=engine.confirmed` and the human-edit conflict handshake depends on it, so a
   caller routed through the tier as declared would drop it. Separately, the tier resolves
   the project as `self.project_dir or self.repo_root` while `plans.apply` uses the plan's
   own recorded relative dir, set that way so a plan stays valid when the repo moves.
3. **`Snapshot.schema_version` is written and never read.** No migration, no staleness
   path, unlike the cache's, which the query firewall degrades on. A baseline that fails
   validation surfaces as a request-shaped refusal rather than "re-run `maintain
   snapshot`". `DRIFT_SCHEMA_VERSION` is in the same state.
4. **The `[project-conformance]` light-floor packaging test does not exist**, though both
   `pyproject.toml` and `references/project.md` say one keeps the floor true. There is no
   wheel-install-and-import test, unlike `storage.conformance`, which has three.
