### PR TITLE
The tier-3 write path carries the plan's directory and the confirmed handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The tier-3 write path can carry the two things that make it safe** ([#241],
+  [#242]). `EditableProject.write_edits` declared one argument while the behavior it
+  governs depends on two more. `confirmed` had nowhere to go, so anything routed
+  through the tier would refuse every apply that met a conflict and could never
+  override one, and an implementation written against the published signature had no
+  way to receive it at all. That is the parameter the human-edit conflict handshake
+  turns on: every target is re-hashed against the content it was planned against, and
+  a file whose hash moved is someone's work, not a stale line to overwrite. The
+  project directory was resolved from engine configuration rather than from the plan
+  being applied, and a plan records its own directory relative to the repository root
+  precisely because that is what survives the repository moving, so the two can name
+  different projects with nothing to say so: the edits would land in whichever
+  project the engine happened to be configured for, hash-checked against that
+  project's files.
+
+  The member is now `write_edits(edits, project_dir, *, confirmed=False)`.
+  `DbtProject` passes both through, and a directory the caller names wins over the
+  one the instance was built with. Passing none keeps the configured pin, which is
+  what a caller holding engine configuration and no plan has always had.
+
+  No shipped path changes behavior, because nothing in the distribution called the
+  tier: `transform apply` calls the module-level `dbt_project.write_edits`, which
+  always resolved both correctly, and `reconcile` reads the tier only to decide
+  whether it may author an edit at all. That is the argument for fixing the signature
+  now rather than after someone builds on it. `runtime_checkable` checks only that a
+  method exists, so a third-party implementation of the one-argument shape keeps
+  satisfying `isinstance` and fails at the call.
+
+- **The conformance suite reaches tier 3** ([#241]). `EditableProjectContract` is the
+  class the suite did not have, and it asserts the behavioral half no shape check can
+  see: an unconfirmed write leaves a target someone else changed alone, and a
+  confirmed one goes through. The two are a pair on purpose, since a `write_edits`
+  that never writes satisfies the first by itself. Its one hook raises rather than
+  defaulting to a skip, unlike `make_unreadable_project`, because the excuse does not
+  carry over. A format may genuinely have no unparseable state, but a format that
+  reached tier 3 writes into a source of truth a human can also edit, so the case
+  where the human got there first exists for every one of them.
+
 ## [1.6.0] - 2026-08-08
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
@@ -16,9 +16,9 @@ runs the contract against your format.
 **Pick the class that matches the tier you implement**, mirroring the protocols
 exactly: :class:`ExploreProjectContract` for a format that can state what it
 declares, :class:`MaintainProjectContract` when it can also produce the two
-snapshot layers. Subclassing a wider contract than your format implements is how
-you find out you have not finished, so the narrow class is a feature rather than a
-convenience.
+snapshot layers, :class:`EditableProjectContract` when it can also receive an edit.
+Subclassing a wider contract than your format implements is how you find out you
+have not finished, so the narrow class is a feature rather than a convenience.
 
 **A project is a source, not a sink, and that shapes this suite.** The storage
 contract can write through the protocol and read back, so it needs no fixtures from
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "DeclaringProjectContract",
+    "EditableProjectContract",
     "ExploreProjectContract",
     "MaintainProjectContract",
     "ProjectFactoryContract",
@@ -334,6 +335,106 @@ class MaintainProjectContract(ExploreProjectContract):
 
         assert restored.transform_layer == snap.transform_layer
         assert restored.semantic_layer == snap.semantic_layer
+
+
+class EditableProjectContract(MaintainProjectContract):
+    """Tier 3. Inherits every tier-1 and tier-2 assertion.
+
+    The write tier is the one where getting it wrong costs someone their work
+    rather than costing an inaccurate report, so what is asserted here is
+    behavioural and none of it is optional.
+
+    **The hook below is mandatory, unlike :meth:`make_unreadable_project`.** That
+    one defaults to skipping because a format may genuinely have no unparseable
+    state. This one gets no such excuse: a format reaching tier 3 writes into a
+    source of truth a human can also edit, so the state where the human got there
+    first exists for every format that reaches it. A tier-3 format that cannot
+    stage that scenario cannot detect it either, and a format that cannot detect it
+    overwrites work silently, which is the one failure this seam exists to prevent.
+
+    **The two write assertions have to be read as a pair.** Refusing an unconfirmed
+    conflict is satisfied trivially by a ``write_edits`` that never writes anything,
+    so the confirmed case is what rules that out. Neither is worth much alone.
+
+    **Deliberately not asserted here: which directory the edits land in.**
+    ``project_dir`` is a slot for the formats keyed by one, so an assertion about it
+    would really be an assertion about being a filesystem format. The shipped dbt
+    format asserts it where it means something, in
+    ``tests/adapters/test_project_parity.py``.
+    """
+
+    def an_edit_against_a_changed_target(self) -> tuple[Any, Any, Any, Any]:
+        """A staged conflict: ``(project, project_dir, edits, read_target)``.
+
+        Build a project, plan an edit against something in it, then change that
+        target behind the plan's back, which is what a human editing during review
+        does. Return, in order:
+
+        - ``project``: the tier-3 project the edits are written through.
+        - ``project_dir``: whatever the caller should pass as ``write_edits``'s
+          second argument. A format not keyed by a directory returns ``None``.
+        - ``edits``: the edit set, pinned to the content from *before* the change.
+        - ``read_target``: a zero-argument callable returning what the target holds
+          right now. Any value that compares equal to itself will do; these
+          assertions only ask whether it moved.
+
+        Return a freshly staged scenario on every call. Both assertions below use
+        it and one of them writes, so a shared fixture would let the second see what
+        the first left behind.
+        """
+
+        raise NotImplementedError(
+            "a tier-3 conformance subclass must implement "
+            "an_edit_against_a_changed_target() -> (project, project_dir, edits, "
+            "read_target), staging the case the write tier exists to get right: a "
+            "human edited the target after the plan pinned its content"
+        )
+
+    def test_satisfies_the_editable_tier(self) -> None:
+        assert tier_of(self.make_project()) >= 3
+
+    def test_an_unconfirmed_write_refuses_a_target_that_moved(self) -> None:
+        """The human edit survives, and nothing is written.
+
+        This is propose-don't-impose at the only layer that can enforce it. dex
+        pins the content an edit was planned against precisely so the window
+        between planning and applying, which is a human review and can be long, does
+        not end with someone's work replaced by a proposal written before it
+        existed.
+        """
+
+        project, project_dir, edits, read_target = (
+            self.an_edit_against_a_changed_target()
+        )
+        before = read_target()
+
+        project.write_edits(edits, project_dir)
+
+        assert read_target() == before, (
+            "write_edits() overwrote a target that changed after the edit was "
+            "planned, with confirmed left at its default. A conflict has to refuse "
+            "the whole apply and write nothing until a human confirms it"
+        )
+
+    def test_a_confirmed_write_overrides_the_conflict(self) -> None:
+        """``confirmed=True`` is the human saying they looked and meant it.
+
+        Without this the refusal above is satisfied by a write path that never
+        writes, and a format could pass the contract by doing nothing at all.
+        """
+
+        project, project_dir, edits, read_target = (
+            self.an_edit_against_a_changed_target()
+        )
+        before = read_target()
+
+        project.write_edits(edits, project_dir, confirmed=True)
+
+        assert read_target() != before, (
+            "write_edits() left the target unchanged with confirmed=True. The "
+            "override is what a human reaches for after reading the conflict "
+            "diffs, so a format that refuses either way has no apply path"
+        )
 
 
 class ProjectFactoryContract:

--- a/packages/dex-core/src/exmergo_dex_core/adapters/project.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/project.py
@@ -148,8 +148,39 @@ class EditableProject(MaintainProject, Protocol):
     naming coincidence.
     """
 
-    def write_edits(self, edits: Any) -> Any:
-        """Write proposed edits back into the project as reviewable diffs."""
+    def write_edits(
+        self, edits: Any, project_dir: Any, *, confirmed: bool = False
+    ) -> Any:
+        """Write proposed edits back into the project as reviewable diffs.
+
+        **``project_dir`` comes from the caller, not from how this project was
+        built.** The caller is applying a stored plan, and a plan records the
+        directory it was pinned against relative to the repository root, which is
+        what keeps it valid when the repository moves (see ``transform.plans``). A
+        project built from engine configuration need not point at that directory, so
+        resolving it here would write the edits into whichever project the engine
+        happened to be configured for, and hash-check them against that project's
+        files. The two agreeing is the common case rather than a guarantee, and the
+        disagreement is silent.
+
+        It is a slot for the formats that have one, exactly as ``repo_root`` and
+        ``project_dir`` are on :class:`ProjectContext`. A format keyed by something
+        other than a directory ignores it, rather than this protocol growing a
+        variant per kind of coordinate.
+
+        **``confirmed`` carries the human-edit conflict handshake, and cannot be
+        left out.** Re-hash every target against the content the edit was planned
+        against; a file whose hash moved is a conflict. With ``confirmed=False`` a
+        conflict refuses the whole apply and writes nothing, surfacing the
+        divergence as diffs for a human to read. With ``confirmed=True`` the
+        conflicts are overridden because someone said so.
+
+        That refusal is propose-don't-impose itself, which is why it is on the
+        signature rather than left to an implementation to remember: a write path
+        that cannot receive ``confirmed`` defaults to overwriting the edit someone
+        made while the plan sat in review. :class:`~.conformance.
+        EditableProjectContract` asserts the behavior, because no shape check can.
+        """
         ...
 
 
@@ -367,5 +398,22 @@ class DbtProject:
     def semantic_layer(self) -> SemanticLayer:
         return snapshot.semantic_layer(self.load())
 
-    def write_edits(self, edits: Any) -> Any:
-        return dbt_project.write_edits(edits, self.project_dir or self.repo_root)
+    def write_edits(
+        self, edits: Any, project_dir: Any = None, *, confirmed: bool = False
+    ) -> Any:
+        """The caller's directory wins over the one this instance was built from.
+
+        ``project_dir`` is optional here and required by the protocol, which is a
+        widening rather than a disagreement: this class is also constructed directly
+        by callers holding engine configuration and no plan, and they have nothing
+        to pass. When they pass nothing the configured pin is used, which is the
+        behavior this method always had. When a caller does pass one it wins, and
+        that is the point: it is the directory the plan being applied was pinned
+        against, and the plan is the authority on where its own hashes came from.
+        """
+
+        return dbt_project.write_edits(
+            edits,
+            project_dir or self.project_dir or self.repo_root,
+            confirmed=confirmed,
+        )

--- a/packages/dex-core/src/exmergo_dex_core/adapters/project.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/project.py
@@ -178,8 +178,9 @@ class EditableProject(MaintainProject, Protocol):
         That refusal is propose-don't-impose itself, which is why it is on the
         signature rather than left to an implementation to remember: a write path
         that cannot receive ``confirmed`` defaults to overwriting the edit someone
-        made while the plan sat in review. :class:`~.conformance.
-        EditableProjectContract` asserts the behavior, because no shape check can.
+        made while the plan sat in review.
+        :class:`~.conformance.EditableProjectContract` asserts the behavior,
+        because no shape check can.
         """
         ...
 

--- a/packages/dex-core/tests/adapters/test_project_parity.py
+++ b/packages/dex-core/tests/adapters/test_project_parity.py
@@ -20,12 +20,13 @@ import pytest
 from exmergo_dex_core import dbt_project
 from exmergo_dex_core.adapters.conformance import (
     DeclaringProjectContract,
+    EditableProjectContract,
     MaintainProjectContract,
     ProjectFactoryContract,
 )
 from exmergo_dex_core.adapters.project import (
     DbtProject,
-    MaintainProject,
+    EditableProject,
     ProjectContext,
     tier_of,
 )
@@ -61,7 +62,33 @@ def _project(root: Path, schema: str | None = None) -> Path:
     return project
 
 
-class TestDbtProject(DeclaringProjectContract, MaintainProjectContract):
+def _staged_conflict(root: Path):
+    """A dbt project whose planned target a human changed after planning.
+
+    Shared by both tier-3 conformance subclasses below rather than written twice,
+    because the two differ in how the project is *constructed* and not at all in
+    what the conflict looks like.
+    """
+
+    project = _project(root)
+    target = project / "models" / "stg_customers.sql"
+    edit = dbt_project.Edit(
+        path="models/stg_customers.sql",
+        new_content="select 2 as id\n",
+        old_content_hash=dbt_project.content_hash(target.read_text(encoding="utf-8")),
+    )
+    # The human, arriving after the plan pinned the hash above.
+    target.write_text("select 3 as id -- mine\n", encoding="utf-8")
+
+    return (
+        DbtProject(root, project),
+        project,
+        [edit],
+        lambda: target.read_text(encoding="utf-8"),
+    )
+
+
+class TestDbtProject(DeclaringProjectContract, EditableProjectContract):
     @pytest.fixture(autouse=True)
     def _root(self, tmp_path: Path):
         # One root per assertion: a project is read from disk, so two assertions
@@ -71,6 +98,9 @@ class TestDbtProject(DeclaringProjectContract, MaintainProjectContract):
     def make_project(self) -> DbtProject:
         project = _project(self.root)
         return DbtProject(self.root, project)
+
+    def an_edit_against_a_changed_target(self):
+        return _staged_conflict(self.root)
 
     def make_unreadable_project(self) -> DbtProject:
         # A dbt_project.yml that is not parseable YAML. dbt is a filesystem format,
@@ -115,16 +145,20 @@ class TestDbtProject(DeclaringProjectContract, MaintainProjectContract):
         )
 
 
-class TestDbtProjectFactory(ProjectFactoryContract, MaintainProjectContract):
+class TestDbtProjectFactory(ProjectFactoryContract, EditableProjectContract):
     """The shipped format, built the way configuration builds it.
 
     The same few lines a third party writes, and the reason the construction half
     is worth running in-repo: every other assertion above constructs `DbtProject`
     directly, which is the one path a host reaching dex as a subprocess cannot
     take.
+
+    `tier` is the write tier rather than the read one because that is what the
+    factory actually returns, and a factory silently building one tier lower than
+    the format implements is exactly what this assertion is for.
     """
 
-    tier = MaintainProject
+    tier = EditableProject
 
     @pytest.fixture(autouse=True)
     def _root(self, tmp_path: Path):
@@ -136,6 +170,9 @@ class TestDbtProjectFactory(ProjectFactoryContract, MaintainProjectContract):
     def empty_context(self) -> ProjectContext:
         _project(self.root)
         return ProjectContext(repo_root=str(self.root), project_dir="analytics")
+
+    def an_edit_against_a_changed_target(self):
+        return _staged_conflict(self.root)
 
 
 class _PathlessProject:
@@ -347,3 +384,68 @@ def test_the_seam_finds_an_unpinned_project_in_a_subdirectory(tmp_path: Path):
 
     assert seam.definitions().present
     assert Path(seam.load().root) == project.resolve()
+
+
+def test_the_write_tier_uses_the_directory_the_caller_passed(tmp_path: Path):
+    """The applying caller's project wins over the one this instance was built for.
+
+    A stored plan records the directory it was pinned against, relative to the repo
+    root, and re-resolves it at apply time; a `DbtProject` built from engine
+    configuration points wherever configuration said. Nothing makes those the same
+    project, and the tier used to resolve from its own configuration, so the edits
+    would land in the engine's project while the hashes were checked against that
+    project's files rather than the plan's.
+
+    Asserted here rather than in the shipped contract because `project_dir` is a
+    slot for the formats keyed by a directory, so the assertion is dbt's to make.
+    """
+
+    configured = _project(tmp_path / "configured")
+    pinned = _project(tmp_path / "pinned")
+    edit = dbt_project.Edit(
+        path="models/stg_customers.sql",
+        new_content="select 2 as id\n",
+        old_content_hash=dbt_project.content_hash(
+            (pinned / "models" / "stg_customers.sql").read_text(encoding="utf-8")
+        ),
+    )
+
+    seam = DbtProject(tmp_path / "configured", configured)
+    result = seam.write_edits([edit], pinned)
+
+    assert result.written == ["models/stg_customers.sql"]
+    assert (pinned / "models" / "stg_customers.sql").read_text(
+        encoding="utf-8"
+    ) == "select 2 as id\n"
+    assert (configured / "models" / "stg_customers.sql").read_text(
+        encoding="utf-8"
+    ) == "select 1 as id\n", (
+        "the edit landed in the configured project rather than the one the caller "
+        "named, which is the disagreement this parameter exists to settle"
+    )
+
+
+def test_the_write_tier_falls_back_to_the_configured_project(tmp_path: Path):
+    """No directory from the caller means the configured pin, as it always did.
+
+    The parameter widens the protocol; it does not change what a caller holding
+    engine configuration and no plan gets. Asserted so the fallback is a decision
+    on the record rather than something a later reader deletes as dead.
+    """
+
+    configured = _project(tmp_path / "configured")
+    edit = dbt_project.Edit(
+        path="models/stg_customers.sql",
+        new_content="select 2 as id\n",
+        old_content_hash=dbt_project.content_hash(
+            (configured / "models" / "stg_customers.sql").read_text(encoding="utf-8")
+        ),
+    )
+
+    seam = DbtProject(tmp_path / "configured", configured)
+    result = seam.write_edits([edit])
+
+    assert result.written == ["models/stg_customers.sql"]
+    assert (configured / "models" / "stg_customers.sql").read_text(
+        encoding="utf-8"
+    ) == "select 2 as id\n"

--- a/references/project.md
+++ b/references/project.md
@@ -34,7 +34,7 @@ implementation is complete rather than partial.
 |---|---|---|---|
 | 1 | `ExploreProject` | `definitions()` | declared keys, joins and metric models reach `explore` |
 | 2 | `MaintainProject` | `transform_layer()`, `semantic_layer()` | the format can be a drift baseline |
-| 3 | `EditableProject` | `write_edits()` | `transform` and `reconcile` may write back |
+| 3 | `EditableProject` | `write_edits(edits, project_dir, *, confirmed=False)` | `transform` and `reconcile` may write back |
 
 `tier_of(project)` reports the highest tier an object satisfies, checked with
 `isinstance` rather than declared, so a format cannot claim a tier it has not
@@ -66,6 +66,28 @@ format whose layers used that vocabulary would have been written into. The
 convention checks are still there as a second line; what changed is that the tier is
 asked first, so the guarantee rests on what your format declared rather than on what
 it happened to be called.
+
+**If you do implement tier 3, two parameters carry the whole safety story.**
+
+`project_dir` is where the edits go, and it comes from the caller rather than from
+however your project was built. dex is applying a stored plan, and a plan records the
+directory it was pinned against relative to the repository root, which is what keeps
+it valid when the repository moves. A project built from engine configuration need
+not point at the same place. Resolving the directory yourself means writing into
+whichever project the engine happened to be configured for while hash-checking
+against that project's files, and the disagreement is silent. If your format is not
+keyed by a directory, ignore the parameter, exactly as you ignore `repo_root` on
+`ProjectContext`.
+
+`confirmed` is the human-edit conflict handshake, and it is most of the reason this
+tier is separable at all. Re-hash every target against the content the edit was
+planned against. A target whose hash moved is a conflict, because a human edited it
+while the plan sat in review. With `confirmed=False` a conflict refuses the whole
+apply and writes nothing, and the divergence comes back as diffs for someone to read.
+With `confirmed=True` that someone has looked and said to go ahead. A write path that
+cannot receive `confirmed` silently overwrites the work, which is the failure this
+seam exists to prevent, so `EditableProjectContract` asserts the behavior rather than
+trusting it: no check on the shape of your class can see it.
 
 ## The one rule that is not visible in the signatures
 
@@ -160,7 +182,8 @@ class TestMyProject(ExploreProjectContract):
 ```
 
 pytest collects the inherited assertions and runs the contract against your format.
-Use `MaintainProjectContract` instead if you reach tier 2, and mix
+Use `MaintainProjectContract` instead if you reach tier 2, `EditableProjectContract`
+if you reach tier 3, and mix
 `ProjectFactoryContract` in front of it if dex will build your format from a name
 rather than be handed an instance. Construction is a separate contract, so a format
 that passes the behavioral suite can still be unreachable from configuration; "the
@@ -185,6 +208,18 @@ Two hooks are worth overriding beyond `make_project`:
   declared key and a declared join actually arrive. It is separate because the two
   contracts answer different questions: whether dex can safely call your format, and
   whether reading it was worth doing.
+
+Tier 3 adds one more hook, and unlike the two above it is **not optional**.
+`an_edit_against_a_changed_target()` returns a project, a directory, an edit set
+pinned to content that has since moved, and a callable reading what the target holds
+now. Two assertions use it: an unconfirmed write must leave the target alone, and a
+confirmed one must go through. They only mean something as a pair, since a
+`write_edits` that never writes satisfies the first on its own. The hook raises
+rather than skipping because the excuse that justifies skipping
+`make_unreadable_project` does not apply here. A format may genuinely have no
+unparseable state, but a format that reached tier 3 writes into a source of truth a
+human can also edit, so the case where the human got there first exists for all of
+them.
 
 The suite needs only pytest: no dialect engine, no connector. A packaging test keeps
 it that way.


### PR DESCRIPTION
## What this changes

`EditableProject.write_edits` declared one argument while the behavior it governs
depends on two more. Both issues are the same signature, which is why they land
together.

**`confirmed` had nowhere to go** (#241). It is what the human-edit conflict
handshake turns on: every target is re-hashed against the content the edit was
planned against, and a file whose hash moved is someone's work rather than a stale
line to overwrite. Anything routed through the tier would refuse every apply that met
a conflict and could never override one, and an implementation written against the
published signature had no way to receive it at all.

**The project directory came from engine configuration rather than from the plan
being applied** (#242). A plan records its own directory relative to the repository
root, precisely because that is what stays valid when the repository moves, so the
two can name different projects with nothing to say so. The edits would land in
whichever project the engine happened to be configured for, hash-checked against that
project's files.

The member is now `write_edits(edits, project_dir, *, confirmed=False)`. `DbtProject`
passes both through, and a directory the caller names wins over the one the instance
was built with. Passing none keeps the configured pin, which is what a caller holding
engine configuration and no plan has always had.

## Why this is a contract fix rather than a behavior fix

Nothing in the distribution called the tier, so no shipped path changes:
`transform apply` calls the module-level `dbt_project.write_edits`, which always
resolved both correctly, and `reconcile` reads the tier only to decide whether it may
author an edit at all.

That is the argument for fixing the signature now rather than after something builds
on it. `runtime_checkable` checks only that a method exists, so a third-party
implementation of the one-argument shape keeps satisfying `isinstance` and fails at
the call. The first person to implement tier 3 against the published signature would
implement the wrong thing, in the one place where getting it wrong overwrites
someone's work.

Deliberately **not** in this PR: routing `plans.apply` through the tier. #171 stopped
short of that on purpose, the write surface is dbt all the way down (`contained_path`,
the seven `EditKind` values, `validate_edit`'s `dbt parse` subprocess), and the
signature is separable from it.

## The conformance suite reaches tier 3

`EditableProjectContract` is the class the suite did not have. The chain stopped at
`MaintainProjectContract`, so a format could reach tier 3 and have nothing assert what
the tier is for.

It asserts the tier, that an unconfirmed write leaves a target someone else changed
alone, and that a confirmed one goes through. **The two write assertions are a pair on
purpose**: a `write_edits` that never writes satisfies the first by itself, so the
confirmed case is what rules out the trivial implementation.

Its one hook raises rather than defaulting to a skip, unlike `make_unreadable_project`,
because the excuse does not carry over. A format may genuinely have no unparseable
state, but a format that reached tier 3 writes into a source of truth a human can also
edit, so the case where the human got there first exists for every one of them.

Both shipped conformance subclasses widen to tier 3, including the factory one, whose
declared `tier` is now `EditableProject`. That is what `from_context` actually
returns, and a factory quietly building one tier below what the format implements is
exactly what that assertion is for.

**Which directory the edits land in stays a dbt assertion**, in
`tests/adapters/test_project_parity.py`, rather than a contract one. `project_dir` is
a slot for the formats keyed by a directory, so asserting it in the shipped contract
would really be asserting that every tier-3 format is a filesystem format.

## Verified by mutation, not only by green

Reverting `DbtProject.write_edits` to its old body under the new signature, which
reproduces both defects exactly, fails precisely three tests: both
`test_a_confirmed_write_overrides_the_conflict` instances and
`test_the_write_tier_uses_the_directory_the_caller_passed`.
`test_an_unconfirmed_write_refuses_a_target_that_moved` correctly still passes, since
the refusal was never the broken half.

## Related issues

Closes #241.
Closes #242.

## Checklist

- [x] Tests pass (`uv run pytest` in `packages/dex-core`): 1837 passed, 80 skipped.
      The one failure is the pre-existing Windows path-separator assertion in
      `test_retargeted_dev_database_is_refused_naming_both_values`, which fails
      identically with this branch stashed
- [x] Eval scoring-core tests pass (`uvx pytest evals`): 26 passed
- [x] If a safety path is touched, the spine still holds: read-only against data,
      cost-guarded, PII flagged not surfaced, propose-don't-impose. This PR is
      propose-don't-impose specifically, and moves it from a promise an
      implementation has to remember into an assertion the contract makes
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free (checked in CI)
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures
