### PR TITLE
Expired BigQuery credentials report a prerequisite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- Expired BigQuery credentials now report a retryable prerequisite instead of
+  an internal error.
+
 ## [1.6.1] - 2026-08-09
 
 ### Fixed

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -16,11 +16,12 @@ simply calls no mutating client API, and the docs recommend read-only roles
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from ..config import BigQueryTarget
 from ..envelope import Paradigm
-from ..errors import ConnectorError
+from ..errors import ConnectorError, PrerequisiteError
 from ..guards.cost_guard import CostGate, OverCeilingError
 from ..guards.sql_guard import assert_select_only
 from .base import (
@@ -104,6 +105,7 @@ class BigQueryAdapter:
         # [bigquery] extra; only this adapter pulls it in.
         try:
             from google.api_core import exceptions as api_exceptions
+            from google.auth import exceptions as auth_exceptions
             from google.cloud import bigquery
         except ImportError as exc:
             raise RuntimeError(
@@ -112,6 +114,7 @@ class BigQueryAdapter:
             ) from exc
         self._bq = bigquery
         self._api_exceptions = api_exceptions
+        self._auth_exceptions = auth_exceptions
         self._client = client or bigquery.Client(
             project=project, credentials=credentials
         )
@@ -229,10 +232,10 @@ class BigQueryAdapter:
 
     def _resolve_datasets(self) -> list[str]:
         if not self.target.datasets:
-            return sorted(
-                f"{self.project}.{item.dataset_id}"
-                for item in self._client.list_datasets(self.project)
+            datasets = self._request(
+                lambda: list(self._client.list_datasets(self.project))
             )
+            return sorted(f"{self.project}.{item.dataset_id}" for item in datasets)
         with blame(self._scope_origin, BigQueryConnectionError):
             return sorted(
                 {self._resolve_dataset(entry) for entry in self.target.datasets}
@@ -259,7 +262,7 @@ class BigQueryAdapter:
         qualified = token if "." in token else f"{self.project}.{token}"
         project, _, dataset = qualified.partition(".")
         try:
-            self._client.get_dataset(qualified)
+            self._request(lambda: self._client.get_dataset(qualified))
         except self._api_exceptions.NotFound as exc:
             raise BigQueryConnectionError(
                 f"scope '{entry}' does not exist: project {project} has no "
@@ -871,6 +874,12 @@ class BigQueryAdapter:
             sql, job_config=job_config, location=self.target.location
         )
         return float(getattr(job, "total_bytes_processed", 0) or 0)
+
+    def _request(self, operation: Callable[[], Any]) -> Any:
+        try:
+            return operation()
+        except self._auth_exceptions.RefreshError as exc:
+            raise PrerequisiteError(str(exc)) from exc
 
     def _cancel(self, job: Any) -> None:
         # Best-effort: the timeout is raised regardless, and a failed cancel

--- a/packages/dex-core/tests/adapters/test_connect_bigquery.py
+++ b/packages/dex-core/tests/adapters/test_connect_bigquery.py
@@ -10,12 +10,14 @@ import pytest
 
 pytest.importorskip("google.cloud.bigquery")
 
+from google.auth.exceptions import RefreshError
 from google.cloud import bigquery
 
 from exmergo_dex_core.adapters import get_adapter, get_dialect
 from exmergo_dex_core.adapters.bigquery import BigQueryAdapter, BigQueryConnectionError
 from exmergo_dex_core.config import BigQueryTarget
-from exmergo_dex_core.envelope import Paradigm
+from exmergo_dex_core.envelope import Paradigm, Reason, reason_for
+from exmergo_dex_core.errors import PrerequisiteError
 from exmergo_dex_core.guards.cost_guard import (
     ConfirmationRequiredError,
     CostGate,
@@ -72,6 +74,23 @@ def test_capabilities_shape(fake_bq_client):
     assert caps["dataset_count"] == 2  # shop + logs
     # Capabilities is a free probe: no queries were issued to compute it.
     assert fake_bq_client.query_calls == []
+
+
+def test_expired_credentials_are_a_prerequisite(fake_bq_client, monkeypatch):
+    message = (
+        "Reauthentication is needed. Please run `gcloud auth "
+        "application-default login` to reauthenticate."
+    )
+
+    def expired(*_args, **_kwargs):
+        yield from ()
+        raise RefreshError(message)
+
+    monkeypatch.setattr(fake_bq_client, "list_datasets", expired)
+    with pytest.raises(PrerequisiteError) as exc_info:
+        make_adapter(fake_bq_client).capabilities()
+    assert reason_for(exc_info.value) is Reason.PREREQUISITE
+    assert str(exc_info.value) == message
 
 
 def test_list_objects_uses_free_api_metadata_only(fake_bq_client):


### PR DESCRIPTION
## What this changes

<!-- A short description of the change and why it is needed. -->

Translates Google Auth `RefreshError` failures at the BigQuery scope-resolution boundary into the existing public `PrerequisiteError`. This preserves the provider reauthentication message while changing the envelope reason from `internal` to `prerequisite`, so hosts can direct users to reauthenticate and retry.

The request wrapper drains lazy dataset iterators inside the translation boundary and also covers configured-dataset probes. A regression test raises the real provider exception lazily and asserts both the reason and unchanged remediation message.

Validation:
- BigQuery adapter tests: 51 passed
- Error, envelope, and BigQuery suites: 85 passed
- Safety-spine and dev-target suites: 166 passed
- Eval scoring-core: 26 passed
- Ruff lint and format checks passed
- Full core run: 1,626 passed and 129 skipped before the remaining optional connector extras were installed; every initially failing group was then rerun successfully with all extras

## Related issues

<!-- e.g. Closes #123. Delete if none. -->

Closes #252

## Checklist

- [x] Tests pass (`uv run pytest` in `packages/dex-core`)
- [x] Eval scoring-core tests pass (`uvx pytest evals`)
- [x] If a safety path is touched, the spine still holds: read-only against data,
      cost-guarded, PII flagged not surfaced, propose-dont-impose
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free (checked in CI)
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures