### PR TITLE
docs(references): describe the tiers as the extension seam, not ProjectAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Changed
+
+- `references/canonical-model.md`'s extension-seam section described a single
+  `ProjectAdapter` protocol with `load()` and `write_edits()` as the live seam. That
+  protocol is superseded, unreferenced, and satisfies no tier, so a format written
+  against it is refused as "not a project", and this is the document a reader reaches
+  before writing one. It now describes the three tiers and points at
+  `references/project.md`.
+
 ## [1.6.1] - 2026-08-09
 
 ### Fixed

--- a/references/canonical-model.md
+++ b/references/canonical-model.md
@@ -80,12 +80,37 @@ credential becomes persistent state.
 ## The extension seam (more formats later)
 
 Supporting more model formats over time does not require a neutral internal model.
-It requires a thin `ProjectAdapter` protocol (`adapters/project.py`) with one
-implementation today, `DbtProject`. Future sources (SQLMesh, Cube) become new
-adapter implementations. The interface is thin and dbt is its only implementation
-in v1; dex does not build a rich neutral model behind it, and it does not project
-the dbt model back out into other formats. dex reasons over the dbt project and
-authors into it directly; there is no one-way exporter path.
+It requires a seam thin enough that a class with the right methods is a project,
+with no base class to inherit and no registration step. That seam is three nested
+protocols in `adapters/project.py`, and a format implements the tiers it can serve:
+
+| tier | protocol | adds |
+|---|---|---|
+| 1 | `ExploreProject` | `definitions()` |
+| 2 | `MaintainProject` | `transform_layer()`, `semantic_layer()` |
+| 3 | `EditableProject` | `write_edits()` |
+
+`DbtProject` is the one implementation dex ships. Future sources (SQLMesh, Cube, an
+orchestrated asset graph) become new implementations of the same protocols without
+touching the engine that reasons over a project. Nothing behind the seam is a rich
+neutral model: `definitions()` returns the engine's existing `ProjectDefinitions`
+rather than a parallel vocabulary that would have to be mapped at every call site,
+and dex does not project the dbt model back out into other formats. dex reasons
+over the project and authors into it directly; there is no one-way exporter path.
+
+Tiers rather than a capability flag, because a flag is a claim the engine has to
+trust while `isinstance(project, EditableProject)` is checkable. A format that
+cannot receive an edit declines tier 3 and cannot accidentally claim otherwise.
+
+[`project.md`](project.md) is the contract itself: what each tier owes its callers,
+the one rule that is not visible in the signatures, how a format is named in
+configuration, and the conformance suite that proves an implementation works.
+Read that before writing a format; this section only says where the seam sits.
+
+> An earlier version of this section named a single `ProjectAdapter` protocol with
+> `load()` and `write_edits()`. That protocol still exists, unreferenced, because it
+> has been public since v1, but it is superseded and satisfies no tier. Anything
+> written against it would be refused as "not a project".
 
 ## The round-trip rule (reconcile, simplified)
 


### PR DESCRIPTION
`references/canonical-model.md`'s section titled "The extension seam (more formats
later)" still names a single `ProjectAdapter` protocol with `load()` and
`write_edits()` as the live seam, with no mention of the three tiers.

That protocol is superseded, unreferenced anywhere in the distribution, and
satisfies no tier. A class written against it fails `isinstance(project,
ExploreProject)` and `construct_project` refuses it as *"not a project: it is
missing definitions"*.

Which makes this the worst place in the tree for that particular staleness: it is
the document someone reads *before* `references/project.md`, so following it
produces exactly the class the engine rejects.

## What changed

The section now names the three tiers with a small table, says why they are tiers
rather than a capability flag, and hands off to `references/project.md` for the
contract itself rather than restating it. `ProjectAdapter` gets a closing note
instead of silence, since a reader who has seen it elsewhere needs to know it is
not the thing to implement.

The section's actual argument, that supporting more formats does not require a
neutral internal model, was correct and is kept, with the reason sharpened: it is
`ProjectDefinitions` being reused rather than a parallel vocabulary that would have
to be mapped at every call site.

## Verification

Docs only. `scripts/check_no_em_dashes.py` clean, LF endings, no code touched and
no test asserts anything about this file.

Found while writing a second format against the seam. Two related issues are filed
separately (#257, #258), and this one is independent of both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
