### PR TITLE
docs(project): decline tier 3 on the artifact, not on the project's origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Changed
+
+- **Declining tier 3 is a question about the artifact an edit lands in, not about
+  where the project came from.** `EditableProject`, `references/project.md` and
+  `CONTRIBUTING.md` all stated the decline as an absolute: a project reduced from a
+  running graph cannot receive an edit. That is right about the reduction and wrong
+  as a general rule, and the two come apart more often than the graph example
+  suggests. An asset graph carries neither column names nor join keys, so a format
+  over one reads its declared keys, joins and semantics from somewhere else, and that
+  somewhere is usually a hand-authored file that nothing regenerates. Those files are
+  a real source of truth and they are the shape `reconcile` already proposes edits
+  to, so a format holding one may reach tier 3 for that channel while still refusing
+  to author a model. Deciding from "this project is graph-derived" alone declines a
+  tier the format could honestly serve. No behavior changes; the guidance does.
+
 ## [1.6.1] - 2026-08-09
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,10 +308,19 @@ A shipped name, a dotted path, or an entry point under `exmergo_dex_core.project
 with shipped names always winning so an install can never silently redirect which
 models a repo is reasoned about.
 
-Declining `EditableProject` is a supported answer, not a gap. A project reduced from
-a running graph cannot receive an edit, because its source of truth is the code that
-produced the graph, and `maintain reconcile` reads that declaration: your format
-gets advisory proposals and no stored plan, by contract rather than by luck.
+Declining `EditableProject` is a supported answer, not a gap. The clearest case is a
+project reduced from a running graph, where the reduction is not the source of truth:
+the code that produced the graph is, so an edit written into the reduction is
+overwritten on the next run. `maintain reconcile` reads that declaration, and your
+format gets advisory proposals and no stored plan, by contract rather than by luck.
+
+Decide it by asking which artifact an edit would land in, not where your project came
+from. Those questions come apart more often than the graph example suggests: an asset
+graph carries neither column names nor join keys, so a format over one reads its
+declared keys, joins and semantics from somewhere else, and that somewhere is usually
+a hand-authored file that nothing regenerates. Such a file is a real source of truth
+and it is the shape `reconcile` already proposes edits to, so a format holding one may
+serve this tier for that channel while still refusing to author a model.
 `references/project.md` covers the tiers, the construction contract, and the rules
 that are not obvious from the signatures.
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/project.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/project.py
@@ -137,12 +137,24 @@ class EditableProject(MaintainProject, Protocol):
     """Tier 3: the write path.
 
     Implemented only by formats whose source of truth can actually receive an edit.
-    A project reduced from a running graph cannot: its source of truth is the code
-    that produced the graph, and writing into the reduction would edit an artifact
-    that is regenerated from something else on the next run.
+    The clearest case that cannot is a project reduced from a running graph, where
+    the reduction is not the source of truth: the code that produced the graph is,
+    and writing into the reduction would edit an artifact regenerated from
+    something else on the next run.
 
-    Declining this tier is the honest answer for such a format, and the reason the
-    tiers exist rather than a ``writeback`` flag. ``maintain reconcile`` reads it:
+    **That test is about the artifact an edit would land in, not about where the
+    project came from**, and the two come apart more often than the graph example
+    suggests. A format may reduce a graph for its model list while reading its
+    declared keys, joins and semantics from hand-authored files that nothing
+    regenerates. Those files are a genuine source of truth, they are exactly the
+    shape ``reconcile`` proposes edits to, and a format holding one can reach this
+    tier for that channel while still declining to author a model. Ask which
+    artifact the edit lands in and whether anything rewrites it; do not infer the
+    answer from the project being graph-derived.
+
+    Declining this tier is the honest answer for a format with no such artifact,
+    and the reason the tiers exist rather than a ``writeback`` flag.
+    ``maintain reconcile`` reads it:
     a format that does not satisfy this protocol gets advisory-only proposals and
     no stored plan, which is the behavior a generated tree previously got by
     naming coincidence.

--- a/references/project.md
+++ b/references/project.md
@@ -46,12 +46,23 @@ other channel: not through the layers, not through a content hash. A format that
 implements only tier 1 has already delivered the part of a project that changes what
 `explore` concludes.
 
-**Tier 3 is the one to decline on purpose.** A project reduced from a running graph
-cannot receive an edit: its source of truth is the code that produced the graph, so
-writing into the reduction would edit an artifact that is regenerated on the next
-run. Declining the tier is the honest answer, and it is why the tiers exist rather
-than a `writeback: no` flag. A flag is a claim the engine has to trust, while a tier
-is checkable.
+**Tier 3 is the one to decline on purpose.** The clearest case is a project reduced
+from a running graph, where the reduction is not the source of truth: the code that
+produced the graph is, so writing into the reduction would edit an artifact that is
+regenerated on the next run. Declining the tier is the honest answer, and it is why
+the tiers exist rather than a `writeback: no` flag. A flag is a claim the engine has
+to trust, while a tier is checkable.
+
+**Ask which artifact the edit lands in, not where the project came from.** Those two
+questions have different answers more often than the graph example suggests. A format
+can reduce a graph for its model list and still read its declared keys, joins and
+semantics from hand-authored files that nothing regenerates, which is a common shape:
+an asset graph carries neither column names nor join keys, so a format over one has
+to get them from somewhere, and that somewhere is usually a file a person wrote. Those
+files are a real source of truth and they are the shape `reconcile` already proposes
+edits to. A format holding one may reach tier 3 for that channel while still refusing
+to author a model, and deciding from "we are graph-derived" alone would decline a tier
+it could honestly serve.
 
 That distinction has teeth, and it is what `maintain reconcile` reads. A format that
 does not implement `EditableProject` gets every finding back as an advisory


### PR DESCRIPTION
`EditableProject`'s docstring, `references/project.md` and `CONTRIBUTING.md` all
state the tier-3 decline as an absolute:

> A project reduced from a running graph cannot receive an edit, because its source
> of truth is the code that produced the graph.

That is right about the reduction and wrong as a general rule, and the two come
apart more often than the graph example suggests.

## Why it is wrong as stated

An asset graph carries neither column names nor join keys. So a format over one
*cannot* read its declared keys, joins or semantics from the graph. It reads them
from somewhere else, and that somewhere is usually a hand-authored file that nothing
regenerates.

Such a file is a real source of truth, and it is precisely the shape reconcile's
highest-value mechanical edit already targets: adding a `unique` test to a column in
schema YAML. A format holding one may honestly reach tier 3 for that channel while
still refusing to author a model.

So the test is **which artifact an edit lands in and whether anything rewrites it**,
not where the project came from. Deciding on origin alone declines a tier the format
could serve, and the docs were teaching exactly that.

## How I found it

By writing a second format and getting it wrong in that direction. I maintain a
Dagster asset graph format at tier 2, and I justified declining tier 3 with the
sentence above for months. It is false for half my project: the models are a
reduction, and the declarations are hand-written YAML that only ever gets read.

The `CONTRIBUTING.md` copy is the one I would flag, since it sits in the section a
format author reads before starting.

## Scope

Docs and one docstring. No behavior changes, and no test asserts the old claim.

Two other sites survive review and are deliberately unchanged, because both phrase
it conditionally rather than universally: `maintain/commands.py:687` describes *a
format that cannot receive an edit*, and `test_safety_spine.py`'s `_NotEditableProject`
is one such format by construction.

## Verification

`ruff check` and `ruff format --check` clean, `tests/adapters` 352 passed 6 skipped,
`check_no_em_dashes.py` clean, LF endings.

Related: #257 and #258, which are about what stands between a tier-3 format and
reconcile actually reaching it. This PR only corrects the reasoning and does not
depend on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
