### PR TITLE
feat(conformance): assert the content a format declares, not only its shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **The conformance suite reaches the content a format declares, not just its
+  shape** ([#259]). Three assertions, each covering a way a format can pass the
+  existing suite while being wrong in a way that costs a real check.
+
+  `DeclaringProjectContract` gains two optional hooks.
+  `a_project_declaring_a_composite_key()` reaches `declared_composite_keys`, which
+  is a separate field from `declared_keys` and which nothing in the suite touched
+  before; it asks for more than two columns, because a format that special-cases the
+  pair passes a two-column fixture and fails a four-column one. A truncated
+  composite key does not read as a missing declaration, it reads as a narrower grain
+  that is simply wrong, which is what makes it worth its own assertion.
+  `a_project_declaring_a_join_with_differently_named_sides()` covers the case
+  `test_a_declared_join_carries_both_sides` structurally cannot: if a fixture names
+  both ends of a join the same, an implementation that copies the source column onto
+  the target satisfies it exactly. The contract refuses a mirrored fixture here.
+
+  `SemanticProjectContract` is new, and it closes the largest hole.
+  `MaintainProjectContract` asserts that an empty project yields an empty semantic
+  layer and never looks at a populated one, so a format that reads every dimension
+  and measure name and drops the physical column behind each passed the whole suite.
+  `SemanticModelDef` keys every field to a column and the drift detector skips any
+  field whose column is `None`, so a layer mapped entirely to `None` validates,
+  serializes, and compares clean forever: the check does not fail, it never runs, and
+  a dropped warehouse column that should raise `dangling_reference` at high severity
+  raises nothing. The absence is indistinguishable from agreement.
+
+  All three are opt-in, and the two on `DeclaringProjectContract` skip with a message
+  naming what goes unchecked rather than silently: an existing implementer's green
+  suite must not turn red on an upgrade, and a format may genuinely have no
+  multi-column grain to express. `DbtProject` implements all three in
+  `tests/adapters/test_project_parity.py`, so the shipped format is held to them too.
+
 ## [1.6.2] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   a dropped warehouse column that should raise `dangling_reference` at high severity
   raises nothing. The absence is indistinguishable from agreement.
 
+  `SemanticProjectContract` asserts tier 2 before anything else, against the project
+  its own hook returns. `semantic_layer` is a tier-2 member, so a format mixing the
+  contract in beside `ExploreProjectContract` would otherwise fail with
+  `AttributeError: no attribute 'semantic_layer'`, naming the missing attribute
+  rather than the tier it belongs to. Checking the hook's project rather than
+  `make_project()` keeps the mixin dependent only on the one fixture it declares.
+
   All three are opt-in, and the two on `DeclaringProjectContract` skip with a message
   naming what goes unchecked rather than silently: an existing implementer's green
   suite must not turn red on an upgrade, and a format may genuinely have no

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,6 +293,18 @@ raises there turns an ordinary state into an outage. Override
 `make_unreadable_project()` to get those assertions running against your format
 instead of skipped.
 
+Mix in the contracts covering what your format *declares*, beside the one for your
+tier. `DeclaringProjectContract` checks that a declared key and a declared join
+arrive, and carries two further hooks worth supplying: a composite key of more than
+two columns (a format that special-cases the pair passes a two-column fixture), and
+a join whose two ends are spelled differently (if both ends of your fixture share a
+name, an implementation that mirrors one side onto the other satisfies it exactly).
+`SemanticProjectContract` checks that each semantic field keeps the warehouse column
+behind it, which is the one no tier assertion can see: the tier contract only looks
+at an *empty* semantic layer, and a format that reads every field name and drops the
+columns maps everything to `None`, which validates, serializes, and compares clean
+forever while the drift check silently never runs.
+
 Mix `ProjectFactoryContract` in front of your tier contract if dex will build your
 format from a name rather than be handed an instance, which is what a host reaching
 dex as a subprocess needs. Naming one is the same shape as naming a storage backend:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,9 @@ name, an implementation that mirrors one side onto the other satisfies it exactl
 behind it, which is the one no tier assertion can see: the tier contract only looks
 at an *empty* semantic layer, and a format that reads every field name and drops the
 columns maps everything to `None`, which validates, serializes, and compares clean
-forever while the drift check silently never runs.
+forever while the drift check silently never runs. It checks your format reaches
+tier 2 before any of that, so mixing it in beside the tier-1 contract fails with a
+sentence naming the tier rather than with a missing-attribute error.
 
 Mix `ProjectFactoryContract` in front of your tier contract if dex will build your
 format from a name rather than be handed an instance, which is what a host reaching

--- a/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
@@ -64,6 +64,7 @@ from ..maintain.snapshot import Snapshot
 from .project import ExploreProject, ProjectContext, tier_of
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from typing import Any
 
     from ..maintain.snapshot import SemanticLayer, TransformLayer
@@ -74,6 +75,7 @@ __all__ = [
     "ExploreProjectContract",
     "MaintainProjectContract",
     "ProjectFactoryContract",
+    "SemanticProjectContract",
 ]
 
 
@@ -216,6 +218,47 @@ class DeclaringProjectContract:
 
         raise NotImplementedError
 
+    def a_project_declaring_a_composite_key(
+        self,
+    ) -> tuple[ExploreProject, str, tuple[str, ...]] | None:
+        """A project whose grain needs more than one column, or ``None``.
+
+        Returns ``(project, model, columns)`` with ``columns`` in declared order.
+
+        **Declare more than two columns.** A format that handles a composite key
+        by special-casing the pair satisfies a two-column fixture and fails a
+        four-column one, so a pair cannot tell you what you came to find out.
+
+        ``None`` skips, because a format may genuinely have no way to express a
+        multi-column grain: dbt's own ``unique`` test is column level, and a
+        format modelling grain one column at a time is not incomplete, it is
+        differently shaped. Override it if you can express one, because
+        ``declared_composite_keys`` is a separate field from ``declared_keys``
+        and nothing else in this suite reaches it.
+        """
+
+        return None
+
+    def a_project_declaring_a_join_with_differently_named_sides(
+        self,
+    ) -> tuple[ExploreProject, str, str, str, str] | None:
+        """A join whose two ends are spelled differently, or ``None``.
+
+        Returns ``(project, model, column, to_model, to_column)``, and ``column``
+        must not equal ``to_column`` -- this contract checks that and refuses a
+        mirrored fixture, because a mirrored one cannot fail for the right reason.
+
+        **This is a distinct case from :meth:`a_project_declaring_a_join` and not
+        a redundant one.** If both ends of your fixture are named ``date``, an
+        implementation that reads the source column and copies it onto the target
+        satisfies the assertion exactly, and the defect ships. A foreign key whose
+        two ends are spelled differently is the ordinary case rather than the
+        exotic one, and a format that mirrors would join on a column the target may
+        not have, surfacing as a wrong answer rather than as a failure.
+        """
+
+        return None
+
     def test_a_declared_unique_key_reaches_the_engine(self) -> None:
         project, model, column = self.a_project_declaring_a_unique_key()
 
@@ -251,6 +294,184 @@ class DeclaringProjectContract:
         assert matching, (
             f"expected a declared join {model}.{column} -> {to_model}.{to_column}, "
             f"got {declared}"
+        )
+
+    def test_a_composite_grain_keeps_every_column_and_their_order(self) -> None:
+        """A truncated composite key is silent, which is what makes it expensive.
+
+        It does not read as a missing declaration. It reads as a declared grain
+        that is simply narrower than the truth, so every check downstream runs
+        against a grain the author never claimed and the findings look like data
+        problems rather than a misread declaration.
+        """
+
+        supplied = self.a_project_declaring_a_composite_key()
+        if supplied is None:
+            pytest.skip(
+                "a_project_declaring_a_composite_key() returned None: this format "
+                "declares it cannot express a multi-column grain, so "
+                "declared_composite_keys goes unchecked"
+            )
+        project, model, columns = supplied
+
+        declared = project.definitions().declared_composite_keys
+        matching = [k for k in declared if k.model == model]
+
+        assert matching, (
+            f"expected a composite key on {model}, got {declared}. A multi-column "
+            "grain belongs in declared_composite_keys, not as several entries in "
+            "declared_keys: those say each column is unique on its own, which is a "
+            "different and much stronger claim"
+        )
+        assert tuple(matching[0].columns) == tuple(columns), (
+            f"expected columns {tuple(columns)} in order, got "
+            f"{tuple(matching[0].columns)}"
+        )
+
+    def test_a_join_keeps_its_two_sides_apart_when_they_are_named_differently(
+        self,
+    ) -> None:
+        """The case :meth:`test_a_declared_join_carries_both_sides` cannot reach.
+
+        An implementation that mirrors the source column onto the target passes
+        that one whenever the fixture's two ends share a name, and this is the
+        assertion that separates them.
+        """
+
+        supplied = self.a_project_declaring_a_join_with_differently_named_sides()
+        if supplied is None:
+            pytest.skip(
+                "a_project_declaring_a_join_with_differently_named_sides() returned "
+                "None: a join whose ends are spelled differently goes unchecked, so "
+                "an implementation that mirrors one side onto the other would pass "
+                "this suite"
+            )
+        project, model, column, to_model, to_column = supplied
+
+        assert column != to_column, (
+            "this fixture has to name its two sides differently, or it cannot "
+            "detect the mirroring it exists to detect"
+        )
+
+        declared = project.definitions().foreign_keys
+        matching = [
+            fk
+            for fk in declared
+            if fk.model == model and fk.column == column and fk.to_model == to_model
+        ]
+
+        assert matching, (
+            f"expected a declared join from {model}.{column} to {to_model}, "
+            f"got {declared}"
+        )
+        assert matching[0].to_column == to_column, (
+            f"the join's target column arrived as {matching[0].to_column!r}, "
+            f"expected {to_column!r}. Reading it as {column!r} is the mirroring "
+            "failure: the far side is a column the target may not even have"
+        )
+
+
+class SemanticProjectContract:
+    """Opt-in, tier 2: a populated semantic layer keeps the column behind each field.
+
+    Mix in beside :class:`MaintainProjectContract` when your format declares
+    semantics at all::
+
+        class TestMyProject(SemanticProjectContract, MaintainProjectContract):
+            def make_project(self): ...
+            def a_project_declaring_a_semantic_model(self): ...
+
+    **Why this is separate from the tier contract, and worth the trouble.**
+    :class:`MaintainProjectContract` asserts that an *empty* project produces an
+    empty semantic layer. Nothing there looks at a populated one, so a format that
+    reads every dimension and measure name and drops the physical column behind
+    each passes the tier suite completely.
+
+    That is not a hypothetical shape. ``SemanticModelDef`` keys every field to a
+    warehouse column, and ``maintain``'s drift detector skips any field whose column
+    is ``None`` -- correctly, because it cannot resolve what it was not given. So a
+    layer mapped entirely to ``None`` validates, serializes, and compares clean
+    forever: the check does not fail, it never runs, and a dropped warehouse column
+    that should raise ``dangling_reference`` at high severity raises nothing. The
+    absence is indistinguishable from agreement, which is the worst property a
+    check can have.
+
+    A format that genuinely declares no semantics should not mix this in. Its empty
+    layer is correct and the tier contract already covers it.
+    """
+
+    def a_project_declaring_a_semantic_model(
+        self,
+    ) -> tuple[Any, str, Mapping[str, str | None], Mapping[str, str | None]]:
+        """A project declaring one semantic model.
+
+        Returns ``(project, name, dimensions, measures)``, where the two mappings
+        are ``field name -> the warehouse column behind it``, exactly as you expect
+        them to arrive on ``SemanticModelDef``.
+
+        **Map a field to ``None`` when your format has no bare column for it**, and
+        include at least one such field if your format can produce one: a computed
+        field, or one whose expression is not a plain column name. ``None`` is the
+        honest answer there and an invented column is not, because a consumer
+        resolving column names would treat a fabricated one as a reference that no
+        longer resolves.
+        """
+
+        raise NotImplementedError(
+            "a semantic conformance subclass must implement "
+            "a_project_declaring_a_semantic_model() -> (project, name, dimensions, "
+            "measures), mapping each field to the warehouse column behind it"
+        )
+
+    def test_a_semantic_field_carries_the_column_behind_it(self) -> None:
+        project, name, dimensions, measures = (
+            self.a_project_declaring_a_semantic_model()
+        )
+
+        layer = project.semantic_layer()
+        matching = [m for m in layer.semantic_models if m.name == name]
+
+        assert matching, (
+            f"expected a semantic model named {name!r}, got "
+            f"{[m.name for m in layer.semantic_models]}"
+        )
+        model = matching[0]
+        assert dict(model.dimensions) == dict(dimensions), (
+            "the dimension to column mapping did not survive. A layer whose columns "
+            "are all None still validates and still compares clean, so the drift "
+            "check simply never runs"
+        )
+        assert dict(model.measures) == dict(measures), (
+            "the measure to column mapping did not survive; see above"
+        )
+
+    def test_a_categorical_dimension_maps_only_to_a_real_column(self) -> None:
+        """``categorical_dimensions`` takes ``str``, not ``str | None``.
+
+        So a field that is categorical *and* unresolved cannot be represented
+        there, and the two properties have to stay independent: being categorical
+        says how the field behaves, having a column says whether it can be checked.
+        A format that collapses them either drops a categorical field that happens
+        to lack a column, or supplies an invented column to keep it. Both are worse
+        than leaving it out of this one mapping, which is what the typing asks for.
+        """
+
+        project, name, _, _ = self.a_project_declaring_a_semantic_model()
+
+        model = next(
+            m for m in project.semantic_layer().semantic_models if m.name == name
+        )
+
+        columns = model.categorical_dimensions.values()
+        assert all(isinstance(c, str) and c for c in columns), (
+            "categorical_dimensions holds a null or empty column: its values are "
+            f"required strings, got {model.categorical_dimensions!r}. Leave an "
+            "unresolved categorical field out of this mapping rather than "
+            "inventing a column to keep it in"
+        )
+        assert set(model.categorical_dimensions) <= set(model.dimensions), (
+            "categorical_dimensions names a field that is not a dimension: "
+            f"{sorted(set(model.categorical_dimensions) - set(model.dimensions))}"
         )
 
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
@@ -398,7 +398,27 @@ class SemanticProjectContract:
 
     A format that genuinely declares no semantics should not mix this in. Its empty
     layer is correct and the tier contract already covers it.
+
+    **Semantics presuppose tier 2, and this checks that first.** ``semantic_layer``
+    is a tier-2 member, so every assertion below would otherwise fail with
+    ``AttributeError: 'MyProject' object has no attribute 'semantic_layer'`` for a
+    format that mixed this in beside :class:`ExploreProjectContract` -- an error
+    about a missing attribute, when the thing to say is that the format has not
+    reached the tier the attribute belongs to. The tier is asserted against the
+    project this contract is actually given rather than against ``make_project()``,
+    so the mixin keeps depending only on the one fixture it declares.
     """
+
+    def test_declaring_semantics_presupposes_the_maintain_tier(self) -> None:
+        project, _, _, _ = self.a_project_declaring_a_semantic_model()
+
+        assert tier_of(project) >= 2, (
+            "a format declaring semantics has to reach tier 2, because "
+            "semantic_layer() is a MaintainProject member and every assertion in "
+            "this contract calls it. Implement transform_layer() and "
+            "semantic_layer(), or drop this mixin if the format declares no "
+            "semantics -- an empty layer is already correct under the tier contract"
+        )
 
     def a_project_declaring_a_semantic_model(
         self,

--- a/packages/dex-core/tests/adapters/test_project_parity.py
+++ b/packages/dex-core/tests/adapters/test_project_parity.py
@@ -23,6 +23,7 @@ from exmergo_dex_core.adapters.conformance import (
     EditableProjectContract,
     MaintainProjectContract,
     ProjectFactoryContract,
+    SemanticProjectContract,
 )
 from exmergo_dex_core.adapters.project import (
     DbtProject,
@@ -88,7 +89,9 @@ def _staged_conflict(root: Path):
     )
 
 
-class TestDbtProject(DeclaringProjectContract, EditableProjectContract):
+class TestDbtProject(
+    DeclaringProjectContract, SemanticProjectContract, EditableProjectContract
+):
     @pytest.fixture(autouse=True)
     def _root(self, tmp_path: Path):
         # One root per assertion: a project is read from disk, so two assertions
@@ -142,6 +145,78 @@ class TestDbtProject(DeclaringProjectContract, EditableProjectContract):
             "customer_id",
             "stg_customers",
             "id",
+        )
+
+    def a_project_declaring_a_join_with_differently_named_sides(self):
+        # dbt's `relationships` test exists to express exactly this, and the
+        # fixture above already happens to use it: `customer_id` on one side, `id`
+        # on the other. Returned again through the widened hook rather than left to
+        # skip, so the assertion that the two stay apart actually runs.
+        return self.a_project_declaring_a_join()
+
+    def a_project_declaring_a_composite_key(self):
+        # Four columns, not two: a format special-casing the pair would pass a
+        # two-column fixture. dbt carries this as a model-level
+        # `unique_combination_of_columns`, which is a different construct from the
+        # column-level `unique` above and lands in a different field.
+        project = _project(
+            self.root,
+            "version: 2\n"
+            "models:\n"
+            "  - name: stg_customers\n"
+            "    tests:\n"
+            "      - unique_combination_of_columns:\n"
+            "          combination_of_columns:\n"
+            "            - tenant_id\n"
+            "            - id\n"
+            "            - valid_from\n"
+            "            - source_system\n",
+        )
+        return (
+            DbtProject(self.root, project),
+            "stg_customers",
+            ("tenant_id", "id", "valid_from", "source_system"),
+        )
+
+    def a_project_declaring_a_semantic_model(self):
+        """One semantic model covering all three ways a field resolves.
+
+        A bare `expr` is the column, an absent one means the field's own name is,
+        and a computed expression resolves to nothing. The third is the case worth
+        having: `markup` is `type: categorical` AND unresolved, so it must appear in
+        `dimensions` mapped to None and must NOT appear in `categorical_dimensions`,
+        whose values are required strings. A format that collapses those two
+        properties either drops the field or invents a column for it.
+        """
+
+        project = _project(self.root)
+        (project / "models" / "semantic.yml").write_text(
+            "semantic_models:\n"
+            "  - name: customers_sm\n"
+            "    model: ref('stg_customers')\n"
+            "    dimensions:\n"
+            "      - name: signed_up_at\n"
+            "        type: time\n"
+            "      - name: region\n"
+            "        type: categorical\n"
+            "        expr: region_code\n"
+            "      - name: markup\n"
+            "        type: categorical\n"
+            "        expr: base_rate * 1.2\n"
+            "    measures:\n"
+            "      - name: revenue\n"
+            "        agg: sum\n"
+            "        expr: revenue_net\n"
+            "      - name: blended\n"
+            "        agg: sum\n"
+            "        expr: revenue_net + adjustments\n",
+            encoding="utf-8",
+        )
+        return (
+            DbtProject(self.root, project),
+            "customers_sm",
+            {"signed_up_at": "signed_up_at", "region": "region_code", "markup": None},
+            {"revenue": "revenue_net", "blended": None},
         )
 
 

--- a/references/project.md
+++ b/references/project.md
@@ -194,7 +194,8 @@ class TestMyProject(ExploreProjectContract):
 
 pytest collects the inherited assertions and runs the contract against your format.
 Use `MaintainProjectContract` instead if you reach tier 2, `EditableProjectContract`
-if you reach tier 3, and mix
+if you reach tier 3, mix `DeclaringProjectContract` and `SemanticProjectContract`
+beside it for the content your format declares, and mix
 `ProjectFactoryContract` in front of it if dex will build your format from a name
 rather than be handed an instance. Construction is a separate contract, so a format
 that passes the behavioral suite can still be unreachable from configuration; "the
@@ -219,6 +220,45 @@ Two hooks are worth overriding beyond `make_project`:
   declared key and a declared join actually arrive. It is separate because the two
   contracts answer different questions: whether dex can safely call your format, and
   whether reading it was worth doing.
+
+  It carries two further hooks that default to skipping, and both are worth
+  supplying if your format can reach the state:
+
+  - **`a_project_declaring_a_composite_key()`** returns `(project, model, columns)`.
+    `declared_composite_keys` is a separate field from `declared_keys` and nothing
+    else in the suite reaches it. **Declare more than two columns**: a format that
+    handles a composite grain by special-casing the pair passes a two-column fixture
+    and fails a four-column one, so a pair cannot tell you what you came to find out.
+    A truncated composite key is the expensive failure here, because it does not read
+    as a missing declaration. It reads as a narrower grain that is simply wrong.
+  - **`a_project_declaring_a_join_with_differently_named_sides()`** returns the same
+    shape as `a_project_declaring_a_join`, with `column != to_column` (the contract
+    checks that and refuses a mirrored fixture). If both ends of your join fixture are
+    spelled the same, an implementation that reads the source column and copies it
+    onto the target satisfies the plain join assertion exactly, and the defect ships.
+    A key whose two ends are named differently is the ordinary case, and a format that
+    mirrors joins on a column the target may not have, surfacing as a wrong answer
+    rather than as a failure.
+
+- **`SemanticProjectContract`**, mixed in beside `MaintainProjectContract` if your
+  format declares semantics at all. Its one hook,
+  `a_project_declaring_a_semantic_model()`, returns `(project, name, dimensions,
+  measures)` where the two mappings are `field name -> the warehouse column behind
+  it`.
+
+  This is the gap most worth closing, because the tier contract cannot see it.
+  `MaintainProjectContract` checks that an *empty* project yields an empty semantic
+  layer and never looks at a populated one, so a format that reads every field name
+  and drops the column behind each passes the tier suite completely. `SemanticModelDef`
+  keys every field to a column and the drift detector skips any field whose column is
+  `None`, correctly, since it cannot resolve what it was not given. A layer mapped
+  entirely to `None` therefore validates, serializes, and compares clean forever: the
+  check does not fail, it never runs, and a dropped warehouse column that should raise
+  `dangling_reference` at high severity raises nothing. Map a field to `None` when you
+  genuinely have no bare column for it, and include one such field if you can produce
+  one, because `categorical_dimensions` takes `str` rather than `str | None` and a
+  field that is categorical *and* unresolved has to be left out of that mapping rather
+  than given an invented column.
 
 Tier 3 adds one more hook, and unlike the two above it is **not optional**.
 `an_edit_against_a_changed_target()` returns a project, a directory, an edit set

--- a/references/project.md
+++ b/references/project.md
@@ -246,6 +246,11 @@ Two hooks are worth overriding beyond `make_project`:
   measures)` where the two mappings are `field name -> the warehouse column behind
   it`.
 
+  It asserts tier 2 first, against the project the hook returns. `semantic_layer`
+  is a tier-2 member, so a format mixing this in beside `ExploreProjectContract`
+  would otherwise fail with `AttributeError: no attribute 'semantic_layer'`, which
+  names the missing attribute rather than the tier it belongs to.
+
   This is the gap most worth closing, because the tier contract cannot see it.
   `MaintainProjectContract` checks that an *empty* project yields an empty semantic
   layer and never looks at a populated one, so a format that reads every field name


### PR DESCRIPTION
Implements #259. Three ways a project format can pass the shipped suite and still be
wrong, each costing a check a caller depends on.

Found the ordinary way: by writing a second format, passing the suite, and then
finding the defects anyway.

## What is added

**Two optional hooks on `DeclaringProjectContract`.**

`a_project_declaring_a_composite_key()` reaches `declared_composite_keys`, a distinct
type from `DeclaredKey` that nothing in the suite touched. It asks for more than two
columns on purpose: a format that special-cases the pair passes a two-column fixture
and fails a four-column one. A truncated composite key is the expensive shape here,
because it does not read as a missing declaration. It reads as a declared grain that
is simply narrower than the truth, so everything downstream runs against a grain the
author never claimed.

`a_project_declaring_a_join_with_differently_named_sides()` covers what
`test_a_declared_join_carries_both_sides` structurally cannot. That assertion takes
both sides from the implementer's own fixture, so if the fixture names them the same,
an implementation that copies the source column onto the target satisfies it exactly.
This hook refuses a mirrored fixture rather than accepting one that cannot detect
mirroring. In my own suite, mutating `to_columns=(field,)` to `to_columns=(column,)`
left everything green until a differently-named case existed.

**`SemanticProjectContract`, new, and the largest hole.**

`MaintainProjectContract` only ever looks at an *empty* semantic layer. So a format
that reads every dimension and measure name and drops the physical column behind each
passes the whole suite. `SemanticModelDef` keys every field to a column and
`maintain/drift.py` skips any field whose column is `None`, correctly, since it cannot
resolve what it was not given. A layer of all `None` therefore validates, serializes
and compares clean forever: the check does not fail, it never runs.

Measured rather than reasoned about, on the format that hit it: a dropped warehouse
column yields **1 finding at severity `high`** with the column mapped, and **0**
without. Discriminating third arm: mapped to a column that still exists also yields 0,
so the detector is not merely firing whenever a column is present.

## Why opt-in

Mandatory would be a breaking change to a published contract for every existing
implementer, and the composite-key case has a legitimate "my format cannot express
this" answer, since dbt's own `unique` test is column level. Where a hook defaults to
skipping, the skip names what goes unchecked: a silent skip is how a format arrives at
"the suite is green" without knowing what did not run.

The two questions I flagged on #259 are still the ones worth a maintainer view, and I
am happy to change either:

1. opt-in versus mandatory;
2. `SemanticProjectContract` as a separate mixin rather than folded into
   `MaintainProjectContract`. Separate because a format that genuinely declares no
   semantics should not have to opt out of anything, and its empty layer is already
   correct under the tier contract.

## Verification

`DbtProject` implements all three in `tests/adapters/test_project_parity.py`, so the
shipped format is held to them too.

Mutation-tested rather than read. Each turns exactly the intended assertion red, and
the restore is green:

| mutation | result |
|---|---|
| composite key truncated to one column | 1 red |
| FK target column mirrored from source | 2 red |
| semantic field column dropped | 1 red |

`ruff check` and `ruff format --check` clean, `tests/adapters` 356 passed 6 skipped,
`check_no_em_dashes.py` clean, LF endings. Rebased on `main` after #260 and #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
