### PR TITLE
A project format says where a proposed edit lands, and which paths it owns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   change as a whole-file create, and the apply that follows reports a conflict on
   a file nobody edited.
 
+  That holds for agent-authored edits too, which is the whole write surface
+  outside reconcile: `transform plan`, `transform macro`, and every
+  `semantic define|update|plan` share one call, and it asked the engine for dbt's
+  directory unconditionally. A format declaring a surface now supplies the
+  directory from its own view, so a repository with no `dbt_project.yml` can
+  reach those commands at all, and one with a dbt project elsewhere in the tree
+  no longer pins an edit against a file the apply will not write. dbt is on the
+  same path either way: its view loads the directory the engine would have named.
+
 - **A plan is applied through the format it was planned against** ([#257]).
   `transform apply` wrote every plan with dbt's writer, which resolves each edit
   under the dbt project and re-hashes what it finds on disk, so a plan a second

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,81 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **A project format can say where its edits land, and which paths it owns**
+  ([#257], [#258]). `maintain reconcile` read the project seam's write tier and
+  then narrowed again on `isinstance(editable, DbtProject)`, so a format that
+  implemented tier 3 in full and passed the shipped conformance suite got exactly
+  what a format declining the tier got. Underneath that, the paths reconcile
+  proposed were literals (`models/staging/stg_<table>.sql` and its `.yml`) built
+  before the format was consulted, so a second format was handed edits naming
+  files it does not have. The two are one seam: those paths are keys into the
+  view the format's own `load()` returned, so a format that answers where an edit
+  goes supplies both halves.
+
+  `PlacingProject` is that seam, beside `EditableProject` rather than on it: the
+  tiers are `runtime_checkable`, so a method added to tier 3 would demote every
+  format that has not implemented it yet, closing the write path for exactly the
+  implementers who were already passing. `edit_path(kind, model)` answers where
+  an edit of a kind lands and may answer `None` to decline that kind, which is
+  the honest answer for a format whose models are reduced from a running graph
+  (no authored staging model) but whose declared keys are hand-written files
+  (a `unique` test lands fine). `editing_surface()` declares the region those
+  paths must stay inside. The write gate now asks for the capability instead of
+  the class.
+
+  dbt reaches identical behaviour by the new route: `edit_path` returns the
+  scaffold convention reconcile hard-coded, and `editing_surface` returns the
+  project's configured model and macro paths, which is what containment checked
+  directly before.
+
+### Changed
+
+- **Containment validates an edit against the surface its own format declared**
+  ([#257], [#258]). `transform plan` validated every edit path against dbt's
+  `model_paths` whatever format produced it, so a second format placing a
+  declaration sidecar was refused at plan time even with the two gates above
+  resolved. Containment stays a safety property and stays mandatory; what moved
+  is who declares the surface. A format that declares none is unaffected and
+  validates against dbt's as before, and dbt's own path is unchanged, including
+  the root manifests allowed by name and the checks that a macro and a model each
+  live where dbt will find them. Escapes (absolute paths, `..`) are refused ahead
+  of the surface and are not a format's to permit.
+
+  The file an edit is pinned against now comes from the same view as the surface
+  it is checked in. Those two disagreeing is not a refusal but a quiet defect:
+  an existing file hashes as absent, the reviewable diff renders a one-line
+  change as a whole-file create, and the apply that follows reports a conflict on
+  a file nobody edited.
+
+- **A plan is applied through the format it was planned against** ([#257]).
+  `transform apply` wrote every plan with dbt's writer, which resolves each edit
+  under the dbt project and re-hashes what it finds on disk, so a plan a second
+  format could now store would still have been refused one stage later and the
+  `write_edits` that format implemented to reach tier 3 would never have been
+  called. Plans planned against dbt are written by dbt exactly as before.
+
+  `EditableProject.write_edits` now documents that its return has to report
+  `written` and `conflicts`, and `EditableProjectContract` asserts it. The apply
+  path reads both to tell a refusal from a write, and a result answering neither
+  fails in both directions at once: a plan recorded as applied that wrote
+  nothing, or a conflict that never reaches the person it was raised for. This is
+  a widening of the tier-3 contract, and a format returning
+  `dbt_project.ApplyResult` (or anything exposing those two) already satisfies
+  it.
+
+- **Reconcile matches the model a format declares, not dbt's spelling of it**
+  ([#258]). The `stg_` convention leaked through file contents as well as
+  through paths: the `unique` test edit looked for a model named `stg_<table>`
+  inside the YAML, so a format that placed its sidecar correctly and named its
+  model `orders` was missed one line before the edit was built, silently. The
+  model is now read from the file the format chose, which is the same string for
+  dbt, whose scaffold path is `models/staging/stg_<table>.yml`. A file declaring
+  no matching column entry now says so in `warnings` instead of skipping in
+  silence, which was indistinguishable from dex deciding the test was already
+  there.
+
 ## [1.6.3] - 2026-08-10
 
 ### Changed

--- a/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
@@ -41,6 +41,12 @@ declared join actually reach the engine, which is the whole reason a project is
 read on the explore path: those two arrive through ``definitions()`` and through no
 other channel.
 
+**If you reach tier 3 you also want** :class:`PlacingProjectContract`, because
+placement is what carries a proposal from reconcile to your write path, and its two
+methods have to agree with each other: a format that places an edit outside the
+surface it declares builds a proposal the plan store then refuses, which reads as
+dex declining rather than as the format contradicting itself.
+
 **If dex is going to build your format rather than be handed one**, mix
 :class:`ProjectFactoryContract` in front. Construction is a separate contract from
 the tiers for the same reason it is separate in storage, and a format that passes
@@ -74,6 +80,7 @@ __all__ = [
     "EditableProjectContract",
     "ExploreProjectContract",
     "MaintainProjectContract",
+    "PlacingProjectContract",
     "ProjectFactoryContract",
     "SemanticProjectContract",
 ]
@@ -676,6 +683,157 @@ class EditableProjectContract(MaintainProjectContract):
             "override is what a human reaches for after reading the conflict "
             "diffs, so a format that refuses either way has no apply path"
         )
+
+    def test_the_write_result_reports_what_happened(self) -> None:
+        """The caller has to be able to tell a refusal from an apply.
+
+        ``transform apply`` reads ``written`` to decide whether the plan is now
+        applied and ``conflicts`` to decide whether to surface the divergence for
+        a human to confirm. Both readings fail closed on a result that answers
+        neither, and they fail in opposite directions: a plan recorded as applied
+        that wrote nothing, or a conflict that never reaches the person it was
+        raised for.
+
+        Asserted on the refusing case because that is the one where the two
+        fields disagree, and so the one a result that reports nothing gets wrong.
+        """
+
+        project, project_dir, edits, _read_target = (
+            self.an_edit_against_a_changed_target()
+        )
+
+        result = project.write_edits(edits, project_dir)
+
+        assert hasattr(result, "written") and hasattr(result, "conflicts"), (
+            "write_edits() returned an object exposing no `written` and "
+            "`conflicts`, so the caller applying a plan cannot tell whether it "
+            "was written or refused. Return an ApplyResult, or something "
+            "answering both"
+        )
+        assert not result.written, (
+            "write_edits() reported paths in `written` while refusing an "
+            "unconfirmed conflict. The apply is what did not happen, so the "
+            "caller marks the plan applied and no one is asked about the "
+            "conflict"
+        )
+        assert result.conflicts, (
+            "write_edits() refused the write but reported no `conflicts`, so the "
+            "divergence it refused over never reaches a human and the apply "
+            "looks like a clean no-op"
+        )
+
+
+class PlacingProjectContract:
+    """Beside tier 3: where an edit lands, and the surface it must land in.
+
+    Mix it in beside :class:`EditableProjectContract`. Placement is what carries a
+    reconcile proposal to your write path, so a format that implements tier 3 and
+    not this one gets advisory proposals and no stored plan, which is the same
+    outcome as declining the tier.
+
+    **What this asserts is that your two answers agree.** Each is checkable alone
+    and neither is interesting alone: ``edit_path`` names a file, and
+    ``editing_surface`` says which region files may be named in. A format placing
+    an edit outside its own declared surface builds a proposal the plan store then
+    refuses, and the refusal reads as dex declining rather than as the format
+    contradicting itself, which is a bad afternoon to debug from the outside.
+    """
+
+    def placeable_model(self) -> str:
+        """A warehouse table your format would place an edit for.
+
+        The table name as the warehouse spells it, not as your format names the
+        model derived from it. Reconcile passes what the finding is about, and the
+        distinction is the one ``edit_path`` is most often gotten wrong on.
+        """
+
+        raise NotImplementedError(
+            "a PlacingProjectContract subclass must implement placeable_model() "
+            "-> str, naming a warehouse table this format would place an edit "
+            "for. Reconcile's findings arrive keyed by table, and placement is "
+            "asked per table"
+        )
+
+    def test_satisfies_the_placing_protocol(self) -> None:
+        from .project import PlacingProject
+
+        assert isinstance(self.make_project(), PlacingProject), (
+            "the format does not satisfy PlacingProject, so reconcile has no path "
+            "to plan an edit against and every proposal it makes stays advisory. "
+            "Both `edit_path` and `editing_surface` are required"
+        )
+
+    def test_it_places_at_least_one_kind(self) -> None:
+        """A format that declines every kind has implemented nothing.
+
+        ``None`` per kind is a complete answer and the protocol exists to allow
+        it, but ``None`` for all of them is the format saying it has nowhere for
+        any edit to go, which is what declining tier 3 already says more directly.
+        """
+
+        from ..transform.plans import EditKind
+
+        project = self.make_project()
+        model = self.placeable_model()
+        placed = {
+            kind: project.edit_path(kind, model)
+            for kind in EditKind
+            if project.edit_path(kind, model) is not None
+        }
+
+        assert placed, (
+            f"edit_path() answered None for every kind on '{model}', so no "
+            "proposal can ever reach this format's write path. A format with "
+            "nowhere for any edit to land should decline tier 3 instead"
+        )
+
+    def test_every_placement_lands_inside_the_declared_surface(self) -> None:
+        """The two methods have to describe the same project.
+
+        Containment is checked against ``editing_surface`` at plan time, whatever
+        ``edit_path`` returned, so a placement outside it is an edit built and
+        then refused.
+        """
+
+        from ..transform.plans import EditKind, PlanError, contained_key
+
+        project = self.make_project()
+        model = self.placeable_model()
+        surface = list(project.editing_surface())
+
+        for kind in EditKind:
+            path = project.edit_path(kind, model)
+            if path is None:
+                continue
+            try:
+                contained_key(path, surface)
+            except PlanError as exc:
+                raise AssertionError(
+                    f"edit_path({kind.value}, {model!r}) placed the edit at "
+                    f"'{path}', which editing_surface() does not admit "
+                    f"({', '.join(surface) or 'nothing'}). The plan store checks "
+                    f"the path against the surface, so this proposal would be "
+                    f"built and then refused: {exc}"
+                ) from exc
+
+    def test_the_declared_surface_cannot_reach_outside_the_project(self) -> None:
+        """A surface is a region of the project, not a way out of it.
+
+        Escapes are refused ahead of the surface no matter what is declared, so
+        this cannot widen anything; declaring one means the format believes it
+        owns something it does not, and the belief is worth catching here rather
+        than as a refusal on the first edit that uses it.
+        """
+
+        from pathlib import PurePosixPath
+
+        for prefix in self.make_project().editing_surface():
+            candidate = PurePosixPath(str(prefix).replace("\\", "/"))
+            assert not candidate.is_absolute() and ".." not in candidate.parts, (
+                f"editing_surface() declares '{prefix}', which is absolute or "
+                "climbs out of the project. dex refuses those regardless, so "
+                "every edit placed under this prefix is refused"
+            )
 
 
 class ProjectFactoryContract:

--- a/packages/dex-core/src/exmergo_dex_core/adapters/project.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/project.py
@@ -195,6 +195,18 @@ class EditableProject(MaintainProject, Protocol):
         made while the plan sat in review.
         :class:`~.conformance.EditableProjectContract` asserts the behavior,
         because no shape check can.
+
+        **What comes back has to say what happened.** ``transform apply`` reads
+        ``written`` to decide whether the plan is now applied, and ``conflicts``
+        to decide whether to show a human the divergence and ask. A return that
+        answers neither leaves the caller unable to tell a refused apply from a
+        successful one, and the safe reading of that ambiguity is the wrong one
+        in both directions: a plan marked applied that was not, or a conflict
+        that never reaches the human it was raised for. Return an object exposing
+        ``written`` (the paths that changed, empty when a conflict refused the
+        apply) and ``conflicts`` (what moved under the plan);
+        :class:`~.dbt_project.ApplyResult` is the shipped one and returning it is
+        the easy answer.
         """
         ...
 
@@ -249,6 +261,37 @@ class PlacingProject(Protocol):
         ``MODEL_SQL``, while its declared keys and joins are hand-written files
         that nothing regenerates and can receive a ``SCHEMA_YML`` test. One
         ``None`` and one path is a complete, honest answer.
+        """
+        ...
+
+    def editing_surface(self) -> list[str]:
+        """The prefixes within which this format's edits may land.
+
+        Placement says where one edit goes. This says which region of the
+        format's keyspace *any* edit may touch, and it exists because the two
+        questions have different callers. ``transform plan`` validates edits an
+        agent authored, so there is no ``(kind, model)`` pair to ask
+        :meth:`edit_path` about and no prior answer to compare against; what it
+        has is a path, and what it needs is whether that path is inside the
+        surface the format admits to owning.
+
+        Containment is a safety property, not a lookup. Writes are confined to a
+        declared surface so a mistaken or adversarial path cannot reach the rest
+        of the repository, and the declaration has to come from the format
+        because only the format knows its own layout. dbt answers with its
+        configured model and macro paths, which is what the engine checked
+        against directly before this seam existed.
+
+        Prefixes are keys into the same space :meth:`edit_path` returns, matched
+        by path segment: ``declarations`` admits ``declarations/orders.yml`` and
+        does not admit ``declarations_backup/orders.yml``. Escapes (absolute
+        paths, ``..``) are refused ahead of this and are not a format's to
+        permit.
+
+        An empty list is a format declaring no editable surface. That is a
+        coherent answer, not a failure, and it refuses every edit rather than
+        admitting all of them: the format is saying it has nowhere for an edit to
+        go, which is the same statement declining tier 3 makes.
         """
         ...
 
@@ -499,3 +542,20 @@ class DbtProject:
 
         suffix = {_EditKind.MODEL_SQL: "sql", _EditKind.SCHEMA_YML: "yml"}.get(kind)
         return None if suffix is None else f"models/staging/stg_{model}.{suffix}"
+
+    def editing_surface(self) -> list[str]:
+        """The project's configured model and macro paths, read from the view.
+
+        Read rather than assumed: a project that configures ``model-paths`` away
+        from ``models`` moves its editing surface with it, and the containment
+        check has always honored that. This returns what the engine computed for
+        itself before the seam existed, so routing dbt through the seam changes
+        nothing about which paths dbt admits.
+
+        The root manifests ``contained_path`` allows by name are not listed here.
+        They are a dbt fact about dbt's own project root rather than a region of
+        the surface, and the check keeps applying them on the dbt path.
+        """
+
+        view = self.load()
+        return list(view.model_paths) + list(view.macro_paths)

--- a/packages/dex-core/src/exmergo_dex_core/adapters/project.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/project.py
@@ -64,12 +64,14 @@ from ..maintain import snapshot
 if TYPE_CHECKING:
     from ..dbt_project import DbtProjectView, ProjectDefinitions
     from ..maintain.snapshot import SemanticLayer, TransformLayer
+    from ..transform.plans import EditKind
 
 __all__ = [
     "DbtProject",
     "EditableProject",
     "ExploreProject",
     "MaintainProject",
+    "PlacingProject",
     "ProjectAdapter",
     "ProjectContext",
     "ProjectFactory",
@@ -193,6 +195,60 @@ class EditableProject(MaintainProject, Protocol):
         made while the plan sat in review.
         :class:`~.conformance.EditableProjectContract` asserts the behavior,
         because no shape check can.
+        """
+        ...
+
+
+@runtime_checkable
+class PlacingProject(Protocol):
+    """Optional beside tier 3: where a proposed edit lands.
+
+    Tier 3 says a format *can* receive an edit. It does not say where the edit
+    goes, and ``maintain reconcile`` decides that before it consults the format:
+    both of its mechanical write paths build ``models/staging/stg_<table>.sql``
+    and ``models/staging/stg_<table>.yml`` and then look those up in the view
+    ``load()`` returned. A second format satisfying tier 3 in full is therefore
+    handed edits naming files it does not have, and its only options are to
+    refuse them or to guess a mapping. A wrong guess writes into the wrong file
+    with a hash check that passes, because the file was not there.
+
+    Implementing this says where. It is deliberately not a request to let a
+    format author the edit *content*: reconcile still decides what to write, and
+    a format that cannot accept what reconcile writes says so per kind, below.
+
+    **A protocol rather than a flag, for the reason the tiers are.** A flag is a
+    claim the engine has to interpret and trust. ``isinstance(project,
+    PlacingProject)`` is checkable, and a format that cannot place an edit
+    cannot accidentally claim it can.
+
+    **Separate from** :class:`EditableProject` **rather than a method on it.**
+    The tiers are ``runtime_checkable``, so a method added to tier 3 silently
+    demotes every format that has not implemented it yet: ``tier_of`` would
+    start answering 2 where it answered 3, and the write path would close for
+    exactly the implementers who were already passing. Beside it, the answer for
+    a format that has not implemented this is "tier 3, placement unknown", which
+    is the truth and is what the caller warns about.
+    """
+
+    def edit_path(self, kind: EditKind, model: str) -> str | None:
+        """Where an edit of ``kind`` for ``model`` lives, or ``None``.
+
+        ``model`` is the warehouse table the finding is about, not a model name
+        in any format's vocabulary: the ``stg_`` prefix is dbt's own scaffold
+        convention and applying it here would push that convention through the
+        seam meant to escape it.
+
+        The return is a key into whatever :meth:`EditableProject.load` returns,
+        not a filesystem path. The format already owns that keyspace; reconcile
+        is only guessing keys into it today.
+
+        **``None`` per kind is the point, not a degenerate case.** The kinds are
+        not equally receivable and a format is expected to answer differently
+        across them. The shape this exists for is a format whose models are
+        reduced from a running graph, and so cannot receive an authored
+        ``MODEL_SQL``, while its declared keys and joins are hand-written files
+        that nothing regenerates and can receive a ``SCHEMA_YML`` test. One
+        ``None`` and one path is a complete, honest answer.
         """
         ...
 
@@ -430,3 +486,16 @@ class DbtProject:
             project_dir or self.project_dir or self.repo_root,
             confirmed=confirmed,
         )
+
+    def edit_path(self, kind: EditKind, model: str) -> str | None:
+        """The scaffold convention, which is what reconcile hard-coded before.
+
+        Both kinds resolve, because for dbt both artifacts are the source of
+        truth. A kind reconcile does not propose today returns ``None`` rather
+        than a path this class would be inventing.
+        """
+
+        from ..transform.plans import EditKind as _EditKind
+
+        suffix = {_EditKind.MODEL_SQL: "sql", _EditKind.SCHEMA_YML: "yml"}.get(kind)
+        return None if suffix is None else f"models/staging/stg_{model}.{suffix}"

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -744,9 +744,10 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
             f"the '{editable.name}' project format implements the write tier, but "
             "does not say where a proposed edit lands, so reconcile has no path to "
             "plan an edit against and every proposal below is advisory. A format "
-            "reaches this path by implementing `PlacingProject`, which answers "
-            "where an edit of a given kind goes and may decline a kind by "
-            "answering None"
+            "reaches this path by implementing `PlacingProject`: `edit_path` "
+            "answers where an edit of a given kind goes and may decline a kind by "
+            "answering None, and `editing_surface` declares the region those "
+            "paths must stay inside"
         )
     else:
         try:
@@ -776,7 +777,17 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
             f"maintain reconcile {drift_class}" if drift_class else "maintain reconcile"
         )
         plan, diffs, plan_warnings = plans_mod.plan(
-            intent, edits, project_dir=view.root, repo_root=repo_root, store=store
+            intent,
+            edits,
+            project_dir=view.root,
+            repo_root=repo_root,
+            store=store,
+            # The format that placed these edits also validates them. Passing it
+            # is what keeps the two halves of the check on the same project: the
+            # surface each path must land in, and the file each edit is pinned
+            # against. dbt reaches the identical checks through this argument as
+            # it did without it, and reuses the view it already loaded.
+            project_format=editable,
         )
         result.diffs = diffs
         result.warnings.extend(plan_warnings)

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -696,7 +696,7 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
     coincidence survivable.
     """
 
-    from ..adapters.project import DbtProject
+    from ..adapters.project import PlacingProject
     from ..transform import plans as plans_mod
     from . import reconcile as reconcile_mod
 
@@ -739,12 +739,14 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
             "Reconcile what these findings describe wherever your models are "
             "actually defined"
         )
-    elif not isinstance(editable, DbtProject):
+    elif not isinstance(editable, PlacingProject):
         warnings.append(
             f"the '{editable.name}' project format implements the write tier, but "
-            "reconcile's mechanical edits are dbt artifacts (a staging model and "
-            "its schema YAML) and dex cannot yet author them for another format, "
-            "so every proposal below is advisory"
+            "does not say where a proposed edit lands, so reconcile has no path to "
+            "plan an edit against and every proposal below is advisory. A format "
+            "reaches this path by implementing `PlacingProject`, which answers "
+            "where an edit of a given kind goes and may decline a kind by "
+            "answering None"
         )
     else:
         try:
@@ -758,6 +760,7 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
         store.load_cache(),
         view,
         pii_overrides=pii_override_paths(engine.config.pii_overrides),
+        placement=editable if isinstance(editable, PlacingProject) else None,
     )
     warnings.extend(build_warnings)
 

--- a/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import yaml
 from pydantic import BaseModel, Field
 
+from ..adapters.project import PlacingProject
 from ..cache import ColumnProfile, Dataset, DexCache
 from ..config import PIIOverrideMatcher
 from ..dbt_project import DbtProjectView
@@ -53,6 +54,21 @@ class Proposal(BaseModel):
 _PATCHABLE = {"column_added", "column_dropped", "column_retyped", "nullability_changed"}
 
 
+def _placed(placement: PlacingProject | None, kind: EditKind, table: str) -> str | None:
+    """Where an edit of ``kind`` for ``table`` goes, asking the format first.
+
+    ``None`` placement is the dbt scaffold convention, which keeps every caller
+    that predates the seam on the paths it already had. A format that answers
+    ``None`` for a kind is declining that kind, and the caller turns it into the
+    same advisory a missing scaffold file produces.
+    """
+
+    if placement is None:
+        suffix = "sql" if kind is EditKind.MODEL_SQL else "yml"
+        return f"models/staging/stg_{table}.{suffix}"
+    return placement.edit_path(kind, table)
+
+
 def build(
     findings: list[DriftFinding],
     snap: Snapshot,
@@ -60,6 +76,7 @@ def build(
     view: DbtProjectView | None,
     *,
     pii_overrides: PIIOverrideMatcher | None = None,
+    placement: PlacingProject | None = None,
 ) -> tuple[list[Proposal], list[PlanEdit], list[str]]:
     """Map findings to proposals and plan edits. Pure: writes nothing.
 
@@ -71,7 +88,11 @@ def build(
 
     ``pii_overrides`` carries the config's reviewed non-PII column paths, so a
     drift-added column a human already cleared is not re-flagged into the
-    scaffolded meta."""
+    scaffolded meta.
+
+    ``placement`` is the format answering where each edit lands. ``None`` keeps
+    the dbt scaffold convention this module hard-coded before the seam existed,
+    so a caller that does not pass one is unaffected."""
 
     proposals: list[Proposal] = []
     edits: list[PlanEdit] = []
@@ -90,13 +111,20 @@ def build(
     for identifier, table_findings in sorted(schema_patches.items()):
         table = identifier.rsplit(".", 1)[-1]
         base = _base_dataset(identifier, cache, snap)
-        model_path = f"models/staging/stg_{table}.sql"
-        if view is None or base is None or model_path not in view.files:
+        model_path = _placed(placement, EditKind.MODEL_SQL, table)
+        if (
+            view is None
+            or base is None
+            or model_path is None
+            or (model_path not in view.files)
+        ):
             reason = (
                 "this project format cannot receive edits"
                 if view is None
                 else "no profiled baseline to rebuild from"
                 if base is None
+                else "this project format has nowhere for a staging model to land"
+                if model_path is None
                 else f"no dex-scaffolded staging model at {model_path}"
             )
             proposals.extend(
@@ -116,6 +144,32 @@ def build(
             continue
         patched = _patched_dataset(base, table_findings, pii_overrides or set())
         table_edits = model_edits(patched)
+        # The scaffold generates both the path and the dbt SQL inside it, so a
+        # format that places a staging model somewhere else would receive dbt
+        # content written to a path the generator did not agree to. Placement
+        # alone cannot close this channel; authoring the content is the larger
+        # design the seam deliberately does not attempt. Refuse rather than
+        # write the mismatch, and say which of the two is missing.
+        misplaced = any(
+            edit.path != _placed(placement, edit.kind, table) for edit in table_edits
+        )
+        if misplaced:
+            proposals.extend(
+                Proposal(
+                    axis="schema",
+                    kind="advisory",
+                    finding_code=finding.code,
+                    identifier=identifier,
+                    column=finding.column,
+                    action=(
+                        "this project format places a staging model somewhere "
+                        "dex cannot author one for it; re-scaffold "
+                        f"stg_{table} wherever that model is defined"
+                    ),
+                )
+                for finding in table_findings
+            )
+            continue
         edits.extend(table_edits)
         changes = ", ".join(
             f"{f.code.replace('_', ' ')} ({f.column})" for f in table_findings
@@ -135,7 +189,7 @@ def build(
             )
         )
 
-    grain_edits, grain_warnings = _grain_test_edits(proposals, view)
+    grain_edits, grain_warnings = _grain_test_edits(proposals, view, placement)
     edits.extend(grain_edits)
     warnings.extend(grain_warnings)
 
@@ -276,7 +330,9 @@ def _patched_dataset(
 
 
 def _grain_test_edits(
-    proposals: list[Proposal], view: DbtProjectView | None
+    proposals: list[Proposal],
+    view: DbtProjectView | None,
+    placement: PlacingProject | None = None,
 ) -> tuple[list[PlanEdit], list[str]]:
     """Back key_lost_uniqueness proposals with a `unique` test edit when the
     scaffolded YAML exists and does not already alert. The duplicates
@@ -296,7 +352,14 @@ def _grain_test_edits(
         if proposal.finding_code != "key_lost_uniqueness" or proposal.column is None:
             continue
         table = (proposal.identifier or "").rsplit(".", 1)[-1]
-        path = f"models/staging/stg_{table}.yml"
+        path = _placed(placement, EditKind.SCHEMA_YML, table)
+        if path is None:
+            warnings.append(
+                f"this project format has nowhere for a test on {proposal.identifier} "
+                "to land, so the lost unique key has no test edit; add a `unique` "
+                "test wherever that model is defined"
+            )
+            continue
         source = view.files.get(path)
         if source is None:
             warnings.append(

--- a/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
@@ -66,8 +66,12 @@ def _placed(placement: PlacingProject | None, kind: EditKind, table: str) -> str
     """
 
     if placement is None:
-        suffix = "sql" if kind is EditKind.MODEL_SQL else "yml"
-        return f"models/staging/stg_{table}.{suffix}"
+        # The same two kinds `DbtProject.edit_path` resolves, declined the same
+        # way for the rest: this branch is that method's convention inlined for
+        # callers holding no format, so answering a path where it answers `None`
+        # would make the shim and the format disagree about the same input.
+        suffix = {EditKind.MODEL_SQL: "sql", EditKind.SCHEMA_YML: "yml"}.get(kind)
+        return None if suffix is None else f"models/staging/stg_{table}.{suffix}"
     return placement.edit_path(kind, table)
 
 

--- a/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
@@ -19,6 +19,8 @@ writes to the project and human edits stay authoritative at apply time.
 
 from __future__ import annotations
 
+from pathlib import PurePosixPath
+
 import yaml
 from pydantic import BaseModel, Field
 
@@ -375,18 +377,44 @@ def _grain_test_edits(
             continue
         if not isinstance(parsed, dict):
             continue
+        # The convention leaks through content as well as through paths, and
+        # placement only closes the path half. This matched `stg_{table}` inside
+        # the YAML, so a format that placed the file correctly and names its
+        # model `orders` was still missed, silently, one line before the edit.
+        #
+        # The model is named after the file the format chose. For dbt that is the
+        # same string it always matched, because the scaffold path is
+        # `models/staging/stg_{table}.yml` and its stem is `stg_{table}`; for a
+        # format placing `declarations/orders.yml` it is `orders`. The format
+        # already answered "where does this table's declaration live", and this
+        # reads the answer instead of asserting dbt's spelling over it. A format
+        # that packs many models into one file finds no entry and is warned
+        # below, which is a refusal to guess rather than a wrong write.
+        declared = PurePosixPath(path).stem
         entry = next(
             (
                 column
                 for model in parsed.get("models") or []
-                if isinstance(model, dict) and model.get("name") == f"stg_{table}"
+                if isinstance(model, dict) and model.get("name") == declared
                 for column in model.get("columns") or []
                 if isinstance(column, dict) and column.get("name") == proposal.column
             ),
             None,
         )
-        if entry is None or "unique" in (entry.get("tests") or []):
-            continue  # already alerting (or no scaffolded column entry to extend)
+        if entry is None:
+            # Split from the "already alerting" skip below, which is silent
+            # because it is correct. This one is a miss: the file resolved and
+            # the column entry did not, and a reader looking at the proposal
+            # would otherwise have no way to tell that from dex declining.
+            warnings.append(
+                f"{path} declares no column '{proposal.column}' under a model "
+                f"named '{declared}', so the lost unique key on "
+                f"{proposal.identifier} has no test edit; add a `unique` test "
+                "there by hand"
+            )
+            continue
+        if "unique" in (entry.get("tests") or []):
+            continue  # already alerting
         entry.setdefault("tests", []).append("unique")
         edits.append(
             PlanEdit(

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -398,7 +398,15 @@ def apply(engine: DexEngine, plan_id: str | None = None) -> ApplyResult:
 
     repo_root = engine.require_repo_root("applying a plan to the dbt project")
     outcome: PlanApplyResult = plans_mod.apply(
-        plan_id, repo_root, store=store, confirmed=engine.confirmed
+        plan_id,
+        repo_root,
+        store=store,
+        confirmed=engine.confirmed,
+        # A plan is applied through the format it was planned against, so a
+        # format that placed an edit into its own keyspace is the one that writes
+        # it. `None` here is a format declining the write tier, and falls back to
+        # dbt's writer, which is where every plan went before the seam.
+        project_format=engine.editable_project(),
     )
     conflicts = [c.model_dump(mode="json") for c in outcome.conflicts]
     if outcome.conflicts and not outcome.written:
@@ -952,6 +960,11 @@ def _make_plan(engine: DexEngine, intent: str, edits: list[PlanEdit]) -> PlanRes
         engine.project_dir(),
         repo_root,
         store=engine.require_full_store("storing a semantic plan"),
+        # Agent-authored edits, which is the caller `editing_surface` exists for:
+        # there is no placement to compare a path against here, only the surface
+        # the format admits to owning. A format declining the write tier is
+        # `None` and validates against dbt's surface as before.
+        project_format=engine.editable_project(),
     )
     return PlanResult(
         plan_id=stored.plan_id,

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -954,17 +954,28 @@ def _failure_message(prefix: str, messages: list[str]) -> str:
 
 def _make_plan(engine: DexEngine, intent: str, edits: list[PlanEdit]) -> PlanResult:
     repo_root = engine.require_repo_root("storing a transform plan")
+    editable = engine.editable_project()
+    # The directory these edits are pinned against has to name the same project
+    # as the surface they are checked in, or an existing file hashes as absent
+    # and the apply that follows conflicts on a file nobody edited. A format
+    # declaring a surface answers both from its own view, so the directory is
+    # left to `plans.plan` to read there rather than asserted from dbt's here.
+    # Everything else predates the seam and keeps dbt's configured pin, which
+    # that function's own fallback (discovery from the repo root) would not
+    # honor. For dbt the two agree by construction: its view loads the same
+    # resolved directory `project_dir()` returns.
+    declares_surface = getattr(editable, "editing_surface", None) is not None
     stored, diffs, warnings = plans_mod.plan(
         intent,
         edits,
-        engine.project_dir(),
+        None if declares_surface else engine.project_dir(),
         repo_root,
         store=engine.require_full_store("storing a semantic plan"),
         # Agent-authored edits, which is the caller `editing_surface` exists for:
         # there is no placement to compare a path against here, only the surface
         # the format admits to owning. A format declining the write tier is
         # `None` and validates against dbt's surface as before.
-        project_format=engine.editable_project(),
+        project_format=editable,
     )
     return PlanResult(
         plan_id=stored.plan_id,

--- a/packages/dex-core/src/exmergo_dex_core/transform/plans.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/plans.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -41,6 +41,7 @@ from ..errors import DexError
 from .validate import find_inlined_secret, validate_edit
 
 if TYPE_CHECKING:
+    from ..adapters.project import EditableProject
     from ..storage import Store
 
 
@@ -85,6 +86,39 @@ class TransformPlan(BaseModel):
     applied_at: str | None = None
 
 
+def contained_key(rel_path: str, surface: list[str]) -> str:
+    """Refuse an edit path outside the surface a project format declared.
+
+    The format-neutral half of containment. ``rel_path`` is a key into whatever
+    the format's ``load()`` returned rather than a filesystem path, so this
+    matches by path segment instead of resolving anything: a format keyed by
+    something other than a directory still gets its surface honored, and a
+    prefix cannot admit a sibling that merely starts with the same characters
+    (``declarations`` admits ``declarations/orders.yml``, not
+    ``declarations_backup/orders.yml``).
+
+    Escapes are refused before the surface is consulted. An absolute path or one
+    climbing out through ``..`` is not a format's to permit, and a format that
+    listed one as its surface would be declaring the rest of the filesystem.
+    """
+
+    candidate = PurePosixPath(rel_path.replace("\\", "/"))
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise PlanError(
+            f"edit path must be project-relative and may not climb out of the "
+            f"project: '{rel_path}'"
+        )
+    for prefix in surface:
+        base = PurePosixPath(str(prefix).replace("\\", "/"))
+        if candidate == base or base in candidate.parents:
+            return rel_path
+    listed = ", ".join(surface) if surface else "none"
+    raise PlanError(
+        f"edit path '{rel_path}' is outside the editing surface this project "
+        f"format declares ({listed}); dex edits only what a format says it owns"
+    )
+
+
 def plan(
     intent: str,
     edits: list[PlanEdit],
@@ -92,6 +126,7 @@ def plan(
     repo_root: Path | str = ".",
     *,
     store: Store,
+    project_format: EditableProject | None = None,
 ) -> tuple[TransformPlan, list[dict[str, Any]], list[str]]:
     """Validate agent-authored edits and store them as a plan. Writes no project file.
 
@@ -101,60 +136,108 @@ def plan(
 
     ``repo_root`` locates the dbt project (the source of truth, always a
     filesystem artifact); ``store`` is where the proposal itself lands.
+
+    ``project_format`` is the format the edits were built against. Omitting it
+    loads the dbt project and validates against dbt's own surface, which is what
+    every caller predating the seam does and gets the behavior it always had. A
+    format passed here supplies both halves of the check that used to be dbt's
+    by assumption: the files an edit is pinned against, and the surface it may
+    land in. Those two must come from the same place. Pinning against dbt's view
+    while placing into a format's own keyspace hashes an existing file as absent,
+    which renders a one-line change as a whole-file create and turns the next
+    apply into a conflict on a file nobody touched.
     """
 
     if not edits:
         raise PlanError("a plan needs at least one edit")
 
-    project = Path(project_dir) if project_dir else find_project(repo_root)
-    view = load_project(project)
+    # A format that declares no surface is not routed through this seam at all:
+    # it goes down the path it went down before the seam existed, loading the dbt
+    # project and validating against dbt's paths. That is a deliberate fallback
+    # rather than an oversight. Such a format cannot place an edit either (the
+    # placement seam and the surface are declared together), so the edits reaching
+    # here are dbt-shaped and dbt's view is the right thing to pin them against.
+    declares_surface = getattr(project_format, "editing_surface", None)
+    if project_format is not None and declares_surface is not None:
+        view = project_format.load()
+        project = Path(project_dir) if project_dir else Path(getattr(view, "root", "."))
+    else:
+        project = Path(project_dir) if project_dir else find_project(repo_root)
+        view = load_project(project)
+
+    # Which validations apply is a question about the view's shape, not about
+    # which class produced it: a format handing back a `DbtProjectView` is
+    # offering dbt's surface and gets dbt's checks, and asking the view keeps
+    # this from becoming the `isinstance(project, DbtProject)` gate the seam
+    # exists to remove.
+    dbt_shaped = isinstance(view, DbtProjectView)
+    surface = [] if dbt_shaped else list(declares_surface())
 
     warnings: list[str] = []
     pinned: list[PlanEdit] = []
     diffs: list[dict[str, Any]] = []
     project_resolved = project.resolve()
-    macro_bases = [(project_resolved / mp).resolve() for mp in view.macro_paths]
+    macro_bases = (
+        [(project_resolved / mp).resolve() for mp in view.macro_paths]
+        if dbt_shaped
+        else []
+    )
     # The one root file each config kind may target, resolved once. Both the
     # kind and the path must agree: a config kind aimed elsewhere, or one of
     # these files reached by any other kind, is refused.
-    root_config = {
-        EditKind.PROJECT_YML: (project_resolved / "dbt_project.yml").resolve(),
-        EditKind.PROFILES_YML: (project_resolved / "profiles.yml").resolve(),
-    }
+    root_config = (
+        {
+            EditKind.PROJECT_YML: (project_resolved / "dbt_project.yml").resolve(),
+            EditKind.PROFILES_YML: (project_resolved / "profiles.yml").resolve(),
+        }
+        if dbt_shaped
+        else {}
+    )
     config_targets = {target: kind for kind, target in root_config.items()}
     for edit in edits:
         # Containment is checked at plan time as well as at write time, so a bad
-        # path is refused before it ever becomes a stored proposal.
-        resolved = contained_path(
-            project, edit.path, view.model_paths, view.macro_paths
-        ).resolve()
-        # Kind and surface must agree: a macro written into models/ would be
-        # parsed as a model and fail the build, and a model written into
-        # macros/ would silently never become a model.
-        in_macros = any(
-            resolved == base or base in resolved.parents for base in macro_bases
-        )
-        if edit.kind is EditKind.MACRO_SQL and not in_macros:
-            raise PlanError(
-                f"a macro_sql edit must live under the project's macro paths "
-                f"({', '.join(view.macro_paths)}), got '{edit.path}'"
+        # path is refused before it ever becomes a stored proposal. Which surface
+        # it is checked against is the format's to say; that it is checked at all
+        # is not.
+        if dbt_shaped:
+            resolved = contained_path(
+                project, edit.path, view.model_paths, view.macro_paths
+            ).resolve()
+            # Kind and surface must agree: a macro written into models/ would be
+            # parsed as a model and fail the build, and a model written into
+            # macros/ would silently never become a model.
+            in_macros = any(
+                resolved == base or base in resolved.parents for base in macro_bases
             )
-        if edit.kind is not EditKind.MACRO_SQL and in_macros:
-            raise PlanError(
-                f"'{edit.path}' is under a macro path but the edit kind is "
-                f"{edit.kind.value}; use macro_sql for macro files"
-            )
-        if edit.kind in root_config and resolved != root_config[edit.kind]:
-            raise PlanError(
-                f"a {edit.kind.value} edit must target the project's "
-                f"{root_config[edit.kind].name}, got '{edit.path}'"
-            )
-        target_kind = config_targets.get(resolved)
-        if target_kind is not None and edit.kind is not target_kind:
-            raise PlanError(
-                f"'{edit.path}' is a project config file but the edit kind is "
-                f"{edit.kind.value}; use {target_kind.value} for it"
-            )
+            if edit.kind is EditKind.MACRO_SQL and not in_macros:
+                raise PlanError(
+                    f"a macro_sql edit must live under the project's macro paths "
+                    f"({', '.join(view.macro_paths)}), got '{edit.path}'"
+                )
+            if edit.kind is not EditKind.MACRO_SQL and in_macros:
+                raise PlanError(
+                    f"'{edit.path}' is under a macro path but the edit kind is "
+                    f"{edit.kind.value}; use macro_sql for macro files"
+                )
+            if edit.kind in root_config and resolved != root_config[edit.kind]:
+                raise PlanError(
+                    f"a {edit.kind.value} edit must target the project's "
+                    f"{root_config[edit.kind].name}, got '{edit.path}'"
+                )
+            target_kind = config_targets.get(resolved)
+            if target_kind is not None and edit.kind is not target_kind:
+                raise PlanError(
+                    f"'{edit.path}' is a project config file but the edit kind is "
+                    f"{edit.kind.value}; use {target_kind.value} for it"
+                )
+        else:
+            # The three checks above read dbt's project layout (its macro paths,
+            # its root manifests) to decide whether a kind and its location
+            # agree. Another format's layout makes no such claim, and asserting
+            # dbt's over it would refuse exactly the edits this seam exists to
+            # allow. Agreement there is the format's own, expressed through what
+            # `edit_path` places and what `write_edits` accepts.
+            contained_key(edit.path, surface)
         current = view.files.get(edit.path)
         if edit.op is EditOp.DELETE and current is None:
             raise PlanError(
@@ -208,12 +291,19 @@ def plan(
     # The whole-plan delete guard: a delete is refused if any file that survives
     # the plan still refers to a deleted model. Run against the pinned edits so
     # an update in this same plan that removes the offending ref is honored.
-    warnings.extend(validate_deletions(view, pinned))
+    #
+    # Both guards below read dbt's dependency vocabulary out of file content:
+    # `ref()` for the orphan scan, and dbt macro calls for the missing-macro
+    # warning. Another format expresses dependency its own way, so running these
+    # over its files would find nothing and report that absence as a clean bill.
+    # Silence is more honest than a check that cannot see what it is checking.
+    if dbt_shaped:
+        warnings.extend(validate_deletions(view, pinned))
 
-    # Late import: scaffold imports PlanEdit from this module.
-    from .scaffold import missing_macro_warnings
+        # Late import: scaffold imports PlanEdit from this module.
+        from .scaffold import missing_macro_warnings
 
-    warnings.extend(missing_macro_warnings(edits, view))
+        warnings.extend(missing_macro_warnings(edits, view))
 
     created_at = datetime.now(UTC).isoformat()
     try:
@@ -237,13 +327,30 @@ def apply(
     *,
     store: Store,
     confirmed: bool = False,
+    project_format: EditableProject | None = None,
 ) -> ApplyResult:
-    """Write a stored plan's edits into the dbt project, hash-checked and
-    all-or-nothing."""
+    """Write a stored plan's edits into the project, hash-checked and
+    all-or-nothing.
+
+    ``project_format`` is the tier-3 format the plan should be written through.
+    Omitting it writes with dbt's own writer, which is what every caller
+    predating the seam does. Passing one matters for the same reason planning
+    through it does: this module's writer resolves each edit as a path under the
+    dbt project and re-hashes what it finds on disk, so a plan placed into
+    another format's keyspace would be refused here even after the plan store
+    accepted it, and the tier-3 ``write_edits`` the format implemented would
+    never be reached. A plan a format could store and not apply is not a write
+    path.
+    """
 
     stored = store.load_plan(plan_id)
     project = Path(repo_root) / stored.project_dir
-    result = write_edits(list(stored.edits), project, confirmed=confirmed)
+    if project_format is None:
+        result = write_edits(list(stored.edits), project, confirmed=confirmed)
+    else:
+        result = project_format.write_edits(
+            list(stored.edits), project, confirmed=confirmed
+        )
     if result.written:
         stored.applied_at = datetime.now(UTC).isoformat()
         store.save_plan(stored)

--- a/packages/dex-core/tests/adapters/test_project_parity.py
+++ b/packages/dex-core/tests/adapters/test_project_parity.py
@@ -22,6 +22,7 @@ from exmergo_dex_core.adapters.conformance import (
     DeclaringProjectContract,
     EditableProjectContract,
     MaintainProjectContract,
+    PlacingProjectContract,
     ProjectFactoryContract,
     SemanticProjectContract,
 )
@@ -90,7 +91,10 @@ def _staged_conflict(root: Path):
 
 
 class TestDbtProject(
-    DeclaringProjectContract, SemanticProjectContract, EditableProjectContract
+    DeclaringProjectContract,
+    SemanticProjectContract,
+    PlacingProjectContract,
+    EditableProjectContract,
 ):
     @pytest.fixture(autouse=True)
     def _root(self, tmp_path: Path):
@@ -104,6 +108,12 @@ class TestDbtProject(
 
     def an_edit_against_a_changed_target(self):
         return _staged_conflict(self.root)
+
+    def placeable_model(self) -> str:
+        # The warehouse table, not `stg_orders`: dbt's scaffold prefix is applied
+        # by `edit_path` on the way out, and passing the prefixed name here would
+        # assert the convention twice and prove it once.
+        return "orders"
 
     def make_unreadable_project(self) -> DbtProject:
         # A dbt_project.yml that is not parseable YAML. dbt is a filesystem format,

--- a/packages/dex-core/tests/maintain/test_project_format.py
+++ b/packages/dex-core/tests/maintain/test_project_format.py
@@ -18,10 +18,17 @@ from __future__ import annotations
 
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
-from exmergo_dex_core.dbt_project import ProjectDefinitions, SourceFile
+from exmergo_dex_core.dbt_project import (
+    ApplyResult,
+    Conflict,
+    ProjectDefinitions,
+    SourceFile,
+    content_hash,
+)
 from exmergo_dex_core.maintain.snapshot import (
     SemanticLayer,
     SourceTable,
@@ -157,12 +164,15 @@ def test_the_flag_falls_back_to_dbt_for_one_command(graph_repo):
 
 _SIDECAR = "declarations/orders.yml"
 
-# The sidecar names its model with dbt's `stg_` prefix. That is not incidental
-# and the test below pins why: placement alone does not carry the naming.
+# The model is named `orders`, not `stg_orders`. The earlier version of this
+# fixture used dbt's prefix because reconcile matched it inside the YAML, so a
+# correctly placed file was still missed on its contents. Naming it in the
+# format's own vocabulary is what pins that the convention no longer leaks
+# through either half.
 _SIDECAR_CONTENT = (
     "version: 2\n"
     "models:\n"
-    "  - name: stg_orders\n"
+    "  - name: orders\n"
     "    columns:\n"
     "      - name: order_id\n"
     "        tests: [not_null]\n"
@@ -185,6 +195,10 @@ class SidecarGraphProject(GraphProject):
     nothing regenerates, and that file can receive a `unique` test. Answering
     `None` for one kind and a path for the other is the whole point of the seam:
     a single boolean here would have to be wrong about one of the two.
+
+    It reads and writes its sidecar for real, because the assertions below follow
+    a proposal through `transform apply` and a stub write path would prove only
+    that dex called something.
     """
 
     name = "sidecar"
@@ -193,25 +207,54 @@ class SidecarGraphProject(GraphProject):
         super().__init__(context)
         self.written: list = []
 
+    def _root(self) -> Path:
+        return Path(self.context.repo_root or ".")
+
     def load(self) -> SidecarView:
-        root = self.context.repo_root or "."
-        return SidecarView(
-            root,
-            {
-                _SIDECAR: SourceFile(
-                    path=_SIDECAR, content=_SIDECAR_CONTENT, sha256="unused"
-                )
-            },
-        )
+        root = self._root()
+        files = {}
+        for path in sorted(root.glob("declarations/*.yml")):
+            content = path.read_text(encoding="utf-8")
+            files[f"declarations/{path.name}"] = SourceFile(
+                path=f"declarations/{path.name}",
+                content=content,
+                sha256=content_hash(content),
+            )
+        return SidecarView(str(root), files)
 
     def edit_path(self, kind: EditKind, model: str) -> str | None:
         if kind is EditKind.SCHEMA_YML:
             return f"declarations/{model}.yml"
         return None
 
+    def editing_surface(self) -> list[str]:
+        return ["declarations"]
+
     def write_edits(self, edits, project_dir=None, *, confirmed: bool = False):
         self.written.append((edits, project_dir, confirmed))
-        return []
+        root = Path(project_dir) if project_dir else self._root()
+        conflicts, staged = [], []
+        for edit in edits:
+            target = root / edit.path
+            current = target.read_text(encoding="utf-8") if target.is_file() else None
+            found = content_hash(current) if current is not None else None
+            if found != edit.old_content_hash:
+                conflicts.append(
+                    Conflict(
+                        path=edit.path,
+                        expected_sha256=edit.old_content_hash,
+                        found_sha256=found,
+                    )
+                )
+            staged.append((target, edit))
+        if conflicts and not confirmed:
+            return ApplyResult(written=[], diffs=[], conflicts=conflicts)
+        for target, edit in staged:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(edit.new_content, encoding="utf-8")
+        return ApplyResult(
+            written=[e.path for _, e in staged], diffs=[], conflicts=conflicts
+        )
 
 
 @pytest.fixture
@@ -226,56 +269,31 @@ def sidecar_repo(maintain_repo, monkeypatch):
         + "project:\n  format: dex_sidecar_format:sidecar_project\n",
         encoding="utf-8",
     )
+    sidecar = maintain_repo.root / _SIDECAR
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(_SIDECAR_CONTENT, encoding="utf-8")
     return maintain_repo
 
 
-def test_the_plan_store_refuses_a_placed_edit_outside_dbts_editing_surface(
-    sidecar_repo,
-):
-    """The third gate, which neither #257 nor #258 describes.
-
-    With the write gate asking a capability and reconcile asking the format
-    where the edit goes, the edit is still refused, and by neither of those: at
-    plan time `plans.plan` calls `load_project` and validates every path against
-    *dbt's* `model_paths`, whatever format produced the edit. So a second format
-    naming a file outside `models/` cannot store a plan even once both of the
-    filed issues are resolved exactly as proposed.
-
-    Pinned as the current behavior rather than fixed here. The containment check
-    is a safety property, not an oversight (writes are confined to a declared
-    editing surface), so widening it means the format declaring that surface,
-    which is a design question and not this seam's to answer.
-    """
-
-    sidecar_repo.snapshot()
-    sidecar_repo.sql("INSERT INTO orders SELECT * FROM orders WHERE order_id <= 10")
-    sidecar_repo.dex("maintain", "grain")
-
-    rc, payload = sidecar_repo.dex("maintain", "reconcile", "grain")
-
-    assert rc == 1 and payload["status"] == "error"
-    assert any(
-        "outside the project's model and macro paths" in message
-        for message in payload["errors"]
-    )
+def _grain_drift(repo):
+    repo.snapshot()
+    repo.sql("INSERT INTO orders SELECT * FROM orders WHERE order_id <= 10")
+    repo.dex("maintain", "grain")
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="the plan store validates every edit against dbt's model paths; a "
-    "format has no way to declare its own editing surface yet",
-)
 def test_a_placing_format_receives_the_test_edit_in_its_own_sidecar(sidecar_repo):
-    """The end state, once the third gate above opens.
+    """The third gate, open: a format's own surface is what its edits are checked
+    against.
 
-    Placement is doing its job by this point: reconcile asked the format and
-    built the edit against `declarations/orders.yml` instead of the scaffold
-    path. What is missing is permission to store a plan touching it.
+    This was a strict xfail through the spike that found the gate. Reconcile
+    asked the format where the edit lands and built it against
+    `declarations/orders.yml`, and then `plans.plan` refused it, because
+    containment validated every path against *dbt's* `model_paths` whatever
+    format produced the edit. The format now declares the surface it owns and
+    the check reads that declaration.
     """
 
-    sidecar_repo.snapshot()
-    sidecar_repo.sql("INSERT INTO orders SELECT * FROM orders WHERE order_id <= 10")
-    sidecar_repo.dex("maintain", "grain")
+    _grain_drift(sidecar_repo)
 
     rc, payload = sidecar_repo.dex("maintain", "reconcile", "grain")
 
@@ -287,6 +305,79 @@ def test_a_placing_format_receives_the_test_edit_in_its_own_sidecar(sidecar_repo
     assert not any(
         d["path"].startswith("models/staging/") for d in payload.get("diffs") or []
     )
+
+
+def test_the_edit_is_pinned_to_the_formats_file_not_dbts_view_of_it(sidecar_repo):
+    """The diff is the one-line change, not the whole file appearing from nowhere.
+
+    Containment and the hash pin are halves of one question, and widening the
+    first without moving the second is a quiet defect rather than a refusal: the
+    edit lands in the format's keyspace while `old_content_hash` comes from dbt's
+    view, which does not have the file. It pins as a create, the reviewable diff
+    shows a hand-written file as brand new, and the apply that follows reports a
+    conflict on a file nobody touched.
+    """
+
+    _grain_drift(sidecar_repo)
+
+    rc, payload = sidecar_repo.dex("maintain", "reconcile", "grain")
+
+    assert rc == 0, payload.get("errors")
+    diff = next(d for d in payload["diffs"] if d["path"] == _SIDECAR)
+    # A file the plan believes is absent diffs against /dev/null and renders
+    # every line as an addition. This one was read from the format's own view, so
+    # it diffs against itself and the untouched declarations survive as context.
+    assert "/dev/null" not in diff["unified"], diff["unified"]
+    # Context lines exist only against a file the plan knew was there. (The
+    # additions are noisier than the change, because the edit round-trips the
+    # YAML through `safe_dump`, which is how the scaffolded dbt path renders too.)
+    assert " version: 2" in diff["unified"].splitlines()
+    assert "unique" in diff["unified"]
+
+
+def test_the_plan_applies_through_the_formats_own_write_path(sidecar_repo):
+    """A plan a format can store and not apply is not a write path.
+
+    `plans.apply` wrote every plan with dbt's module-level writer, which resolves
+    each edit under the dbt project and re-hashes what it finds on disk. So the
+    plan this format can now store would still have been refused one stage later,
+    and the `write_edits` it implemented to reach tier 3 would never have been
+    called.
+    """
+
+    _grain_drift(sidecar_repo)
+    rc, payload = sidecar_repo.dex("maintain", "reconcile", "grain")
+    assert rc == 0, payload.get("errors")
+
+    rc, applied = sidecar_repo.dex("transform", "apply", payload["data"]["plan_id"])
+
+    assert rc == 0, applied.get("errors")
+    written = (sidecar_repo.root / _SIDECAR).read_text(encoding="utf-8")
+    assert "unique" in written
+    assert "not_null" in written
+
+
+def test_the_format_declaring_its_surface_does_not_widen_it(sidecar_repo):
+    """Containment stays a safety property; only the authority moved.
+
+    The format says which paths it owns, and dex still refuses anything outside
+    them. A format that could name any path would not be declaring a surface, it
+    would be turning the check off, and the check is what keeps a mistaken or
+    adversarial path from reaching the rest of the repository.
+    """
+
+    from exmergo_dex_core.transform.plans import PlanError, contained_key
+
+    surface = SidecarGraphProject.editing_surface(None)
+
+    assert contained_key("declarations/orders.yml", surface)
+    for refused in (
+        "declarations_backup/orders.yml",  # a sibling sharing the prefix
+        "models/staging/stg_orders.yml",  # inside dbt's surface, not this one
+        "../outside.yml",  # an escape, never a format's to permit
+    ):
+        with pytest.raises(PlanError):
+            contained_key(refused, surface)
 
 
 def test_a_placing_format_still_declines_the_staging_model_channel(sidecar_repo):

--- a/packages/dex-core/tests/maintain/test_project_format.py
+++ b/packages/dex-core/tests/maintain/test_project_format.py
@@ -21,12 +21,13 @@ import types
 
 import pytest
 
-from exmergo_dex_core.dbt_project import ProjectDefinitions
+from exmergo_dex_core.dbt_project import ProjectDefinitions, SourceFile
 from exmergo_dex_core.maintain.snapshot import (
     SemanticLayer,
     SourceTable,
     TransformLayer,
 )
+from exmergo_dex_core.transform.plans import EditKind
 
 _NOTE = "models are assets in an orchestrated graph, so no file backs a definition"
 
@@ -152,3 +153,155 @@ def test_the_flag_falls_back_to_dbt_for_one_command(graph_repo):
     assert rc == 0 and payload["status"] == "ok"
     assert payload["data"]["transform_layer"]["file_count"] > 0
     assert _NOTE not in payload["warnings"]
+
+
+_SIDECAR = "declarations/orders.yml"
+
+# The sidecar names its model with dbt's `stg_` prefix. That is not incidental
+# and the test below pins why: placement alone does not carry the naming.
+_SIDECAR_CONTENT = (
+    "version: 2\n"
+    "models:\n"
+    "  - name: stg_orders\n"
+    "    columns:\n"
+    "      - name: order_id\n"
+    "        tests: [not_null]\n"
+)
+
+
+class SidecarView:
+    """The half of a graph-derived project that is a file someone wrote."""
+
+    def __init__(self, root: str, files: dict[str, SourceFile]) -> None:
+        self.root = root
+        self.files = files
+
+
+class SidecarGraphProject(GraphProject):
+    """Tier 3 for one channel only, which is the shape #258 is about.
+
+    The models are a reduction of a running graph and cannot receive an authored
+    staging model. The declared keys live in a hand-written YAML sidecar that
+    nothing regenerates, and that file can receive a `unique` test. Answering
+    `None` for one kind and a path for the other is the whole point of the seam:
+    a single boolean here would have to be wrong about one of the two.
+    """
+
+    name = "sidecar"
+
+    def __init__(self, context) -> None:
+        super().__init__(context)
+        self.written: list = []
+
+    def load(self) -> SidecarView:
+        root = self.context.repo_root or "."
+        return SidecarView(
+            root,
+            {
+                _SIDECAR: SourceFile(
+                    path=_SIDECAR, content=_SIDECAR_CONTENT, sha256="unused"
+                )
+            },
+        )
+
+    def edit_path(self, kind: EditKind, model: str) -> str | None:
+        if kind is EditKind.SCHEMA_YML:
+            return f"declarations/{model}.yml"
+        return None
+
+    def write_edits(self, edits, project_dir=None, *, confirmed: bool = False):
+        self.written.append((edits, project_dir, confirmed))
+        return []
+
+
+@pytest.fixture
+def sidecar_repo(maintain_repo, monkeypatch):
+    module = types.ModuleType("dex_sidecar_format")
+    module.sidecar_project = SidecarGraphProject
+    monkeypatch.setitem(sys.modules, "dex_sidecar_format", module)
+
+    config = maintain_repo.root / ".dex" / "config.yml"
+    config.write_text(
+        config.read_text(encoding="utf-8")
+        + "project:\n  format: dex_sidecar_format:sidecar_project\n",
+        encoding="utf-8",
+    )
+    return maintain_repo
+
+
+def test_the_plan_store_refuses_a_placed_edit_outside_dbts_editing_surface(
+    sidecar_repo,
+):
+    """The third gate, which neither #257 nor #258 describes.
+
+    With the write gate asking a capability and reconcile asking the format
+    where the edit goes, the edit is still refused, and by neither of those: at
+    plan time `plans.plan` calls `load_project` and validates every path against
+    *dbt's* `model_paths`, whatever format produced the edit. So a second format
+    naming a file outside `models/` cannot store a plan even once both of the
+    filed issues are resolved exactly as proposed.
+
+    Pinned as the current behavior rather than fixed here. The containment check
+    is a safety property, not an oversight (writes are confined to a declared
+    editing surface), so widening it means the format declaring that surface,
+    which is a design question and not this seam's to answer.
+    """
+
+    sidecar_repo.snapshot()
+    sidecar_repo.sql("INSERT INTO orders SELECT * FROM orders WHERE order_id <= 10")
+    sidecar_repo.dex("maintain", "grain")
+
+    rc, payload = sidecar_repo.dex("maintain", "reconcile", "grain")
+
+    assert rc == 1 and payload["status"] == "error"
+    assert any(
+        "outside the project's model and macro paths" in message
+        for message in payload["errors"]
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="the plan store validates every edit against dbt's model paths; a "
+    "format has no way to declare its own editing surface yet",
+)
+def test_a_placing_format_receives_the_test_edit_in_its_own_sidecar(sidecar_repo):
+    """The end state, once the third gate above opens.
+
+    Placement is doing its job by this point: reconcile asked the format and
+    built the edit against `declarations/orders.yml` instead of the scaffold
+    path. What is missing is permission to store a plan touching it.
+    """
+
+    sidecar_repo.snapshot()
+    sidecar_repo.sql("INSERT INTO orders SELECT * FROM orders WHERE order_id <= 10")
+    sidecar_repo.dex("maintain", "grain")
+
+    rc, payload = sidecar_repo.dex("maintain", "reconcile", "grain")
+
+    assert rc == 0 and payload["status"] == "ok", payload.get("errors")
+    diff = next((d for d in payload.get("diffs") or [] if d["path"] == _SIDECAR), None)
+    assert diff is not None, payload
+    assert "unique" in diff["unified"]
+    # And nothing was planned against the dbt convention it used to assume.
+    assert not any(
+        d["path"].startswith("models/staging/") for d in payload.get("diffs") or []
+    )
+
+
+def test_a_placing_format_still_declines_the_staging_model_channel(sidecar_repo):
+    """`None` for MODEL_SQL keeps the scaffold channel advisory, by declaration.
+
+    Placement decides where, not what. The staging model's content is dbt SQL the
+    scaffold generates, so a format that cannot host that content declines the
+    kind and reconcile degrades to advice instead of writing dbt into its tree.
+    """
+
+    sidecar_repo.snapshot()
+    sidecar_repo.dex("maintain", "schema")
+
+    rc, payload = sidecar_repo.dex("maintain", "reconcile", "schema")
+
+    assert rc == 0 and payload["status"] == "ok"
+    assert {p["kind"] for p in payload["data"]["proposals"]} == {"advisory"}
+    assert not any(d["path"].endswith(".sql") for d in payload.get("diffs") or [])

--- a/packages/dex-core/tests/maintain/test_project_format.py
+++ b/packages/dex-core/tests/maintain/test_project_format.py
@@ -16,6 +16,7 @@ in-memory graph instead is describing the seam.
 
 from __future__ import annotations
 
+import json
 import sys
 import types
 from pathlib import Path
@@ -378,6 +379,122 @@ def test_the_format_declaring_its_surface_does_not_widen_it(sidecar_repo):
     ):
         with pytest.raises(PlanError):
             contained_key(refused, surface)
+
+
+@pytest.fixture
+def authored_repo(tmp_path, dex, monkeypatch):
+    """The sidecar format alone, with no dbt project sharing its root.
+
+    Deliberately not `sidecar_repo`. That fixture puts `dbt_project.yml` and
+    `declarations/` at the same path, so dbt's directory and the format's view
+    root coincide and a caller confusing the two still lands on the right file.
+    Separating them is what makes the confusion observable, and separated is the
+    normal case for a format that is not dbt: it has no reason to be rooted where
+    a dbt project happens to sit, or for one to exist at all.
+    """
+
+    module = types.ModuleType("dex_sidecar_format")
+    module.sidecar_project = SidecarGraphProject
+    monkeypatch.setitem(sys.modules, "dex_sidecar_format", module)
+
+    root = tmp_path / "repo"
+    (root / ".dex").mkdir(parents=True)
+    (root / ".dex" / "config.yml").write_text(
+        "project:\n  format: dex_sidecar_format:sidecar_project\n", encoding="utf-8"
+    )
+    sidecar = root / _SIDECAR
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(_SIDECAR_CONTENT, encoding="utf-8")
+    return root
+
+
+def _authored_edit(tmp_path: Path, content: str) -> Path:
+    payload = tmp_path / "edits.json"
+    payload.write_text(
+        json.dumps(
+            {"edits": [{"path": _SIDECAR, "kind": "schema_yml", "content": content}]}
+        ),
+        encoding="utf-8",
+    )
+    return payload
+
+
+_AUTHORED = _SIDECAR_CONTENT.replace("tests: [not_null]", "tests: [not_null, unique]")
+
+
+def test_an_authored_plan_needs_no_dbt_project_when_the_format_declares_one(
+    authored_repo, tmp_path, dex
+):
+    """`transform plan` reaches a format that brought its own project.
+
+    The agent-authored path asked the engine for dbt's directory unconditionally
+    and passed it beside the format, so a repository with no `dbt_project.yml`
+    failed while locating a project nothing was going to read. That is the whole
+    write surface for an authored edit (`transform plan`, `transform macro`, and
+    every `semantic define|update|plan` route through the same call), so a format
+    could declare a surface, place an edit into it, and still never be reachable
+    except through reconcile.
+    """
+
+    rc, payload = dex(
+        "--repo-root",
+        str(authored_repo),
+        "transform",
+        "plan",
+        "add a unique test",
+        "--edits-file",
+        str(_authored_edit(tmp_path, _AUTHORED)),
+    )
+
+    assert rc == 0 and payload["status"] == "ok", payload.get("errors")
+    assert payload["data"]["paths"] == [_SIDECAR]
+
+
+def test_an_authored_edit_is_pinned_and_applied_where_the_format_put_it(
+    authored_repo, tmp_path, dex
+):
+    """Both halves come from the format, with a dbt project present to be wrong about.
+
+    dbt lives in a subdirectory here, so a plan pinned against dbt's directory
+    resolves this edit under `analytics/` on the way out: the file it hashed is
+    not the file it writes. That reads as a create against a hand-written file,
+    and the apply that follows either conflicts on a file nobody edited or lands
+    the write in a tree that never had one.
+    """
+
+    (authored_repo / "analytics").mkdir()
+    (authored_repo / "analytics" / "dbt_project.yml").write_text(
+        "name: dex_test\nversion: '1.0.0'\nprofile: dex_test\n", encoding="utf-8"
+    )
+
+    rc, payload = dex(
+        "--repo-root",
+        str(authored_repo),
+        "transform",
+        "plan",
+        "add a unique test",
+        "--edits-file",
+        str(_authored_edit(tmp_path, _AUTHORED)),
+    )
+    assert rc == 0, payload.get("errors")
+    # Pinned against the file that is there, so the diff is the one-line change
+    # rather than a hand-written file appearing from nowhere.
+    diff = next(d for d in payload["diffs"] if d["path"] == _SIDECAR)
+    assert "/dev/null" not in diff["unified"], diff["unified"]
+
+    rc, applied = dex(
+        "--repo-root",
+        str(authored_repo),
+        "transform",
+        "apply",
+        payload["data"]["plan_id"],
+    )
+
+    assert rc == 0, applied.get("errors")
+    assert not applied["data"].get("conflicts")
+    assert applied["data"]["written"] == [_SIDECAR]
+    assert "unique" in (authored_repo / _SIDECAR).read_text(encoding="utf-8")
+    assert not (authored_repo / "analytics" / _SIDECAR).exists()
 
 
 def test_a_placing_format_still_declines_the_staging_model_channel(sidecar_repo):

--- a/packages/dex-core/tests/maintain/test_reconcile.py
+++ b/packages/dex-core/tests/maintain/test_reconcile.py
@@ -286,3 +286,30 @@ def test_orphan_relation_reconcile_is_advisory_with_drop_statement(maintain_repo
     assert orphan_proposals and all(p["kind"] == "advisory" for p in orphan_proposals)
     assert "DROP TABLE" in orphan_proposals[0]["action"]
     assert "warehouse.main.stg_orders" in orphan_proposals[0]["action"]
+
+
+def test_the_no_format_fallback_answers_exactly_what_dbt_answers():
+    """`_placed(None, ...)` is `DbtProject.edit_path` inlined, including its `None`.
+
+    The fallback exists for callers holding no format and is documented as the
+    dbt scaffold convention, so the two have to agree about every kind or the
+    convention has two definitions. Declining is the half that is easy to lose:
+    a suffix picked by "SQL or otherwise" answers a `models/staging/*.yml` path
+    for kinds that have nothing to do with staging models, and a path is not
+    `None`, so the caller builds an edit instead of degrading to the advisory it
+    produces for a kind nobody can place.
+    """
+
+    from exmergo_dex_core.adapters.project import DbtProject
+    from exmergo_dex_core.maintain.reconcile import _placed
+    from exmergo_dex_core.transform.plans import EditKind
+
+    for kind in EditKind:
+        assert _placed(None, kind, "orders") == DbtProject().edit_path(kind, "orders")
+
+    # And the two kinds reconcile proposes still resolve, so the parity above is
+    # not both sides having gone silent.
+    staged = "models/staging/stg_orders"
+    assert _placed(None, EditKind.MODEL_SQL, "orders") == f"{staged}.sql"
+    assert _placed(None, EditKind.SCHEMA_YML, "orders") == f"{staged}.yml"
+    assert _placed(None, EditKind.MACRO_SQL, "orders") is None

--- a/references/project.md
+++ b/references/project.md
@@ -40,6 +40,15 @@ implementation is complete rather than partial.
 `isinstance` rather than declared, so a format cannot claim a tier it has not
 implemented.
 
+One protocol sits beside the tiers rather than in them, `PlacingProject`, and
+reaching `reconcile`'s write path means implementing it as well as tier 3. It is
+described under [Where an edit lands](#where-an-edit-lands-and-what-you-own)
+below. It is beside rather than on tier 3 because these protocols are
+`runtime_checkable`: a method added to tier 3 would demote every format that has
+not implemented it yet, so `tier_of` would start answering 2 where it answered 3
+and the write path would close for exactly the implementers who were already
+passing.
+
 **Tier 1 is where the value is concentrated, and it is easy to underestimate.**
 Declared keys and declared joins reach dex through `definitions()` and through no
 other channel: not through the layers, not through a content hash. A format that
@@ -70,13 +79,13 @@ proposal, with no edits and no stored plan, and a warning naming the format and 
 tier it declined. The findings themselves are still surfaced: declining the write
 tier removes dex's authority to author an edit, not your need to see the drift.
 
-That used to hold by accident. Reconcile's two mechanical write paths gate on the
-`models/staging/stg_<table>.*` scaffold convention and fail closed, so a generated
+That used to hold by accident. Reconcile's two mechanical write paths gated on the
+`models/staging/stg_<table>.*` scaffold convention and failed closed, so a generated
 tree was safe as long as its own directory naming happened not to collide, and a
-format whose layers used that vocabulary would have been written into. The
-convention checks are still there as a second line; what changed is that the tier is
-asked first, so the guarantee rests on what your format declared rather than on what
-it happened to be called.
+format whose layers used that vocabulary would have been written into. The guarantee
+now rests on what your format declared rather than on what it happened to be called:
+the tier is asked first, and the paths themselves come from the format rather than
+from that convention.
 
 **If you do implement tier 3, two parameters carry the whole safety story.**
 
@@ -99,6 +108,66 @@ With `confirmed=True` that someone has looked and said to go ahead. A write path
 cannot receive `confirmed` silently overwrites the work, which is the failure this
 seam exists to prevent, so `EditableProjectContract` asserts the behavior rather than
 trusting it: no check on the shape of your class can see it.
+
+**What you return has to say what happened.** `transform apply` reads `written` to
+decide whether the plan is now applied and `conflicts` to decide whether to show a
+human the divergence and ask. A result answering neither fails in both directions at
+once: a plan recorded as applied that wrote nothing, or a conflict that never reaches
+the person it was raised for. Return `dbt_project.ApplyResult`, or anything exposing
+those two.
+
+## Where an edit lands, and what you own
+
+Tier 3 says your format *can* receive an edit. It does not say where the edit goes,
+and reconcile decides that before it consults you. `PlacingProject` is where you
+answer, and reaching the write path means implementing both of its methods.
+
+```python
+from exmergo_dex_core.transform.plans import EditKind
+
+
+class MyProject:  # ... tier 3 methods as above
+    def edit_path(self, kind: EditKind, model: str) -> str | None:
+        if kind is EditKind.SCHEMA_YML:
+            return f"declarations/{model}.yml"
+        return None  # no authored staging model in this format
+
+    def editing_surface(self) -> list[str]:
+        return ["declarations"]
+```
+
+`edit_path(kind, model)` says where an edit of that kind for that table lives. Two
+things about it are easy to get wrong. `model` is the warehouse table the finding is
+about, not a model name in your vocabulary: the `stg_` prefix is dbt's own scaffold
+convention and dex does not apply it here. And the return is a key into whatever your
+`load()` returns rather than a filesystem path, because your format already owns that
+keyspace.
+
+**Answering `None` for a kind is a complete answer, not a degenerate one.** The kinds
+are not equally receivable and you are expected to differ across them. `SCHEMA_YML`
+is a mutation of a file you already have. `MODEL_SQL` carries dbt SQL that dex
+generates alongside the path, so placement alone cannot open that channel: a format
+that places a staging model elsewhere gets the proposal as advice rather than having
+dbt written into its tree. One `None` and one path is the shape this exists for.
+
+`editing_surface()` declares the region those paths must stay inside, and it is a
+different question with a different caller. `transform plan` validates edits an agent
+authored, where there is no `(kind, model)` pair to ask `edit_path` about and no
+prior answer to compare against, only a path and the question of whether it is inside
+what you admit to owning. Prefixes are matched by path segment, so `declarations`
+admits `declarations/orders.yml` and does not admit `declarations_backup/orders.yml`.
+Absolute paths and paths climbing out through `..` are refused ahead of this and are
+not yours to permit. An empty list is coherent: it refuses every edit rather than
+admitting all of them, which is the same statement declining tier 3 makes.
+
+This is containment, which is a safety property and stays mandatory. What the seam
+moved is who declares the surface, not whether there is one.
+
+**One thing dex still spells its own way.** The `unique` test edit finds your model
+inside the placed file by the file's own name (`declarations/orders.yml` means a
+model named `orders`). If you pack several models into one file, no entry matches and
+you get a warning instead of an edit, which is a refusal to guess rather than a wrong
+write.
 
 ## The one rule that is not visible in the signatures
 
@@ -195,7 +264,8 @@ class TestMyProject(ExploreProjectContract):
 pytest collects the inherited assertions and runs the contract against your format.
 Use `MaintainProjectContract` instead if you reach tier 2, `EditableProjectContract`
 if you reach tier 3, mix `DeclaringProjectContract` and `SemanticProjectContract`
-beside it for the content your format declares, and mix
+beside it for the content your format declares, mix `PlacingProjectContract` beside
+it if you implement placement, and mix
 `ProjectFactoryContract` in front of it if dex will build your format from a name
 rather than be handed an instance. Construction is a separate contract, so a format
 that passes the behavioral suite can still be unreachable from configuration; "the
@@ -276,6 +346,18 @@ rather than skipping because the excuse that justifies skipping
 unparseable state, but a format that reached tier 3 writes into a source of truth a
 human can also edit, so the case where the human got there first exists for all of
 them.
+
+`PlacingProjectContract`, mixed in beside it, has one hook that is likewise not
+optional. `placeable_model()` returns a warehouse table your format would place an
+edit for, spelled as the warehouse spells it rather than as your format names the
+model derived from it, because that is how reconcile's findings arrive and it is the
+thing `edit_path` is most often gotten wrong on. The assertions are cheap and mostly
+about your two answers agreeing: at least one kind places somewhere, every path
+`edit_path` returns is inside `editing_surface()`, and the surface itself stays
+within the project. The middle one is the reason the contract exists, since a
+placement outside your own declared surface builds a proposal the plan store then
+refuses, and from the outside that reads as dex declining rather than as the format
+contradicting itself.
 
 The suite needs only pytest: no dialect engine, no connector. A packaging test keeps
 it that way.


### PR DESCRIPTION
## What this changes

Both issues, and the two gates behind them that neither describes. Marco's call on the design question this PR was opened to ask: containment widens so a format can declare its own editing surface, and dbt's stays intact.

**The two issues are one seam.** #257 is a class check deciding *whether* a format may receive an edit, #258 is hard-coded paths deciding *where*. They separate less than they look: the paths reconcile builds are not filesystem paths, they are keys into the view the format's own `load()` returned (`reconcile.py` looks up `model_path not in view.files` and `view.files.get(path)`). So a format that answers "where does an edit of this kind for this table go" supplies both. `PlacingProject` asks that question, and the gate stops asking `isinstance(editable, DbtProject)`.

**It sits beside `EditableProject`, not on it.** The tiers are `runtime_checkable`, so a method added to tier 3 demotes every format that has not implemented it yet: `tier_of` starts answering 2 where it answered 3, and the write path closes for exactly the implementers who were already passing.

## The two further gates, both now open

**Containment, at plan time.** `plans.plan` validated every edit against **dbt's** `model_paths` whatever format produced it, so a second format placing a declaration sidecar was refused even with #257 and #258 resolved exactly as proposed. `editing_surface()` is where a format declares the region its edits may land in, and containment reads that declaration. It stays a safety property and stays mandatory; only the authority moved. A format that declares no surface validates against dbt's, as before.

It is a second method rather than a widened `edit_path` because `transform plan` validates edits an *agent* authored: there is no `(kind, model)` pair to ask placement about and no prior answer to compare against, only a path and the question of whether the format admits to owning it.

**The pin has to come from the same view as the surface.** Reconcile already built the sidecar's *content* from the format's view while `plans.plan` read `view.files` off dbt's. Widening containment alone leaves those two disagreeing, which is not a refusal but a quiet defect: the sidecar pins `old_content_hash=None`, the reviewable diff renders an existing hand-written file as a whole-file create, and the apply that follows reports a conflict on a file nobody touched. Both halves now come from the format.

**A fourth gate, at apply time.** `plans.apply` wrote every plan with `dbt_project.write_edits`, which resolves each edit under the dbt project and re-hashes what it finds on disk. So the plan a format can now store would have been refused one stage later, and the tier-3 `write_edits` it implemented would never have been called. A plan a format can store and not apply is not a write path, so `transform apply` routes through the format the plan was planned against.

That one comes with a widening of the tier-3 contract, which is the change here most worth your eye: `EditableProject.write_edits` now documents that its return has to report `written` and `conflicts`, and `EditableProjectContract` asserts it. The apply path reads both to tell a refusal from a write, and a result answering neither fails in both directions at once. A format returning `dbt_project.ApplyResult`, or anything exposing those two, already satisfies it.

## dbt is unchanged, by construction

`edit_path` returns the scaffold convention reconcile hard-coded. `editing_surface` returns the configured model and macro paths containment already read. The root manifests are still allowed by name, the macro and root-config kind checks still run, `validate_deletions` and the missing-macro warnings still run, and a plan planned against dbt is still written by dbt's writer.

Which validations apply is asked of the **view's shape**, not of the format's class: a format handing back a `DbtProjectView` is offering dbt's surface and gets dbt's checks. That keeps the seam from growing back the `isinstance(project, DbtProject)` gate it exists to remove.

## Two smaller findings, both fixed rather than flagged

**The kinds are not equally reachable, and `None` per kind is load-bearing.** `SCHEMA_YML` is a mutation of the format's own file. `MODEL_SQL` carries dbt SQL that `model_edits` generates alongside the path, so placement alone cannot open that channel; a format that places a staging model elsewhere is refused rather than written into. This is the argument for a seam over a boolean: a single flag would have to be wrong about one of the two kinds for the graph-derived format that motivated #258.

**The convention leaked through content, not only paths.** `_grain_test_edits` matched `model.get("name") == f"stg_{table}"` inside the YAML, so a sidecar naming its model `orders` was missed even when the path resolved. It now reads the model from the file the format chose, which is the same string for dbt (`models/staging/stg_<table>.yml` has stem `stg_<table>`). The fixture no longer needs the `stg_` prefix to get that far, which is what pins it. The miss also has its own warning now instead of sharing a silent `continue` with the already-alerting case.

## Conformance

`PlacingProjectContract` ships beside the others, and `TestDbtProject` mixes it in so the shipped format runs what a third party runs. Its one assertion worth having is the cross-check neither method can make alone: every path `edit_path` returns has to be inside `editing_surface()`. A format placing outside its own declared surface builds a proposal the plan store then refuses, and from the outside that reads as dex declining rather than as the format contradicting itself.

## Related issues

Closes #257. Closes #258.

## Checklist

- [x] Tests pass (`uv run pytest` in `packages/dex-core`): 1996 passed, 80 skipped
- [x] Eval scoring-core tests pass (`uvx pytest evals`): 26 passed
- [x] If a safety path is touched, the spine still holds: read-only against data, cost-guarded, PII flagged not surfaced, propose-don't-impose
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free (checked in CI)
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures

On the safety box, since this PR moves a guard. Containment was the safety property under discussion and it is still enforced on every edit, still ahead of any write, and still refuses escapes (absolute paths, `..`) without consulting the format at all. What changed is that dbt no longer answers the question on another format's behalf. Propose-don't-impose is likewise unchanged and now reaches further: a second format's plan goes through the same hash-pinned, conflict-refusing apply, which is what the widened `write_edits` return exists to keep honest.
