### PR TITLE
A dev-target refusal should not mix path separators mid-sentence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   multi-column grain to express. `DbtProject` implements all three in
   `tests/adapters/test_project_parity.py`, so the shipped format is held to them too.
 
+### Fixed
+
+- **A dev-target refusal no longer mixes path separators mid-sentence on
+  Windows.** The message names the config file beside the profile it disagrees
+  with, and the first half is built from a literal (`.dex/config.yml`) while the
+  second took the platform separator, so a Windows reader got
+  `.dex/config.yml and analytics\profiles.yml`. Both halves are repo-relative
+  labels a reader matches against paths written in configuration rather than
+  paths anything opens, so both now use forward slashes. The assertion that
+  covers it was passing on CI and failing on a Windows checkout, which is the
+  other half of the same bug.
+
 ## [1.6.2] - 2026-08-09
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/dev_target.py
@@ -807,7 +807,16 @@ def _declares_sources(project: Path) -> bool:
 
 
 def _relative(path: Path, repo_root: Path | str) -> str:
+    """A repo-relative path for display, with forward slashes on every platform.
+
+    The messages this feeds name it beside `.dex/config.yml`, which is built from
+    a literal and so always uses forward slashes. Returning the native separator
+    made the two halves of one sentence disagree on Windows:
+    ``.dex/config.yml and analytics\\profiles.yml``. These are labels a reader
+    matches against paths written in configuration, not paths anything opens.
+    """
+
     try:
-        return str(path.resolve().relative_to(Path(repo_root).resolve()))
+        return path.resolve().relative_to(Path(repo_root).resolve()).as_posix()
     except ValueError:
-        return str(path)
+        return path.as_posix()


### PR DESCRIPTION
## What this changes

`transform`'s dev-target refusal names the config file beside the profile it disagrees with. The first half of that sentence is built from a literal and always used forward slashes; the second came from `_relative`, which returned the platform separator. So on a Windows checkout one sentence read:

```
.dex/config.yml and analytics\profiles.yml disagree about the dev target:
```

Both halves are repo-relative labels a reader matches against paths written in configuration, not paths anything opens, so both use forward slashes now. `_relative` has a single call site, so the change is contained to this message.

The other half of the same bug is that `test_retargeted_dev_database_is_refused_naming_both_values` asserts `"analytics/profiles.yml" in message`, so it passes on your Linux CI and fails on a Windows checkout. I left the assertion as written rather than loosening it to accept either separator, on the grounds that the message really should not vary by platform here. If you would rather keep the native separator and relax the test instead, say so and I will flip it.

Found while running the suite on Windows against `81d57d2`. Mentioned in passing on #263; sending it separately as offered there.

## Related issues

None. Unfiled, and small enough that a PR seemed better than an issue first.

## Checklist

- [x] Tests pass (`uv run pytest` in `packages/dex-core`)
- [x] Eval scoring-core tests pass (`uvx pytest evals`)
- [x] If a safety path is touched, the spine still holds: read-only against data, cost-guarded, PII flagged not surfaced, propose-don't-impose
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free (checked in CI)
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures

On the local run: 1868 passed, 34 failed, and all 34 need the `dbt` CLI on PATH, which this box does not have. That count was 35 before this change and the one that went away is the assertion above. No safety path is touched; the box is ticked because the refusal itself is a guardrail and it still refuses, with the same two values named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
