### PR TITLE
`explore query` and `explore cluster` decide from the cache without opening a connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,17 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   reaches the same opener afterwards and raises there, which is where a caller
   about to run SQL wants to hear it.
 
+- **`explore cluster` refuses from the cache again without a connection.** The
+  same probe was added to `cluster` in the same change, in front of the two
+  things that command decides from the cache alone: that there is no cache at
+  all, and that the named object is not in it. Both refusals sat below the
+  acquisition, so both became connector errors. `auto_profile` defaults to
+  `true`, which made this the ordinary path rather than an opt-in one, and
+  `--no-auto-profile` the only remaining way to reach either refusal offline.
+  The same fall-through applies, with the same limit: an object that *is*
+  profiled still needs a connection to build its sample, so it reaches the
+  opener at the bottom of `cluster` and raises there.
+
 ## [1.6.3] - 2026-08-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,26 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   silence, which was indistinguishable from dex deciding the test was already
   there.
 
+### Fixed
+
+- **The PII firewall decides again without a warehouse connection.** Since 1.6.3,
+  `explore query` opened a connection before the guard ran: the object-gap probe
+  added with the auto-profiling work took an already-open adapter, and the
+  acquisition ahead of it was unguarded. Every query naming a relation therefore
+  needed a reachable warehouse before the firewall could refuse anything, so a
+  caller holding a profiled cache and no connector got a connector error where
+  1.6.2 returned a refusal. That reaches further than an inconvenience: the guard
+  reads cached PII flags and needs no warehouse to decide, so gating it on a
+  connection turns a policy decision into a connectivity one and closes the
+  firewall in exactly the offline environments that cannot bill for a mistake.
+
+  The acquisition is now as tolerant as the use one level below it, where an
+  unreadable column signature already "settles nothing" and falls through. A
+  failed open settles nothing either. Drift detection is unchanged wherever a
+  connection exists, and nothing is swallowed: a statement that passes the guard
+  reaches the same opener afterwards and raises there, which is where a caller
+  about to run SQL wants to hear it.
+
 ## [1.6.3] - 2026-08-10
 
 ### Changed

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -1828,7 +1828,22 @@ def cluster(
     warnings: list[str] = []
     profiled_names: list[str] = []
     if auto:
-        adapter = engine._adapter("explore cluster")
+        try:
+            adapter = engine._adapter("explore cluster")
+        except DexError:
+            # The same tolerance the query path applies, at the second site the
+            # object-gap probe was added to. `cluster` decides two things from
+            # the cache alone -- "there is no cache" and "that object is not in
+            # it" -- and both refusals sit below this acquisition, so gating it
+            # here made them unreachable wherever no connector is installed.
+            #
+            # `auto_profile` defaults to True, so this is the ordinary path and
+            # not an opt-in one; `--no-auto-profile` was the only way left to
+            # reach either refusal offline. Nothing is swallowed: an object that
+            # IS profiled still needs a connection to build its sample, reaches
+            # the opener at the bottom of this function, and raises there.
+            adapter = None
+    if adapter is not None:
         gap = _object_gap(adapter, cache, [obj])
         if gap.absent:
             raise RequestError(gap.refusal())

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -49,7 +49,7 @@ from ..config import (
     blob_override_paths,
     pii_override_paths,
 )
-from ..errors import PrerequisiteError, RequestError
+from ..errors import DexError, PrerequisiteError, RequestError
 from ..guards.cost_guard import (
     ConfirmationRequiredError,
     CostGuardError,
@@ -1014,7 +1014,24 @@ def _run_statements(
 
         named = list(dict.fromkeys(name for names in reads.values() for name in names))
         if named:
-            shared.adapter = engine._adapter("explore query")
+            try:
+                shared.adapter = engine._adapter("explore query")
+            except DexError:
+                # No connection settles nothing, exactly as an unreadable column
+                # signature settles nothing inside `_object_gap`. That tolerance
+                # already exists one level down; it was missing here, at the
+                # acquisition, and the difference is not cosmetic: the guard below
+                # decides from cached PII flags and needs no warehouse at all, so
+                # letting an absent connector stop it turns a policy decision into
+                # a connectivity one and closes the firewall in exactly the
+                # offline environments that cannot bill for a mistake.
+                #
+                # Nothing is swallowed. A statement that PASSES the guard reaches
+                # the same opener below and raises there, which is where a caller
+                # who is about to run SQL wants to hear that the warehouse is
+                # unreachable. Only a refusal now returns without it.
+                shared.adapter = None
+        if shared.adapter is not None:
             gap = _object_gap(shared.adapter, cache, named)
             if gap.absent:
                 # Only the statements that named a missing object are refused; a

--- a/packages/dex-core/tests/explore/conftest.py
+++ b/packages/dex-core/tests/explore/conftest.py
@@ -18,6 +18,24 @@ def _isolated_repo_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.chdir(tmp_path)
 
 
+def unreachable_warehouse(monkeypatch) -> None:
+    """Every attempt to open a connection fails, the way an uninstalled connector
+    extra or an absent credential fails. Applied AFTER the cache exists, because
+    building one legitimately needs the warehouse this then takes away.
+
+    Shared by `test_query.py` and `test_cluster.py`: #269 hoisted an adapter
+    acquisition in front of a cache-decided refusal in *both* commands, so both
+    need the same warehouse taken away from underneath them."""
+
+    from exmergo_dex_core.engine import DexEngine
+    from exmergo_dex_core.errors import ConnectorError
+
+    def _refuse(self, *args, **kwargs):
+        raise ConnectorError("the connector extra is not installed")
+
+    monkeypatch.setattr(DexEngine, "_adapter", _refuse)
+
+
 @pytest.fixture
 def airbnb_duckdb(tmp_path: Path) -> Path:
     """Three raw tables: person-name and free-text columns that must be flagged,

--- a/packages/dex-core/tests/explore/test_cluster.py
+++ b/packages/dex-core/tests/explore/test_cluster.py
@@ -20,6 +20,8 @@ from exmergo_dex_core.explore import cluster as cluster_mod
 from exmergo_dex_core.explore import commands
 from exmergo_dex_core.guards.sql_guard import assert_select_only
 
+from .conftest import unreachable_warehouse
+
 _HAS_SKLEARN = importlib.util.find_spec("sklearn") is not None
 requires_sklearn = pytest.mark.skipif(
     not _HAS_SKLEARN, reason="needs the [cluster] extra (scikit-learn)"
@@ -182,6 +184,67 @@ def test_cluster_without_cache_is_refused_with_the_fix(
     assert not (repo / ".dex").exists(), "a refused gate writes nothing"
     # A machine-readable reason alongside the prose.
     assert payload["reason"] == "prerequisite"
+
+
+@requires_sklearn
+def test_a_cluster_prerequisite_refusal_needs_no_connection(
+    clusterable_duckdb: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """The second site of the same #269 hoist, and the reason this file changed
+    alongside `test_query.py`.
+
+    `cluster` decides from the cache twice -- "no cache at all" and "that object
+    is not in it" -- and both refusals moved *behind* `engine._adapter` when the
+    object-gap probe was added. `auto_profile` defaults to True, so this is the
+    ordinary path rather than an opt-in one, and the refusal a caller holding
+    only a cache used to get became a connectivity error instead.
+
+    Measured, not read: at 1.6.2 this returned `reason: prerequisite`; at 1.6.3
+    the same invocation returns a connector failure.
+    """
+
+    repo = _mapped_repo(clusterable_duckdb, tmp_path, capsys)
+    unreachable_warehouse(monkeypatch)
+
+    rc = main(
+        [
+            "explore",
+            "cluster",
+            "not_a_table",
+            "--path",
+            str(clusterable_duckdb),
+            "--repo-root",
+            str(repo),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 1 and payload["status"] == "error", payload
+    message = payload["errors"][0]
+    assert "not a profiled object" in message, (
+        "the cache-decided refusal did not survive an unreachable warehouse; it "
+        f"is being gated on a connection it does not need. Got: {message!r}"
+    )
+    assert payload["reason"] == "prerequisite", payload["reason"]
+
+
+@requires_sklearn
+def test_a_cluster_that_passes_the_cache_gate_still_reports_an_unreachable_warehouse(
+    clusterable_duckdb: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """The control for the test above, and the reason it is not a swallowed error.
+
+    Tolerating a failed open is worth nothing if it hides the failure from a
+    caller about to scan. It does not: only a refusal returns without a
+    connection, and a profiled object still needs one to build its sample, so it
+    reaches the opener at the bottom of `cluster` and raises there.
+    """
+
+    repo = _mapped_repo(clusterable_duckdb, tmp_path, capsys)
+    unreachable_warehouse(monkeypatch)
+
+    payload = _cluster(clusterable_duckdb, repo, capsys=capsys, expect_error=True)
+    assert "connector extra is not installed" in payload["errors"][0]
 
 
 @requires_sklearn

--- a/packages/dex-core/tests/explore/test_query.py
+++ b/packages/dex-core/tests/explore/test_query.py
@@ -386,6 +386,75 @@ def test_pii_carrying_query_is_refused_and_logged(
     assert "NAME" in entries[-1]["reason"]
 
 
+def _unreachable_warehouse(monkeypatch) -> None:
+    """Every attempt to open a connection fails, the way an uninstalled connector
+    extra or an absent credential fails. Applied AFTER the cache exists, because
+    building one legitimately needs the warehouse this then takes away."""
+    from exmergo_dex_core.engine import DexEngine
+    from exmergo_dex_core.errors import ConnectorError
+
+    def _refuse(self, *args, **kwargs):
+        raise ConnectorError("the connector extra is not installed")
+
+    monkeypatch.setattr(DexEngine, "_adapter", _refuse)
+
+
+def test_a_pii_refusal_needs_no_connection(
+    airbnb_duckdb: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """The firewall decides from cached flags, so it must decide with the
+    warehouse unreachable.
+
+    Regression: the object-gap probe added in #269 opened a connection before
+    this guard ran, which turned a policy refusal into a connectivity error and
+    closed the firewall wherever no connector is installed -- CI, an offline
+    box, any caller holding only a cache. `_object_gap` already treats an
+    unreadable column signature as settling nothing; an absent connection is the
+    same kind of doubt and now falls through the same way.
+    """
+    repo = _mapped_repo(airbnb_duckdb, tmp_path, capsys)
+    _unreachable_warehouse(monkeypatch)
+
+    payload = _query(
+        "SELECT MIN(NAME) FROM RAW_HOSTS",
+        airbnb_duckdb,
+        repo,
+        capsys,
+        expect_error=True,
+    )
+
+    message = payload["errors"][0]
+    assert "query refused" in message, (
+        "the PII refusal did not survive an unreachable warehouse; the guard is "
+        f"being gated on a connection it does not need. Got: {message!r}"
+    )
+    assert "RAW_HOSTS.NAME" in message and "(name)" in message
+    assert _log_entries(repo)[-1]["decision"] == "refused"
+
+
+def test_a_query_that_passes_the_guard_still_reports_an_unreachable_warehouse(
+    airbnb_duckdb: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """The control for the test above, and the reason it is not a swallowed error.
+
+    Tolerating a failed open would be worth nothing if it hid the failure from a
+    caller about to run SQL. It does not: only a refusal returns without a
+    connection, and anything still live reaches the opener again and raises there.
+    """
+    repo = _mapped_repo(airbnb_duckdb, tmp_path, capsys)
+    _unreachable_warehouse(monkeypatch)
+
+    payload = _query(
+        "SELECT COUNT(*) FROM RAW_HOSTS",
+        airbnb_duckdb,
+        repo,
+        capsys,
+        expect_error=True,
+    )
+
+    assert "connector extra is not installed" in payload["errors"][0]
+
+
 def test_write_and_pragma_are_refused(airbnb_duckdb: Path, tmp_path: Path, capsys):
     repo = _mapped_repo(airbnb_duckdb, tmp_path, capsys)
     for sql in ("INSERT INTO RAW_HOSTS VALUES (9, 'x')", "PRAGMA database_list"):

--- a/packages/dex-core/tests/explore/test_query.py
+++ b/packages/dex-core/tests/explore/test_query.py
@@ -15,6 +15,8 @@ from exmergo_dex_core.config import DexConfig, QueryLimits, save_config
 from exmergo_dex_core.storage import FilesystemStore
 from exmergo_dex_core.storage.filesystem import QUERIES_FILE
 
+from .conftest import unreachable_warehouse
+
 
 def _run(argv: list[str], capsys, *, expect_error: bool = False) -> dict:
     rc = main(argv)
@@ -386,19 +388,6 @@ def test_pii_carrying_query_is_refused_and_logged(
     assert "NAME" in entries[-1]["reason"]
 
 
-def _unreachable_warehouse(monkeypatch) -> None:
-    """Every attempt to open a connection fails, the way an uninstalled connector
-    extra or an absent credential fails. Applied AFTER the cache exists, because
-    building one legitimately needs the warehouse this then takes away."""
-    from exmergo_dex_core.engine import DexEngine
-    from exmergo_dex_core.errors import ConnectorError
-
-    def _refuse(self, *args, **kwargs):
-        raise ConnectorError("the connector extra is not installed")
-
-    monkeypatch.setattr(DexEngine, "_adapter", _refuse)
-
-
 def test_a_pii_refusal_needs_no_connection(
     airbnb_duckdb: Path, tmp_path: Path, capsys, monkeypatch
 ):
@@ -413,7 +402,7 @@ def test_a_pii_refusal_needs_no_connection(
     same kind of doubt and now falls through the same way.
     """
     repo = _mapped_repo(airbnb_duckdb, tmp_path, capsys)
-    _unreachable_warehouse(monkeypatch)
+    unreachable_warehouse(monkeypatch)
 
     payload = _query(
         "SELECT MIN(NAME) FROM RAW_HOSTS",
@@ -442,7 +431,7 @@ def test_a_query_that_passes_the_guard_still_reports_an_unreachable_warehouse(
     connection, and anything still live reaches the opener again and raises there.
     """
     repo = _mapped_repo(airbnb_duckdb, tmp_path, capsys)
-    _unreachable_warehouse(monkeypatch)
+    unreachable_warehouse(monkeypatch)
 
     payload = _query(
         "SELECT COUNT(*) FROM RAW_HOSTS",


### PR DESCRIPTION
## What this changes

`explore query` opened a warehouse connection before the PII firewall ran. One line:

```python
named = list(dict.fromkeys(name for names in reads.values() for name in names))
if named:
    shared.adapter = engine._adapter("explore query")   # unguarded
    gap = _object_gap(shared.adapter, cache, named)
```

`named` is non-empty for essentially every real query, so this is the ordinary path rather than an edge case. A caller holding a profiled cache and no reachable connector now gets a connector error where 1.6.2 returned a refusal.

**Why that is more than an inconvenience.** The guard decides from cached PII flags. It needs no warehouse to reach its answer, so gating it on a connection converts a policy decision into a connectivity one, and it fails in the direction that matters: the firewall is closed in exactly the environments that cannot bill for a mistake. CI, an offline box, anything holding only a cache.

**The fix is a consistency fix rather than a new tolerance.** `_object_gap` already declines to conclude anything from a connection it could not read:

```python
try:
    _meta, columns = adapter.table_metadata(identifier)
except Exception:  # noqa: S112 -- an unreadable signature settles nothing
    continue
```

That tolerance exists one level below the acquisition and was missing at it. "No adapter at all" is the same category of doubt as "unreadable signature", and it now falls through the same way.

**Nothing is swallowed, and this is the half worth checking.** Only a refusal returns without a connection. A statement that *passes* the guard reaches `shared.adapter or engine._adapter(...)` below and raises there, which is where a caller about to run SQL wants to hear that the warehouse is unreachable. The second test asserts exactly that.

Drift detection is untouched: wherever a connection exists, `_object_gap` runs as before and #269 keeps everything it was built for. The change is only about what happens when there is no connection to be had.

## The second site: `explore cluster`

Added after the first review pass, by asking what *else* #269 changed rather than
what its symptom was. #269's own title names two commands, and `cluster` took the
identical unguarded acquisition:

```python
if auto:
    adapter = engine._adapter("explore cluster")   # unguarded
    gap = _object_gap(adapter, cache, [obj])
```

It sits above the two things `cluster` decides from the cache alone, and both are
refusals: `no exploration cache yet` and `'<obj>' is not a profiled object`. At
1.6.2 both returned before any connection; at 1.6.3 both are connector errors.
`auto_profile` defaults to `true`, so this is the ordinary path and not an opt-in
one, which leaves `--no-auto-profile` as the only way to reach either refusal
offline.

**The claim here is narrower than the one above, and deliberately so.** This half
is not the PII firewall. `cluster` drops PII-flagged columns during feature
selection, but that only matters for an object that *is* profiled, which needs a
connection anyway to build its sample. What regressed is a prerequisite refusal,
not a policy one. Both are the same defect in the same change, so they are fixed
together, but only the query half closes a safety hole.

Measured rather than read, on the installed wheels:

| | 1.6.2 | 1.6.3 |
|---|---|---|
| `explore cluster` on an object not in the cache, warehouse unreachable | `reason: prerequisite` | connector failure |

The fix is the query path's fall-through applied unchanged, and its limit is the
same: a profiled object still reaches the opener at the bottom of `cluster` and
raises there. `_unreachable_warehouse` moves to `conftest.py` as
`unreachable_warehouse`, since two test files now need it.

## Scope

The batching rework is not implicated; the probe simply landed in front of the guard. I have deliberately **not** reordered `inspect_query` ahead of `_object_gap`, which would also turn the symptom green but at the cost of the drift check that probe exists to perform.

## How this was found

Downstream, on a bump to 1.6.3. `catincloud-labs-vps` carries a control asserting that a PII refusal is free and offline, built on a synthetic cache and deliberately no credentials, and it went red on the bump. The relevant part of its contract:

> `explore/commands.py::query` reads the cache, masks overridden columns, and calls `inspect_query` (the firewall) **before** `engine._adapter(...)` ever opens a connection. A refusal returns without credentials, network, or billing.

Reproduced two ways, which is what ruled out a local environment: with no credentials it asked for ADC, and on CI with no BigQuery extra it asked for the connector. Two messages, one cause.

## Verification

Proven red before green, since a guard that cannot fail is the thing this repo keeps finding:

- With the test in place and the acquisition unguarded, `test_a_pii_refusal_needs_no_connection` **fails**: `assert 'query refused' in 'the connector extra is not installed'`. That is the regression, reproduced in-tree.
- With the fix, both new tests pass.
- The cluster half was proven the same way: `test_a_cluster_prerequisite_refusal_needs_no_connection` fails as `assert 'not a profiled object' in 'the connector extra is not installed'` with the acquisition unguarded, and the guard was then **reviewed by mutation**: deleting it turns the test red again and restoring it green.
- Full suite on Windows, all CI extras synced: **2070 passed, 65 skipped, zero failures**. Re-measured after rebasing onto `d61e4db`; the count moved from 2056 because #263 landed in between, and none of the arrivals fail here.
- `ruff check` and `ruff format --check` clean on both touched files.

The control test passes both with and without the fix, which is intended: it guards the direction this change must not break.

## Related

Refs #269, which added the probe. No issue filed; the defect is against the code's own stated tolerance rather than a design question, so it seemed shorter to bring the fix.

## Checklist

- [x] Tests pass (`uv run pytest` in `packages/dex-core`)
- [x] Eval scoring-core tests pass (`uvx pytest evals`)
- [x] If a safety path is touched, the spine still holds: read-only against data, cost-guarded, PII flagged not surfaced, propose-don't-impose
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free (checked in CI)
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures

On the safety box: this is a safety path and it moves toward the spine rather than across it. The firewall now refuses in cases where it previously could not run, and no case that refused before stops refusing. The change adds no new way for flagged data to be surfaced, since the only behaviour that changes is whether a refusal is reachable without a connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


