### PR TITLE
Fix null entry on transform build spend-ledger rows

### DIFF
--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -767,6 +767,7 @@ def _record_build_spend(
             "at": datetime.now(UTC).isoformat(),
             "connector": connector,
             "command": "transform build",
+            "entry": "settlement",
             field: float(billed),
             "job_id": None,
             "statement_sha256": None,


### PR DESCRIPTION
Fixes #277.

## Problem

`transform build` writes its spend directly to `.dex/spend.jsonl` through `_record_build_spend`, bypassing the cost gate's `_append` which always includes `"entry": kind`. As a result, every `transform build` row carried `"entry": null` while `maintain check` and `explore query` rows correctly carried `"entry": "settlement"`.

Filtering on `entry == "settlement"` therefore drops every `transform build` row, which is the single largest spender in a normal session.

## Fix

Add `"entry": "settlement"` to the dict passed to `append_spend_log` in `_record_build_spend` so all settlement rows are self-describing.

## Files changed

- `packages/dex-core/src/exmergo_dex_core/transform/commands.py`: +1 line

## Verification

```
uv run pytest tests/transform/test_build.py tests/transform/test_apply.py tests/transform/test_deps.py tests/transform/test_init.py tests/transform/test_parse.py tests/transform/test_validate.py -x
```
123 passed, 7 skipped.