### PR TITLE
SCRUM-1058-Entity matching strips table-name suffixes and layer prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,33 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   silence, which was indistinguishable from dex deciding the test was already
   there.
 
+### Fixed
+
+- **Entity matching survives table-name suffixes and layer prefixes**
+  ([#208]). A foreign key matched a parent by comparing the singularized
+  column stem against the parent table's name, layer prefix stripped, so a
+  parent named plainly for its entity matched
+  (`inventory_transactions.product_id -> products.id`), but a parent whose
+  name also carried a CDC history suffix or a landing-zone suffix did not:
+  singularizing `conversation_id` yields `conversation`, and nothing
+  recovered `conversation` from `conversation_history_data`, so inference
+  fell back to a child-to-child edge between two tables that merely shared
+  the FK's name, measured at an orphan fraction of 1.0.
+
+  Entity matching now also compares against the parent's name with a small,
+  ordered set of prefixes (`stg_`, `src_`, `raw_`, `dim_`, `fct_`, `fact_`,
+  `int_`, `base_`) and suffixes (`_history`, `_data`, `_raw`, `_snapshot`,
+  `_current`) stripped, repeated until none remain, plus a table-version
+  suffix (`_v2`, `_v3`, ...) always stripped. A match that needed stripping
+  scores below an exact match to the same key, so an unambiguous case is
+  never re-ranked behind a guess that needed help, and `explore
+  relationships`/`explore map`'s notes say when a join relied on it. Where
+  stripping resolves more than one candidate parent, both are proposed
+  instead of the matcher picking one, and `--verify` decides between them.
+  The affix list lives in `.dex/config.yml` under `entity_affixes`
+  (`prefixes`/`suffixes`), small by default and overridable for a house
+  convention it doesn't already cover.
+
 ## [1.6.3] - 2026-08-10
 
 ### Changed

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -351,6 +351,38 @@ def blob_override_paths(overrides: list[BlobOverride]) -> set[str]:
     return {entry.column.strip().lower() for entry in overrides}
 
 
+class EntityAffixes(BaseModel):
+    """Table-name prefixes and suffixes entity matching strips as a
+    lower-confidence fallback, tried only once an exact entity-name match
+    fails (see ``explore.relationships._match_parent``).
+
+    These are the default output of CDC history modes, landing-zone
+    conventions (``_data``/``_raw``/``_stg``), and layered-warehouse naming
+    (``stg_``/``dim_``/``fct_``), not exotic house choices, but house
+    conventions still vary enough that the list is overridable. Deliberately
+    small by default: an ordered set covers the common cases without turning
+    entity matching into a grab-bag of guesses. A trailing version marker
+    (``_v2``, ``_v3``, ...) is always stripped and is not part of this list,
+    since it is a structural convention rather than a house-specific word.
+    """
+
+    prefixes: list[str] = Field(
+        default_factory=lambda: [
+            "stg",
+            "src",
+            "raw",
+            "dim",
+            "fct",
+            "fact",
+            "int",
+            "base",
+        ]
+    )
+    suffixes: list[str] = Field(
+        default_factory=lambda: ["history", "data", "raw", "snapshot", "current"]
+    )
+
+
 class SemanticConfig(BaseModel):
     """How ``explore semantic`` reaches the semantic layer.
 
@@ -485,6 +517,11 @@ class DexConfig(BaseModel):
     cache: CacheConfig = Field(default_factory=CacheConfig)
     budget: Budget = Field(default_factory=Budget)
     ranking_hints: list[str] = Field(default_factory=list)
+    # Affixes entity matching strips as a lower-confidence fallback when an
+    # exact entity name misses (issue #208). The default list is small on
+    # purpose; house-specific conventions (a shop's own `_bak`/`ods_`) are the
+    # reason this is overridable rather than fixed.
+    entity_affixes: EntityAffixes = Field(default_factory=EntityAffixes)
     query: QueryLimits = Field(default_factory=QueryLimits)
     cluster: ClusterLimits = Field(default_factory=ClusterLimits)
     # How many top-ranked objects `explore map` deep-profiles on a large

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -681,7 +681,13 @@ def relationships(
     # this run or reused. Inference and merge fold by identifier over the union.
     datasets = profiled + list(fresh_reused.values())
     suppressed: list[rel_mod.SuppressedMatch] = []
-    inferred = rel_mod.infer_relationships(datasets, suppressed=suppressed)
+    affix_matches: list[rel_mod.AffixMatch] = []
+    inferred = rel_mod.infer_relationships(
+        datasets,
+        suppressed=suppressed,
+        affixes=config.entity_affixes,
+        affix_matches=affix_matches,
+    )
     if verify:
         probe_cost, candidates, objects = _verify_estimate(adapter, inferred)
         verify_pending = command_args.verify_handshake(
@@ -768,6 +774,7 @@ def relationships(
             "dataset mapped alongside its source)"
         )
     notes.extend(_generic_name_notes(suppressed))
+    notes.extend(_affix_match_notes(affix_matches))
     if carried_relationships > 0:
         notes.append(
             f"carried forward {carried_relationships} prior relationship(s) "
@@ -1593,7 +1600,13 @@ def map(
     all_selected = profiled + list(fresh_reused.values())
     _annotate_grain(profiled, defs, orphaned=orphaned)
     suppressed: list[rel_mod.SuppressedMatch] = []
-    inferred = rel_mod.infer_relationships(all_selected, suppressed=suppressed)
+    affix_matches: list[rel_mod.AffixMatch] = []
+    inferred = rel_mod.infer_relationships(
+        all_selected,
+        suppressed=suppressed,
+        affixes=config.entity_affixes,
+        affix_matches=affix_matches,
+    )
     if verify:
         probe_cost, candidates, objects = _verify_estimate(adapter, inferred)
         verify_pending = command_args.verify_handshake(
@@ -1721,6 +1734,7 @@ def map(
             "dataset mapped alongside its source)"
         )
     notes.extend(_generic_name_notes(suppressed))
+    notes.extend(_affix_match_notes(affix_matches))
     if verify_pending is not None:
         notes.append(
             "relationships saved unverified; verification awaits confirmation "
@@ -2680,6 +2694,25 @@ def _generic_name_notes(suppressed: list[rel_mod.SuppressedMatch]) -> list[str]:
         f"({shown}{more}); a name shared this widely (the norm for Firestore/"
         "Mongo/DynamoDB-style CDC exports) is a naming convention, not evidence "
         "of a relationship, so these never reached --verify"
+    ]
+
+
+def _affix_match_notes(affix_matches: list[rel_mod.AffixMatch]) -> list[str]:
+    """Explain when a join matched only after stripping a configured entity
+    affix (see `EntityAffixes`), so the lower confidence these joins carry
+    doesn't read as an unexplained demotion (issue #208)."""
+
+    if not affix_matches:
+        return []
+    examples = ", ".join(
+        f"{m.child_column} -> {m.parent} (stripped to {m.stripped_to})"
+        for m in affix_matches[:5]
+    )
+    more = f", +{len(affix_matches) - 5} more" if len(affix_matches) > 5 else ""
+    return [
+        f"matched {len(affix_matches)} join(s) to a parent name only after "
+        f"stripping a configured prefix/suffix ({examples}{more}); scored below "
+        "an exact entity-name match to the same key"
     ]
 
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/relationships.py
@@ -23,6 +23,7 @@ from ..cache import (
     RelationshipKind,
     match_identifier,
 )
+from ..config import EntityAffixes
 from ..dbt_project import ProjectDefinitions
 from ..progress import ProgressReporter
 from .profile import NEAR_UNIQUE_RATIO
@@ -58,6 +59,12 @@ _COLUMN_ALIAS_PREFIX = re.compile(r"^[a-z]{1,3}_", re.IGNORECASE)
 # a name that's merely popular.
 _GENERIC_NAME_MIN_HOSTS = 3
 
+# A trailing table-version marker (`_v2`, `_v3`, ...), stripped unconditionally
+# when the configured `EntityAffixes` don't resolve a match on their own. This
+# is a structural convention (like the `_ID_SUFFIXES` shapes), not a
+# house-specific word, so it isn't part of the configurable affix lists.
+_VERSION_SUFFIX = re.compile(r"_v\d+$", re.IGNORECASE)
+
 
 class SuppressedMatch(NamedTuple):
     """A same-named-FK match withheld because the shared name is too generic
@@ -67,6 +74,54 @@ class SuppressedMatch(NamedTuple):
 
     shared_name: str
     host_count: int
+
+
+class AffixMatch(NamedTuple):
+    """A join matched only after stripping a configured entity affix (see
+    `EntityAffixes`) from the parent's table name, because the exact-name tier
+    missed. Recorded so a caller can report when a match relied on
+    affix-stripping rather than an exact entity name; scored lower than an
+    exact match to the same key (issue #208)."""
+
+    child_column: str
+    parent: str
+    stripped_to: str
+
+
+def _strip_configured_affixes(name: str, affixes: EntityAffixes) -> str:
+    """Lowercased ``name`` with configured prefixes/suffixes, and a trailing
+    version marker, stripped repeatedly until none remain.
+
+    Repetition (rather than one pass) is what lets a name layered with more
+    than one convention reduce fully: `conversation_history_data` sheds
+    `_data` and then `_history` in two passes of the same suffix loop, in
+    whatever order the config lists them.
+    """
+
+    stripped = name.lower()
+    changed = True
+    while changed:
+        changed = False
+        version = _VERSION_SUFFIX.search(stripped)
+        if version is not None and version.start() > 0:
+            stripped = stripped[: version.start()]
+            changed = True
+            continue
+        for suffix in affixes.suffixes:
+            tail = f"_{suffix.lower()}"
+            if stripped.endswith(tail) and len(stripped) > len(tail):
+                stripped = stripped[: -len(tail)]
+                changed = True
+                break
+        if changed:
+            continue
+        for prefix in affixes.prefixes:
+            head = f"{prefix.lower()}_"
+            if stripped.startswith(head) and len(stripped) > len(head):
+                stripped = stripped[len(head) :]
+                changed = True
+                break
+    return stripped
 
 
 def _fk_stem(column_name: str) -> str | None:
@@ -174,7 +229,11 @@ def _key_host_counts(keyed: dict[str, list[list[str]]]) -> dict[str, int]:
 
 
 def infer_relationships(
-    datasets: list[Dataset], *, suppressed: list[SuppressedMatch] | None = None
+    datasets: list[Dataset],
+    *,
+    suppressed: list[SuppressedMatch] | None = None,
+    affixes: EntityAffixes | None = None,
+    affix_matches: list[AffixMatch] | None = None,
 ) -> list[Relationship]:
     """Infer many-to-one joins from column names, type compatibility, and the
     aggregate signals already profiled (uniqueness, distinct counts, min/max).
@@ -187,6 +246,13 @@ def infer_relationships(
     `_GENERIC_NAME_MIN_HOSTS`) is recorded to ``suppressed`` when a caller
     passes a list, so the withheld count and the names involved can be
     reported; the default ``None`` costs nothing extra.
+
+    ``affixes`` (a project's configured :class:`EntityAffixes`, or ``None`` to
+    skip the tier entirely) lets a parent whose name carries a house-convention
+    suffix or prefix the exact entity-name tier can't see (a CDC history table,
+    a landing-zone `_data`/`_raw` suffix, ...) still match, at a base confidence
+    kept below the exact tier's; matches made this way are recorded to
+    ``affix_matches`` the same way suppressions are.
     """
 
     keyed = {d.identifier: candidate_keys(d) for d in datasets}
@@ -202,7 +268,14 @@ def infer_relationships(
                 if parent.identifier == child.identifier:
                     continue
                 match = _match_parent(
-                    col, stem, parent, keyed[parent.identifier], host_counts, suppressed
+                    col,
+                    stem,
+                    parent,
+                    keyed[parent.identifier],
+                    host_counts,
+                    suppressed,
+                    affixes,
+                    affix_matches,
                 )
                 if match is not None:
                     to_columns, confidence = match
@@ -574,6 +647,8 @@ def _match_parent(
     parent_keys: list[list[str]],
     host_counts: dict[str, int],
     suppressed: list[SuppressedMatch] | None,
+    affixes: EntityAffixes | None = None,
+    affix_matches: list[AffixMatch] | None = None,
 ) -> tuple[list[str], float] | None:
     parent_table = parent.identifier.rsplit(".", 1)[-1]
     stripped = _LAYER_PREFIX.sub("", parent_table)
@@ -602,6 +677,34 @@ def _match_parent(
             if pcol is not None and _type_compatible(col.data_type, pcol.data_type):
                 base = 0.85 if target in parent_key_names else 0.5
                 return [pcol.name], _score(base, col, pcol)
+
+    # Weaker: the exact-name tier above missed because the parent's name
+    # carries a house-convention affix a bare layer prefix doesn't cover (a
+    # CDC history table, a landing-zone `_data`/`_raw` suffix, a versioned
+    # `_v2` table, ...). Stripping the configured affixes and retrying the
+    # same comparison catches these (issue #208), at a base confidence kept
+    # below every tier above so an unambiguous match is never re-ranked
+    # behind a guess that needed help. Tried only when `affixes` is passed,
+    # so a caller that doesn't configure it pays nothing extra.
+    if affixes is not None:
+        affix_stripped = _strip_configured_affixes(stripped, affixes)
+        if affix_stripped and affix_stripped != stripped.lower():
+            affix_entities = {affix_stripped, _singularize(affix_stripped).lower()}
+            if stem_l in affix_entities or _singularize(stem).lower() in affix_entities:
+                targets = list(_ID_SUFFIXES)
+                targets += [f"{stem_l}_{suffix}" for suffix in _ID_SUFFIXES]
+                targets += [f"{stem_l}{suffix}" for suffix in _ID_SUFFIXES]
+                for target in targets:
+                    pcol = parent_cols.get(target)
+                    if pcol is not None and _type_compatible(
+                        col.data_type, pcol.data_type
+                    ):
+                        base = 0.5 if target in parent_key_names else 0.25
+                        if affix_matches is not None:
+                            affix_matches.append(
+                                AffixMatch(col.name, parent.identifier, affix_stripped)
+                            )
+                        return [pcol.name], _score(base, col, pcol)
 
     # Same-named foreign key shared by both tables (e.g. customer_id in both),
     # joining to the parent's key of that name. Trusted only when the name

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -21,6 +21,7 @@ from exmergo_dex_core.cache import (
     RelationshipKind,
 )
 from exmergo_dex_core.cli import main
+from exmergo_dex_core.config import EntityAffixes
 from exmergo_dex_core.dbt_project import DeclaredForeignKey, ProjectDefinitions
 from exmergo_dex_core.explore.commands import (
     _carry_forward_relationships,
@@ -329,6 +330,232 @@ def test_dealiased_match_skips_when_stripped_to_a_bare_suffix():
     a = _ds("db.main.alpha", [_col("a_key", distinct=2, unique=True)], rows=2)
     b = _ds("db.main.beta", [_col("b_key", distinct=2)], rows=2)
     assert infer_relationships([a, b]) == []
+
+
+# --- affix-stripped entity matching (issue #208) -------------------------------
+
+
+def test_history_data_suffixed_parent_is_not_matched_without_affixes_configured():
+    """The affix-stripping tier is opt-in per call: a caller that doesn't pass
+    `affixes` sees the exact pre-fix behavior, unchanged."""
+
+    parent = _ds(
+        "db.main.conversation_history_data",
+        [_col("id", distinct=5, unique=True)],
+        rows=5,
+    )
+    child = _ds(
+        "db.main.conversation_part_history_data",
+        [_col("conversation_id", distinct=5)],
+        rows=20,
+    )
+    assert infer_relationships([parent, child]) == []
+
+
+def test_history_data_suffix_is_stripped_when_affixes_are_configured():
+    """The exact scenario from issue #208: singularizing conversation_id yields
+    conversation, but the parent table carries both a CDC history suffix and a
+    landing-zone data suffix. Stripping both in sequence (`_data`, then
+    `_history`) recovers the match."""
+
+    parent = _ds(
+        "db.main.conversation_history_data",
+        [_col("id", distinct=5, unique=True)],
+        rows=5,
+    )
+    child = _ds(
+        "db.main.conversation_part_history_data",
+        [_col("conversation_id", distinct=5)],
+        rows=20,
+    )
+    rels = infer_relationships([parent, child], affixes=EntityAffixes())
+    assert len(rels) == 1
+    rel = rels[0]
+    assert rel.from_dataset == "db.main.conversation_part_history_data"
+    assert rel.from_columns == ["conversation_id"]
+    assert rel.to_dataset == "db.main.conversation_history_data"
+    assert rel.to_columns == ["id"]
+    assert rel.confidence < 0.85
+
+
+def test_affix_stripped_match_scores_below_an_exact_match_to_the_same_shape():
+    """A match that needed stripping must rank below an unambiguous exact
+    match, so ranking still prefers the case that needed no help."""
+
+    exact = infer_relationships(
+        [
+            _ds("db.main.products", [_col("id", distinct=5, unique=True)], rows=5),
+            _ds(
+                "db.main.inventory_transactions",
+                [_col("product_id", distinct=5)],
+                rows=20,
+            ),
+        ],
+        affixes=EntityAffixes(),
+    )
+    stripped = infer_relationships(
+        [
+            _ds(
+                "db.main.product_history_data",
+                [_col("id", distinct=5, unique=True)],
+                rows=5,
+            ),
+            _ds("db.main.inventory_events", [_col("product_id", distinct=5)], rows=20),
+        ],
+        affixes=EntityAffixes(),
+    )
+    assert len(exact) == 1
+    assert len(stripped) == 1
+    assert exact[0].confidence > stripped[0].confidence
+
+
+def test_versioned_parent_table_suffix_is_stripped():
+    """A versioned table (`_v2`) is a structural convention, always stripped,
+    not part of the configurable affix list."""
+
+    parent = _ds("db.main.products_v2", [_col("id", distinct=5, unique=True)], rows=5)
+    child = _ds("db.main.orders", [_col("product_id", distinct=5)], rows=20)
+    rels = infer_relationships([parent, child], affixes=EntityAffixes())
+    assert len(rels) == 1
+    assert rels[0].to_dataset == "db.main.products_v2"
+
+
+def test_layer_prefix_alone_needs_no_affix_config():
+    """A bare layer prefix (already handled by `_LAYER_PREFIX`) must still
+    match with `affixes=None`; the new tier only extends what the exact tier
+    can't already see."""
+
+    hosts = _ds("db.main.RAW_HOSTS", [_col("ID", distinct=2, unique=True)], rows=2)
+    listings = _ds("db.main.RAW_LISTINGS", [_col("HOST_ID", distinct=2)], rows=2)
+    rels = infer_relationships([hosts, listings])
+    assert len(rels) == 1
+    assert rels[0].confidence >= 0.85
+
+
+def test_ambiguous_affix_stripped_candidates_are_both_proposed():
+    """Where stripping produces two candidate parents, both must be proposed;
+    the matcher must not pick a winner (issue #208 acceptance criterion)."""
+
+    history = _ds(
+        "db.main.conversation_history_data",
+        [_col("id", distinct=5, unique=True)],
+        rows=5,
+    )
+    current = _ds(
+        "db.main.conversation_current_data",
+        [_col("id", distinct=5, unique=True)],
+        rows=5,
+    )
+    replies = _ds("db.main.replies", [_col("conversation_id", distinct=5)], rows=20)
+    rels = infer_relationships([history, current, replies], affixes=EntityAffixes())
+    targets = {r.to_dataset for r in rels}
+    assert targets == {
+        "db.main.conversation_history_data",
+        "db.main.conversation_current_data",
+    }
+
+
+def test_affix_stripped_match_is_recorded():
+    affix_matches: list = []
+    parent = _ds(
+        "db.main.conversation_history_data",
+        [_col("id", distinct=5, unique=True)],
+        rows=5,
+    )
+    child = _ds(
+        "db.main.conversation_part_history_data",
+        [_col("conversation_id", distinct=5)],
+        rows=20,
+    )
+    rels = infer_relationships(
+        [parent, child], affixes=EntityAffixes(), affix_matches=affix_matches
+    )
+    assert len(rels) == 1
+    assert len(affix_matches) == 1
+    assert affix_matches[0].child_column == "conversation_id"
+    assert affix_matches[0].parent == "db.main.conversation_history_data"
+    assert affix_matches[0].stripped_to == "conversation"
+
+
+def test_configured_affixes_can_be_narrowed_or_disabled():
+    """The affix list is configurable and small by default, not exhaustive: a
+    project can shrink or empty it, and a suffix outside the configured set
+    stays unmatched."""
+
+    parent = _ds(
+        "db.main.conversation_history_data",
+        [_col("id", distinct=5, unique=True)],
+        rows=5,
+    )
+    child = _ds(
+        "db.main.conversation_part_history_data",
+        [_col("conversation_id", distinct=5)],
+        rows=20,
+    )
+    assert (
+        infer_relationships([parent, child], affixes=EntityAffixes(suffixes=[]))
+        == []
+    )
+
+
+def test_relationships_envelope_explains_affix_stripped_matches(
+    tmp_path: Path, capsys
+):
+    """End-to-end: `explore relationships` wires the default configured
+    `entity_affixes` through by default, proposes the affix-stripped edge, and
+    explains it in `notes`."""
+
+    duckdb = pytest.importorskip("duckdb")
+    path = tmp_path / "intercom.duckdb"
+    conn = duckdb.connect(str(path))
+    conn.execute("CREATE TABLE conversation_history_data (id INTEGER)")
+    conn.execute("INSERT INTO conversation_history_data SELECT * FROM range(5)")
+    conn.execute(
+        "CREATE TABLE conversation_part_history_data (conversation_id INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO conversation_part_history_data "
+        "SELECT i % 5 FROM range(20) t(i)"
+    )
+    conn.close()
+
+    payload = _run(["explore", "relationships", "--path", str(path)], capsys)
+    data = payload["data"]
+    by_fk = {tuple(r["from_columns"]): r for r in data["relationships"]}
+    rel = by_fk[("conversation_id",)]
+    assert rel["to_dataset"].endswith(".conversation_history_data")
+    assert rel["to_columns"] == ["id"]
+    assert any("stripping a configured prefix/suffix" in n for n in data["notes"])
+
+
+def test_affix_stripped_join_survives_verify(tmp_path: Path, capsys):
+    """The exact scenario from issue #208's acceptance criteria: the
+    affix-stripped join is proposed and survives `--verify` (zero orphans lift
+    its confidence rather than the probe demoting it away)."""
+
+    duckdb = pytest.importorskip("duckdb")
+    path = tmp_path / "intercom.duckdb"
+    conn = duckdb.connect(str(path))
+    conn.execute("CREATE TABLE conversation_history_data (id INTEGER)")
+    conn.execute("INSERT INTO conversation_history_data SELECT * FROM range(5)")
+    conn.execute(
+        "CREATE TABLE conversation_part_history_data (conversation_id INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO conversation_part_history_data "
+        "SELECT i % 5 FROM range(20) t(i)"
+    )
+    conn.close()
+
+    payload = _run(
+        ["explore", "relationships", "--path", str(path), "--verify"], capsys
+    )
+    data = payload["data"]
+    by_fk = {tuple(r["from_columns"]): r for r in data["relationships"]}
+    rel = by_fk[("conversation_id",)]
+    assert rel["to_dataset"].endswith(".conversation_history_data")
+    assert rel["verified"] is True
+    assert rel["orphan_fraction"] == 0.0
 
 
 # --- same-lineage / replica folding --------------------------------------------

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -493,14 +493,11 @@ def test_configured_affixes_can_be_narrowed_or_disabled():
         rows=20,
     )
     assert (
-        infer_relationships([parent, child], affixes=EntityAffixes(suffixes=[]))
-        == []
+        infer_relationships([parent, child], affixes=EntityAffixes(suffixes=[])) == []
     )
 
 
-def test_relationships_envelope_explains_affix_stripped_matches(
-    tmp_path: Path, capsys
-):
+def test_relationships_envelope_explains_affix_stripped_matches(tmp_path: Path, capsys):
     """End-to-end: `explore relationships` wires the default configured
     `entity_affixes` through by default, proposes the affix-stripped edge, and
     explains it in `notes`."""
@@ -514,8 +511,7 @@ def test_relationships_envelope_explains_affix_stripped_matches(
         "CREATE TABLE conversation_part_history_data (conversation_id INTEGER)"
     )
     conn.execute(
-        "INSERT INTO conversation_part_history_data "
-        "SELECT i % 5 FROM range(20) t(i)"
+        "INSERT INTO conversation_part_history_data SELECT i % 5 FROM range(20) t(i)"
     )
     conn.close()
 
@@ -542,8 +538,7 @@ def test_affix_stripped_join_survives_verify(tmp_path: Path, capsys):
         "CREATE TABLE conversation_part_history_data (conversation_id INTEGER)"
     )
     conn.execute(
-        "INSERT INTO conversation_part_history_data "
-        "SELECT i % 5 FROM range(20) t(i)"
+        "INSERT INTO conversation_part_history_data SELECT i % 5 FROM range(20) t(i)"
     )
     conn.close()
 


### PR DESCRIPTION
Closes : https://github.com/exmergo/dex/issues/208
Relationship inference matched a foreign key to a parent by comparing the singularized column stem to the parent table's name (layer prefix stripped), so a CDC history suffix, a landing-zone suffix (_data/_raw/_stg), or a versioned table name defeated the match entirely.
Adds a new, lower-confidence match tier that strips a small configurable set of prefixes/suffixes (entity_affixes in .dex/config.yml) plus a table-version suffix, and retries the entity-name comparison.
A stripped match never outranks an exact match to the same key, and explore relationships/explore map's notes say when a join relied on it. Where stripping resolves more than one candidate parent, both are proposed and --verify decides.
Before : 
<img width="1617" height="140" alt="image" src="https://github.com/user-attachments/assets/346511a5-61d8-4b25-8f58-83d0a9c2e337" />
After: 
<img width="1612" height="205" alt="image" src="https://github.com/user-attachments/assets/2e132db9-b619-4366-a566-1416a9bfe3d2" />
