### PR TITLE
SCRUM-1064-transform plan warns on authored/declared column drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,28 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   project's configured model and macro paths, which is what containment checked
   directly before.
 
+- **`transform plan` warns when a model's authored columns diverge from its
+  declared schema.yml contract** ([#214]). A model's schema.yml entry is the
+  closest thing a dbt project has to a column contract, and plan time is the
+  cheapest moment to check it, but nothing did: a model authored with a
+  different column set than its declaration passed silently. `transform plan`
+  now compares the authored SELECT list against the declared columns for
+  every model actually being planned, and warns in both directions: a
+  declared column the SELECT does not produce, and a produced column the
+  declaration does not name.
+
+  The check never refuses. The declaration is often the side that is stale,
+  and the caller is often deliberately changing the model, so a warning in
+  the same envelope as the diff is what matters, not a block. A model with no
+  declared columns produces no warning, since there is no contract to check
+  against. Where the SELECT list cannot be resolved statically (a bare
+  `select *`, a qualified `t.*`, or a macro standing in for a whole column
+  with no alias), the warning says so instead of guessing; an aliased macro
+  call is still resolved by its own alias. Declared columns are read with
+  this same plan's own schema.yml edits overlaid on the project, so a model
+  and its documentation edited together in one plan are compared against
+  each other, not against a stale on-disk file.
+
 ### Changed
 
 - **Containment validates an edit against the surface its own format declared**

--- a/packages/dex-core/src/exmergo_dex_core/transform/plans.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/plans.py
@@ -19,8 +19,10 @@ from enum import Enum
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
+import sqlglot
 import yaml
 from pydantic import BaseModel
+from sqlglot import expressions as exp
 
 from ..dbt_project import (
     REF_PATTERN,
@@ -38,7 +40,7 @@ from ..dbt_project import (
 )
 from ..diffs import file_diff
 from ..errors import DexError
-from .validate import find_inlined_secret, validate_edit
+from .validate import _PLACEHOLDER, find_inlined_secret, strip_jinja, validate_edit
 
 if TYPE_CHECKING:
     from ..adapters.project import EditableProject
@@ -304,6 +306,7 @@ def plan(
         from .scaffold import missing_macro_warnings
 
         warnings.extend(missing_macro_warnings(edits, view))
+        warnings.extend(column_contract_warnings(edits, view))
 
     created_at = datetime.now(UTC).isoformat()
     try:
@@ -433,6 +436,137 @@ def validate_deletions(view: DbtProjectView, edits: list[PlanEdit]) -> list[str]
                 "remove the schema.yml entry in a follow-up edit"
             )
     return warnings
+
+
+def column_contract_warnings(edits: list[PlanEdit], view: DbtProjectView) -> list[str]:
+    """Warn when a model's authored SELECT list diverges from what its
+    schema.yml declares, in either direction (issue #214).
+
+    schema.yml is the closest thing a dbt project has to a column contract,
+    and plan time is the cheapest moment to check it against what was actually
+    authored. Always a warning, never a refusal: the declaration is
+    frequently the side that is stale, and the caller is often deliberately
+    changing the model's shape.
+
+    Scoped to models actually authored in this plan (not every model in the
+    project) and only when that model declares a ``columns:`` list at all; a
+    model with none has no contract to compare against and produces nothing.
+    Declared columns are read with this plan's own SCHEMA_YML upserts
+    overlaid on the current project files, so a model and its doc edited
+    together in the same plan are compared against each other, not against a
+    stale on-disk declaration.
+
+    Where the authored SELECT list cannot be resolved statically (a bare
+    ``select *``, a qualified ``t.*``, or an unaliased macro call standing in
+    for a column), the comparison is skipped and that is said outright,
+    rather than guessed at.
+    """
+
+    schema_sources = {
+        path: source.content
+        for path, source in view.files.items()
+        if path.endswith((".yml", ".yaml"))
+    }
+    for edit in edits:
+        if edit.kind is EditKind.SCHEMA_YML and edit.new_content is not None:
+            schema_sources[edit.path] = edit.new_content
+
+    declared_by_model: dict[str, list[str]] = {}
+    for content in schema_sources.values():
+        try:
+            parsed = yaml.safe_load(content)
+        except yaml.YAMLError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        for entry in parsed.get("models") or []:
+            if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+                continue
+            columns = [
+                column["name"]
+                for column in entry.get("columns") or []
+                if isinstance(column, dict) and isinstance(column.get("name"), str)
+            ]
+            if columns:
+                declared_by_model[entry["name"]] = columns
+
+    warnings: list[str] = []
+    for edit in edits:
+        if (
+            edit.kind is not EditKind.MODEL_SQL
+            or edit.op is not EditOp.UPSERT
+            or edit.new_content is None
+        ):
+            continue
+        model = Path(edit.path).stem
+        declared = declared_by_model.get(model)
+        if not declared:
+            continue
+        declared_lower = {c.lower() for c in declared}
+
+        produced = _select_columns(edit.new_content)
+        if produced is None:
+            warnings.append(
+                f"{edit.path}: schema.yml declares column(s) for {model}, but "
+                "the SELECT list could not be resolved statically (a `select "
+                "*`/`t.*`, or a macro standing in for a column); the "
+                "contract comparison was skipped"
+            )
+            continue
+
+        missing = sorted(declared_lower - produced)
+        if missing:
+            warnings.append(
+                f"{edit.path}: schema.yml declares column(s) {', '.join(missing)} "
+                f"for {model} that the SELECT list does not produce"
+            )
+        extra = sorted(produced - declared_lower)
+        if extra:
+            warnings.append(
+                f"{edit.path}: the SELECT list produces column(s) "
+                f"{', '.join(extra)} not declared in schema.yml for {model}"
+            )
+    return warnings
+
+
+def _select_columns(sql: str) -> set[str] | None:
+    """The lowercased output column names of a model's outermost SELECT, or
+    ``None`` if they cannot be resolved statically.
+
+    Unresolvable covers a bare ``select *``, a qualified ``t.*``, an unaliased
+    macro call standing in for a column (indistinguishable from a real column
+    once jinja is stripped to a placeholder, and can expand to any number of
+    real columns), a set operation (a UNION's branches can each project
+    differently), and anything that fails to parse. An *aliased* macro call
+    (``{{ some_macro(x) }} as total``) is resolvable: the alias is the real
+    output name regardless of what expression computed it.
+    """
+
+    stripped = strip_jinja(sql)
+    if not stripped:
+        return None
+    try:
+        parsed = sqlglot.parse_one(stripped, read="duckdb")
+    except Exception:
+        return None
+
+    node = parsed
+    while isinstance(node, (exp.With, exp.Subquery)):
+        node = node.this
+    if not isinstance(node, exp.Select):
+        return None
+
+    columns: set[str] = set()
+    for projection in node.expressions:
+        if isinstance(projection, exp.Star):
+            return None
+        if isinstance(projection, exp.Column) and isinstance(projection.this, exp.Star):
+            return None
+        name = projection.alias_or_name
+        if not name or _PLACEHOLDER in name:
+            return None
+        columns.add(name.lower())
+    return columns or None
 
 
 def _plan_id(intent: str, edits: list[PlanEdit]) -> str:

--- a/packages/dex-core/tests/transform/test_plan.py
+++ b/packages/dex-core/tests/transform/test_plan.py
@@ -400,6 +400,168 @@ def test_project_yml_dropping_a_model_path_warns(dbt_project_dir: Path):
     assert any("model-paths drops" in w and "models" in w for w in warnings)
 
 
+# --- column contract: authored SELECT list vs. declared schema.yml (#214) -----
+
+
+def test_column_contract_warns_when_a_declared_column_is_missing(
+    dbt_project_dir: Path,
+):
+    """Declaring both `id` and `email` (in the same plan) but authoring a
+    SELECT that only produces `id` warns, naming the missing column."""
+
+    schema_edit = _cfg_edit(
+        "models/staging/schema.yml",
+        "version: 2\nmodels:\n  - name: stg_customers\n    columns:\n"
+        "      - name: id\n      - name: email\n",
+        transform.EditKind.SCHEMA_YML,
+    )
+    model_edit = _cfg_edit(
+        "models/staging/stg_customers.sql",
+        "select 1 as id\n",
+        transform.EditKind.MODEL_SQL,
+    )
+    plan, _diffs, warnings = transform.plan(
+        "drop email from the select",
+        [schema_edit, model_edit],
+        dbt_project_dir,
+        repo_root=dbt_project_dir.parent,
+        store=FilesystemStore(dbt_project_dir.parent),
+    )
+    assert plan.plan_id  # the plan still validates and stores
+    assert any("email" in w and "does not produce" in w for w in warnings), warnings
+
+
+def test_column_contract_warns_when_select_adds_an_undeclared_column(
+    dbt_project_dir: Path,
+):
+    """`stg_customers`' schema.yml declares only `id`; authoring a SELECT that
+    also produces `email` warns, naming the undeclared column."""
+
+    model_edit = _cfg_edit(
+        "models/staging/stg_customers.sql",
+        "select 1 as id, 'a@example.com' as email\n",
+        transform.EditKind.MODEL_SQL,
+    )
+    plan, _diffs, warnings = transform.plan(
+        "add email to the select",
+        [model_edit],
+        dbt_project_dir,
+        repo_root=dbt_project_dir.parent,
+        store=FilesystemStore(dbt_project_dir.parent),
+    )
+    assert plan.plan_id
+    assert any("email" in w and "not declared" in w for w in warnings), warnings
+
+
+def test_column_contract_is_silent_when_no_columns_are_declared(
+    dbt_project_dir: Path,
+):
+    """A model whose schema.yml entry declares no `columns:` list has no
+    contract to compare against, and the whole-project scan must not reach
+    into an unrelated model (`stg_customers`) this plan never touched."""
+
+    schema_edit = _cfg_edit(
+        "models/staging/stg_orders.yml",
+        "version: 2\nmodels:\n  - name: stg_orders\n",
+        transform.EditKind.SCHEMA_YML,
+    )
+    model_edit = _cfg_edit(
+        "models/staging/stg_orders.sql",
+        "select 1 as id, 2 as customer_id\n",
+        transform.EditKind.MODEL_SQL,
+    )
+    plan, _diffs, warnings = transform.plan(
+        "add stg_orders",
+        [schema_edit, model_edit],
+        dbt_project_dir,
+        repo_root=dbt_project_dir.parent,
+        store=FilesystemStore(dbt_project_dir.parent),
+    )
+    assert plan.plan_id
+    assert not any("stg_orders" in w for w in warnings), warnings
+    # stg_customers' own on-disk mismatch (declares `id`, selects `id, email`)
+    # must stay silent too: this plan never authored that model.
+    assert not any("stg_customers" in w for w in warnings), warnings
+
+
+def test_column_contract_reports_a_select_star_as_unresolvable(
+    dbt_project_dir: Path,
+):
+    schema_edit = _cfg_edit(
+        "models/staging/schema.yml",
+        "version: 2\nmodels:\n  - name: stg_customers\n    columns:\n"
+        "      - name: id\n",
+        transform.EditKind.SCHEMA_YML,
+    )
+    model_edit = _cfg_edit(
+        "models/staging/stg_customers.sql",
+        "select * from raw_customers\n",
+        transform.EditKind.MODEL_SQL,
+    )
+    plan, _diffs, warnings = transform.plan(
+        "star it",
+        [schema_edit, model_edit],
+        dbt_project_dir,
+        repo_root=dbt_project_dir.parent,
+        store=FilesystemStore(dbt_project_dir.parent),
+    )
+    assert plan.plan_id
+    assert any("could not be resolved statically" in w for w in warnings), warnings
+
+
+def test_column_contract_reports_an_unaliased_macro_column_as_unresolvable(
+    dbt_project_dir: Path,
+):
+    """A macro standing in for a whole column (no alias) can expand to any
+    number of real columns once dbt renders it, so it is unresolvable exactly
+    like `select *` -- not a guessable single column named `__dex_jinja__`."""
+
+    model_edit = _cfg_edit(
+        "models/staging/stg_customers.sql",
+        "select {{ dbt_utils.star(ref('raw_customers')) }} from raw_customers\n",
+        transform.EditKind.MODEL_SQL,
+    )
+    plan, _diffs, warnings = transform.plan(
+        "splat it",
+        [model_edit],
+        dbt_project_dir,
+        repo_root=dbt_project_dir.parent,
+        store=FilesystemStore(dbt_project_dir.parent),
+    )
+    assert plan.plan_id
+    assert any("could not be resolved statically" in w for w in warnings), warnings
+
+
+def test_column_contract_resolves_an_aliased_macro_column(dbt_project_dir: Path):
+    """A macro call given an explicit alias has a known output name regardless
+    of what expression computed it, so it is resolvable, unlike a bare macro
+    standing in for an unknown number of columns."""
+
+    schema_edit = _cfg_edit(
+        "models/staging/schema.yml",
+        "version: 2\nmodels:\n  - name: stg_customers\n    columns:\n"
+        "      - name: id\n      - name: total\n",
+        transform.EditKind.SCHEMA_YML,
+    )
+    model_edit = _cfg_edit(
+        "models/staging/stg_customers.sql",
+        "select 1 as id, {{ some_macro(x) }} as total\n",
+        transform.EditKind.MODEL_SQL,
+    )
+    plan, _diffs, warnings = transform.plan(
+        "compute total",
+        [schema_edit, model_edit],
+        dbt_project_dir,
+        repo_root=dbt_project_dir.parent,
+        store=FilesystemStore(dbt_project_dir.parent),
+    )
+    assert plan.plan_id
+    assert not any(
+        "could not be resolved statically" in w or "declares column" in w
+        for w in warnings
+    ), warnings
+
+
 def test_plan_cli_refuses_an_inlined_profiles_secret(
     dbt_project_dir: Path, tmp_path: Path, capsys
 ):


### PR DESCRIPTION
Closes : https://github.com/exmergo/dex/issues/214

transform plan compared nothing against a model's declared columns: in schema.yml, so an authored SELECT list could silently diverge from the project's own contract.
Adds column_contract_warnings() in plans.py, run for every MODEL_SQL upsert actually in the plan (not the whole project): warns when a declared column isn't produced, and when a produced column isn't declared.
Declared columns are read with this plan's own SCHEMA_YML edits overlaid on the project, so a model and its doc edited together in one plan are compared against each other, not a stale on-disk file.
Where the SELECT list can't be resolved statically (select *, t.*, or an unaliased macro standing in for a column), the warning says so instead of guessing; an aliased macro call still resolves by its alias.
Always a warning, never a refusal: the plan still validates and stores regardless.

<img width="1606" height="107" alt="image" src="https://github.com/user-attachments/assets/ad566538-896a-465a-b5bc-e6a4206d9cb5" />

