### PR TITLE
A BigQuery profile estimate reserves for an escalation query only where the   probe could actually issue one

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.6.4] - 2026-08-13
+
 ### Added
 
 - **A verified join with a catastrophic orphan rate is now a finding, not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,45 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   profiled still needs a connection to build its sample, so it reaches the
   opener at the bottom of `cluster` and raises there.
 
+### Fixed
+
+- **A BigQuery profile estimate reserves for an escalation query only where the
+  probe could actually issue one, and says how much of itself is reserve**
+  ([#299]). Since 1.6.0 the estimate held three per-table 10 MB floors rather
+  than two: the value-domain probe added in that release
+  ([#203]) took a reserve beside the near-unique and composite ones. The reserve
+  scales with object count rather than data size, so on a warehouse of many
+  small tables the release moved a 12-object `explore map` estimate by 125.8 MB
+  in one step and started refusing a nightly refresh that had run for months.
+
+  Three of the reserves were provably unspendable rather than merely unlikely,
+  and are now dropped. A view has no row count (BigQuery reports none, and the
+  profiling aggregate's own `COUNT(*)` is read per batch and never written back
+  to the object), and all three probes return early without one, so a view held
+  three floors no run could ever spend. Nested and repeated columns get no
+  approximate distinct in the aggregate batch, and every probe's eligibility
+  starts from one, so a table of nothing else can no more escalate than a blob
+  column already excluded from the scan; the composite reserve was already
+  conditioned on having two columns, but counted columns that can never join a
+  pair. And a value domain needs at least one distinct value within a tenth of
+  the non-null rows, so no column of a table below ten rows can qualify. The
+  thresholds that imply that floor moved next to `ValueDomainSample` so the
+  estimator and the probe cannot drift apart. Nothing else was narrowed: the
+  reserve is dropped only where a probe's own guard already rules the query out,
+  because an estimate that reserves for a query that cannot run is merely loose,
+  while one that skips a query that can is the defect [#107] closed.
+
+  That leaves the common case, a warehouse of small flat tables, reserving
+  exactly as much as before, which is the second half of this. The confirm
+  handshake and the over-ceiling refusal now split the estimate into measured
+  dry-run scan and held reserve, in prose and in `reserved_bytes` /
+  `reserved_queries`. A refusal previously said only "raise the budget or narrow
+  the work" about a number that could be three quarters reserve, leaving the
+  operator to reconstruct the split from `.dex/spend.jsonl` afterwards to find
+  out whether the estimate grew because the warehouse did or because dex added a
+  probe. Over-ceiling refusals reach the connector's own description of the
+  estimate for the first time; before this only the confirmation payload did.
+
 ## [1.6.3] - 2026-08-10
 
 ### Changed

--- a/packages/dex-core/src/exmergo_dex_core/adapters/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/base.py
@@ -23,6 +23,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import date, datetime, time
 from decimal import Decimal
+from math import ceil
 from typing import Protocol, runtime_checkable
 
 from ..envelope import Paradigm
@@ -121,6 +122,24 @@ class ValueDomainSample:
 
     values: list[tuple[object, int]]
     total_distinct: int
+
+
+# A column's value domain is reported only when its distinct count clears BOTH
+# bars: small absolutely (the cap) and small relative to the table (the
+# fraction), so a tiny table's near-key column does not qualify on the absolute
+# count alone. Deliberately conservative: this codebase's general posture is to
+# under-report rather than over-report, and a false negative here just costs one
+# more `explore query`.
+#
+# They live beside the sample type rather than in `explore.profile` because a
+# metered adapter has to reserve for the probe *before* profiling runs, and the
+# two sides would drift apart the moment one of them moved. VALUE_DOMAIN_MIN_ROWS
+# is what the fraction implies rather than a threshold of its own: a domain needs
+# at least one distinct value, so a table below it can never clear the fraction
+# and never produces a probe worth reserving for.
+VALUE_DOMAIN_CAP = 25
+VALUE_DOMAIN_MAX_FRACTION = 0.10
+VALUE_DOMAIN_MIN_ROWS = ceil(1 / VALUE_DOMAIN_MAX_FRACTION)
 
 
 @dataclass(frozen=True)

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -17,6 +17,7 @@ simply calls no mutating client API, and the docs recommend read-only roles
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from ..config import BigQueryTarget
@@ -25,6 +26,7 @@ from ..errors import ConnectorError, PrerequisiteError
 from ..guards.cost_guard import CostGate, OverCeilingError
 from ..guards.sql_guard import assert_select_only
 from .base import (
+    VALUE_DOMAIN_MIN_ROWS,
     ColumnAggregate,
     ColumnMeta,
     ObjectMeta,
@@ -61,6 +63,25 @@ _MIN_BILLED_BYTES = 10 * 1024 * 1024
 # min/max, and non-null counting via COUNTIF (COUNT DISTINCT is invalid on
 # them and plain COUNT is not supported for every one of these types).
 _NESTED_FIELD_TYPES = {"RECORD", "STRUCT", "JSON", "GEOGRAPHY", "RANGE", "INTERVAL"}
+
+
+@dataclass(frozen=True)
+class _EstimateComposition:
+    """What a profile estimate is made of: measured dry-run scan versus
+    escalation reserve.
+
+    The two halves answer different questions and a caller deciding whether to
+    raise a budget needs them apart. The scan half is a dry-run of statements
+    that will certainly run; the reserve half is headroom held for probes that
+    may never be issued (see :meth:`BigQueryAdapter.profile_estimate`). Quoting
+    only the sum is what left a refused nightly run unable to tell a warehouse
+    that had grown from a release that had added a reserve (issue #299).
+    """
+
+    scan_bytes: float
+    scan_queries: int
+    reserved_bytes: float
+    reserved_queries: int
 
 
 def _regexp_predicate(qcol: str, pattern: str) -> str:
@@ -130,6 +151,10 @@ class BigQueryAdapter:
         self._tables: dict[str, Any] = {}
         self._resolved_datasets: list[str] | None = None
         self._notes: dict[str, list[str]] = {}
+        # What the last profile estimate was made of, so the handshake and the
+        # over-ceiling refusal can attribute the number they quote. Per command,
+        # like `_notes`: one command builds at most one profile estimate.
+        self._composition: _EstimateComposition | None = None
 
     # --- capabilities ---------------------------------------------------------
 
@@ -684,18 +709,18 @@ class BigQueryAdapter:
         what BigQuery actually bills, and an unfloored estimate would send the
         agent into a ladder of budget rejections.
 
-        The total also reserves one floor per table for each of the two
-        possible escalation queries (``exact_distinct_counts`` for a
-        near-unique column, ``distinct_combination_counts`` for a composite
-        key candidate): whether either actually runs depends on the aggregate
-        batch's own approximate results, which do not exist yet at estimate
-        time, so there is no way to dry-run them here. Reserving their floor
-        unconditionally keeps this total a ceiling profiling will not exceed,
-        rather than a number a run that does escalate blows past -- the exact
-        gap this estimator used to leave open (issue #107). Skipped only when
-        a table is provably empty (``row_count == 0``); an unknown row count
-        (views, whose count is never known before the aggregate that reveals
-        it) still reserves, since escalation is not ruled out.
+        The total also reserves one floor per table for each of the three
+        escalation queries a profile may still issue after that batch
+        (:meth:`exact_distinct_counts`, :meth:`value_domain_counts`,
+        :meth:`distinct_combination_counts`). Whether any of them runs depends
+        on the batch's own approximate results, which do not exist yet at
+        estimate time, so there is no way to dry-run them here. Holding their
+        floor keeps this total a ceiling profiling will not exceed rather than
+        a number a run that does escalate blows past, which is the gap this
+        estimator used to leave open (issue #107). See
+        :meth:`_escalation_reserve` for what narrows each one, and
+        :attr:`_composition` for how the reserve is reported apart from the
+        scan it rides with.
 
         Blob-type columns are excluded from the batches the same way
         ``explore.profile.profile`` excludes them from the scan itself
@@ -704,6 +729,9 @@ class BigQueryAdapter:
 
         blob_paths = include_blobs or set()
         per_table: dict[str, float] = {}
+        scan_bytes = 0.0
+        scan_queries = 0
+        reserved_queries = 0
         for identifier in identifiers:
             meta, columns = self.table_metadata(identifier)
             if self._unqueryable(identifier):
@@ -732,20 +760,67 @@ class BigQueryAdapter:
                     sample_percent=sample_percent,
                 )
                 try:
-                    total += max(self._dry_run(sql), float(_MIN_BILLED_BYTES))
+                    batch = max(self._dry_run(sql), float(_MIN_BILLED_BYTES))
                 except self._api_exceptions.BadRequest:
                     self._note(
                         identifier,
                         "could not estimate an aggregate scan (dry-run failed); "
                         "the object is skipped",
                     )
-            if scan_columns and meta.row_count != 0:
-                total += float(_MIN_BILLED_BYTES)  # exact_distinct_counts
-                total += float(_MIN_BILLED_BYTES)  # value_domain_counts
-                if len(scan_columns) >= 2:
-                    total += float(_MIN_BILLED_BYTES)  # distinct_combination_counts
+                    continue
+                total += batch
+                scan_bytes += batch
+                scan_queries += 1
+            reserved = self._escalation_reserve(meta, scan_columns)
+            total += reserved * float(_MIN_BILLED_BYTES)
+            reserved_queries += reserved
             per_table[identifier] = total
+        self._composition = _EstimateComposition(
+            scan_bytes=scan_bytes,
+            scan_queries=scan_queries,
+            reserved_bytes=reserved_queries * float(_MIN_BILLED_BYTES),
+            reserved_queries=reserved_queries,
+        )
         return sum(per_table.values()), per_table
+
+    def _escalation_reserve(
+        self, meta: ObjectMeta, scan_columns: list[ColumnMeta]
+    ) -> int:
+        """How many escalation queries to hold a billing floor for on one table.
+
+        A reserve is dropped only where the probe's own guard already rules the
+        query out from metadata alone, never as a guess about what is likely: an
+        estimate that reserves for a query that cannot run is merely loose, while
+        one that skips a query that can is the defect issue #107 closed. So each
+        condition below mirrors one in ``explore.profile``, and moving one
+        without the other is the bug to watch for.
+
+        - Nothing at all without a row count. All three probes return early on a
+          falsy one, and a BigQuery view never has one: ``_object_meta`` nulls it
+          and the aggregate's own ``COUNT(*)`` is read per batch, never written
+          back to the object. So a view provably cannot escalate, and the reserve
+          it used to hold was money no run could spend.
+        - Nothing for columns BigQuery cannot count distinctly. Nested and
+          repeated fields get no approximate distinct in the aggregate batch, and
+          every probe's eligibility starts from one, so they can no more trigger
+          an escalation than a blob column already excluded from the scan.
+        - No value domain below :data:`VALUE_DOMAIN_MIN_ROWS` rows, which is what
+          the probe's row-relative fraction implies once a domain needs at least
+          one distinct value.
+        - No composite probe below two countable columns, since a combination
+          needs two members. This was already conditioned, but on the raw column
+          count, which counts columns that can never join a pair.
+        """
+
+        countable = [c for c in scan_columns if not self._is_nested(c.data_type)]
+        if not countable or not meta.row_count:
+            return 0
+        reserved = 1  # exact_distinct_counts
+        if meta.row_count >= VALUE_DOMAIN_MIN_ROWS:
+            reserved += 1  # value_domain_counts
+        if len(countable) >= 2:
+            reserved += 1  # distinct_combination_counts
+        return reserved
 
     def query_estimate(self, sql: str) -> float:
         """The dry-run byte estimate for one firewall-approved query, floored to
@@ -761,20 +836,14 @@ class BigQueryAdapter:
         """The bytes-scanned handshake payload: names the per-query billing
         floor baked into every number here, so a small-table estimate reads as
         a trustworthy ceiling instead of one the actual bill will exceed
-        (issue #107). The escalation-reserve clause only applies to a
-        multi-table call (``per_table`` set, i.e. a profile-shaped estimate);
-        a single ad-hoc query or cluster sample has no such reserve to explain.
+        (issue #107).
+
+        Deliberately a pure function of its arguments. What a *profile* estimate
+        is made of is answered by :meth:`profile_reserve` instead, because this
+        method also describes estimates that carry no reserve (an ad-hoc query,
+        a mid-command verify checkpoint) and it cannot tell which it was handed.
         """
 
-        note = (
-            f"BigQuery bills at least {_MIN_BILLED_BYTES:,} bytes (10 MB) per "
-            "query; every number here already reflects that floor"
-        )
-        if per_table:
-            note += (
-                ", including a reserve for the escalation queries a "
-                "multi-table profile may still add after its initial scan"
-            )
         data: dict[str, object] = {
             "estimated_bytes": estimate,
             "hint": (
@@ -782,11 +851,49 @@ class BigQueryAdapter:
                 "<bytes> (the ceiling in bytes; 10000000000 is 10 GB, about "
                 "$0.06 on-demand)"
             ),
-            "notes": [note],
+            "notes": [
+                f"BigQuery bills at least {_MIN_BILLED_BYTES:,} bytes (10 MB) "
+                "per query; every number here already reflects that floor"
+            ],
         }
         if per_table:
             data["per_table_bytes"] = per_table
         return data
+
+    def profile_reserve(self, estimate: float) -> dict | None:
+        """How much of ``estimate`` is escalation reserve rather than measured
+        scan, as a sentence plus the two numbers behind it. ``None`` when this
+        command priced no profile, so there is nothing to attribute.
+
+        The confirm handshake and the over-ceiling refusal both reach for this,
+        which is the point of it existing: a refusal that quotes a number
+        without saying what it is made of leaves the operator to reconstruct
+        the split from the spend ledger by hand, which is what issue #299
+        reported doing. Only the command-level handshake asks, because only
+        that estimate is the one :meth:`profile_estimate` built.
+
+        The remainder is described rather than the recorded scan half quoted,
+        because a caller may have added statement estimates of its own to the
+        total (``explore query`` prices an auto-profile and its statements in
+        one handshake) and those are dry-run figures too.
+        """
+
+        composition = self._composition
+        if composition is None or not composition.reserved_queries:
+            return None
+        return {
+            "note": (
+                f"{composition.reserved_bytes:,.0f} bytes of this estimate is "
+                f"escalation reserve: {composition.reserved_queries} queries at "
+                f"BigQuery's {_MIN_BILLED_BYTES:,}-byte per-query minimum, held "
+                "for probes a profile may add after its aggregate scan and may "
+                "never issue. The remaining "
+                f"{estimate - composition.reserved_bytes:,.0f} bytes is dry-run "
+                "scan"
+            ),
+            "reserved_bytes": composition.reserved_bytes,
+            "reserved_queries": composition.reserved_queries,
+        }
 
     def _min_billed_floor(self, sql: str) -> float:
         """BigQuery bills at least ``_MIN_BILLED_BYTES`` per table a query

--- a/packages/dex-core/src/exmergo_dex_core/command_args.py
+++ b/packages/dex-core/src/exmergo_dex_core/command_args.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from .adapters.base import Adapter
 from .config import CONFIG_FILE
 from .envelope import Cost
-from .guards.cost_guard import ConfirmationRequiredError, CostGate
+from .guards.cost_guard import ConfirmationRequiredError, CostGate, OverCeilingError
 from .results import ConfirmationRequest, Result
 from .storage import DEX_DIR
 
@@ -117,8 +117,24 @@ def billed_handshake(
     gate = cost_gate(adapter)
     if gate is None:
         return
+    # What a connector can say about the composition of the estimate it just
+    # priced, asked once and used by both refusals below. Only this handshake
+    # asks: it is the one whose estimate the connector's profile pricing built,
+    # and a mid-command phase (verify probes) prices something else entirely.
+    reserve = getattr(adapter, "profile_reserve", None)
+    reserve = reserve(estimate) if reserve is not None else None
     try:
         gate.preflight_command(estimate)
+    except OverCeilingError as exc:
+        # A refusal is the message an operator acts on and the one that carries
+        # the least. Without this, an estimate padded with escalation reserve
+        # reads as work the warehouse is about to do, and the only way to tell
+        # the two apart is to reconstruct the split from the spend ledger
+        # afterwards (issue #299). Re-raised rather than mutated so the
+        # exception stays a plain immutable refusal, carrying the same cost.
+        if reserve is None:
+            raise
+        raise OverCeilingError(f"{exc}. {reserve['note']}", cost=exc.cost) from exc
     except ConfirmationRequiredError as exc:
         # The payload speaks the connector's unit. An adapter that knows more
         # than the raw magnitude (Snowflake's credit translation, its
@@ -139,6 +155,14 @@ def billed_handshake(
             }
             if per_table:
                 data["per_table_bytes"] = per_table
+        if reserve is not None:
+            # Prose and flat keys both: the note is what a person reads when
+            # deciding whether raising the budget buys work or headroom, and
+            # the keys are so a host branching on the split does not have to
+            # parse the sentence to find it.
+            data["reserved_bytes"] = reserve["reserved_bytes"]
+            data["reserved_queries"] = reserve["reserved_queries"]
+            data["notes"] = [*data.get("notes", []), reserve["note"]]
         if notes:
             data.setdefault("notes", [])
             data["notes"] = [*data["notes"], *notes]

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -16,6 +16,8 @@ from dataclasses import replace
 from datetime import UTC, datetime
 
 from ..adapters.base import (
+    VALUE_DOMAIN_CAP,
+    VALUE_DOMAIN_MAX_FRACTION,
     Adapter,
     ColumnAggregate,
     is_blob_type,
@@ -62,15 +64,6 @@ _COMPOSITE_PAIR_CAP = 5
 # competing hypothesis, not filler) still gets its own slot even if it
 # reuses a column.
 _COMPOSITE_REDUNDANCY_RATIO = 3.0
-
-# A column's value domain is reported only when its distinct count clears
-# BOTH bars: small absolutely (this cap) and small relative to the table
-# (the fraction below), so a tiny table's near-key column does not qualify
-# on the absolute count alone. Deliberately conservative -- this codebase's
-# general posture is to under-report rather than over-report, and a false
-# negative here just costs one more `explore query`.
-_VALUE_DOMAIN_CAP = 25
-_VALUE_DOMAIN_MAX_FRACTION = 0.10
 
 # Name patterns mapped to a PII category and a base confidence. Matched on the
 # snake-normalized column name (camelCase is split first, so "firstName" matches
@@ -839,23 +832,23 @@ def _probe_value_domains(
             continue
         if agg.is_unique and agg.null_fraction in (0.0, None):
             continue  # single-column key
-        if not agg.distinct_count or agg.distinct_count > _VALUE_DOMAIN_CAP:
+        if not agg.distinct_count or agg.distinct_count > VALUE_DOMAIN_CAP:
             continue
         non_null = row_count * (1 - (agg.null_fraction or 0.0))
-        if non_null <= 0 or agg.distinct_count > non_null * _VALUE_DOMAIN_MAX_FRACTION:
+        if non_null <= 0 or agg.distinct_count > non_null * VALUE_DOMAIN_MAX_FRACTION:
             continue
         eligible.append(name)
     if not eligible:
         return {}
 
-    samples = domain_fn(identifier, eligible, limit=_VALUE_DOMAIN_CAP)
+    samples = domain_fn(identifier, eligible, limit=VALUE_DOMAIN_CAP)
     domains: dict[str, ValueDomain] = {}
     for name, sample in samples.items():
         agg = aggregates[name]
         non_null = row_count * (1 - (agg.null_fraction or 0.0))
         if (
             non_null <= 0
-            or sample.total_distinct > non_null * _VALUE_DOMAIN_MAX_FRACTION
+            or sample.total_distinct > non_null * VALUE_DOMAIN_MAX_FRACTION
         ):
             # The approximate pre-check under-estimated the true fraction:
             # this is really a near-key column, so report no domain at all

--- a/packages/dex-core/tests/adapters/test_connect_bigquery.py
+++ b/packages/dex-core/tests/adapters/test_connect_bigquery.py
@@ -215,14 +215,57 @@ def test_describe_estimate_names_the_per_query_floor(fake_bq_client):
     assert any("10,485,760" in note or "10 MB" in note for note in described["notes"])
 
 
+def test_profile_reserve_splits_the_escalation_reserve_from_the_scan(fake_bq_client):
+    """The reserve is most of a small-table estimate, so a caller sizing a
+    budget has to be able to tell it from measured scan (issue #299)."""
+
+    adapter = make_adapter(fake_bq_client)
+    # Nothing priced yet, so there is nothing to attribute and the adapter says
+    # so rather than reporting a zero split.
+    assert adapter.profile_reserve(40 * MB) is None
+
+    total, _per_table = adapter.profile_estimate(["test-proj.shop.customers"])
+    reserve = adapter.profile_reserve(total)
+    # customers: one floored batch plus three reserved floors.
+    assert reserve["reserved_queries"] == 3
+    assert reserve["reserved_bytes"] == 30 * MB
+    assert "3 queries" in reserve["note"]
+    # The remainder is the dry-run half, named as such.
+    assert "10,485,760 bytes is dry-run scan" in reserve["note"]
+
+
+def test_profile_reserve_is_silent_when_nothing_could_escalate(fake_bq_client):
+    """An estimate with no reserve in it has no split to report, and saying so
+    with a zero would read as a measurement rather than an absence."""
+
+    from fakes.bigquery import FakeBigQueryClient, FakeTable
+
+    client = FakeBigQueryClient(
+        project="test-proj",
+        tables=[
+            FakeTable(
+                project="test-proj",
+                dataset_id="shop",
+                table_id="empty_table",
+                schema=[bigquery.SchemaField("id", "INTEGER")],
+                num_rows=0,
+                num_bytes=0,
+            )
+        ],
+    )
+    adapter = make_adapter(client)
+    total, _per_table = adapter.profile_estimate(["test-proj.shop.empty_table"])
+    assert adapter.profile_reserve(total) is None
+
+
 def test_profile_estimate_floors_each_batch_at_the_billing_minimum(fake_bq_client):
     adapter = make_adapter(fake_bq_client)
     total, per_table = adapter.profile_estimate(["test-proj.shop.customers"])
     # One batch over one table (the raw 5000-byte scan floors to the minimum)
-    # plus a floor reserved for each of the three possible escalation queries
-    # (customers has 2 non-blob columns and 100 rows, so all three are
-    # possible): 10 MB aggregate + 10 MB near-unique reserve + 10 MB
-    # value-domain reserve + 10 MB composite reserve.
+    # plus a floor reserved for each escalation query customers' metadata
+    # leaves possible (2 scalar columns, 100 rows, so all three are): 10 MB
+    # aggregate + 10 MB near-unique reserve + 10 MB value-domain reserve +
+    # 10 MB composite reserve.
     assert per_table["test-proj.shop.customers"] == 40 * MB
     assert total == 40 * MB
 
@@ -458,12 +501,15 @@ def test_profile_estimate_sums_free_dry_runs(fake_bq_client):
         ["test-proj.shop.customers", "test-proj.shop.events", "test-proj.logs.requests"]
     )
     # Each queryable table is one below-floor batch (floors to the minimum)
-    # plus a floor reserved for each of its three possible escalation queries
-    # (both tables have >= 2 non-blob columns and > 0 rows): 40 MB apiece.
+    # plus a floor per escalation query its metadata leaves possible. customers
+    # has two scalar columns and 100 rows, so all three are: 40 MB. events has
+    # only one column BigQuery can count distinctly (payload is a STRUCT,
+    # labels is REPEATED, and neither gets an approximate distinct), so a
+    # composite pair cannot be formed and that reserve is dropped: 30 MB.
     assert per_table["test-proj.shop.customers"] == 40 * MB
-    assert per_table["test-proj.shop.events"] == 40 * MB
+    assert per_table["test-proj.shop.events"] == 30 * MB
     assert per_table["test-proj.logs.requests"] == 0.0  # unqueryable, skipped
-    assert total == 80 * MB
+    assert total == 70 * MB
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
 
@@ -527,13 +573,14 @@ def test_profile_estimate_skips_the_reserve_for_a_provably_empty_table(fake_bq_c
     assert total == 10 * MB
 
 
-def test_profile_estimate_still_reserves_for_a_view_with_unknown_row_count(
+def test_profile_estimate_reserves_nothing_for_a_view_with_unknown_row_count(
     fake_bq_client,
 ):
-    """A view's row count is never known before the aggregate that reveals it
-    (BigQuery reports no stored row count for a view), so 'unknown' must still
-    reserve for escalation rather than being mistaken for 'empty' (issue #107).
-    """
+    """BigQuery reports no stored row count for a view, and nothing fills one
+    in later: the profiling aggregate's own COUNT(*) is read per batch and
+    never written back to the object. All three escalation probes return early
+    on a falsy row count, so a view provably cannot escalate and the floors it
+    used to reserve were money no run could spend (issue #299)."""
 
     from fakes.bigquery import FakeBigQueryClient, FakeTable
 
@@ -556,9 +603,79 @@ def test_profile_estimate_still_reserves_for_a_view_with_unknown_row_count(
     )
     adapter = make_adapter(client)
     total, per_table = adapter.profile_estimate(["test-proj.shop.a_view"])
-    # Full reserve still applies despite the unknown (None) row count.
-    assert per_table["test-proj.shop.a_view"] == 40 * MB
-    assert total == 40 * MB
+    # Aggregate batch floor only; the unknown row count rules out all three.
+    assert per_table["test-proj.shop.a_view"] == 10 * MB
+    assert total == 10 * MB
+
+
+def _sized_table_client(**table_kwargs):
+    from fakes.bigquery import FakeBigQueryClient, FakeTable
+
+    return FakeBigQueryClient(
+        project="test-proj",
+        tables=[
+            FakeTable(
+                project="test-proj",
+                dataset_id="shop",
+                num_bytes=5_000,
+                **table_kwargs,
+            )
+        ],
+    )
+
+
+def test_profile_estimate_skips_the_value_domain_reserve_on_a_tiny_table():
+    """A value domain needs at least one distinct value within a tenth of the
+    non-null rows, so no column of a table below VALUE_DOMAIN_MIN_ROWS can ever
+    qualify and the probe can never be issued. One row either side of the bar,
+    since the whole point is that the reserve tracks the probe's own rule."""
+
+    from exmergo_dex_core.adapters.base import VALUE_DOMAIN_MIN_ROWS
+
+    schema = [
+        bigquery.SchemaField("id", "INTEGER"),
+        bigquery.SchemaField("status", "STRING"),
+    ]
+    below = make_adapter(
+        _sized_table_client(
+            table_id="tiny", schema=schema, num_rows=VALUE_DOMAIN_MIN_ROWS - 1
+        )
+    )
+    # Batch floor plus the near-unique and composite reserves, not the domain.
+    assert below.profile_estimate(["test-proj.shop.tiny"])[0] == 30 * MB
+
+    at_bar = make_adapter(
+        _sized_table_client(
+            table_id="tiny", schema=schema, num_rows=VALUE_DOMAIN_MIN_ROWS
+        )
+    )
+    assert at_bar.profile_estimate(["test-proj.shop.tiny"])[0] == 40 * MB
+
+
+def test_profile_estimate_reserves_nothing_for_an_all_nested_table():
+    """Nested and repeated fields get no approximate distinct in the aggregate
+    batch, and every escalation's eligibility starts from one, so a table with
+    nothing else in it can no more escalate than a blob column already excluded
+    from the scan."""
+
+    adapter = make_adapter(
+        _sized_table_client(
+            table_id="nested_only",
+            schema=[
+                bigquery.SchemaField(
+                    "payload",
+                    "RECORD",
+                    fields=[bigquery.SchemaField("tag", "STRING")],
+                ),
+                bigquery.SchemaField("labels", "STRING", mode="REPEATED"),
+                bigquery.SchemaField("shape", "GEOGRAPHY"),
+            ],
+            num_rows=100_000,
+        )
+    )
+    total, per_table = adapter.profile_estimate(["test-proj.shop.nested_only"])
+    assert per_table["test-proj.shop.nested_only"] == 10 * MB
+    assert total == 10 * MB
 
 
 def _blob_fake_client():

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -171,6 +171,11 @@ def test_unconfirmed_profile_returns_needs_confirmation(
     # columns, 100 rows): 10 + 10 + 10 + 10 = 40 MB.
     assert envelope.cost.estimate == 40 * MB
     assert envelope.data["per_table_bytes"] == {"test-proj.shop.customers": 40 * MB}
+    # Three of those four floors are reserve, split out so the caller can see
+    # whether a raised budget buys work or headroom (#299).
+    assert envelope.data["reserved_bytes"] == 30 * MB
+    assert envelope.data["reserved_queries"] == 3
+    assert any("escalation reserve" in n for n in envelope.data["notes"])
     assert "--confirm" in envelope.data["hint"]
     # Nothing executed: only free metadata and dry-runs happened.
     assert all(c.dry_run for c in fake_bq_client.query_calls)
@@ -206,9 +211,11 @@ def test_unconfirmed_map_estimates_selected_objects(
     envelope = _dispatch(tmp_path, subcommand="map")
     assert envelope.status.value == "needs_confirmation"
     # customers and events each floor to the per-query minimum plus a floor
-    # per possible escalation query (40 MB apiece); logs.requests needs a
-    # partition filter, so it contributes zero.
-    assert envelope.cost.estimate == 2 * 40 * MB
+    # per escalation query their metadata leaves possible (40 MB for customers,
+    # 30 MB for events, whose only distinct-countable column cannot form a
+    # composite pair); logs.requests needs a partition filter, so it
+    # contributes zero.
+    assert envelope.cost.estimate == 70 * MB
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
 
@@ -267,8 +274,9 @@ def test_unconfirmed_map_excludes_fresh_cached_objects(
     envelope = _dispatch(tmp_path, subcommand="map")
     assert envelope.status.value == "needs_confirmation"
     # Only events is priced now (customers is fresh-cached, requests is
-    # partition-filtered to zero), so the estimate halves versus the no-cache run.
-    assert envelope.cost.estimate == 40 * MB
+    # partition-filtered to zero), so the estimate drops to that table's share
+    # of the no-cache run.
+    assert envelope.cost.estimate == 30 * MB
     assert "test-proj.shop.customers" not in envelope.data["per_table_bytes"]
     assert any("fresh-cached" in note for note in envelope.data["notes"])
     assert all(c.dry_run for c in fake_bq_client.query_calls)
@@ -715,6 +723,11 @@ def test_verify_beyond_budget_checkpoints_before_any_probe(
     cache = FilesystemStore(tmp_path).load_cache()
     assert cache.relationships and not cache.relationships[0].verified
     assert any("unverified" in note for note in envelope.data["notes"])
+    # The verify phase prices overlap probes, which carry no escalation
+    # reserve. The profile estimate earlier in this same command did, and
+    # attributing that one to this number would describe the wrong estimate.
+    assert "reserved_bytes" not in envelope.data
+    assert not any("escalation reserve" in n for n in envelope.data["notes"])
 
 
 def test_relationships_verify_beyond_budget_checkpoints(
@@ -868,6 +881,34 @@ def test_over_ceiling_refusal_reports_the_metered_paradigm(
     assert all(c.dry_run for c in fake_bq_client.query_calls)
     # #170: a machine-readable reason alongside the prose.
     assert envelope.reason is Reason.GUARD
+
+
+def test_over_ceiling_refusal_attributes_the_estimate_it_refused_on(
+    fake_bq_client, route_adapter, tmp_path
+):
+    """Three quarters of this estimate is escalation reserve, and a refusal
+    that quotes only the total leaves the operator to reconstruct the split
+    from the spend ledger to find out whether the number grew because the
+    warehouse did (issue #299)."""
+
+    route_adapter(fake_bq_client)
+    envelope = _dispatch(
+        tmp_path,
+        subcommand="profile",
+        objects=["customers"],
+        confirm=True,
+        budget=float(MB),
+    )
+    assert envelope.status.value == "error"
+    message = envelope.errors[0]
+    assert "exceeds the ceiling" in message
+    # 3 of the 4 floors in customers' 40 MB estimate are reserve.
+    assert "31,457,280 bytes of this estimate is escalation reserve" in message
+    assert "3 queries" in message
+    assert "10,485,760 bytes is dry-run scan" in message
+    # Still a refusal that spends nothing and cannot be confirmed through.
+    assert envelope.cost.estimate == 40 * MB
+    assert all(c.dry_run for c in fake_bq_client.query_calls)
 
 
 def test_no_ceiling_refusal_reports_the_metered_paradigm(

--- a/packages/dex-core/tests/explore/test_profile.py
+++ b/packages/dex-core/tests/explore/test_profile.py
@@ -1589,6 +1589,32 @@ def test_value_domain_excluded_when_fraction_exceeds_cutoff_on_small_table():
     assert datasets[0].columns[0].value_domain is None
 
 
+def test_no_column_can_have_a_value_domain_below_the_minimum_row_count():
+    """The fraction implies a floor on rows, and a metered adapter reserves
+    budget against that floor rather than against the fraction it cannot
+    evaluate before the scan (issue #299). This pins the two together: below
+    VALUE_DOMAIN_MIN_ROWS not even the narrowest possible column qualifies, so
+    an estimator that skips the reserve there skips a query that cannot run."""
+
+    from exmergo_dex_core.adapters.base import (
+        VALUE_DOMAIN_MIN_ROWS,
+        ValueDomainSample,
+    )
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    below = _StubAdapter(rows=VALUE_DOMAIN_MIN_ROWS - 1, approx={"code": 1})
+    profile_mod.profile(below, ["db.s.t"])
+    assert below.domain_calls == []
+
+    at_bar = _StubAdapter(
+        rows=VALUE_DOMAIN_MIN_ROWS,
+        approx={"code": 1},
+        domains={"code": ValueDomainSample(values=[("x", 10)], total_distinct=1)},
+    )
+    profile_mod.profile(at_bar, ["db.s.t"])
+    assert at_bar.domain_calls == [["code"]]
+
+
 def test_value_domain_excluded_for_composite_key_member():
     """`line_no` is well within the cap and fraction on its own, but it is a
     proven composite-key member, so it must report no domain even though the

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -1848,6 +1848,58 @@ def test_bigquery_over_ceiling_cannot_be_confirmed_through(fake_bq_client):
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
 
+def test_bigquery_a_narrowed_reserve_still_bounds_what_profiling_bills():
+    # Family 2: the estimate is a ceiling actual spend will not exceed (#107),
+    # and that has to survive every reserve the estimator declines to hold
+    # (#299). A view is the sharpest case: it has no row count, so all three
+    # escalation probes bail and the estimator now reserves nothing at all for
+    # it. If any of them could still run, this is where the quoted number would
+    # turn out to be less than the bill.
+    from fakes.bigquery import FakeBigQueryClient, FakeTable
+
+    from exmergo_dex_core.explore import profile as profile_mod
+
+    bigquery = pytest.importorskip("google.cloud.bigquery")
+    client = FakeBigQueryClient(
+        project="test-proj",
+        tables=[
+            FakeTable(
+                project="test-proj",
+                dataset_id="shop",
+                table_id="customers_v",
+                schema=[
+                    bigquery.SchemaField("id", "INTEGER"),
+                    bigquery.SchemaField("tier", "STRING"),
+                ],
+                num_rows=100,  # nulled out for a view, which is the point
+                num_bytes=5_000,
+                table_type="VIEW",
+            )
+        ],
+        row_resolver=lambda sql: [
+            {
+                "n_total": 100,
+                "nn_0": 100,
+                "nd_0": 100,
+                "mn_0": 1,
+                "mx_0": 100,
+                "nn_1": 100,
+                "nd_1": 3,
+                "d_0": 100,
+                "d_1": 3,
+            }
+        ],
+    )
+    adapter = _bq_adapter(client)
+    estimate, _per_table = adapter.profile_estimate(["test-proj.shop.customers_v"])
+    profile_mod.profile(adapter, ["test-proj.shop.customers_v"])
+    billed = adapter.cost_gate.spend_summary()["bytes_billed"]
+    assert billed <= estimate
+    # And no escalation was attempted, which is why nothing was reserved.
+    executed = [c for c in client.query_calls if not c.dry_run]
+    assert len(executed) == 1
+
+
 def test_bigquery_every_executed_job_is_server_capped(fake_bq_client):
     # Family 2: defense in depth past the client-side gate; a wrong estimate
     # cannot overrun the budget because the service enforces the cap.

--- a/references/bigquery.md
+++ b/references/bigquery.md
@@ -72,6 +72,35 @@ BigQuery bills a 10 MB minimum per query; a remaining budget below that is
 refused with the math rather than letting the job fail server-side. Query-cache
 hits bill zero and are recorded as such.
 
+### What a profile estimate is made of
+
+A profile's cost is not one query per table. After the aggregate scan, a
+profile may issue up to three more queries against the same table: an exact
+distinct count for a near-unique column, a value-domain probe for a
+low-cardinality one, and a composite-key probe. Which of them run depends on
+the aggregate scan's own approximate results, so none can be dry-run before it,
+and the estimate holds one 10 MB floor apiece instead. A reserve is dropped only
+where an object's metadata already rules the query out: a view (no row count, so
+no probe can run), a table of nested or repeated columns only (no approximate
+distinct, which every probe starts from), a table too small for a value domain,
+or one with too few countable columns to form a composite pair.
+
+The reserve scales with object count rather than data size, so on a warehouse of
+many small tables it can be most of the number. Both the `needs_confirmation`
+payload and the over-ceiling refusal split it out, in prose and in
+`reserved_bytes` / `reserved_queries`, so a raised budget is a decision rather
+than a guess:
+
+```
+220,200,960 bytes of this estimate is escalation reserve: 21 queries at
+BigQuery's 10,485,760-byte per-query minimum, held for probes a profile may add
+after its aggregate scan and may never issue. The remaining 533,991,980 bytes
+is dry-run scan
+```
+
+A mid-command verify checkpoint prices overlap probes, which carry no reserve,
+so it reports none rather than repeating the profile's.
+
 ## Profiling behavior
 
 - Aggregates only (`COUNT`, `APPROX_COUNT_DISTINCT`, `MIN`/`MAX` on safe
@@ -84,9 +113,11 @@ hits bill zero and are recorded as such.
 - With `bigquery.max_full_profile_bytes` set, larger tables are profiled from
   a `TABLESAMPLE SYSTEM` block sample, flagged as approximate, and uniqueness
   is not judged.
-- Exact distinct-count escalation (the uniqueness proof) spends only within
-  the already-confirmed budget and degrades to approximate verdicts when the
-  remaining budget cannot cover it.
+- Exact distinct-count escalation (the uniqueness proof), the composite-key
+  probe, and the value-domain probe each spend only within the
+  already-confirmed budget, and degrade (to an approximate verdict, no
+  composite key, or no reported domain) plus a table note when the remaining
+  budget cannot cover them.
 
 ## Read-only, in depth
 

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -195,6 +195,14 @@ retry with a raised budget on an over-ceiling refusal without asking.
 Metadata is free (`connect test`, `inventory` run immediately), and OK
 envelopes report actual spend under `data.spend`.
 
+On BigQuery a profiling estimate holds a 10 MB floor per table for each
+escalation query a profile may still issue after its aggregate scan, so on a
+warehouse of many small tables most of the number can be reserve for work that
+never happens. Both the handshake and the over-ceiling refusal report that split
+(`reserved_bytes` and `reserved_queries`, and in the prose). Pass it on when you
+surface the estimate: whether a number is scan or reserve changes whether
+raising the budget is buying work or headroom.
+
 When an estimate is larger than the work deserves, narrow the scope rather than
 raise the budget. `--scope` (repeatable) bounds a command to part of the
 configured source allowlist, in the connector's own vocabulary: a dataset on

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.3"
+DEX_CORE_VERSION = "1.6.4"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.3"
+DEX_CORE_VERSION = "1.6.4"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.3"
+DEX_CORE_VERSION = "1.6.4"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
# The escalation reserve holds less, and says how much it holds

Closes #299.

`profile_estimate` held three per-table 10 MB floors where 1.5.2 held two. The
third arrived with the value-domain probe in 1.6.0 (#203) and carried no
precondition. The reserve scales with object count rather than data size, so a
reporter's 12-object nightly `explore map` moved 125.8 MB in one release and has
been refused against a 500 MB ceiling since 2026-08-09.

They asked for one of three things: condition the reserve, document it, or fold
it into what #278 will report. This does the first two and the useful half of the
third, and is explicit that the first one does not fix their number.

## The reserve was holding money no run could spend

Three cases, all decidable from metadata the estimator already has, and all
provably impossible rather than merely unlikely:

**A view.** BigQuery reports no stored row count for one, and nothing fills it in
later: the profiling aggregate's own `COUNT(*)` is read per batch inside
`_read_aggregates` and never written back to the object. All three probes return
early on a falsy row count. So a view could never escalate and was holding three
floors regardless. The old docstring defended this explicitly, saying an unknown
row count "still reserves, since escalation is not ruled out". It is ruled out,
by the probes' own first line.

**A table of nested and repeated columns only.** Those get no approximate
distinct in the aggregate batch (`RECORD`, `ARRAY`, `JSON`, `GEOGRAPHY`, `RANGE`,
`INTERVAL`), and every probe's eligibility starts from one. They can no more
trigger an escalation than a blob column already excluded from the scan. The
composite reserve was already conditioned on having two columns, but on the raw
column count, which counts columns that can never join a pair.

**A table below ten rows.** A value domain needs at least one distinct value
within a tenth of the non-null rows, so nothing on such a table can qualify. The
two thresholds that imply that floor moved from `explore/profile.py` to
`adapters/base.py`, beside `ValueDomainSample`, because the estimator now depends
on them and a copy in the adapter would drift the first time either moved. That
is the same route `is_blob_type` already travels: predicates both the pricing
side and the profiling side have to agree on live in `base`.

Nothing else was narrowed, and the comment on `_escalation_reserve` says why: a
reserve is dropped only where a probe's own guard already rules the query out. An
estimate that reserves for a query that cannot run is loose; one that skips a
query that can is the defect #107 closed.

## Which is why the second half matters more

On the reporter's warehouse none of the three fire. Eleven small flat reporting
tables with more than ten rows reserve exactly as much as before. Value-domain
eligibility rests on approximate distinct counts that do not exist until the
scan has run, and on the PII name classification, which lives in
`explore.profile` and is deliberately unreachable from an adapter. Their 125.8 MB
is real and stays, and holding it is correct.

What they were actually missing was the ability to read their own refusal. It
said:

```
estimated cost 754192940.0 exceeds the ceiling 500000000.0 (bytes_scanned);
raise the budget or narrow the work
```

about a number that was 75% reserve on their warehouse, and they reconstructed
the split by hand from `.dex/spend.jsonl` to work out whether the estimate had
grown because the warehouse had or because dex had added a probe. It now says:

```
estimated cost 754192940.0 exceeds the ceiling 500000000.0 (bytes_scanned);
raise the budget or narrow the work. 220,200,960 bytes of this estimate is
escalation reserve: 21 queries at BigQuery's 10,485,760-byte per-query minimum,
held for probes a profile may add after its aggregate scan and may never issue.
The remaining 533,991,980 bytes is dry-run scan
```

The same sentence rides on the `needs_confirmation` payload, with
`reserved_bytes` and `reserved_queries` as flat keys so a host does not have to
parse prose.

Two structural notes. `billed_handshake` reached the connector's own description
of an estimate only on the confirmation path; an over-ceiling refusal, the more
consequential of the two and the one carrying the least, got nothing. It now
catches `OverCeilingError` beside `ConfirmationRequiredError` and re-raises with
the same `cost` and the split appended. That is also where #278's historical
ratio belongs when it lands.

And the split is asked for in `billed_handshake`, not folded into
`describe_estimate`. The first version of this did fold it in, which was wrong:
`verify_handshake` calls the same describer for a mid-command phase, so a verify
checkpoint would have reported the earlier profile's reserve as part of an
overlap-probe estimate it has nothing to do with. `describe_estimate` stays a
pure function of its arguments; `profile_reserve(estimate)` answers the
composition question, and only the command-level handshake, whose estimate the
profile pricing actually built, asks it. `test_verify_beyond_budget_checkpoints`
pins that the checkpoint reports no reserve.

## Measured on BigQuery, not just on fakes

Against `test_thelook_ecommerce` (8 tables, one 369 MB, one empty,
one at exactly 10 rows), unconfirmed `explore map`:

| | estimate | reserve |
|---|---|---|
| 1.6.3 | `754,192,940` | not reported |
| this branch | `754,192,940` | `220,200,960` over 21 queries (29%) |

Identical, which is the honest result: every table there is flat and populated,
so nothing narrows. The narrowing was measured separately, in `dex_ci`, on one
view, one all-nested table, and one 9-row table:

| | 1.6.3 | this branch |
|---|---|---|
| `dex299_orders_v` (view) | `41,943,040` | `10,485,760` |
| `dex299_nested_only` | `41,943,040` | `10,485,760` |
| `dex299_tiny` (9 rows) | `41,943,040` | `31,457,280` |
| total | `125,829,120` | `52,428,800` |

The 1.6.3 column is the real published wheel via `uvx --from
exmergo-dex-core[bigquery]==1.6.3`, not arithmetic. The three scratch objects
were dropped afterwards.

## One thing the dogfood turned up that this does not fix

That confirmed run billed `772,800,512` against a `754,192,940` estimate: **2.5%
over**. The estimate is identical on 1.6.3, so this is pre-existing and untouched
here, but it contradicts what the reserve is documented to buy.

The cause is that each reserve is one flat `_MIN_BILLED_BYTES`, not a dry-run.
Twenty queries settled: 8 aggregate batches and 12 escalations, against 21
reserved. So the reserve over-held by 9 floors and still came up short, because
the escalations that did run on the big tables (`events` at 369 MB) each billed
far more than 10 MB. Two opposite errors that partially cancel, and on a
warehouse with any large table in it the under-reserve wins.

There is a sound upper bound available: an escalation query reads a subset of the
columns its aggregate batch already dry-ran, so `max(floor, batch_dry_run)` per
reserved escalation would make the total a genuine ceiling. It would also raise
estimates sharply on exactly the large tables, which is the opposite of what #299
is asking for, so it is a trade to decide deliberately rather than fold in here.
Worth its own issue.

## Files

- `adapters/base.py`: the value-domain thresholds and the row floor they imply.
- `adapters/bigquery.py`: `_escalation_reserve`, `_EstimateComposition`,
  `profile_reserve`, and the rewritten `profile_estimate` docstring, which said
  "two" and named two of three.
- `command_args.py`: the over-ceiling branch and where the split attaches.
- `explore/profile.py`: imports the thresholds instead of owning them.
- Tests: `test_connect_bigquery.py` (the view test inverts; two new boundary
  tests; a reserve-composition test), `test_billed_handshake.py` (the `events`
  arithmetic, plus a refusal-attribution test), `test_safety_spine.py` (a new
  Family 2 test that a narrowed reserve still bounds what profiling bills),
  `test_profile.py` (pins the minimum row count to the probe behaviorally).
- Docs: `references/bigquery.md` had never mentioned the reserve or the third
  escalation at all; `skills/explore/SKILL.md`; `CHANGELOG.md`.
