### PR TITLE
Classify an unreadable cache, and rebuild an unreadable drift report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,68 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   new persisted state and a new cross-command annotation pass. Filed as a
   follow-up rather than folded in here.
   
+- **`CacheUnreadableError`**, exported from the package root and from
+  `exmergo_dex_core.storage`. The sibling of `CacheRequiredError` that
+  `BaselineUnreadableError` is of `NoBaselineError`: both remediate the same way,
+  so the status is identical, but "nothing has been explored here" and "what was
+  explored will not parse" are different facts about a deployment and only one of
+  them suggests something went wrong. A host can page on the second without
+  matching on prose.
+
+  It carries no `schema_version`, unlike the baseline's, and the asymmetry is the
+  one already reasoned out in `maintain/snapshot.py`: the cache's version drives a
+  `<` comparison that *degrades*, where the baseline's is a membership test that
+  *refuses*. A degrading version leaves no refusal for the attribute to carry.
+
+### Fixed
+
+- **A corrupt exploration cache no longer reports as a bad request** ([#249]).
+  `load_cache` raises on a document it cannot parse, and pydantic's
+  `ValidationError` subclasses `ValueError`, so an unreadable cache fell through
+  to the CLI catch-all and was classified as `reason: request`. That tells an
+  operator they typed something wrong, and tells a host to retry with different
+  arguments, when the fix is a command nobody has run. It is the same defect
+  `_require_baseline` fixed for the baseline in 1.6.3, on the load the storage
+  contract had already flagged: *"this load has no such wrapper yet [...] raise a
+  `ValueError` so the load is classifiable when it gets one."* All thirteen
+  engine call sites, across `explore`, `maintain` and `transform`, now go through
+  `readable_cache`, including the one `transform test --scaffold` added above:
+  it types every value in a `given` row from the cache, so an unreadable one
+  reached the catch-all there too.
+
+  `explore/semantic/local.py` is deliberately **not** routed through it. Its bare
+  `except Exception: return None` is documented as intentional, because a metric
+  query is governed by dimension name before any SQL exists and a repo that never
+  ran `explore map` can still query metrics. Routing it would make
+  `explore semantic query` refuse where it currently degrades.
+
+- **An unreadable drift report is rebuilt instead of refused** ([#249]). Same
+  root cause, deliberately opposite remedy, and the one the note beside
+  `DRIFT_SCHEMA_VERSION` pre-committed to: a baseline is *vouched for* and
+  nothing else reproduces it, while a drift report is *derived* and
+  `maintain check` regenerates it from the baseline on demand. `_stored_drift`
+  treats a document that will not parse as absent, so `_record_axes` rebuilds it
+  exactly as it already did for a report measured against a different baseline,
+  and `reconcile` raises the `NoBaselineError` naming `maintain check` that it
+  already raised for a missing one. No new error class, because neither caller
+  needed one.
+
+### Changed
+
+- **`readable_cache` classifies rather than requires**, which is why there is no
+  `_require_cache` mirroring `_require_baseline`. Every `load_snapshot` caller
+  needs a baseline, so that helper can refuse on `None`. Absence is *legal* at
+  most cache call sites: `explore profile`, `explore relationships` and
+  `explore map` read a prior cache only to merge pre-run state and a first run
+  has none, `maintain snapshot` falls back to a metadata capture, and
+  `_baseline_warnings` merely skips a warning. `None` is returned unchanged and
+  every caller keeps the absence policy it already had.
+
+- The refusal names the cost. `maintain snapshot` is free on every connector, so
+  the baseline's remedy can say "just re-run it"; `explore map` re-profiles the
+  warehouse and **bills**. An operator choosing between investigating a corrupt
+  document and replacing it needs that said before they run it.
+
 ## [1.6.4] - 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,52 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   already raised for a missing one. No new error class, because neither caller
   needed one.
 
+- **A declared join is measured, and the measurement does not revise the
+  declaration** ([#163]). A relationship the project declares could not be
+  verified at any budget, by any flag, from any caller: verify selected its
+  probes by `kind`, and the skip happened *upstream* of `--verify`, so asking for
+  verification spent nothing extra and covered nothing extra. `fanout_pairs` was
+  permanently empty for a project that declares its joins, and `maintain grain`
+  returned a result indistinguishable from a clean join graph. The same `kind`
+  gate had since spread: the catastrophic orphan-rate finding added in 1.6.4
+  ([#207]) was unreachable for exactly the cooperative case it was written for,
+  because inference finds no edges where the project already declares them.
+
+  The split this turns on is that a declaration is a claim *about the data*, and
+  the overlap SQL does not care how the relationship was learned. **Measurement**
+  (`verified`, `orphan_fraction`) now applies to both kinds. **Confidence
+  arithmetic stays inferred-only**: demoting a declared 1.0 on a measured 0.2
+  orphan rate would report a data defect as though dex had grown less sure of an
+  edge the project stated. The disagreement surfaces through `orphan_findings`
+  instead, with its own wording, because "the project and the warehouse disagree"
+  is a different and more actionable claim than a shared name that turned out not
+  to be a shared key.
+
+  Two things this needed beyond lifting the filter. `declared_relationships()`
+  was called *after* the verify handshake, so lifting the filter alone would have
+  changed nothing on `explore relationships` or `explore map`; both now verify the
+  merged set, which also means no measurement can be discarded by the merge rule
+  that prefers a declared edge over the same inferred one, since at merge time
+  nothing has been measured yet. And `probe_candidates` is now the single
+  definition of what verify runs on, shared by `verify_relationships`,
+  `probe_statements` and `_verify_estimate`, which previously agreed only by each
+  hard-coding the same filter. Pricing N probes and issuing N+M under-reports
+  spend *before* it happens, which is the one thing the cost preflight exists to
+  prevent.
+
+  Cost and scope. `--verify` now costs one additional probe per declared edge on
+  a billed connector, covered by the existing handshake precisely because the
+  estimate and the run select through the same function. The declared channel
+  only exists under `--use-project`, so this is invisible in any fixture that
+  maps without the flag. Composite keys stay excluded, explicitly rather than by
+  omission: `_overlap_probe_sql` joins on the first column of each side, which
+  answers about a *different* relationship and would report its orphan count as
+  the join's, so composites stay unverified until the probe itself spans a key.
+  And the fix is **not retroactive**, since `grain_plan` reads the baseline
+  snapshot and existing snapshots hold declared joins at `verified: false`;
+  fanout drift on a declared join needs a fresh `maintain snapshot` taken after
+  the join was declared.
+
 ### Changed
 
 - **`readable_cache` classifies rather than requires**, which is why there is no

--- a/packages/dex-core/src/exmergo_dex_core/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/__init__.py
@@ -55,6 +55,7 @@ _EXPORTS = {
     "BaselineUnreadableError": "maintain.commands",
     "BudgetExhaustedError": "results",
     "CacheRequiredError": "explore.commands",
+    "CacheUnreadableError": "storage.base",
     "CeilingRequiredError": "guards.cost_guard",
     "ClusterDependencyError": "explore.cluster",
     "ClusterError": "explore.cluster",
@@ -154,6 +155,7 @@ if TYPE_CHECKING:  # what a type checker and an IDE see; never run
         to_envelope,
     )
     from .storage import (
+        CacheUnreadableError,
         Document,
         ExploreStore,
         FilesystemStore,
@@ -179,6 +181,7 @@ __all__ = [
     "BaselineUnreadableError",
     "BudgetExhaustedError",
     "CacheRequiredError",
+    "CacheUnreadableError",
     "CeilingRequiredError",
     "ClusterDependencyError",
     "ClusterError",

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -63,7 +63,7 @@ from ..guards.query_firewall import (
 from ..guards.sql_guard import referenced_relations, split_statements
 from ..progress import ProgressReporter
 from ..results import BudgetExhaustedError, ConfirmationRequest, to_envelope
-from ..storage import Document, ExploreStore
+from ..storage import CacheUnreadableError, Document, ExploreStore, readable_cache
 from . import cluster as cluster_mod
 from . import diagram as diagram_mod
 from . import inventory as inventory_mod
@@ -489,7 +489,7 @@ def profile(
     # Capture pre-run cache state before any checkpoint write, so the success-path
     # compose reads the pre-run cache rather than a checkpoint this run wrote.
     now = datetime.now(UTC)
-    prior = store.load_cache()
+    prior = readable_cache(store)
 
     identifiers = _resolve_identifiers(adapter, objects)
     connector = adapter.name
@@ -596,7 +596,7 @@ def relationships(
     # Capture pre-run cache state before any checkpoint write, so the success-path
     # compose reads the pre-run cache rather than a checkpoint this run wrote.
     now = datetime.now(UTC)
-    prior = store.load_cache()
+    prior = readable_cache(store)
     accumulated: list[Dataset] = []
     over_ceiling = False
     verify_pending: ConfirmationRequest | None = None
@@ -999,7 +999,7 @@ def _run_statements(
     limits = config.query
     now = datetime.now(UTC)
     at = now.isoformat()
-    cache = store.load_cache()
+    cache = readable_cache(store)
     # The firewall parses in the active connector's dialect, so BigQuery SQL
     # (backticks, COUNTIF) is inspected as BigQuery, not as DuckDB.
     dialect = get_dialect(engine.connector or config.connector)
@@ -1542,7 +1542,7 @@ def map(
     # Capture pre-run cache state before any checkpoint write, so the success-path
     # compose reads the pre-run cache rather than a checkpoint this run wrote.
     now = datetime.now(UTC)
-    prior = store.load_cache()
+    prior = readable_cache(store)
     accumulated: list[Dataset] = []
     over_ceiling = False
     verify_pending: ConfirmationRequest | None = None
@@ -1856,7 +1856,7 @@ def cluster(
 
     store = engine.store
     config = engine.config
-    cache = store.load_cache()
+    cache = readable_cache(store)
     now = datetime.now(UTC)
     auto = config.auto_profile if auto_profile is None else auto_profile
 
@@ -2091,7 +2091,7 @@ def diagram(engine: DexEngine, *, full: bool = False) -> DiagramResult:
     nothing and a diagram of an unexplored warehouse look identical.
     """
 
-    cache = engine.store.load_cache()
+    cache = readable_cache(engine.store)
     if cache is None:
         raise CacheRequiredError(
             "no exploration cache yet; run `explore map` first so there is a "
@@ -2122,7 +2122,7 @@ def diagram(engine: DexEngine, *, full: bool = False) -> DiagramResult:
 def cmd_diagram(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     try:
         return to_envelope(diagram(engine, full=getattr(args, "full", False)))
-    except (CacheRequiredError, ValueError) as exc:
+    except (CacheRequiredError, CacheUnreadableError, ValueError) as exc:
         return env.error_for(exc)
 
 
@@ -2139,6 +2139,7 @@ def cmd_cluster(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
         )
     except (
         CacheRequiredError,
+        CacheUnreadableError,
         ValueError,
         cluster_mod.ClusterError,
         cluster_mod.ClusterDependencyError,

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -39,7 +39,7 @@ from ..adapters.base import name_list
 from ..config import pii_override_paths
 from ..errors import PrerequisiteError, ProjectError, RepoRootRequiredError
 from ..results import ConfirmationRequest, to_envelope
-from ..storage import Document, FilesystemStore, MaintainStore
+from ..storage import Document, FilesystemStore, MaintainStore, readable_cache
 from . import drift as drift_mod
 from . import snapshot as snapshot_mod
 from .results import DriftResult, LayerFingerprint, ReconcileResult, SnapshotResult
@@ -234,6 +234,39 @@ def _require_baseline(store: MaintainStore) -> snapshot_mod.Snapshot:
     return snap
 
 
+def _stored_drift(store: MaintainStore) -> drift_mod.DriftReport | None:
+    """The stored drift report, treating one that will not parse as absent.
+
+    The opposite policy from :func:`_require_baseline`, and the reason is the one
+    already written down beside ``DRIFT_SCHEMA_VERSION`` in :mod:`.drift`: the
+    baseline is *vouched for* and nothing else reproduces it, while a drift
+    report is *derived* and `maintain check` regenerates it from the baseline on
+    demand. So a document this engine cannot read has a cheap correct answer here
+    that the baseline does not have, and that note pre-committed to this one:
+    "treat it as absent and rebuild, rather than refuse".
+
+    Both callers already have an absent path, so this widens a handled state
+    rather than adding one. ``_record_axes`` discards a report measured against a
+    different baseline wholesale, which is the same "throw it away and remeasure"
+    it now does for an unparseable one; ``reconcile`` raises
+    :class:`NoBaselineError` naming `maintain check`, which is the correct remedy
+    for a report that cannot be read as much as for one that was never written.
+
+    ⚠️ Deliberately silent about *which* of the two happened, unlike the cache and
+    the baseline. Rebuilding is free and automatic here, so an operator has
+    nothing to decide and a warning would be noise on a path that self-heals.
+    """
+
+    try:
+        return store.load_drift()
+    except ValueError:
+        # Same convention as `_require_baseline` and `readable_cache`: a backend
+        # signals "this document will not parse" with a ValueError, whatever its
+        # own deserializer raises. Swallowed rather than classified because the
+        # remedy runs itself on the very next line of both callers.
+        return None
+
+
 def snapshot(engine: DexEngine) -> SnapshotResult:
     """Capture the known-good baseline every drift axis is measured against.
 
@@ -247,7 +280,7 @@ def snapshot(engine: DexEngine) -> SnapshotResult:
     config = engine.config
     warnings: list[str] = []
 
-    cache = store.load_cache()
+    cache = readable_cache(store)
     requested = engine.connector or config.connector
     usable = cache is not None and bool(cache.datasets)
     if usable and cache.provenance.connector not in (None, requested):
@@ -702,7 +735,7 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
 
     store = engine.store
     snap = _require_baseline(store)
-    report = store.load_drift()
+    report = _stored_drift(store)
     if report is None:
         raise NoBaselineError(
             "no drift report yet; run `maintain check` (or a focused detector) "
@@ -755,10 +788,14 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
         except (ProjectError, ValueError) as exc:
             raise ProjectError(f"reconcile edits a project: {exc}") from exc
 
+    # Hoisted rather than inlined into the call: this load can now refuse, and a
+    # refusal raised from inside an argument list reads as though `build` did it.
+    cache = readable_cache(store)
+
     proposals, edits, build_warnings = reconcile_mod.build(
         findings,
         snap,
-        store.load_cache(),
+        cache,
         view,
         pii_overrides=pii_override_paths(engine.config.pii_overrides),
         placement=editable if isinstance(editable, PlacingProject) else None,
@@ -890,7 +927,7 @@ def _record_axes(
     a focused detector refreshes only itself, but never across baselines:
     findings measured against an older snapshot are dropped wholesale."""
 
-    report = store.load_drift()
+    report = _stored_drift(store)
     if report is None or report.snapshot_created_at != snap.created_at:
         report = drift_mod.DriftReport()
     report.connector = connector
@@ -1079,7 +1116,7 @@ def _baseline_warnings(
     """
 
     warnings: list[str] = []
-    cache = store.load_cache()
+    cache = readable_cache(store)
     if (
         cache is not None
         and cache.provenance.updated_at

--- a/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
@@ -45,14 +45,14 @@ from .snapshot import SemanticLayer, Snapshot, TransformLayer
 #: does not recognize therefore has a cheap correct answer (rebuild) that the
 #: baseline does not have.
 #:
-#: What is *not* yet handled, and is a real gap rather than a decision: a drift
-#: report that fails to parse still raises out of `load_drift` uncaught and is
-#: classified as a request error, exactly the defect `_require_baseline` fixes
-#: for the baseline. The argument above is about versioning, not about
-#: corruption, and it does not cover that. Left out of the change for #243
-#: because the right remedy differs (treat it as absent and rebuild, rather than
-#: refuse), which deserves its own decision rather than symmetry with the
-#: baseline.
+#: Corruption is handled separately from versioning, and the remedy the paragraph
+#: above predicted is the one that shipped. A drift report that fails to parse
+#: used to raise out of `load_drift` uncaught and be classified as a request
+#: error, telling an operator they typed something wrong; `_stored_drift` now
+#: catches that and treats it as absent, so both callers take the rebuild path
+#: they already had for a missing report. Deliberately NOT the baseline's
+#: refusal: the argument above is exactly why the same input deserves opposite
+#: answers on the two documents.
 DRIFT_SCHEMA_VERSION = 1
 
 FREE_AXES = ("schema", "volume")

--- a/packages/dex-core/src/exmergo_dex_core/storage/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/__init__.py
@@ -21,6 +21,7 @@ this package. It is deliberately not imported here: it needs pytest, and a bare
 """
 
 from .base import (
+    CacheUnreadableError,
     Document,
     ExploreStore,
     MaintainStore,
@@ -28,6 +29,7 @@ from .base import (
     Store,
     StoreContext,
     StoreFactory,
+    readable_cache,
     spend_total,
 )
 from .filesystem import DEX_DIR, FilesystemStore
@@ -36,6 +38,7 @@ from .resolver import build_store, resolve_store_factory
 
 __all__ = [
     "DEX_DIR",
+    "CacheUnreadableError",
     "Document",
     "ExploreStore",
     "FilesystemStore",
@@ -46,6 +49,7 @@ __all__ = [
     "StoreContext",
     "StoreFactory",
     "build_store",
+    "readable_cache",
     "resolve_store_factory",
     "spend_total",
 ]

--- a/packages/dex-core/src/exmergo_dex_core/storage/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/base.py
@@ -49,11 +49,43 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from pydantic import ValidationError
+
+from ..errors import PrerequisiteError
+
 if TYPE_CHECKING:
     from ..cache import DexCache
     from ..maintain.drift import DriftReport
     from ..maintain.snapshot import Snapshot
     from ..transform.plans import EditKind, TransformPlan
+
+
+class CacheUnreadableError(PrerequisiteError):
+    """A cache exists and this engine cannot read it.
+
+    The counterpart of :class:`~.explore.commands.CacheRequiredError`, drawing
+    the same distinction :class:`~.maintain.commands.BaselineUnreadableError`
+    draws against :class:`~.maintain.commands.NoBaselineError`. Both remediate
+    the same way, so the status is the same, but "nothing has been explored
+    here" and "what was explored will not parse" are different facts about the
+    deployment, and only one of them suggests something went wrong. A host that
+    wants to page on the second and not the first can tell them apart without
+    matching on prose.
+
+    No ``schema_version`` attribute, unlike the baseline's, and the asymmetry is
+    already reasoned out in ``maintain/snapshot.py``: the cache's version drives
+    a ``<`` comparison in the query firewall that *degrades* (an old cache is
+    still usable, so the firewall widens taint and carries on), where the
+    baseline's is a membership test that *refuses*. A degrading version has no
+    refusal for this class to carry, so the only state that reaches it is a
+    document that did not parse. If a supported-set gate is ever added here,
+    that is when the attribute earns its place.
+
+    Lives here rather than beside ``CacheRequiredError`` because three packages
+    load a cache (``explore``, ``maintain``, ``transform``) and none of them
+    imports ``explore.commands`` today. Storage is the neutral home they already
+    share, and it is where the contract below asks for the raise this classifies.
+    """
 
 
 class Document(str, Enum):
@@ -124,10 +156,11 @@ class ExploreStore(Protocol):
         what the shipped backends raise by validating the model). That is the
         convention the engine reads as "this document will not parse", and it is
         what ``load_snapshot`` is caught on to report a corrupt baseline as a
-        prerequisite failure rather than as a bad request. This load has no such
-        wrapper yet, so what a backend raises here reaches the engine's catch-all
-        either way; raise a ``ValueError`` so the load is classifiable when it
-        gets one, not because it is classified today.
+        prerequisite failure rather than as a bad request. :func:`readable_cache`
+        is the equivalent wrapper for this load, and every engine call site goes
+        through it, so a ``ValueError`` raised here is now classified as
+        :class:`CacheUnreadableError` rather than reaching the CLI catch-all and
+        being reported as a bad request.
         """
         ...
 
@@ -398,6 +431,65 @@ class StoreFactory(Protocol):
     """
 
     def __call__(self, context: StoreContext) -> ExploreStore: ...
+
+
+#: Appended wherever the remedy is a fresh cache. Unlike `maintain snapshot`,
+#: which is free on every connector, `explore map` re-profiles the warehouse and
+#: therefore BILLS. An operator deciding between investigating the stored
+#: document and replacing it needs that said before they run it, for the same
+#: reason the baseline's remedy says what a replacement silently absorbs.
+_REMAP_BILLS = (
+    "note that `explore map` re-profiles the warehouse and bills for it, so a "
+    "corrupt document worth investigating is worth copying aside first"
+)
+
+
+def readable_cache(store: ExploreStore) -> DexCache | None:
+    """The stored cache, or a refusal naming the command that rebuilds one.
+
+    :meth:`ExploreStore.load_cache` raises on a document it cannot parse, and
+    pydantic's ``ValidationError`` subclasses ``ValueError``, so an unreadable
+    cache fell through to the CLI catch-all and was classified as a *request*
+    error. That tells an operator they typed something wrong when the fix is
+    `explore map`, and it is exactly the retry-versus-stop distinction
+    :class:`~..errors.PrerequisiteError` exists to carry. The ``load_cache``
+    contract above already asks backends to raise a ``ValueError`` "so the load
+    is classifiable when it gets one, not because it is classified today"; this
+    is the wrapper it was written for.
+
+    **It classifies, it does not require**, and the asymmetry with
+    :func:`~..maintain.commands._require_baseline` is deliberate rather than an
+    omission. Every ``load_snapshot`` caller needs a baseline, so that helper can
+    refuse on ``None``. Absence is *legal* at most cache call sites: `explore
+    profile`, `explore relationships` and `explore map` read a prior cache only
+    to merge pre-run state and a first run has none, `maintain snapshot` falls
+    back to a metadata capture, and ``_baseline_warnings`` merely skips a
+    warning. A ``_require_cache`` refusing on ``None`` would break five commands.
+    So ``None`` is returned unchanged, every caller keeps the absence policy it
+    already had, and only the unparseable case gains a class.
+    """
+
+    try:
+        return store.load_cache()
+    except ValueError as exc:
+        # ValueError rather than pydantic's ValidationError, which it subclasses.
+        # The contract above requires a backend to raise on a document it cannot
+        # parse and has never named the exception; the store protocol is public,
+        # and a backend deserializing its own rows raises whatever `json` or its
+        # driver raises. Catching only pydantic's error would leave every
+        # third-party backend reproducing the exact defect this function fixes,
+        # which is the kind of gap that looks fixed from inside this repo.
+        detail = (
+            f"{exc.error_count()} validation error(s)"
+            if isinstance(exc, ValidationError)
+            else str(exc)
+        )
+        raise CacheUnreadableError(
+            f"the stored exploration cache could not be read ({detail}). It is "
+            "either corrupt or written by a newer dex whose shape this engine "
+            "does not know. Re-run `explore map` to rebuild it, or move to the "
+            f"dex that wrote it if that is what happened; {_REMAP_BILLS}"
+        ) from exc
 
 
 def spend_total(

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -31,7 +31,7 @@ from ..dbt_project import ApplyResult as PlanApplyResult
 from ..dbt_project import EditOp
 from ..errors import DexError
 from ..results import to_envelope
-from ..storage import Store
+from ..storage import Store, readable_cache
 from . import plans as plans_mod
 from . import semantic as semantic_mod
 from .plans import EditKind, PlanEdit
@@ -397,7 +397,7 @@ def test_scaffold(engine: DexEngine, model_name: str | None) -> TestScaffoldResu
 
     project = engine.project_dir()
     view = load_project(project)
-    cache = engine.store.load_cache()
+    cache = readable_cache(engine.store)
     edits, inputs = test_scaffold_mod.unit_test_scaffold_edits(view, cache, model_name)
 
     from .build import shadow_parse

--- a/packages/dex-core/src/exmergo_dex_core/transform/row_attribution.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/row_attribution.py
@@ -38,6 +38,7 @@ from ..dbt_project import EditOp
 from ..dbt_project import load as load_project
 from ..errors import DexError
 from ..guards.query_firewall import QueryRefusedError, inspect_query
+from ..storage import readable_cache
 from .plans import EditKind
 
 if TYPE_CHECKING:
@@ -900,7 +901,7 @@ def attribute(
     # reading the same SQL. The cache is loaded only when counting, so the
     # named-only path stays free of both the store read and the connection.
     resolver = (
-        cache_resolver(engine.store.load_cache(), dialect)
+        cache_resolver(readable_cache(engine.store), dialect)
         if counting
         else naming_resolver
     )
@@ -1048,7 +1049,7 @@ def _count(
     """
 
     records = [m.record for m in models]
-    cache = engine.store.load_cache()
+    cache = readable_cache(engine.store)
     statements: list[_Statement] = []
 
     for index, model in enumerate(models):

--- a/packages/dex-core/src/exmergo_dex_core/transform/scaffold.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/scaffold.py
@@ -23,7 +23,7 @@ from importlib import resources
 from ..cache import Dataset
 from ..dbt_project import DbtProjectView
 from ..errors import DexError
-from ..storage import ExploreStore
+from ..storage import ExploreStore, readable_cache
 from .plans import EditKind, PlanEdit
 
 _SOURCES_FILE = "models/staging/_dex_sources.yml"
@@ -50,7 +50,7 @@ class ScaffoldError(DexError):
 def scaffold_edits(tables: list[str], store: ExploreStore) -> list[PlanEdit]:
     """Build the plan edits that scaffold staging models for the named tables."""
 
-    cache = store.load_cache()
+    cache = readable_cache(store)
     if cache is None:
         raise ScaffoldError(
             "no exploration cache yet; run `explore map` first so the scaffold has "

--- a/packages/dex-core/tests/maintain/test_unreadable_cache.py
+++ b/packages/dex-core/tests/maintain/test_unreadable_cache.py
@@ -1,0 +1,148 @@
+"""A cache that will not parse is a prerequisite failure, not a bad request.
+
+`load_cache` raises on a document it cannot parse, and pydantic's
+`ValidationError` subclasses `ValueError`, so an unreadable cache reached the CLI
+catch-all and was classified as a REQUEST error: the operator was told they typed
+something wrong when the fix is `explore map`. `storage/base.py` already asked
+backends to raise a `ValueError` "so the load is classifiable when it gets one";
+`readable_cache` is the wrapper that classifies it.
+
+**Why these tests live under `tests/maintain/`** even though most of the commands
+they drive are `explore` ones: `maintain_repo` is the only fixture that builds a
+warehouse, runs `explore map`, and hands back a CLI runner, which is exactly the
+state a cache test needs. `tests/maintain/test_snapshot.py` sets the precedent by
+parametrizing six commands from here for the baseline half of the same defect.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+#: Every entry point that loads the cache and can be driven from the CLI with no
+#: extra state, which is the set `readable_cache` replaced.
+#:
+#: Parametrized rather than asserted once on `explore profile`, for the reason
+#: `BASELINE_READERS` gives in test_snapshot.py: a refusal arm that runs on one
+#: command proves the helper and says nothing about whether the others reach it.
+#: Reverting any single site to a bare `store.load_cache()` has to turn exactly
+#: one of these red, and that is the property the parametrization buys.
+CACHE_READERS = (
+    ("explore", "profile", "customers"),
+    ("explore", "relationships"),
+    ("explore", "map"),
+    ("explore", "diagram"),
+    ("maintain", "snapshot"),
+)
+
+
+def _rewrite_cache(root: Path, **changes) -> None:
+    """Edit the stored cache in place, the way a bad migration or a hand-edit
+    would. Goes through the file rather than the model so the document can hold a
+    shape the model would refuse to construct."""
+
+    path = root / ".dex" / "cache.json"
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    doc.update(changes)
+    path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+@pytest.mark.parametrize("argv", CACHE_READERS, ids=lambda a: " ".join(a))
+def test_a_corrupt_cache_is_a_prerequisite_not_a_bad_request(maintain_repo, argv):
+    """The defect. `reason: request` tells a caller its input was wrong, so a
+    host retries with different arguments forever while the real fix is to
+    rebuild the cache. `prerequisite` is the retry-versus-stop distinction."""
+
+    _rewrite_cache(maintain_repo.root, datasets="not a list")
+
+    code, payload = maintain_repo.dex(*argv)
+
+    assert code != 0
+    assert payload["reason"] == "prerequisite", (
+        "a corrupt cache must not report as a bad request: the call is well "
+        "formed and a named command fixes it"
+    )
+    message = " ".join(payload["errors"])
+    assert "could not be read" in message and "explore map" in message
+
+
+@pytest.mark.parametrize("argv", CACHE_READERS, ids=lambda a: " ".join(a))
+def test_the_refusal_says_that_rebuilding_bills(maintain_repo, argv):
+    """`maintain snapshot` is free everywhere, so "just re-run it" costs nothing
+    and the baseline's remedy can say so plainly. `explore map` re-profiles the
+    warehouse and BILLS. An operator choosing between investigating the stored
+    document and replacing it needs that said before they run it, not after."""
+
+    _rewrite_cache(maintain_repo.root, datasets="not a list")
+
+    _, payload = maintain_repo.dex(*argv)
+
+    message = " ".join(payload["errors"])
+    assert "bills" in message, (
+        "the remedy names a billed command; saying so is the difference between "
+        "an informed replacement and a surprise invoice"
+    )
+
+
+def test_an_absent_cache_is_not_reported_as_unreadable(maintain_repo):
+    """The arm that keeps the two states apart, and the one that makes this a
+    classifier rather than a `_require_cache`.
+
+    Absence is LEGAL at most of these call sites: a first run has no cache, and
+    `explore map` exists precisely to create one. So the absent case must not
+    borrow the corrupt case's message, and `explore map` must still succeed.
+    """
+
+    (maintain_repo.root / ".dex" / "cache.json").unlink()
+
+    code, payload = maintain_repo.dex("explore", "map")
+
+    assert code == 0, payload.get("errors")
+    assert payload["reason"] is None
+    assert "could not be read" not in json.dumps(payload)
+
+
+def test_a_first_run_with_no_cache_is_not_refused(maintain_repo):
+    """The second half of the absence arm, on a command that only READS a prior
+    cache to merge pre-run state. A `_require_cache` mirroring
+    `_require_baseline` would refuse here, which is why this fix classifies
+    instead of requiring."""
+
+    (maintain_repo.root / ".dex" / "cache.json").unlink()
+
+    code, payload = maintain_repo.dex("explore", "profile", "customers")
+
+    assert code == 0, payload.get("errors")
+    assert payload["reason"] is None
+
+
+@pytest.mark.parametrize("argv", CACHE_READERS, ids=lambda a: " ".join(a))
+def test_a_readable_cache_is_not_refused(maintain_repo, argv):
+    """The quiet arm. Without it the assertions above are equally consistent with
+    EVERY cache being refused, on every command -- which would also make the
+    corrupt-cache test pass, for the wrong reason."""
+
+    code, payload = maintain_repo.dex(*argv)
+
+    assert code == 0, payload.get("errors")
+    assert payload["reason"] is None
+
+
+def test_the_error_is_public_and_distinct_from_the_absent_one():
+    """The unit arm on the public surface. A host that wants to page on "the
+    cache is corrupt" and not on "nothing has been explored" has to be able to
+    import the class and tell the two apart without matching on prose."""
+
+    import exmergo_dex_core as dex
+    from exmergo_dex_core.errors import PrerequisiteError
+    from exmergo_dex_core.explore.commands import CacheRequiredError
+
+    assert issubclass(dex.CacheUnreadableError, PrerequisiteError), (
+        "same status as its sibling: the call was well formed"
+    )
+    assert not issubclass(dex.CacheUnreadableError, CacheRequiredError), (
+        "distinct from absence, or the distinction this adds is unobservable"
+    )
+    assert not issubclass(CacheRequiredError, dex.CacheUnreadableError)

--- a/packages/dex-core/tests/maintain/test_unreadable_drift.py
+++ b/packages/dex-core/tests/maintain/test_unreadable_drift.py
@@ -1,0 +1,130 @@
+"""A drift report that will not parse is treated as absent, not refused.
+
+The opposite policy from the baseline and the cache, and deliberately so. The
+reasoning was already written down beside `DRIFT_SCHEMA_VERSION` in
+`maintain/drift.py` before this shipped: the baseline is *vouched for* and
+nothing else reproduces it, while a drift report is *derived* and `maintain
+check` regenerates it from the baseline on demand. So an unreadable report has a
+cheap correct answer -- rebuild -- that an unreadable baseline does not have.
+
+That note also named the defect it was leaving open: an unparseable report
+"still raises out of `load_drift` uncaught and is classified as a request
+error". `_stored_drift` closes it by taking the rebuild path both callers
+already had for a missing report.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from exmergo_dex_core.maintain.drift import DriftReport
+
+
+def _corrupt_drift(root: Path) -> None:
+    """Break the stored drift report through the file, so the document holds a
+    shape the model would refuse to construct.
+
+    ⚠️ The write is followed by a positive control on the inducer itself, and it
+    is not decoration: the first version of this helper set a ``findings`` key,
+    which `DriftReport` does not have. The document still parsed, every arm below
+    exercised a perfectly healthy report, and the refusal test passed for the
+    wrong reason. A corruption fixture that has quietly stopped corrupting is
+    indistinguishable from a fix that works.
+    """
+
+    path = root / ".dex" / "drift.json"
+    assert path.exists(), "no drift report to corrupt; run `maintain check` first"
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    doc["axes"] = "not a mapping"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        DriftReport.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def test_a_corrupt_drift_report_is_rebuilt_rather_than_refused(maintain_repo):
+    """The defect, and the shape of its fix.
+
+    Before `_stored_drift`, the `ValidationError` from `load_drift` reached the
+    CLI catch-all and `maintain check` reported `reason: request` -- an operator
+    told to fix their arguments, for a file they never typed. It now rebuilds,
+    which is what `_record_axes` already did for a report measured against a
+    different baseline.
+    """
+
+    maintain_repo.snapshot()
+    maintain_repo.dex("maintain", "check")
+    _corrupt_drift(maintain_repo.root)
+
+    code, payload = maintain_repo.dex("maintain", "check")
+
+    assert code == 0, payload.get("errors")
+    assert payload["reason"] is None, (
+        "an unreadable derived document is rebuilt, not reported as bad input"
+    )
+
+
+def test_the_rebuilt_report_is_written_back_readable(maintain_repo):
+    """Rebuilding has to leave the corruption gone rather than route around it
+    once. Otherwise every subsequent run pays the same silent recovery, and the
+    stored document stays broken for anything that reads it directly."""
+
+    maintain_repo.snapshot()
+    maintain_repo.dex("maintain", "check")
+    _corrupt_drift(maintain_repo.root)
+
+    maintain_repo.dex("maintain", "check")
+
+    stored = (maintain_repo.root / ".dex" / "drift.json").read_text(encoding="utf-8")
+    assert isinstance(json.loads(stored)["axes"], dict), (
+        "the rebuild replaced the corrupt document rather than skipping past it"
+    )
+    DriftReport.model_validate_json(stored)
+
+
+def test_reconcile_names_the_command_that_rebuilds(maintain_repo):
+    """`reconcile` is the caller whose absent path REFUSES rather than rebuilds,
+    and that is still the right answer for a corrupt report: it has nothing to
+    propose from. The refusal it already had for a missing report is the correct
+    one here too, so this adds no class -- it routes to the existing message."""
+
+    maintain_repo.snapshot()
+    maintain_repo.dex("maintain", "check")
+    _corrupt_drift(maintain_repo.root)
+
+    code, payload = maintain_repo.dex("maintain", "reconcile")
+
+    assert code != 0
+    assert payload["reason"] == "prerequisite"
+    message = " ".join(payload["errors"])
+    assert "maintain check" in message, (
+        "the remedy names the command that produces a report, which is the same "
+        "answer an absent one gets"
+    )
+
+
+@pytest.mark.parametrize("subcommand", ("check", "schema", "volume"))
+def test_a_readable_drift_report_is_not_discarded(maintain_repo, subcommand):
+    """The quiet arm, and it has to assert MORE than a zero exit.
+
+    "Treat unreadable as absent" is one bug away from "treat everything as
+    absent", and that bug is invisible on exit codes: axes would silently stop
+    merging across runs and every report would look freshly built. So this pins
+    that a prior axis SURVIVES a later focused run, which is the behaviour a
+    too-eager rebuild would destroy.
+    """
+
+    maintain_repo.snapshot()
+    maintain_repo.dex("maintain", "check")
+
+    code, payload = maintain_repo.dex("maintain", subcommand)
+    assert code == 0, payload.get("errors")
+
+    doc = json.loads(
+        (maintain_repo.root / ".dex" / "drift.json").read_text(encoding="utf-8")
+    )
+    assert doc["axes"], "a readable report kept its merged axes across runs"

--- a/references/storage.md
+++ b/references/storage.md
@@ -274,10 +274,15 @@ deserializes its own rows: `maintain` catches a `ValueError` out of `load_snapsh
 and classifies it as a prerequisite failure, which is what tells a host to stop and
 rebuild the baseline rather than retry the command. Anything else reaches the
 engine's catch-all and is reported to the operator as a bad request they made, when
-the fix is a dex command they have not run. The other loads carry no such wrapper
-yet: a raise out of `load_cache` or `load_drift` reaches the catch-all whatever its
-type. Raise a `ValueError` there anyway, so those loads are classifiable when they
-get one, rather than because it is classified today.
+the fix is a dex command they have not run. The other two loads are wrapped the
+same way now, and they resolve to opposite answers on purpose. `load_cache` goes
+through `readable_cache`, which raises `CacheUnreadableError` naming `explore map`
+and saying that rebuilding bills. `load_drift` goes through `_stored_drift`, which
+treats an unparseable report as **absent**: a drift report is derived rather than
+vouched for, `maintain check` regenerates it from the baseline on demand, and both
+callers already had a path for a missing one. So raise a `ValueError` from any of
+the three and the engine classifies it; what it does next depends on whether the
+document can be rebuilt without asking anyone.
 
 **A stored `schema_version` is not the store's to police.** Documents carry one and
 the engine reads it: the query firewall degrades on an old cache, and `maintain`


### PR DESCRIPTION
## What this changes

`load_cache` raises on a document it cannot parse, and pydantic's `ValidationError`
subclasses `ValueError`, so an unreadable cache fell through to the CLI catch-all
and was classified as `reason: request`. That tells an operator they typed
something wrong, and tells a host to retry with different arguments, when the fix
is a command nobody has run.

This is the same defect `_require_baseline` fixed for the baseline, on the loads
the codebase had already flagged as unfixed. Both notes are quoted rather than
paraphrased, because they are what this PR implements:

> `storage/base.py`, on `load_cache`: *"This load has no such wrapper yet, so what
> a backend raises here reaches the engine's catch-all either way; raise a
> `ValueError` so the load is classifiable when it gets one, not because it is
> classified today."*

> `maintain/drift.py`, beside `DRIFT_SCHEMA_VERSION`: *"What is not yet handled,
> and is a real gap rather than a decision: a drift report that fails to parse
> still raises out of `load_drift` uncaught and is classified as a request error
> [...] the right remedy differs (treat it as absent and rebuild, rather than
> refuse)."*

So this applies an existing pattern in two places, and takes the drift remedy that
note already chose rather than proposing a new one.

### It classifies; it does not require

**The issue asked for a `_require_cache` mirroring `_require_baseline`, and that
shape does not fit.** `_require_baseline` can *require* because all six
`load_snapshot` call sites are identical and every one needs a baseline. Absence
is **legal** at most cache call sites: `explore profile`, `explore relationships`
and `explore map` read a prior cache only to merge pre-run state and a first run
has none; `maintain snapshot` falls back to a metadata capture; `_baseline_warnings`
just skips a warning. A `_require_cache` refusing on `None` would break five
commands.

`readable_cache` therefore returns `None` unchanged and every caller keeps the
absence policy it already had. Only the unparseable case gains a class.

### Thirteen call sites, and one deliberate exclusion

All thirteen engine sites across `explore`, `maintain` and `transform` now go through
it. The issue listed ten; `transform/row_attribution.py` has since added two more, and
`transform test --scaffold` (#303) added a thirteenth while this sat in review, which
the rebase onto main picked up. It types every value in a `given` row from the
exploration cache, so an unreadable cache reached the catch-all there too.

🔴 **`explore/semantic/local.py` is deliberately not routed through it.** Its bare
`except Exception: return None` is documented as intentional (a metric query is
governed by dimension name before any SQL exists, so a repo that never ran
`explore map` can still query metrics), and routing it would make
`explore semantic query` refuse where it currently degrades.

### Where it lives, and why not beside `CacheRequiredError`

`storage/base.py` rather than `explore/commands.py`. Three packages load a cache
and **none of them imports `explore.commands`** today, so the natural home would
have added `transform -> explore` and `maintain -> explore` edges at three modules.
Storage is the neutral home they already share, it is where the contract asking for
the raise lives, and `spend_total` is the precedent for a module-level helper there.
Happy to move it if you would rather it sat next to its sibling.

### The drift half takes the opposite remedy, on purpose

`_stored_drift` treats an unparseable report as **absent**. Both callers already
had that path: `_record_axes` discards a report measured against a different
baseline wholesale, and `reconcile` raises the `NoBaselineError` naming
`maintain check`. No new error class, because neither caller needed one.

`CacheUnreadableError` carries no `schema_version`, unlike `BaselineUnreadableError`.
The asymmetry is the one already reasoned out in `maintain/snapshot.py`: the cache's
version drives a `<` comparison that *degrades*, where the baseline's is a
membership test that *refuses*. A degrading version leaves no refusal to carry.

## Reviewed by mutation

| mutation | result |
|---|---|
| one cache site back to `store.load_cache()` | exactly that command's two arms red; the operator sees the raw `1 validation error for DexCache ...`, which is the defect itself |
| `_record_axes` back to `store.load_drift()` | exactly its two arms red, `reconcile`'s stay green |

⚠️ **The drift corruption fixture carries a positive control, and it earned it.**
An earlier version set a `findings` key that `DriftReport` does not have. The
document still parsed, every arm exercised a perfectly healthy report, and the
refusal test passed for the wrong reason. It now asserts the induced document
actually fails `model_validate_json`, so a fixture that quietly stops corrupting
cannot look like a fix that works.

The quiet arms are the other half: `test_a_readable_cache_is_not_refused` and
`test_a_readable_drift_report_is_not_discarded`. Without them, every assertion
above is equally consistent with *every* cache being refused and *every* report
being discarded.

## Related issues

Closes #249.

⚠️ **#285 is adjacent**: it rewrites `_record_axes` around the `load_drift` line
without touching the line itself. A textual conflict is likely and trivial; happy
to rebase whichever lands second.

## Checklist

- [x] Tests pass (`uv run pytest` in `packages/dex-core`) - **2118 passed, 65 skipped**, from 2094 before
- [x] Eval scoring-core tests pass (`uvx pytest evals`) - 26 passed
- [x] If a safety path is touched, the spine still holds: read-only against data, cost-guarded, PII flagged not surfaced, propose-don't-impose - refusal-path only; nothing queries, and the refusal names that `explore map` **bills**, which the previous behaviour did not
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free (checked in CI) - `check_no_em_dashes.py` clean; `ruff check` and `ruff format --check` clean
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures

