### PR TITLE
`dex demo` generates a seeded local warehouse, so a first run needs no credentials

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ profiles.yml
 # .dex/ is just local-testing residue. Anchored to root so test fixtures that
 # intentionally include a .dex/ deeper in the tree are preserved.
 /.dex/
+# The demo warehouse `dex demo` generates. Same reasoning: it belongs in an
+# end-user's directory, and in this repo it is only ever dogfooding residue.
+# Anchored to root, and the wal sibling covers a run interrupted mid-write.
+/dex_demo.duckdb
+/dex_demo.duckdb.wal
 
 # ─── Python ──────────────────────────────────────────────────────────────────
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,13 @@ silently: with no `.dex/config.yml` anywhere up the tree and no explicit
 DuckDB target, so a command run from a subdirectory of your project resolves the
 project's real config instead of a wrong default.
 
+With no warehouse to point at yet, `demo` generates one and writes the config for
+it, so `demo` then `explore map` is a working first run on a machine with no
+credentials and no network.
+
 | Subcommand | Returns |
 |---|---|
+| `demo [path]` | generates a seeded local DuckDB warehouse (7 tables, 29,512 rows) plus a `.dex/config.yml` beside it, so a first run needs no warehouse, no credentials, and no network; both artifacts are listed in `data.created` and `data.next_steps` names the commands worth running next. The path is positional and resolves against the working directory, defaulting to `dex_demo.duckdb`; `--path` is refused here rather than honored, since everywhere else it names the warehouse dex *reads*. Create-only, with no `--confirm` that can talk past it: an existing file at the target is a refusal (`reason: guard`), a missing parent directory is a refusal (`reason: request`), no directories are ever created, and a `.dex/config.yml` at or above the target is left untouched with a warning rather than shadowed by a second one. The data is generated from a pinned seed, so the counts quoted in the docs are the counts a user sees, and it is deliberately flawed: a key that lost uniqueness to a double-loaded batch, a key mixing two id schemes, a join whose columns share a name and none of their values, an empty table, two columns whose declared type contradicts their content, and personal data alongside two designed false positives. Needs the `[duckdb]` extra and says so by name when it is absent (`reason: prerequisite`) |
 | `connect test` | capabilities, dialect, `read_only: true`; DuckDB takes `--path`, every warehouse connector takes repeatable `--scope` (BigQuery also accepts its older `--project`/`--dataset`), never written to config; Snowflake and Databricks report the pinned warehouse and its credit or DBU rate |
 | `explore inventory [--rank]` | ranked object summary (counts, sizes; no rows) |
 | `explore profile <objects>` | column profiles + PII flags (column, category, confidence) + candidate keys, grain, data-quality warnings; `--use-project` lets a semantic model's declared primary entity override the heuristic grain (disagreements noted) |
@@ -72,8 +77,8 @@ project's real config instead of a wrong default.
 | `maintain reconcile [<class>]` | propose the dbt edits that reconcile detected drift, as a stored plan of diffs tagged mechanical or advisory (never applied; apply with `transform apply <plan-id>`) |
 | `viz preview` | emit the dbt semantic model to the Viz preview (not yet implemented) |
 
-Skill-to-subcommand mapping: `explore` fronts `connect`/`explore`; `transform`
-fronts `transform`, `semantic`, and `viz`; `maintain` fronts the whole
+Skill-to-subcommand mapping: `explore` fronts `demo`/`connect`/`explore`;
+`transform` fronts `transform`, `semantic`, and `viz`; `maintain` fronts the whole
 `maintain` group. Within `maintain`, detection (`check`, `schema`, `volume`,
 `grain`, `semantic`) is read-only; only `reconcile` emits diffs, and applying
 them is `transform apply`. Detection is read-only on every connector, but read-only
@@ -140,7 +145,14 @@ them.
 2. Profile, don't exfiltrate. Understanding is built from aggregates, not raw rows.
 3. Read-only against data; writes confined to the repo. DuckDB opens read-only;
    generated SQL is SELECT-only; agent-authored SQL runs only through the query
-   firewall; builds run against a dev target only, never prod.
+   firewall; builds run against a dev target only, never prod. `dex demo` is the
+   one verb that creates a data file, and the exception is narrower than the rule
+   it sits inside: it only ever creates, refusing rather than overwriting and with
+   no confirmation flag that can override that, so it cannot open, inspect, or
+   replace a warehouse it did not make. The generator sits on its own path and
+   never reaches a connector, which is why the read-only open above has no branch
+   it could take; the moment the file exists it is user data and is read like any
+   other warehouse.
 4. Cost-aware by connector. Nothing dex runs touches the warehouse without a
    ceiling. The source allowlist in `.dex/config.yml` is a committed cost
    boundary: `--scope` narrows it for one command and can never widen it, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,81 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **`dex demo` generates a seeded local warehouse, so a first run needs no
+  credentials** ([#301]). The packaging has described a "zero-credential DuckDB
+  on-ramp" since the extras were laid out, and it delivers one: a base install
+  pulls no cloud client stack. The on-ramp just had no content. To see dex do
+  anything at all, a stranger had to supply a warehouse, discover credentials,
+  and accept a cost estimate against real data, which is the highest-friction
+  possible starting point and, for a read that touches a metered connector, the
+  one a cautious person is least willing to take on faith. The first run was
+  doing double duty as an evaluation.
+
+  `dex demo` builds a small e-commerce DuckDB warehouse (7 tables, 29,512 rows)
+  in the directory you are standing in, plus a `.dex/config.yml` beside it, so
+  everything after it runs with no flags. One command, no credentials, no cloud
+  account, no network. It also lands in `dex --help`, which is where #296
+  measured first contact actually happening.
+
+  **It is seeded to be realistically broken**, because a first run that reports
+  a clean bill of health teaches nothing. `order_item_id` lost its uniqueness to
+  a batch loaded twice, so grain has a verdict to give; `products.sku` mixes
+  numeric and md5-shaped ids from a merged catalogue, so a cast to a number
+  would silently drop a tenth of the rows; `web_events.customer_id` shares the
+  CRM's column name and type but none of its values, so inference proposes the
+  join and `--verify` collapses it at 100% orphans rather than shipping a join
+  that returns all-NULL parents and looks like it worked; `returns` is the table
+  an interrupted load left empty; `orders.placed_at` is a VARCHAR holding
+  timestamps and `web_events.occurred_at` a BIGINT holding epoch milliseconds,
+  the two shapes #204 detects. `customers.email` and `full_name` are personal
+  data the query firewall refuses to project, and `warehouse_locations.city` and
+  its coordinates are PII false positives on a building, which are a designed
+  behavior and cheapest to meet on data nobody minds. Five minutes in, a new
+  user has seen dex refuse something and report a finding they did not know to
+  look for.
+
+  **Deterministic, because the documentation quotes it.** One pinned seed, a
+  random stream restricted to primitives stable across CPython releases, and no
+  wall clock anywhere: every date is measured back from a fixed anchor, so the
+  file does not change overnight. A test pins a sha256 over every generated
+  cell, so an edit that would move a count printed in a README fails CI instead
+  of shipping documentation that disagrees with what the user sees. For a tool
+  whose claim is precision, that disagreement is worse than having no quickstart.
+
+  **Create-only, and structurally off the connector write path.** An existing
+  file at the target is a refusal with no `--confirm` that can talk past it,
+  because a confirmable overwrite would put a real warehouse one typo away from
+  being replaced and naming another path costs nothing. No parent directory is
+  ever created. A `.dex/config.yml` at or above the target is left untouched
+  with a warning, and the printed commands switch to the explicit `--path`
+  form, so a demo run inside someone's project cannot shadow their config with a
+  second one. `--path` itself is refused rather than honored or ignored: it
+  names the warehouse dex *reads* everywhere else, and this is the one command
+  that writes one. The generator sits in its own module, imports `duckdb`
+  directly, and reaches neither the adapter nor the SQL guard, so
+  `test_read_only_duckdb_refuses_writes` keeps no branch it could have taken;
+  two new safety-spine tests hold that mechanically rather than by argument, one
+  scanning the package for every `duckdb.connect(` and requiring
+  `read_only=True` outside the generator, the other opening a freshly generated
+  file through the adapter and confirming a write is still refused.
+
+  Deliberately not done: no `.duckdb` committed to git (the storage format has
+  broken backward compatibility before, so a stale file would fail on the first
+  command a stranger runs, and binary blobs do not delta-compress, so every
+  regeneration would be permanent history weight); no fixture shipped as data in
+  the wheel, which the skills would then fetch per version per environment; no
+  second repository to clone, which is exactly the friction this removes; and no
+  download on first use, since corporate proxies are common in the environments
+  this is meant to reassure and the first run is the one place that cannot
+  afford to fail. A dbt project is out of scope: `transform init` already
+  bootstraps one, and `dex demo` can chain into it when the demo needs to cover
+  authoring or drift.
+
+  `generate_demo_warehouse` is exported from the package, and
+  `examples/quickstart.py` now builds its warehouse with it, so the library
+  example and the CLI on-ramp show the same data and the packaging suite
+  verifies the generator against a freshly built wheel.
+
 - **`transform test --scaffold <model>` derives a dbt unit test from a
   model's own inputs** ([#215]). Writing a unit test by hand means restating
   every input's column set with correctly typed values before the assertion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   `read_only=True` outside the generator, the other opening a freshly generated
   file through the adapter and confirming a write is still refused.
 
+  Rows are staged through a CSV and bulk-loaded with `COPY` rather than
+  inserted as bound values, which is not a micro-optimization: DuckDB's
+  per-value binding measures about 1.7k rows/s on 1.5.5 against 90k on 1.5.4,
+  so an insert-based load made this command take anywhere from one second to
+  eighteen depending on which release the user happened to resolve, with the
+  slow number being the one a fresh install gets today. `COPY` reads at ~680k
+  rows/s on both, so the command lands at ~0.2s regardless. `COPY` into an
+  existing table uses that table's declared types, so nothing restates a
+  schema, the staging file lives in the system temp directory rather than
+  beside the target, and the loaded data is asserted cell-for-cell identical to
+  the generated rows.
+
   Deliberately not done: no `.duckdb` committed to git (the storage format has
   broken backward compatibility before, so a stale file would fail on the first
   command a stranger runs, and binary blobs do not delta-compress, so every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.6.5] - 2026-08-14
+
 ### Added
 
 - **`dex demo` generates a seeded local warehouse, so a first run needs no

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,17 @@ Everything is deterministic and free: no cloud account is needed. The live
 cloud integration tests under `tests/integration/` collect as skipped with
 the enabling variables named in the skip reason.
 
+To try a change by hand rather than through the suite, generate the demo
+warehouse in a scratch directory outside the checkout and drive the CLI against
+it. It is the same seeded fixture the documentation quotes, so what you see there
+is what a user sees:
+
+```
+mkdir /tmp/dex-scratch && cd /tmp/dex-scratch
+uv run --project ~/path/to/dex/packages/dex-core python -m exmergo_dex_core demo
+uv run --project ~/path/to/dex/packages/dex-core python -m exmergo_dex_core explore map
+```
+
 ## Live BigQuery integration tests
 
 `tests/integration/` runs the real loop against BigQuery: ADC discovery, the

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/exmergo-dex-core?logo=pypi&logoColor=white&color=165dfc)](https://pypi.org/project/exmergo-dex-core/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-165dfc)](LICENSE)
+[![data-eng-bench](https://img.shields.io/badge/data--eng--bench-57%25-33cf56)](benchmarks/data-eng-bench/README.md)
 [![ADE-bench](https://img.shields.io/badge/ADE--bench-76%25-33cf56)](benchmarks/ade_bench/README.md)
 [![CI](https://github.com/exmergo/dex/actions/workflows/ci.yml/badge.svg)](https://github.com/exmergo/dex/actions/workflows/ci.yml)
 
@@ -123,19 +124,42 @@ DuckDB is free and local, so nothing here asks you to confirm a spend. On BigQue
 or Snowflake the same commands return an estimate first and run only once you agree
 to it.
 
-## Benchmark
+## Benchmarks
 
-On ADE-bench (75 analytics-engineering tasks: fix, build, and extend dbt
-projects on DuckDB), `dex` reaches **76% task resolution with Claude Sonnet 5**,
-at **2.5x lower cost than Claude Fable 5**.
+We run `dex` on two public analytics-engineering benchmarks. Every run's raw
+per-task results are committed, including the ones that flatter us least.
+
+### data-eng-bench (Snowflake, 103 tasks)
+
+Each task hands the agent a **2,356-model dbt project on a 489 MB DuckDB
+warehouse** and a prescriptive ticket, then runs a hidden pytest suite after a
+cold `dbt run`. Scoring is binary and total: one failed assertion is a zero.
+
+`dex` + **Claude Sonnet 5** resolves **59 of 103 tasks (57.3%)**, with dex firing
+on **98% of trials**. That is nominally the highest published Sonnet 5 figure and
+statistically indistinguishable from the 56.6% Snowflake published for both Claude
+Code and their own CoCo harness, since 0.7 points on 103 tasks is less than one
+task. Read it as parity, not as a win.
+
+Because the reward is all-or-nothing, we also publish assertion-level results:
+**89.7% of assertions pass** (task-weighted), and 19 of the 44 unresolved tasks
+missed by exactly one assertion. Full methodology and the per-check record are in
+the [data-eng-bench README](benchmarks/data-eng-bench/README.md).
+
+### ADE-bench (dbt Labs, 75 tasks)
+
+Fix, build, and extend dbt projects on DuckDB. `dex` + **Claude Sonnet 5** reaches
+**76% task resolution**, at **2.5x lower cost than Claude Fable 5**.
 
 <img width="719" height="283" alt="image" src="https://github.com/user-attachments/assets/9f8bca64-6508-4590-9fa7-bb1ac077263d" />
 
 
 With `dex`, accuracy clusters tightly across models (72-76%) while cost does not,
-so you can run an inexpensive model and still get top-tier results. Full
-methodology, per-model cost, and the raw `results.json` for every run are in the
-[benchmark README](benchmarks/ade_bench/README.md).
+so you can run an inexpensive model and still get top-tier results. One honest
+caveat on this one: dex was actually invoked in only 15 of the 75 Sonnet 5 trials,
+and on those 15 it netted a single extra task, so the 76% is mostly a statement
+about the model rather than about `dex`. Per-model cost and the raw `results.json`
+for every run are in the [ADE-bench README](benchmarks/ade_bench/README.md).
 
 ### On benchmarks
 
@@ -144,7 +168,14 @@ measures whether tests pass; it does not measure what matters most in practice:
 the experience of the human engineer working with the agent. Trust in a diff,
 clarity of the proposed change, cost surfaced before spend, and sensitive data
 kept out of context never show up in a pass rate. We optimize for that
-experience first and treat the benchmark as a floor, not the goal.
+experience first and treat these scores as guide posts, not as the goal.
+
+Two habits follow from that. We report **how often `dex` actually ran** next to
+the accuracy, because a score with the tool firing on 98% of trials and the same
+score with it firing on 20% are different claims and only the first says anything
+about `dex`. And we do not turn a gap smaller than the noise into a headline: a
+single run, one attempt per task, tells you roughly where a setup stands, not that
+it is better than the one a point below it.
 
 ## Connectors
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ intent.
 
 **`dex` is analytics engineering** for Claude Code and **any agent**: **data warehouse
 exploration**, **dbt transformation** and **semantic modeling**, and **schema-drift
-maintenance** on dbt. Point it at your warehouse (or a local DuckDB file) and your
+maintenance** on dbt. Point it at your warehouse (or a local DuckDB file, or the one
+`dex demo` generates for you) and your
 dbt project; it learns the landscape, writes and refactors your dbt transformations
 and semantic models, and tells you what to fix when anything drifts. The dbt
 project is the source of truth; every change is a reviewable diff. Read-only
@@ -75,6 +76,52 @@ time. `dex` owns exactly that loop.
 
 <img width="484" height="344" alt="image" src="https://github.com/user-attachments/assets/ff714eaf-f0b2-46d6-8a4b-c69791740f18" />
 
+## Try it in three commands, on your laptop
+
+No warehouse, no credentials, no cloud account, no network. `dex demo` generates a
+small e-commerce DuckDB warehouse locally and points the following commands at it.
+
+```
+pip install "exmergo-dex-core[duckdb]"
+dex demo
+dex explore map
+```
+
+`dex demo` writes two files in the directory you are standing in, and refuses rather
+than overwrite anything: `dex_demo.duckdb` (7 tables, 29,512 rows) and a
+`.dex/config.yml` so everything after it runs with no flags. The data is generated
+from a pinned seed, so what you see is what is written here.
+
+It is seeded to be **realistically broken**, because a first run that reports a clean
+bill of health teaches you nothing. `explore map` flags 6 columns as personal data,
+infers 5 joins, and reports 5 data-quality findings. Then:
+
+```
+dex explore profile order_items products
+dex explore relationships --verify
+dex explore query "select email from customers"
+```
+
+- **A broken grain.** `order_item_id is not unique: 13000 distinct over 14000 rows`,
+  because a batch was loaded twice. Any join on it silently fans out.
+- **A key that mixes id schemes.** `sku` is `90% numeric, 10% 32-character
+  hexadecimal (md5-shaped)`, from a merged catalogue. Cast it to a number and you
+  drop 10% of your rows without an error.
+- **A join that looks right and is not.** `web_events.customer_id` shares the CRM's
+  column name and type, so it is inferred; verification finds **100% of values have
+  no match**, so the inference collapses instead of shipping a join that returns all
+  NULLs and looks like it worked.
+- **A refusal.** The query firewall declines to project `customers.email` into
+  context. `select count(distinct email) from customers` runs, because a statistic
+  is not a value.
+- Plus a table an interrupted load left empty, two columns whose declared type
+  contradicts their content, and two PII **false positives** on a distribution
+  centre's city and coordinates, which are a designed behaviour and worth meeting
+  early.
+
+DuckDB is free and local, so nothing here asks you to confirm a spend. On BigQuery
+or Snowflake the same commands return an estimate first and run only once you agree
+to it.
 
 ## Benchmark
 

--- a/packages/dex-core-stub/README.md
+++ b/packages/dex-core-stub/README.md
@@ -5,7 +5,12 @@ published as **[exmergo-dex-core](https://pypi.org/project/exmergo-dex-core/)**.
 
 ```
 pip install "exmergo-dex-core[duckdb]"
+dex demo
+dex explore map
 ```
+
+`dex demo` generates a small local warehouse to try it against, so the first run
+needs no credentials and no network.
 
 dex is the agent-native analytics engineering toolkit: explore a warehouse,
 transform raw data into dbt models and a semantic layer, and maintain it as the

--- a/packages/dex-core/README.md
+++ b/packages/dex-core/README.md
@@ -16,7 +16,7 @@ every change is a reviewable diff.
 pip install "exmergo-dex-core"
 ```
 
-Connector client libraries live behind extras. DuckDB is an in-memory data warehouse,
+Connector client libraries live behind extras. DuckDB is an embedded data warehouse,
 so you can start from there if you want to test Dex locally. We aim to support all major
 data warehouses. Please suggest any missing connectors on [GitHub](https://github.com/exmergo/dex)!
 
@@ -40,6 +40,36 @@ hosted semantic layer needs no connector, no dbt-core, and no SQL parser. Every
 other command validates SQL before running it, which is why the connector extras
 carry the dialect engine; run one without a connector installed and dex refuses
 with the install to use rather than guessing.
+
+## First run, with nothing to point it at
+
+`[duckdb]` is also what carries the on-ramp, so a fresh install has something to
+work against before you have wired up a warehouse:
+
+```
+pip install "exmergo-dex-core[duckdb]"
+dex demo
+dex explore map
+```
+
+`dex demo` generates a small e-commerce warehouse (7 tables, 29,512 rows) in the
+current directory and a `.dex/config.yml` beside it, so everything after it runs
+with no flags. No credentials, no cloud account, no network. The data comes from a
+pinned seed, so every run produces the same rows and the numbers quoted here are the
+numbers you get.
+
+It is seeded to be realistically broken rather than tidy: a key that lost its
+uniqueness to a double-loaded batch, a key mixing two id schemes from a merged
+catalogue, a join whose columns share a name and none of their values, a table an
+interrupted load left empty, two columns whose declared type contradicts their
+content, and personal data alongside two deliberate false positives. `explore map`
+finds 6 PII columns, 5 joins, and 5 data-quality findings; `explore query "select
+email from customers"` is refused, and the same count over the same column is not.
+
+The generation is create-only: it writes a new file and refuses rather than replace
+one, with no confirmation flag that can talk past that, and it will not write a
+`.dex/config.yml` where a project already has one. `generate_demo_warehouse` is
+public, so the Python API can build the same fixture.
 
 ## Two surfaces, one engine
 
@@ -69,9 +99,10 @@ instead, and a backend published as its own package is selectable by name from
 [`references/storage.md`](../../references/storage.md).
 
 [`examples/quickstart.py`](examples/quickstart.py) is the whole flow in one
-runnable file: map a warehouse, read the inferred joins, see PII flagged, ask a
-question, and watch the firewall refuse one it should. It builds its own
-throwaway DuckDB file, so it runs anywhere:
+runnable file: map a warehouse, read the inferred joins and the data-quality
+findings, see PII flagged, ask a question, and watch the firewall refuse one it
+should. It generates the same demo warehouse `dex demo` builds, into a throwaway
+directory, so it runs anywhere and reports the same findings:
 
 ```
 pip install "exmergo-dex-core[duckdb]"
@@ -158,6 +189,14 @@ subcommands are stateless and the agent orchestrates multi-step flows.
 dex connect test --path data.duckdb
 ```
 
+With nothing to point at yet, `dex demo` builds one and every command after it needs
+no flags:
+
+```
+dex demo
+dex connect test
+```
+
 The CLI is the API's first consumer rather than a parallel implementation: it
 parses arguments, builds an engine, and wraps the result it gets back. See
 [`references/command-contract.md`](../../references/command-contract.md) for the
@@ -171,6 +210,14 @@ BigQuery, Snowflake, Databricks, Amazon Redshift, and Postgres, through either
 the command contract or the Python API.
 
 ### Commands
+
+`demo`: generates a seeded local DuckDB warehouse and wires it up, so a first run
+needs no warehouse and no credentials. One command, no network, and deterministic:
+the row counts and column names the documentation quotes are the ones you get. It is
+the only verb that creates a data file, and it is create-only by construction, so it
+never opens, inspects, or replaces a warehouse you already have. The generator lives
+on its own path, never through a connector, which is what keeps the read-only rule
+true everywhere else.
 
 `explore`: ranks what matters in an unfamiliar warehouse, profiles columns
 selectively, flags PII, surfaces grain and data-quality warnings, infers joins

--- a/packages/dex-core/examples/quickstart.py
+++ b/packages/dex-core/examples/quickstart.py
@@ -3,9 +3,11 @@
     pip install "exmergo-dex-core[duckdb]"
     python quickstart.py
 
-Everything below runs against a throwaway DuckDB file this script creates, so it
-is safe to run anywhere. Point `DexEngine` at your own warehouse by changing the
-connector and config; nothing else in the flow changes.
+Everything below runs against the same seeded demo warehouse `dex demo` builds,
+generated here into a throwaway directory, so it is safe to run anywhere and the
+findings it reports are the ones the documentation quotes. Point `DexEngine` at
+your own warehouse by changing the connector and config; nothing else in the flow
+changes.
 
 Run by `tests/test_packaging.py` against a freshly built wheel, so if this stops
 working the suite says so.
@@ -16,40 +18,22 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-import duckdb
-
-from exmergo_dex_core import DexEngine, QueryRefusedError
-
-
-def make_warehouse(directory: Path) -> Path:
-    """A two-table shop: customers with an email column, and their orders."""
-
-    path = directory / "shop.duckdb"
-    conn = duckdb.connect(str(path))
-    conn.execute("""
-        CREATE TABLE customers AS SELECT * FROM (VALUES
-            (1, 'ada@example.com', 'EU'),
-            (2, 'grace@example.com', 'US'),
-            (3, 'alan@example.com', 'EU')
-        ) AS t(id, email, region)
-    """)
-    conn.execute("""
-        CREATE TABLE orders AS SELECT * FROM (VALUES
-            (1, 1, 10.50), (2, 1, 20.00), (3, 2, 5.25), (4, 3, 7.00)
-        ) AS t(id, customer_id, total)
-    """)
-    conn.close()
-    return path
+from exmergo_dex_core import DexEngine, QueryRefusedError, generate_demo_warehouse
 
 
 def main() -> None:
     workspace = Path(tempfile.mkdtemp())
-    warehouse = make_warehouse(workspace)
+
+    # The same generator behind `dex demo`: a small e-commerce warehouse with
+    # deliberately seeded flaws, so this run reports real findings rather than a
+    # clean bill of health.
+    warehouse = generate_demo_warehouse(workspace / "shop.duckdb")
+    print(f"generated {warehouse.row_count} rows across {len(warehouse.tables)} tables")
 
     # No store passed, so state lives in this process and nothing is written to
     # disk. Pass store=FilesystemStore(repo_root) to keep a .dex/ cache between
     # runs, which is what the CLI does.
-    with DexEngine(connector="duckdb", path=str(warehouse)) as dex:
+    with DexEngine(connector="duckdb", path=str(warehouse.path)) as dex:
         # 1. Map the warehouse: inventory, profiling, and join inference in one
         #    pass. On a big warehouse this profiles the top-ranked tables only.
         mapped = dex.map()
@@ -63,16 +47,16 @@ def main() -> None:
         # 2. Results carry domain objects, not JSON. `cache` is the composed
         #    DexCache this run wrote.
         for dataset in mapped.cache.datasets:
-            columns = ", ".join(c.name for c in dataset.columns)
-            print(f"  {dataset.identifier}: {dataset.row_count} rows ({columns})")
+            print(f"  {dataset.identifier}: {dataset.row_count} rows")
 
-        for rel in mapped.cache.relationships:
-            print(
-                f"  join: {rel.from_dataset}.{rel.from_columns[0]} -> "
-                f"{rel.to_dataset}.{rel.to_columns[0]}"
-            )
+        # 3. Profiling reports what it found wrong, not just what is there: a key
+        #    that is not unique, a column whose declared type contradicts its
+        #    content, a table that a half-failed load left empty.
+        for dataset in mapped.cache.datasets:
+            for finding in dataset.data_quality:
+                print(f"  finding: {dataset.identifier}: {finding}")
 
-        # 3. PII is detected during profiling and reported as a flag, never as a
+        # 4. PII is detected during profiling and reported as a flag, never as a
         #    value. No email address appears anywhere in the result.
         for dataset in mapped.cache.datasets:
             for column in dataset.columns:
@@ -83,17 +67,17 @@ def main() -> None:
                         f"(confidence {column.pii.confidence:.2f})"
                     )
 
-        # 4. Ask a question. The query firewall checks it against what profiling
+        # 5. Ask a question. The query firewall checks it against what profiling
         #    learned, and results come back columnar and row-capped. Ordering is
         #    the query's job, not the engine's: a bare GROUP BY returns groups in
         #    whatever order the aggregate produced them, which varies run to run.
         result = dex.query(
-            "select region, count(*) as customers from customers "
-            "group by region order by region"
+            "select status, count(*) as orders from orders "
+            "group by status order by status"
         )
         print(f"query -> {result.columns}: {result.cells}")
 
-        # 5. The same firewall refuses to project a PII column, so a careless
+        # 6. The same firewall refuses to project a PII column, so a careless
         #    query cannot pull personal data into your program.
         try:
             dex.query("select email from customers")
@@ -101,9 +85,9 @@ def main() -> None:
         except QueryRefusedError as refusal:
             print(f"  refused, as designed: {refusal}")
 
-        # 6. Profile a single table on demand. Objects already profiled this
+        # 7. Profile a single table on demand. Objects already profiled this
         #    session are served from the cache rather than scanned again.
-        profiled = dex.profile("orders")
+        profiled = dex.profile("order_items")
         print(
             f"profiled {profiled.profiled_count}, "
             f"reused {profiled.cache_hit_count} from cache"

--- a/packages/dex-core/src/exmergo_dex_core/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/__init__.py
@@ -67,7 +67,12 @@ _EXPORTS = {
     "Cost": "envelope",
     "CostGuardError": "guards.cost_guard",
     "CredentialDiscoveryError": "connect",
+    "DEMO_FILENAME": "demo",
     "Dataset": "cache",
+    "DemoDependencyError": "demo",
+    "DemoError": "demo",
+    "DemoPathError": "demo",
+    "DemoTargetExistsError": "demo",
     "DexCache": "cache",
     "DexConfig": "config",
     "DexEngine": "engine",
@@ -103,6 +108,7 @@ _EXPORTS = {
     "StoreContext": "storage",
     "StoreFactory": "storage",
     "StoreRequiredError": "errors",
+    "generate_demo_warehouse": "demo",
     "render_er_mermaid": "explore.diagram",
     "to_envelope": "results",
 }
@@ -115,6 +121,14 @@ if TYPE_CHECKING:  # what a type checker and an IDE see; never run
         CredentialDiscoveryError,
         ScopeError,
         SemanticSource,
+    )
+    from .demo import (
+        DEMO_FILENAME,
+        DemoDependencyError,
+        DemoError,
+        DemoPathError,
+        DemoTargetExistsError,
+        generate_demo_warehouse,
     )
     from .engine import DexEngine
     from .envelope import Cost, Paradigm
@@ -176,6 +190,7 @@ except PackageNotFoundError:
 # checker) sees the public surface without executing anything. `tests/
 # test_engine.py` asserts the two stay in step and that every name resolves.
 __all__ = [
+    "DEMO_FILENAME",
     "BaselineUnreadableError",
     "BudgetExhaustedError",
     "CacheRequiredError",
@@ -192,6 +207,10 @@ __all__ = [
     "CostGuardError",
     "CredentialDiscoveryError",
     "Dataset",
+    "DemoDependencyError",
+    "DemoError",
+    "DemoPathError",
+    "DemoTargetExistsError",
     "DexCache",
     "DexConfig",
     "DexEngine",
@@ -228,6 +247,7 @@ __all__ = [
     "StoreFactory",
     "StoreRequiredError",
     "__version__",
+    "generate_demo_warehouse",
     "render_er_mermaid",
     "to_envelope",
 ]

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -61,6 +61,11 @@ COMMAND_SURFACE: dict[str, list[str]] = {
         "reconcile",
     ],
     "viz": ["preview"],
+    # demo: the on-ramp. No subcommands, because there is exactly one thing to
+    # do and it is the first command a new user runs. It is also the only verb
+    # that creates a data file, which is why it lives on its own path (see
+    # `demo/warehouse.py`) rather than anywhere near a connector.
+    "demo": [],
 }
 
 
@@ -163,7 +168,23 @@ def _build_parser() -> argparse.ArgumentParser:
     common = _sub_connection_options()
     groups = parser.add_subparsers(dest="group", required=True)
     for group, subcommands in COMMAND_SURFACE.items():
-        gp = groups.add_parser(group, parents=[common])
+        # `demo` is the only group carrying help text, and deliberately so: the
+        # top-level --help is where a stranger's first contact lands, and the one
+        # thing worth saying there is what to run when you have no warehouse yet.
+        gp = groups.add_parser(
+            group,
+            parents=[common],
+            help=(
+                "create a seeded local DuckDB warehouse to try dex against "
+                "(no credentials, no network)"
+                if group == "demo"
+                else None
+            ),
+        )
+        if group == "demo":
+            # Positional rather than --path: --path names the warehouse dex
+            # reads, everywhere, and this is the one command that writes one.
+            gp.add_argument("target", nargs="?", default=None)
         if subcommands:
             sub = gp.add_subparsers(dest="subcommand", required=True)
             for name in subcommands:
@@ -363,6 +384,14 @@ def dispatch(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
 
 
 def _run(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
+    # First, and without `ensure_dialect_available`: demo authors no SQL a guard
+    # has to clear, and it must stay reachable on the lightest install that can
+    # run it, which is the one a first-time user has.
+    if args.group == "demo":
+        from .demo.commands import cmd_demo
+
+        return cmd_demo(args, engine)
+
     if args.group == "connect" and args.subcommand == "test":
         from .results import to_envelope
 

--- a/packages/dex-core/src/exmergo_dex_core/command_args.py
+++ b/packages/dex-core/src/exmergo_dex_core/command_args.py
@@ -23,7 +23,7 @@ from .results import ConfirmationRequest, Result
 from .storage import DEX_DIR
 
 
-def _resolve_dex_root(start: Path) -> Path | None:
+def resolve_dex_root(start: Path) -> Path | None:
     """Nearest ancestor of ``start`` holding a ``.dex/config.yml``, or None.
 
     dex is used like git or dbt: the config lives at the project root, but
@@ -59,7 +59,7 @@ def repo_root(args: argparse.Namespace) -> str:
     ``open_adapter``) behave as designed."""
 
     raw = getattr(args, "repo_root", ".")
-    resolved = _resolve_dex_root(Path(raw))
+    resolved = resolve_dex_root(Path(raw))
     return str(resolved) if resolved is not None else raw
 
 

--- a/packages/dex-core/src/exmergo_dex_core/demo/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/demo/__init__.py
@@ -1,0 +1,42 @@
+"""`dex demo`: a seeded local warehouse, so a first run needs no credentials.
+
+Installing dex leaves nothing to point it at. This package closes that gap: one
+command, no credentials, no cloud account, and no network builds a small DuckDB
+warehouse with real-looking e-commerce data and real, deliberately seeded flaws,
+so the first `explore` run reports findings instead of a clean bill of health.
+
+:mod:`.warehouse` generates and writes the file and is the only writable path in
+the engine; :mod:`.commands` is the CLI shim over it and owns the surrounding
+project wiring (the `.dex/config.yml` that lets every following command run with
+no flags at all).
+"""
+
+from __future__ import annotations
+
+from .warehouse import (
+    DEMO_FILENAME,
+    DEMO_SEED,
+    DemoDependencyError,
+    DemoError,
+    DemoPathError,
+    DemoTable,
+    DemoTargetExistsError,
+    DemoWarehouse,
+    build_tables,
+    generate_demo_warehouse,
+    row_digest,
+)
+
+__all__ = [
+    "DEMO_FILENAME",
+    "DEMO_SEED",
+    "DemoDependencyError",
+    "DemoError",
+    "DemoPathError",
+    "DemoTable",
+    "DemoTargetExistsError",
+    "DemoWarehouse",
+    "build_tables",
+    "generate_demo_warehouse",
+    "row_digest",
+]

--- a/packages/dex-core/src/exmergo_dex_core/demo/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/demo/commands.py
@@ -1,0 +1,175 @@
+"""The `dex demo` shim: generate the warehouse, wire it up, name what to run next.
+
+Two jobs beyond the generation itself. It writes a `.dex/config.yml` beside the
+new file, so the commands it prints need no flags at all and the run reads like a
+working project rather than a loose file. And it refuses to write that config
+where one already exists at or above the target, because a second config in a
+subdirectory would silently shadow the user's real one for every command run
+there; in that case the warehouse is still created and the printed commands
+switch to the explicit ``--path`` form.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+from pydantic import Field
+
+from .. import envelope as env
+from ..command_args import resolve_dex_root
+from ..config import CONFIG_FILE, DexConfig, DuckDBTarget, save_config
+from ..diffs import file_diff
+from ..engine import DexEngine
+from ..results import Result, to_envelope
+from ..storage import DEX_DIR
+from .warehouse import DEMO_FILENAME, DemoPathError, generate_demo_warehouse
+
+
+class DemoResult(Result):
+    """What `dex demo` built, and what to run against it."""
+
+    path: str
+    seed: int
+    row_count: int
+    tables: list[dict[str, Any]] = Field(default_factory=list)
+    created: list[str] = Field(default_factory=list)
+    next_steps: list[dict[str, str]] = Field(default_factory=list)
+
+    def data(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "seed": self.seed,
+            "object_count": len(self.tables),
+            "row_count": self.row_count,
+            "tables": self.tables,
+            "created": self.created,
+            "next_steps": self.next_steps,
+        }
+
+
+# Spelled out here rather than inline below so the SELECT reads as the printed
+# text it is: nothing in this module ever executes a statement.
+_PII_PROBE = 'dex explore query "select email from customers"'
+
+
+def _next_steps(flags: str) -> list[dict[str, str]]:
+    """The tour. Three commands that each end in a finding, plus the refusal.
+
+    Ordered so the run builds on itself: map first because everything downstream
+    reads the cache it writes, then the two findings that need no argument, then
+    the refusal, which only means anything once profiling has flagged the column.
+    """
+
+    return [
+        {
+            "command": f"dex explore map{flags}",
+            "shows": (
+                "ranks the seven objects, profiles them, flags the personal data, "
+                "and infers the joins. Free and local: DuckDB bills nothing, so "
+                "nothing here asks you to confirm a spend. On BigQuery or "
+                "Snowflake this same command returns an estimate first and runs "
+                "only once you agree to it"
+            ),
+        },
+        {
+            "command": f"dex explore profile order_items products{flags}",
+            "shows": (
+                "order_item_id is not unique, so any join on it fans out; sku is a "
+                "key that mixes two id schemes, so casting it to a number would "
+                "silently drop rows"
+            ),
+        },
+        {
+            "command": f"dex explore relationships --verify{flags}",
+            "shows": (
+                "orders joins cleanly to customers, and web_events.customer_id "
+                "matches the name but none of the values, so the inference "
+                "collapses instead of shipping a join that returns nothing"
+            ),
+        },
+        {
+            "command": _PII_PROBE + flags,
+            "shows": (
+                "refused: the query firewall does not let personal data cross into "
+                "context. Count it or aggregate it instead, and that runs"
+            ),
+        },
+    ]
+
+
+def cmd_demo(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
+    """Build the demo warehouse and return the one envelope the contract expects.
+
+    Takes the engine for signature consistency with every other command shim and
+    deliberately does not use it: demo reaches no warehouse, no store, and no
+    project, so anything it read off the engine would be a connection it has no
+    business resolving.
+    """
+
+    read_path = getattr(args, "path", None)
+    if read_path:
+        raise DemoPathError(
+            "dex demo takes the file to create as a positional argument, not "
+            "--path: everywhere else --path names the warehouse dex reads, and "
+            f"this is the one command that writes one. Use `dex demo {read_path}`"
+        )
+
+    target = Path(getattr(args, "target", None) or DEMO_FILENAME)
+    warehouse = generate_demo_warehouse(target)
+
+    # The config goes beside the warehouse, and only where nothing above already
+    # owns one: `resolve_dex_root` is the same walk every command uses to find
+    # its project, so agreeing with it here is what stops the demo shadowing a
+    # real config with one of its own.
+    root = target.parent
+    config_path = root / DEX_DIR / CONFIG_FILE
+    config_rel = str(config_path)
+    existing_root = resolve_dex_root(root)
+    created = [str(target)]
+    diffs: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    if existing_root is None:
+        save_config(
+            DexConfig(connector="duckdb", duckdb=DuckDBTarget(path=target.name)), root
+        )
+        created.append(config_rel)
+        diffs.append(
+            file_diff(config_rel, None, config_path.read_text(encoding="utf-8"))
+        )
+        # Bare commands only work from the directory the config landed in, so the
+        # flagless tour is offered only when that is where the caller already is.
+        flags = "" if root == Path() else f" --path {target}"
+    else:
+        warnings.append(
+            f"'{existing_root}' already has a .dex/config.yml and it was left "
+            "untouched; the commands below name the demo warehouse explicitly "
+            "rather than repointing your project at it"
+        )
+        flags = f" --path {target}"
+
+    return to_envelope(
+        DemoResult(
+            path=str(target),
+            seed=warehouse.seed,
+            row_count=warehouse.row_count,
+            tables=[
+                {"name": t.name, "row_count": len(t.rows), "note": t.note}
+                for t in warehouse.tables
+            ],
+            created=created,
+            next_steps=_next_steps(flags),
+            diffs=diffs,
+            warnings=warnings,
+            notes=[
+                "the data is generated from a pinned seed, so every run of this "
+                "command produces the same rows and the counts quoted in the docs "
+                "are the counts you have",
+                "the flaws are deliberate: a broken grain, a key that mixes id "
+                "schemes, a join with no overlap, an empty table, two columns "
+                "whose declared type contradicts their content, and personal data "
+                "alongside two false positives",
+            ],
+        )
+    )

--- a/packages/dex-core/src/exmergo_dex_core/demo/warehouse.py
+++ b/packages/dex-core/src/exmergo_dex_core/demo/warehouse.py
@@ -1,0 +1,552 @@
+"""The seeded demo warehouse: the one place in the engine that writes a data file.
+
+Everything else dex does against a warehouse is a read. This module is the single
+exception, and it is deliberately its own path so that exception stays visible:
+it imports ``duckdb`` directly and never :mod:`..adapters.duckdb`, so the
+read-only open in the adapter has no branch that could ever be relaxed, and it
+never touches the SQL guard, because the statements here are ``CREATE TABLE`` and
+parameterized ``INSERT`` rather than anything an agent authored. A safety-spine
+test asserts both of those mechanically rather than trusting this paragraph.
+
+Creating a file is not writing to a user's data. The rule that keeps those two
+apart is create-only: a target that already exists is refused outright, with no
+confirmation flag that could talk past it, and the parent directory is never
+created. So the worst a mistyped path can do is fail.
+
+The data is generated rather than committed, for three reasons. DuckDB's storage
+format has broken backward compatibility before, and a stale file would fail on
+the first command a stranger ever runs; a binary blob does not delta-compress, so
+every regeneration would be permanent history weight; and the skills resolve the
+engine per version per environment, so weight in the wheel is paid for repeatedly.
+
+**Determinism is a contract, not a nicety.** The READMEs quote row counts and
+column names from this data, so a change here that silently moved a number would
+make the documentation wrong in the one place a new user is most likely to be
+reading it. Hence one pinned seed, a random stream restricted to
+``randrange``/``random`` (stable across CPython releases), no wall-clock anywhere
+(every date is measured back from :data:`_ANCHOR`), and :func:`row_digest`, which
+a test pins so drift fails CI instead of shipping.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+from ..errors import DexError
+
+# The default target. A name rather than a path: where it lands is the command's
+# decision (the directory the user is standing in), not this module's.
+DEMO_FILENAME = "dex_demo.duckdb"
+
+# Pinned. Changing it changes every count the documentation quotes, so it is a
+# documentation edit as much as a code one.
+DEMO_SEED = 20260301
+
+# Every generated date is measured backwards from here, so the file a user
+# generates today is byte-identical to the one generated a year from now.
+_ANCHOR = date(2026, 3, 31)
+
+# 2026-01-01T00:00:00Z. `web_events.occurred_at` is declared BIGINT and holds
+# epoch *milliseconds*, which is the unit confusion `explore profile` reports.
+_EPOCH_MS_START = 1_767_225_600_000
+_NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000
+
+
+class DemoError(DexError):
+    """Base for the refusals `dex demo` raises."""
+
+
+class DemoPathError(DemoError):
+    """The target path cannot be used: no parent directory, or not a file.
+
+    Distinct from :class:`DemoTargetExistsError` because it is bad input rather
+    than a guard: the caller names a different path and it works.
+    """
+
+
+class DemoTargetExistsError(DemoError):
+    """Something already sits at the target path, so the demo refused.
+
+    Deliberately not confirmable. The whole promise of this command is that it
+    never opens, inspects, or overwrites a warehouse you already have, and a
+    ``--confirm`` that could talk past this refusal would put a real warehouse
+    one typo away from being replaced. The fix is to name a different path.
+    """
+
+
+class DemoDependencyError(DemoError):
+    """The DuckDB client (the ``[duckdb]`` extra) is missing.
+
+    Its own type, and surfaced as a ``prerequisite`` refusal naming the install,
+    because this is very likely the first command a new user runs: a bare
+    ``ImportError`` here would land on someone who has no idea yet that
+    connector clients live behind extras.
+    """
+
+
+@dataclass(frozen=True)
+class DemoTable:
+    """One generated relation: its DDL, its rows, and why it is in the demo.
+
+    ``note`` is user-facing. It is what lets the envelope say what each table is
+    there to teach, so the first run is a tour rather than a pile of tables.
+    """
+
+    name: str
+    columns: tuple[tuple[str, str], ...]
+    rows: tuple[tuple, ...]
+    note: str
+
+
+@dataclass(frozen=True)
+class DemoWarehouse:
+    """What a generation produced, for the command layer to report."""
+
+    path: Path
+    tables: tuple[DemoTable, ...]
+    seed: int
+    digest: str
+
+    @property
+    def row_count(self) -> int:
+        return sum(len(t.rows) for t in self.tables)
+
+
+# The value pools the generator draws from. Order is part of the seed contract:
+# rows are picked by index, so reordering a pool changes the generated data and
+# therefore every count the documentation quotes.
+_FIRST_NAMES = (
+    "Ada",
+    "Grace",
+    "Alan",
+    "Katherine",
+    "Edsger",
+    "Barbara",
+    "Tim",
+    "Radia",
+    "Donald",
+    "Frances",
+    "Ken",
+    "Margaret",
+    "Dennis",
+    "Adele",
+    "Linus",
+    "Jean",
+    "Guido",
+    "Karen",
+    "Bjarne",
+    "Sophie",
+)
+_LAST_NAMES = (
+    "Lovelace",
+    "Hopper",
+    "Turing",
+    "Johnson",
+    "Dijkstra",
+    "Liskov",
+    "Berners",
+    "Perlman",
+    "Knuth",
+    "Allen",
+    "Thompson",
+    "Hamilton",
+    "Ritchie",
+    "Goldberg",
+    "Torvalds",
+    "Bartik",
+    "Rossum",
+    "Sparck",
+    "Stroustrup",
+    "Wilson",
+)
+_COUNTRIES = ("NL", "BE", "DE", "FR", "ES", "IT", "PL", "SE")
+_ORDER_STATUS = ("placed", "paid", "shipped", "delivered", "cancelled")
+_PRODUCT_ADJECTIVES = (
+    "Compact",
+    "Insulated",
+    "Folding",
+    "Reinforced",
+    "Lightweight",
+    "Modular",
+)
+_PRODUCT_MATERIALS = ("Steel", "Bamboo", "Ceramic", "Linen", "Copper", "Walnut")
+_PRODUCT_NOUNS = (
+    "Kettle",
+    "Lamp",
+    "Crate",
+    "Stool",
+    "Planter",
+    "Carafe",
+    "Shelf",
+    "Trivet",
+)
+_CATEGORIES = ("kitchen", "lighting", "storage", "furniture", "garden", "tableware")
+_PAGE_PATHS = (
+    "/",
+    "/search",
+    "/product",
+    "/cart",
+    "/checkout",
+    "/orders",
+    "/help",
+    "/account",
+)
+
+# Distribution centres, written out rather than generated: twelve rows whose
+# whole job is to trip the PII detector on data that is not personal at all.
+# `city` reads as an address and `latitude`/`longitude` as a location, but this
+# is a building. Twelve distinct values each, deliberately: at five or fewer the
+# engine de-rates those two categories, and the point here is to meet a false
+# positive that actually blocks. `site_name` is the counterweight: a closed
+# all-caps vocabulary, which profiling recognizes as reference data and de-rates
+# below the block threshold, so the same run shows evidence moving both ways.
+_LOCATIONS = (
+    ("ROTTERDAM DC", "Rotterdam", 51.9244, 4.4777, 48000),
+    ("ANTWERP DC", "Antwerp", 51.2194, 4.4025, 39000),
+    ("HAMBURG DC", "Hamburg", 53.5511, 9.9937, 52000),
+    ("LILLE HUB", "Lille", 50.6292, 3.0573, 21000),
+    ("VALENCIA HUB", "Valencia", 39.4699, -0.3763, 18000),
+    ("MILAN HUB", "Milan", 45.4642, 9.1900, 24000),
+    ("POZNAN DC", "Poznan", 52.4064, 16.9252, 31000),
+    ("MALMO HUB", "Malmo", 55.6050, 13.0038, 16000),
+    ("LYON HUB", "Lyon", 45.7640, 4.8357, 19000),
+    ("UTRECHT SPOKE", "Utrecht", 52.0907, 5.1214, 9000),
+    ("BREMEN SPOKE", "Bremen", 53.0793, 8.8017, 8000),
+    ("GHENT SPOKE", "Ghent", 51.0543, 3.7174, 7500),
+)
+
+
+def _money(cents: int) -> Decimal:
+    """A DECIMAL value built from an integer, never from a float.
+
+    Going through float would make the stored value depend on binary rounding,
+    which is exactly the kind of drift the pinned digest exists to catch.
+    """
+
+    return Decimal(f"{cents // 100}.{cents % 100:02d}")
+
+
+def _uuid_shaped(token: str) -> str:
+    """A canonical dashed 8-4-4-4-12 identifier derived from ``token``.
+
+    Derived rather than drawn from ``uuid4`` so it is reproducible; canonical
+    rather than merely hex-shaped because profiling recognizes only the dashed
+    form as a UUID, and this column is here to be the *homogeneous* key that
+    produces no shape warning, against which ``products.sku`` is the contrast.
+    """
+
+    digest = hashlib.md5(token.encode("utf-8"), usedforsecurity=False).hexdigest()
+    return (
+        f"{digest[:8]}-{digest[8:12]}-{digest[12:16]}-{digest[16:20]}-{digest[20:32]}"
+    )
+
+
+def build_tables(seed: int = DEMO_SEED) -> tuple[DemoTable, ...]:
+    """The whole warehouse as in-memory rows, with no I/O and no connection.
+
+    Split from :func:`generate_demo_warehouse` so the data can be inspected,
+    digested, and asserted on without anything being written anywhere. Each
+    block below is one relation and one lesson; the flaws are seeded on purpose,
+    because a first run that reports a clean bill of health teaches nothing.
+    """
+
+    # A pinned Mersenne Twister is the whole point: the documentation quotes the
+    # counts this produces, and nothing generated here is a secret (S311).
+    rnd = random.Random(seed)  # noqa: S311
+
+    # --- customers: the PII true positives, and the clean parent key ----------
+    customers: list[tuple] = []
+    for i in range(1, 1201):
+        first = _FIRST_NAMES[rnd.randrange(len(_FIRST_NAMES))]
+        last = _LAST_NAMES[rnd.randrange(len(_LAST_NAMES))]
+        customers.append(
+            (
+                i,
+                f"{first.lower()}.{last.lower()}{i}@example.com",
+                f"{first} {last}",
+                _COUNTRIES[rnd.randrange(len(_COUNTRIES))],
+                _ANCHOR - timedelta(days=rnd.randrange(30, 1100)),
+                _money(rnd.randrange(1500, 480000)),
+            )
+        )
+
+    # --- products: a mixed-shape candidate key, and a name that is not a person
+    # `sku` is unique and non-null, which is what makes it a candidate key and
+    # therefore eligible for the value-shape check. That eligibility is why the
+    # mixed shapes cannot ride on `order_items.order_item_id` below: that column
+    # is deliberately not unique, so it would never be looked at this way.
+    products: list[tuple] = []
+    for i in range(1, 301):
+        sku = (
+            str(400000 + i)
+            if i <= 270
+            else hashlib.md5(
+                f"catalog-merge-{i}".encode(), usedforsecurity=False
+            ).hexdigest()
+        )
+        adjective = _PRODUCT_ADJECTIVES[rnd.randrange(len(_PRODUCT_ADJECTIVES))]
+        material = _PRODUCT_MATERIALS[rnd.randrange(len(_PRODUCT_MATERIALS))]
+        noun = _PRODUCT_NOUNS[rnd.randrange(len(_PRODUCT_NOUNS))]
+        products.append(
+            (
+                i,
+                sku,
+                f"{adjective} {material} {noun}",
+                _CATEGORIES[rnd.randrange(len(_CATEGORIES))],
+                _money(rnd.randrange(450, 39000)),
+            )
+        )
+
+    # --- orders: the clean side, plus a timestamp stored as text --------------
+    # `placed_at` is declared VARCHAR and holds ISO-8601 timestamps, which is the
+    # single most common shape of "the declared type contradicts the content".
+    orders: list[tuple] = []
+    for i in range(1, 5001):
+        placed = _ANCHOR - timedelta(days=rnd.randrange(0, 420))
+        hour, minute, second = rnd.randrange(24), rnd.randrange(60), rnd.randrange(60)
+        orders.append(
+            (
+                i,
+                1 + rnd.randrange(1200),
+                _ORDER_STATUS[rnd.randrange(len(_ORDER_STATUS))],
+                _money(rnd.randrange(900, 92000)),
+                f"{placed.isoformat()} {hour:02d}:{minute:02d}:{second:02d}",
+            )
+        )
+
+    # --- order_items: the broken grain ----------------------------------------
+    # Thirteen thousand real line items, then a thousand rows from a batch that
+    # was loaded twice. The key is the table's own, so profiling reports it as
+    # broken grain rather than shrugging at a repeated foreign key.
+    item_ids = list(range(1, 13001)) + [1 + rnd.randrange(13000) for _ in range(1000)]
+    order_items = [
+        (
+            item_id,
+            1 + rnd.randrange(5000),
+            1 + rnd.randrange(300),
+            1 + rnd.randrange(5),
+            _money(rnd.randrange(450, 39000)),
+        )
+        for item_id in item_ids
+    ]
+
+    # --- web_events: the join that has to be declined, and epoch milliseconds --
+    # `customer_id` shares the parent's name and type, so an edge is inferred on
+    # the name alone. The values are from the analytics vendor's own id space and
+    # overlap the CRM's by nothing, so verification collapses the inference. This
+    # is the failure that otherwise ships: the join runs, returns all-NULL parent
+    # attributes, and looks like it worked.
+    web_events = [
+        (
+            _uuid_shaped(f"event-{i}"),
+            900000 + rnd.randrange(60000),
+            f"sess-{rnd.randrange(90000):05d}",
+            _PAGE_PATHS[rnd.randrange(len(_PAGE_PATHS))],
+            _EPOCH_MS_START + rnd.randrange(_NINETY_DAYS_MS),
+        )
+        for i in range(9000)
+    ]
+
+    locations = [
+        (i, site, city, lat, lng, capacity)
+        for i, (site, city, lat, lng, capacity) in enumerate(_LOCATIONS, start=1)
+    ]
+
+    return (
+        DemoTable(
+            name="customers",
+            columns=(
+                ("customer_id", "INTEGER"),
+                ("email", "VARCHAR"),
+                ("full_name", "VARCHAR"),
+                ("country_code", "VARCHAR"),
+                ("signup_date", "DATE"),
+                ("lifetime_value", "DECIMAL(10,2)"),
+            ),
+            rows=tuple(customers),
+            note=(
+                "email and full_name are personal data; profiling flags both and "
+                "the query firewall refuses to project them"
+            ),
+        ),
+        DemoTable(
+            name="products",
+            columns=(
+                ("product_id", "INTEGER"),
+                ("sku", "VARCHAR"),
+                ("product_name", "VARCHAR"),
+                ("category", "VARCHAR"),
+                ("list_price", "DECIMAL(10,2)"),
+            ),
+            rows=tuple(products),
+            note=(
+                "sku is a key that mixes two id schemes from a merged catalogue; "
+                "product_name is a name that is not a person, and is not flagged"
+            ),
+        ),
+        DemoTable(
+            name="orders",
+            columns=(
+                ("order_id", "BIGINT"),
+                ("customer_id", "INTEGER"),
+                ("status", "VARCHAR"),
+                ("order_total", "DECIMAL(10,2)"),
+                ("placed_at", "VARCHAR"),
+            ),
+            rows=tuple(orders),
+            note=(
+                "the clean join: every customer_id matches. placed_at is declared "
+                "VARCHAR but holds timestamps"
+            ),
+        ),
+        DemoTable(
+            name="order_items",
+            columns=(
+                ("order_item_id", "BIGINT"),
+                ("order_id", "BIGINT"),
+                ("product_id", "INTEGER"),
+                ("quantity", "INTEGER"),
+                ("unit_price", "DECIMAL(10,2)"),
+            ),
+            rows=tuple(order_items),
+            note=(
+                "a batch was loaded twice, so order_item_id is not unique and any "
+                "join on it fans out"
+            ),
+        ),
+        DemoTable(
+            name="web_events",
+            columns=(
+                ("event_id", "VARCHAR"),
+                ("customer_id", "INTEGER"),
+                ("session_id", "VARCHAR"),
+                ("page_path", "VARCHAR"),
+                ("occurred_at", "BIGINT"),
+            ),
+            rows=tuple(web_events),
+            note=(
+                "customer_id shares the CRM's column name but none of its values; "
+                "occurred_at is declared BIGINT and holds epoch milliseconds"
+            ),
+        ),
+        DemoTable(
+            name="warehouse_locations",
+            columns=(
+                ("location_id", "INTEGER"),
+                ("site_name", "VARCHAR"),
+                ("city", "VARCHAR"),
+                ("latitude", "DOUBLE"),
+                ("longitude", "DOUBLE"),
+                ("capacity_units", "INTEGER"),
+            ),
+            rows=tuple(locations),
+            note=(
+                "the designed false positives: city and the coordinates are "
+                "flagged as personal data, and these are buildings"
+            ),
+        ),
+        DemoTable(
+            name="returns",
+            columns=(
+                ("return_id", "INTEGER"),
+                ("order_id", "BIGINT"),
+                ("reason_code", "VARCHAR"),
+                ("returned_at", "DATE"),
+            ),
+            rows=(),
+            note="the load that half-failed: the table exists and holds nothing",
+        ),
+    )
+
+
+def row_digest(tables: tuple[DemoTable, ...]) -> str:
+    """A sha256 over every generated column and cell, in declaration order.
+
+    The executable half of the determinism promise. A test pins this value, so
+    any edit that would move a row count or a column name quoted in the
+    documentation fails there rather than shipping a README that disagrees with
+    what the user sees.
+    """
+
+    digest = hashlib.sha256()
+    for table in tables:
+        digest.update(table.name.encode("utf-8"))
+        for name, sql_type in table.columns:
+            digest.update(f"\x00{name}:{sql_type}".encode())
+        for row in table.rows:
+            cells = "\x1f".join("" if cell is None else str(cell) for cell in row)
+            digest.update(b"\n")
+            digest.update(cells.encode("utf-8"))
+    return digest.hexdigest()
+
+
+def generate_demo_warehouse(
+    path: str | Path, *, seed: int = DEMO_SEED
+) -> DemoWarehouse:
+    """Create a new DuckDB file at ``path`` and seed it. Never overwrite.
+
+    The three refusals here are the whole safety story of this module, and they
+    all run before ``duckdb`` is even imported, so a refused call has opened
+    nothing. On any failure after the file exists it is removed again, so a
+    half-written warehouse is never left behind for the read-only adapter to
+    find and report as real.
+    """
+
+    target = Path(path)
+    if target.exists() or target.is_symlink():
+        raise DemoTargetExistsError(
+            f"'{target}' already exists; dex demo only ever creates a new file and "
+            "never opens, inspects, or replaces one you already have. Name a "
+            "different path, for example `dex demo demo2.duckdb`"
+        )
+    parent = target.parent
+    if not parent.is_dir():
+        raise DemoPathError(
+            f"'{parent}' is not an existing directory; dex demo writes one file and "
+            "creates no directories. Create it first, or name a path inside a "
+            "directory that exists"
+        )
+
+    try:
+        import duckdb
+    except ImportError as exc:
+        raise DemoDependencyError(
+            "dex demo builds a local DuckDB warehouse, which needs the duckdb "
+            "client: reinstall the engine with the on-ramp extra, "
+            '`pip install "exmergo-dex-core[duckdb]"`. It pulls no cloud client '
+            "and needs no credentials"
+        ) from exc
+
+    tables = build_tables(seed)
+    connection = duckdb.connect(str(target))
+    try:
+        # Table and column names are module constants a few lines above, never
+        # caller input, and every value goes in as a bound parameter, so the only
+        # interpolation here is the shape of a statement this file wrote itself.
+        for table in tables:
+            columns = ", ".join(f"{name} {sql}" for name, sql in table.columns)
+            connection.execute(f"CREATE TABLE {table.name} ({columns})")
+            if not table.rows:
+                continue
+            placeholders = ", ".join("?" for _ in table.columns)
+            connection.executemany(
+                f"INSERT INTO {table.name} VALUES ({placeholders})",  # noqa: S608
+                [list(row) for row in table.rows],
+            )
+        # Fold the write-ahead log into the database file before closing, so the
+        # command leaves exactly the one artifact it reported creating.
+        connection.execute("CHECKPOINT")
+    except Exception:
+        connection.close()
+        target.unlink(missing_ok=True)
+        raise
+    connection.close()
+
+    return DemoWarehouse(
+        path=target, tables=tables, seed=seed, digest=row_digest(tables)
+    )

--- a/packages/dex-core/src/exmergo_dex_core/demo/warehouse.py
+++ b/packages/dex-core/src/exmergo_dex_core/demo/warehouse.py
@@ -5,8 +5,9 @@ exception, and it is deliberately its own path so that exception stays visible:
 it imports ``duckdb`` directly and never :mod:`..adapters.duckdb`, so the
 read-only open in the adapter has no branch that could ever be relaxed, and it
 never touches the SQL guard, because the statements here are ``CREATE TABLE`` and
-parameterized ``INSERT`` rather than anything an agent authored. A safety-spine
-test asserts both of those mechanically rather than trusting this paragraph.
+a ``COPY`` off a file this module just wrote, rather than anything an agent
+authored. A safety-spine test asserts both of those mechanically rather than
+trusting this paragraph.
 
 Creating a file is not writing to a user's data. The rule that keeps those two
 apart is create-only: a target that already exists is refused outright, with no
@@ -30,8 +31,10 @@ a test pins so drift fails CI instead of shipping.
 
 from __future__ import annotations
 
+import csv
 import hashlib
 import random
+import tempfile
 from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
@@ -495,6 +498,19 @@ def generate_demo_warehouse(
     nothing. On any failure after the file exists it is removed again, so a
     half-written warehouse is never left behind for the read-only adapter to
     find and report as real.
+
+    Rows are staged through a CSV in a temporary directory and bulk-loaded with
+    ``COPY``, rather than inserted as bound values, purely for speed: DuckDB's
+    per-value binding costs about 1.7k rows/s on 1.5.5 and 90k on 1.5.4, so an
+    insert-based load put this command anywhere between one second and eighteen
+    depending on which release the user happened to resolve. ``COPY`` reads at
+    ~680k rows/s on both, which is the difference between the on-ramp feeling
+    instant and feeling broken. ``COPY`` into an existing table also uses that
+    table's declared types, so nothing here restates or re-sniffs a schema, and
+    the staging file lives in the system temp directory (never beside the
+    target) so the command still creates exactly the one artifact it reports.
+    Worth knowing if this data ever grows a nullable column: CSV cannot tell an
+    empty string from NULL, and every column generated here is non-null.
     """
 
     target = Path(path)
@@ -526,18 +542,22 @@ def generate_demo_warehouse(
     connection = duckdb.connect(str(target))
     try:
         # Table and column names are module constants a few lines above, never
-        # caller input, and every value goes in as a bound parameter, so the only
-        # interpolation here is the shape of a statement this file wrote itself.
-        for table in tables:
-            columns = ", ".join(f"{name} {sql}" for name, sql in table.columns)
-            connection.execute(f"CREATE TABLE {table.name} ({columns})")
-            if not table.rows:
-                continue
-            placeholders = ", ".join("?" for _ in table.columns)
-            connection.executemany(
-                f"INSERT INTO {table.name} VALUES ({placeholders})",  # noqa: S608
-                [list(row) for row in table.rows],
-            )
+        # caller input, so the only interpolation is the shape of a statement
+        # this file wrote itself; the one value that varies, the staging path,
+        # binds as a parameter.
+        with tempfile.TemporaryDirectory(prefix="dex-demo-") as staging:
+            for table in tables:
+                columns = ", ".join(f"{name} {sql}" for name, sql in table.columns)
+                connection.execute(f"CREATE TABLE {table.name} ({columns})")
+                if not table.rows:
+                    continue
+                rows_csv = Path(staging) / f"{table.name}.csv"
+                with rows_csv.open("w", newline="", encoding="utf-8") as handle:
+                    csv.writer(handle).writerows(table.rows)
+                connection.execute(
+                    f"COPY {table.name} FROM ? (FORMAT CSV, HEADER FALSE)",
+                    [str(rows_csv)],
+                )
         # Fold the write-ahead log into the database file before closing, so the
         # command leaves exactly the one artifact it reported creating.
         connection.execute("CHECKPOINT")

--- a/packages/dex-core/src/exmergo_dex_core/envelope.py
+++ b/packages/dex-core/src/exmergo_dex_core/envelope.py
@@ -231,6 +231,11 @@ def _reason_overrides() -> list[tuple[type[BaseException], Reason]]:
     # Always safe: no imports of their own (`errors.py`) or explicitly
     # designed to import without the dialect engine (`guards/dialect.py` is
     # the module that checks whether sqlglot is even installed).
+    from .demo.warehouse import (
+        DemoDependencyError,
+        DemoPathError,
+        DemoTargetExistsError,
+    )
     from .errors import (
         ConfigurationError,
         ConnectorError,
@@ -241,6 +246,9 @@ def _reason_overrides() -> list[tuple[type[BaseException], Reason]]:
     from .guards.dialect import DialectDependencyError
 
     overrides: list[tuple[type[BaseException], Reason]] = [
+        (DemoTargetExistsError, Reason.GUARD),
+        (DemoDependencyError, Reason.PREREQUISITE),
+        (DemoPathError, Reason.REQUEST),
         (DialectDependencyError, Reason.PREREQUISITE),
         (PrerequisiteError, Reason.PREREQUISITE),  # CacheRequiredError, NoBaselineError
         (ConnectorError, Reason.CONNECTION),  # every *ConnectionError subclass
@@ -281,6 +289,11 @@ def _reason_overrides() -> list[tuple[type[BaseException], Reason]]:
     # isinstance, so a new DexError subclass only needs an entry when its own
     # reason diverges from its parent's.
     _reason_overrides_cache = [
+        # A demo target that already exists is a safety refusal, not bad input:
+        # the command declines to touch a warehouse it did not create.
+        (DemoTargetExistsError, Reason.GUARD),
+        (DemoDependencyError, Reason.PREREQUISITE),
+        (DemoPathError, Reason.REQUEST),
         (SemanticQueryRefusedError, Reason.GUARD),  # policy, not backend failure
         (ClusterDependencyError, Reason.PREREQUISITE),  # install the extra, retry
         (DialectDependencyError, Reason.PREREQUISITE),

--- a/packages/dex-core/tests/demo/conftest.py
+++ b/packages/dex-core/tests/demo/conftest.py
@@ -1,0 +1,18 @@
+"""Fixtures for the demo on-ramp.
+
+`dex demo` resolves its target against the process working directory, because
+that is where a person typing it expects a file to appear. Every test here
+therefore has to run somewhere disposable, or the suite would leave warehouses
+and `.dex/` directories in the checkout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)

--- a/packages/dex-core/tests/demo/test_commands.py
+++ b/packages/dex-core/tests/demo/test_commands.py
@@ -1,0 +1,197 @@
+"""`dex demo` through the CLI: one envelope, two artifacts, four refusals.
+
+Driven through `main(argv)` rather than the generator, because everything under
+test here is the command's own behavior: what it wires up, what it declines to
+wire up, and what it tells the caller to run next.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.cli import main
+from exmergo_dex_core.demo import DEMO_FILENAME
+
+pytest.importorskip("duckdb")
+
+
+def _run(argv: list[str], capsys) -> dict:
+    rc = main(argv)
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1, "exactly one envelope line"
+    payload = json.loads(out)
+    assert rc == (1 if payload["status"] == "error" else 0), payload
+    return payload
+
+
+def test_demo_creates_the_warehouse_and_wires_it_up(tmp_path: Path, capsys):
+    payload = _run(["demo"], capsys)
+
+    assert payload["status"] == "ok"
+    data = payload["data"]
+    assert data["path"] == DEMO_FILENAME
+    assert data["object_count"] == 7
+    assert data["row_count"] == 29512
+    assert data["created"] == [DEMO_FILENAME, ".dex/config.yml"]
+    assert (tmp_path / DEMO_FILENAME).is_file()
+
+    # The config is what lets every printed command run with no flags at all,
+    # which is the difference between a loose file and a working project.
+    from exmergo_dex_core.config import load_config
+
+    config = load_config(tmp_path)
+    assert config is not None
+    assert config.connector == "duckdb"
+    assert config.duckdb is not None and config.duckdb.path == DEMO_FILENAME
+    assert [d["op"] for d in payload["diffs"]] == ["create"]
+
+    assert [step["command"] for step in data["next_steps"]] == [
+        "dex explore map",
+        "dex explore profile order_items products",
+        "dex explore relationships --verify",
+        'dex explore query "select email from customers"',
+    ]
+    assert all(step["shows"] for step in data["next_steps"])
+
+
+def test_demo_creates_nothing_but_what_it_reports(tmp_path: Path, capsys):
+    """No write-ahead log left behind, no cache, no plans directory: the two
+    artifacts named in `created` are exactly the two that exist."""
+
+    payload = _run(["demo"], capsys)
+
+    on_disk = sorted(
+        str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*") if p.is_file()
+    )
+    assert on_disk == sorted(payload["data"]["created"])
+
+
+def test_demo_names_no_paradigm_because_it_resolved_no_connector(capsys):
+    """`free_local` is DuckDB's positive answer about a connector that was
+    actually resolved, never a stand-in for having nothing to say. The demo
+    opens no connection at all, so it claims nothing."""
+
+    payload = _run(["demo"], capsys)
+    assert payload["cost"] == {"paradigm": None, "estimate": None, "ceiling": None}
+
+
+def test_demo_takes_a_target_path(tmp_path: Path, capsys):
+    (tmp_path / "sandbox").mkdir()
+    payload = _run(["demo", "sandbox/shop.duckdb"], capsys)
+
+    assert payload["data"]["path"] == "sandbox/shop.duckdb"
+    assert (tmp_path / "sandbox" / "shop.duckdb").is_file()
+    # The config lands beside the warehouse, so the commands have to name the
+    # file: a bare `explore map` run from here would not find that config.
+    assert all(
+        "--path sandbox/shop.duckdb" in step["command"]
+        for step in payload["data"]["next_steps"]
+    )
+
+
+def test_a_second_demo_refuses_rather_than_overwriting(tmp_path: Path, capsys):
+    _run(["demo"], capsys)
+    before = (tmp_path / DEMO_FILENAME).read_bytes()
+
+    payload = _run(["demo"], capsys)
+    assert payload["status"] == "error"
+    assert payload["reason"] == "guard"
+    assert "already exists" in payload["errors"][0]
+    assert (tmp_path / DEMO_FILENAME).read_bytes() == before
+
+
+def test_confirm_cannot_buy_through_the_overwrite_refusal(tmp_path: Path, capsys):
+    """Deliberately unconfirmable. A `--confirm` that could talk past this would
+    put a real warehouse one typo away from being replaced."""
+
+    _run(["demo"], capsys)
+    payload = _run(["demo", "--confirm"], capsys)
+    assert payload["status"] == "error"
+    assert payload["reason"] == "guard"
+
+
+def test_a_missing_parent_directory_is_a_clean_refusal(tmp_path: Path, capsys):
+    payload = _run(["demo", "nope/shop.duckdb"], capsys)
+
+    assert payload["status"] == "error"
+    assert payload["reason"] == "request"
+    assert "creates no directories" in payload["errors"][0]
+    assert not (tmp_path / "nope").exists()
+
+
+def test_path_is_refused_rather_than_silently_ignored(capsys):
+    """`--path` names the warehouse dex reads, everywhere else. Honoring it here
+    would blur the one distinction this command exists to keep sharp, and
+    ignoring it would be worse: a flag accepted and dropped reads as a setting
+    that took effect."""
+
+    payload = _run(["demo", "--path", "shop.duckdb"], capsys)
+
+    assert payload["status"] == "error"
+    assert payload["reason"] == "request"
+    assert "dex demo shop.duckdb" in payload["errors"][0]
+
+
+def test_an_existing_config_above_the_target_is_left_alone(tmp_path: Path, capsys):
+    """A second config in a subdirectory would shadow the user's real one for
+    every command run there, so the demo declines to write one and says so."""
+
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".dex").mkdir()
+    committed = tmp_path / ".dex" / "config.yml"
+    committed.write_text(
+        "connector: duckdb\nduckdb:\n  path: production.duckdb\n", encoding="utf-8"
+    )
+    (tmp_path / "scratch").mkdir()
+
+    payload = _run(["demo", "scratch/shop.duckdb"], capsys)
+
+    assert payload["status"] == "ok"
+    assert payload["data"]["created"] == ["scratch/shop.duckdb"]
+    assert not (tmp_path / "scratch" / ".dex").exists()
+    assert "production.duckdb" in committed.read_text(encoding="utf-8")
+    assert any("left untouched" in w for w in payload["warnings"])
+    assert payload["diffs"] == []
+    assert all(
+        "--path scratch/shop.duckdb" in step["command"]
+        for step in payload["data"]["next_steps"]
+    )
+
+
+def test_the_generated_warehouse_drives_the_whole_explore_tour(tmp_path: Path, capsys):
+    """The claim the documentation makes, run end to end: every command the
+    envelope prints works, and each one lands the finding it promises."""
+
+    _run(["demo"], capsys)
+
+    mapped = _run(["explore", "map"], capsys)["data"]
+    assert mapped["object_count"] == 7
+    assert mapped["pii_column_count"] == 6
+    assert mapped["relationship_count"] == 5
+
+    profiled = _run(["explore", "profile", "order_items", "products"], capsys)
+    notes = [n for d in profiled["data"]["datasets"] for n in d["data_quality"]]
+    assert any("order_item_id is not unique" in n for n in notes)
+    assert any("mixes value shapes" in n for n in notes)
+
+    verified = _run(["explore", "relationships", "--verify"], capsys)["data"]
+    edges = {
+        (r["from_dataset"].split(".")[-1], r["from_columns"][0]): r
+        for r in verified["relationships"]
+    }
+    assert edges[("orders", "customer_id")]["orphan_fraction"] == 0.0
+    assert edges[("web_events", "customer_id")]["orphan_fraction"] == 1.0
+    assert any("is not evidence of a shared key" in n for n in verified["notes"])
+
+    refused = _run(["explore", "query", "select email from customers"], capsys)
+    assert refused["reason"] == "guard"
+    assert "PII-flagged" in refused["errors"][0]
+    # And the refusal is policy rather than breakage: the same table answers an
+    # aggregate over the same column.
+    counted = _run(
+        ["explore", "query", "select count(distinct email) as n from customers"], capsys
+    )
+    assert counted["data"]["cells"] == [[1200]]

--- a/packages/dex-core/tests/demo/test_warehouse.py
+++ b/packages/dex-core/tests/demo/test_warehouse.py
@@ -1,0 +1,263 @@
+"""The generated warehouse: deterministic, create-only, and flawed on purpose.
+
+Two kinds of assertion here. The first pins determinism, because the READMEs
+quote counts and column names out of this data and a silent drift would make the
+documentation wrong exactly where a new user is reading it. The second pins each
+seeded flaw at the level of the data itself, so a change that quietly healed one
+fails here rather than in the explore suite, where it would read as a detector
+regression instead of a fixture regression.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.demo import (
+    DEMO_FILENAME,
+    DEMO_SEED,
+    DemoDependencyError,
+    DemoPathError,
+    DemoTargetExistsError,
+    build_tables,
+    generate_demo_warehouse,
+    row_digest,
+)
+
+# The pinned digest. If an edit to the generator moves this, the counts and
+# column names quoted in README.md, packages/dex-core/README.md, and
+# references/duckdb.md have to be re-checked against real output and updated in
+# the same change; then, and only then, update this value.
+GOLDEN_DIGEST = "bb3dc590fd38eca798b0bfd28619d3e974f66107ec88535e8fb577806126a37f"
+
+EXPECTED_ROWS = {
+    "customers": 1200,
+    "products": 300,
+    "orders": 5000,
+    "order_items": 14000,
+    "web_events": 9000,
+    "warehouse_locations": 12,
+    "returns": 0,
+}
+
+
+def _table(name: str):
+    return next(t for t in build_tables() if t.name == name)
+
+
+def _column(table, name: str) -> int:
+    return next(i for i, (col, _type) in enumerate(table.columns) if col == name)
+
+
+def test_the_generated_data_is_byte_for_byte_the_documented_data():
+    """The determinism contract, as one number.
+
+    A generator whose output drifts would make every quoted row count in the
+    documentation quietly wrong, which for a tool whose claim is precision is
+    worse than having no quickstart at all.
+    """
+
+    tables = build_tables()
+    assert row_digest(tables) == GOLDEN_DIGEST
+    assert {t.name: len(t.rows) for t in tables} == EXPECTED_ROWS
+    assert sum(len(t.rows) for t in tables) == 29512
+    # Two runs in the same process, and a re-seeded run, agree: the stream is
+    # pinned rather than merely happening to start from the same place.
+    assert row_digest(build_tables()) == GOLDEN_DIGEST
+    assert row_digest(build_tables(DEMO_SEED)) == GOLDEN_DIGEST
+
+
+def test_a_different_seed_produces_different_data():
+    """The digest is measuring the data, not a constant that ignores its input."""
+
+    assert row_digest(build_tables(DEMO_SEED + 1)) != GOLDEN_DIGEST
+
+
+def test_no_generated_value_depends_on_the_wall_clock():
+    """Every date is measured back from a fixed anchor.
+
+    A single `date.today()` would make the file change daily, which is the same
+    documentation failure as an unpinned seed but harder to notice, since it
+    reproduces perfectly within one day.
+    """
+
+    from exmergo_dex_core.demo import warehouse
+
+    source = Path(warehouse.__file__).read_text(encoding="utf-8")
+    for forbidden in ("date.today", "datetime.now", "datetime.utcnow", "time.time"):
+        assert forbidden not in source, forbidden
+
+
+# --- the seeded flaws, each pinned in the data itself ---------------------------
+
+
+def test_the_order_item_key_repeats_a_double_loaded_batch():
+    items = _table("order_items")
+    ids = [row[_column(items, "order_item_id")] for row in items.rows]
+    assert len(ids) == 14000
+    assert len(set(ids)) == 13000, "1000 rows come from a batch loaded twice"
+
+
+def test_the_sku_key_is_unique_but_mixes_two_id_schemes():
+    """Both halves matter. Uniqueness is what makes `sku` a candidate key, which
+    is the only thing profiling checks value shapes on; the mix is the finding."""
+
+    products = _table("products")
+    skus = [row[_column(products, "sku")] for row in products.rows]
+    assert len(set(skus)) == len(skus) == 300
+    numeric = [s for s in skus if s.isdigit()]
+    hexed = [s for s in skus if not s.isdigit()]
+    assert len(numeric) == 270 and len(hexed) == 30
+    assert all(len(s) == 32 and re.fullmatch(r"[0-9a-f]{32}", s) for s in hexed)
+
+
+def test_the_web_event_customer_ids_overlap_the_crm_by_nothing():
+    customers = _table("customers")
+    events = _table("web_events")
+    known = {row[_column(customers, "customer_id")] for row in customers.rows}
+    referenced = {row[_column(events, "customer_id")] for row in events.rows}
+    assert known and referenced
+    assert not (known & referenced), "the join has to be declined, not demoted"
+
+
+def test_the_returns_table_exists_and_is_empty():
+    returns = _table("returns")
+    assert returns.rows == ()
+    assert [name for name, _type in returns.columns] == [
+        "return_id",
+        "order_id",
+        "reason_code",
+        "returned_at",
+    ]
+
+
+def test_two_columns_contradict_their_declared_type():
+    """One string-encoded timestamp and one epoch-in-milliseconds integer: the
+    two shapes `explore profile` reports, and the two that silently break a
+    downstream cast."""
+
+    orders = _table("orders")
+    assert dict(orders.columns)["placed_at"] == "VARCHAR"
+    placed = [row[_column(orders, "placed_at")] for row in orders.rows]
+    assert all(re.fullmatch(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", v) for v in placed)
+
+    events = _table("web_events")
+    assert dict(events.columns)["occurred_at"] == "BIGINT"
+    occurred = [row[_column(events, "occurred_at")] for row in events.rows]
+    # Thirteen digits: inside the plausible epoch-milliseconds window, and well
+    # outside the epoch-seconds one, so the reported unit cannot be ambiguous.
+    assert all(1_700_000_000_000 < v < 1_800_000_000_000 for v in occurred)
+
+
+def test_the_personal_data_and_the_false_positives_are_both_present():
+    """The demo has to carry real PII and real false positives, because the
+    false positives are designed behavior and the first run is where meeting
+    them is cheapest."""
+
+    customers = _table("customers")
+    assert {"email", "full_name"} <= {name for name, _ in customers.columns}
+    emails = [row[_column(customers, "email")] for row in customers.rows]
+    assert len(set(emails)) == 1200, "unique, so the flag is raised to 0.95"
+
+    locations = _table("warehouse_locations")
+    names = {name for name, _ in locations.columns}
+    assert {"site_name", "city", "latitude", "longitude"} <= names
+    sites = [row[_column(locations, "site_name")] for row in locations.rows]
+    # An all-caps closed vocabulary is what profiling recognizes as reference
+    # data, de-rating the generic name flag below the block threshold.
+    assert len(set(sites)) == 12
+    assert all(re.fullmatch(r"[A-Z]+( [A-Z]+)*", s) for s in sites)
+    cities = [row[_column(locations, "city")] for row in locations.rows]
+    assert len(set(cities)) == 12, "five or fewer would be de-rated instead"
+
+    # And the true negative: `product` is a non-person qualifier, so this one
+    # must not be flagged. Meeting it beside the false positives is the lesson.
+    assert "product_name" in {name for name, _ in _table("products").columns}
+
+
+# --- create-only ----------------------------------------------------------------
+
+
+def test_generating_creates_the_file_and_nothing_else(tmp_path: Path):
+    duckdb = pytest.importorskip("duckdb")
+    target = tmp_path / DEMO_FILENAME
+    warehouse = generate_demo_warehouse(target)
+
+    assert warehouse.path == target
+    assert warehouse.row_count == 29512
+    assert sorted(p.name for p in tmp_path.iterdir()) == [DEMO_FILENAME]
+
+    # Read back through a read-only connection, which also proves the file is a
+    # real, checkpointed database rather than something only the writer can open.
+    counts: dict[str, int] = {}
+    connection = duckdb.connect(str(target), read_only=True)
+    try:
+        for name in EXPECTED_ROWS:
+            # The table names are this test's own constants, never input.
+            sql = f"SELECT COUNT(*) FROM {name}"  # noqa: S608
+            counts[name] = connection.execute(sql).fetchone()[0]
+    finally:
+        connection.close()
+    assert counts == EXPECTED_ROWS
+
+
+def test_an_existing_target_is_refused_and_left_untouched(tmp_path: Path):
+    """The one promise this command cannot break: it never opens, inspects, or
+    replaces a warehouse it did not create."""
+
+    pytest.importorskip("duckdb")
+    target = tmp_path / "already-here.duckdb"
+    target.write_bytes(b"not really a database")
+
+    with pytest.raises(DemoTargetExistsError, match="already exists"):
+        generate_demo_warehouse(target)
+    assert target.read_bytes() == b"not really a database"
+
+
+def test_a_directory_at_the_target_path_is_refused(tmp_path: Path):
+    pytest.importorskip("duckdb")
+    target = tmp_path / "warehouse.duckdb"
+    target.mkdir()
+
+    with pytest.raises(DemoTargetExistsError):
+        generate_demo_warehouse(target)
+
+
+def test_a_missing_parent_directory_is_refused_rather_than_created(tmp_path: Path):
+    with pytest.raises(DemoPathError, match="not an existing directory"):
+        generate_demo_warehouse(tmp_path / "nope" / "demo.duckdb")
+    assert not (tmp_path / "nope").exists()
+
+
+def test_a_missing_duckdb_client_names_the_extra_to_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """This is very likely someone's first dex command, so a bare ImportError
+    would land on a person who does not yet know connector clients live behind
+    extras. The refusal names the install line instead."""
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "duckdb", None)
+    with pytest.raises(DemoDependencyError, match=r"exmergo-dex-core\[duckdb\]"):
+        generate_demo_warehouse(tmp_path / DEMO_FILENAME)
+    assert not (tmp_path / DEMO_FILENAME).exists()
+
+
+def test_the_path_refusals_run_before_duckdb_is_even_imported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Order matters: a refused call must have opened nothing, and the only way
+    to prove nothing was opened is to refuse while the client is unavailable."""
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "duckdb", None)
+    existing = tmp_path / "demo.duckdb"
+    existing.touch()
+    with pytest.raises(DemoTargetExistsError):
+        generate_demo_warehouse(existing)
+    with pytest.raises(DemoPathError):
+        generate_demo_warehouse(tmp_path / "nope" / "demo.duckdb")

--- a/packages/dex-core/tests/test_cli_contract.py
+++ b/packages/dex-core/tests/test_cli_contract.py
@@ -36,6 +36,11 @@ def _all_commands() -> list[list[str]]:
                 if group == "explore" and sub == "cluster":
                     argv += ["some_table", "--repo-root", "missing-dex-fixture-dir"]
                 argvs.append(argv)
+        elif group == "demo":
+            # The one verb that creates a file. Pointed at a directory that does
+            # not exist so the contract is exercised through its clean refusal
+            # rather than by seeding a warehouse into the checkout.
+            argvs.append([group, "missing-dex-fixture-dir/demo.duckdb"])
         else:
             argvs.append([group])
     return argvs

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -57,6 +57,7 @@ def _run_isolated(
     *,
     extras: list[str] | None = None,
     pins: list[str] | None = None,
+    cwd: Path | None = None,
 ) -> subprocess.CompletedProcess:
     """Run ``code`` against the built wheel in a fresh environment.
 
@@ -88,7 +89,7 @@ def _run_isolated(
         ],
         capture_output=True,
         text=True,
-        cwd=PACKAGE_ROOT.parent,
+        cwd=str(cwd or PACKAGE_ROOT.parent),
     )
 
 
@@ -383,19 +384,60 @@ def test_the_quickstart_example_runs_against_the_installed_package(wheel: str):
     assert done.returncode == 0, done.stderr
 
     out = done.stdout
-    # The flow really ran: a map, the inferred join, the PII flag, a query.
-    assert "mapped 2 objects, 1 relationship(s)" in out
-    assert "join: shop.main.orders.customer_id -> shop.main.customers.id" in out
-    assert "PII: shop.main.customers.email is email" in out
+    # The flow really ran: the generator, a map, the findings, the PII flag, a
+    # query. The counts are the ones the READMEs quote, so a drift in the seeded
+    # data fails here too, against a real wheel rather than the source tree.
+    assert "generated 29512 rows across 7 tables" in out
+    assert "mapped 7 objects, 5 relationship(s)" in out
+    assert "order_item_id is not unique" in out
+    assert "PII: shop.main.customers.email is email (confidence 0.95)" in out
     # Exact cells, which is only stable because the example's query orders its
     # groups. A bare GROUP BY returns them in whatever order the hash aggregate
     # produced, so this assertion used to fail roughly one run in fifty.
-    assert "[['EU', 2], ['US', 1]]" in out
+    assert "[['cancelled', 996], ['delivered', 968], ['paid', 1044]" in out
     assert "refused, as designed" in out
     # PII stayed flagged and never surfaced, all the way out to stdout.
     assert "@example.com" not in out
     # And the default store wrote nothing beside the warehouse.
     assert "files in the workspace: ['shop.duckdb']" in out
+
+
+def test_the_first_run_on_ramp_works_on_a_clean_install(wheel: str, tmp_path: Path):
+    """The claim the README makes, made against a real wheel.
+
+    A stranger installs one extra, runs one command, and the next one works with
+    no flags, no credentials, and no network. Every part of that is a packaging
+    claim as much as an engine one, which is why it is asserted here: the demo
+    has to be inside the wheel, reachable from the console script, and satisfied
+    by `[duckdb]` alone.
+    """
+
+    import json
+
+    demo = _run_isolated(
+        wheel,
+        "from exmergo_dex_core.cli import main; raise SystemExit(main(['demo']))",
+        extras=["duckdb"],
+        cwd=tmp_path,
+    )
+    assert demo.returncode == 0, demo.stderr
+    envelope = json.loads(demo.stdout)
+    assert envelope["status"] == "ok"
+    assert envelope["data"]["created"] == ["dex_demo.duckdb", ".dex/config.yml"]
+    assert envelope["data"]["row_count"] == 29512
+
+    mapped = _run_isolated(
+        wheel,
+        "from exmergo_dex_core.cli import main;"
+        "raise SystemExit(main(['explore', 'map']))",
+        extras=["duckdb"],
+        cwd=tmp_path,
+    )
+    assert mapped.returncode == 0, mapped.stderr
+    payload = json.loads(mapped.stdout)
+    assert payload["status"] == "ok"
+    assert payload["data"]["object_count"] == 7
+    assert payload["data"]["pii_column_count"] == 6
 
 
 def test_the_installed_console_script_speaks_the_command_contract(wheel: str):

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -410,34 +410,33 @@ def test_the_first_run_on_ramp_works_on_a_clean_install(wheel: str, tmp_path: Pa
     claim as much as an engine one, which is why it is asserted here: the demo
     has to be inside the wheel, reachable from the console script, and satisfied
     by `[duckdb]` alone.
+
+    Both commands run in one isolated interpreter rather than two. Building the
+    environment is what this file pays for, and doing it twice buys nothing here:
+    what is under test is that `[duckdb]` alone satisfies the on-ramp, not that
+    the two commands are separate processes, which every other suite already
+    covers by calling `main` repeatedly.
     """
 
     import json
 
-    demo = _run_isolated(
+    done = _run_isolated(
         wheel,
-        "from exmergo_dex_core.cli import main; raise SystemExit(main(['demo']))",
+        "import json;from exmergo_dex_core.cli import main;"
+        "main(['demo']);main(['explore', 'map'])",
         extras=["duckdb"],
         cwd=tmp_path,
     )
-    assert demo.returncode == 0, demo.stderr
-    envelope = json.loads(demo.stdout)
-    assert envelope["status"] == "ok"
-    assert envelope["data"]["created"] == ["dex_demo.duckdb", ".dex/config.yml"]
-    assert envelope["data"]["row_count"] == 29512
+    assert done.returncode == 0, done.stderr
 
-    mapped = _run_isolated(
-        wheel,
-        "from exmergo_dex_core.cli import main;"
-        "raise SystemExit(main(['explore', 'map']))",
-        extras=["duckdb"],
-        cwd=tmp_path,
-    )
-    assert mapped.returncode == 0, mapped.stderr
-    payload = json.loads(mapped.stdout)
-    assert payload["status"] == "ok"
-    assert payload["data"]["object_count"] == 7
-    assert payload["data"]["pii_column_count"] == 6
+    created, mapped = (json.loads(line) for line in done.stdout.splitlines())
+    assert created["status"] == "ok"
+    assert created["data"]["created"] == ["dex_demo.duckdb", ".dex/config.yml"]
+    assert created["data"]["row_count"] == 29512
+    # The second command found the config the first one wrote, with no flags.
+    assert mapped["status"] == "ok"
+    assert mapped["data"]["object_count"] == 7
+    assert mapped["data"]["pii_column_count"] == 6
 
 
 def test_the_installed_console_script_speaks_the_command_contract(wheel: str):

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -152,6 +152,72 @@ def test_heterogeneous_key_note_carries_no_raw_value(tmp_path: Path):
     assert "90% numeric" in notes and "md5-shaped" in notes
 
 
+# `dex demo` is the one verb that creates a data file, so the read-only rule has
+# to hold around it in a way a reader can check rather than take on trust. Two
+# tests do that: the generator is structurally sealed off from the connector, and
+# the file it produces is opened read-only like any other the moment it exists.
+
+
+def test_the_demo_generator_is_the_only_writable_duckdb_open():
+    """No writable DuckDB connection exists in the engine outside the generator.
+
+    Asserted over the source rather than at runtime because the claim is about
+    what the code can do, not about what one path happened to do: a future
+    `read_only=False` anywhere in the adapter tree is the regression, and it
+    would pass every behavioral test until someone pointed dex at a warehouse
+    they cared about.
+    """
+
+    import exmergo_dex_core
+
+    package_root = Path(exmergo_dex_core.__file__).parent
+    generator = package_root / "demo" / "warehouse.py"
+    openers = [
+        path
+        for path in package_root.rglob("*.py")
+        if "duckdb.connect(" in path.read_text(encoding="utf-8")
+    ]
+    assert generator in openers, "the generator is the one that writes"
+    for path in openers:
+        if path == generator:
+            continue
+        source = path.read_text(encoding="utf-8")
+        assert "read_only=True" in source, f"{path} opens DuckDB without read_only"
+        assert "read_only=False" not in source, f"{path} opens DuckDB writable"
+
+    # And the generator imports neither the adapter nor the guards, so the
+    # read-only open and the SELECT-only guard have no branch it could take.
+    # Read off the import statements rather than the file text, so the prose
+    # explaining the separation cannot be mistaken for a violation of it.
+    import ast
+
+    imported: set[str] = set()
+    for node in ast.walk(ast.parse(generator.read_text(encoding="utf-8"))):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add(node.module or "")
+    assert not any("adapters" in name or "guards" in name for name in imported), (
+        f"the generator must stay off the connector path: {sorted(imported)}"
+    )
+
+
+def test_a_generated_demo_warehouse_is_opened_read_only(tmp_path: Path):
+    """The loop closed: the moment the demo file exists it is user data, and the
+    adapter treats it exactly like a warehouse dex did not create."""
+
+    pytest.importorskip("duckdb")
+    from exmergo_dex_core.demo import generate_demo_warehouse
+
+    warehouse = generate_demo_warehouse(tmp_path / "demo.duckdb")
+    adapter = DuckDBAdapter(warehouse.path)
+    try:
+        with pytest.raises(Exception):
+            adapter._conn.execute("DELETE FROM customers")
+    finally:
+        adapter.close()
+
+
 def test_combination_probe_sql_is_select_only_in_every_dialect():
     # The composite-key probe shares one SQL builder across the adapters; the
     # statement must parse as a single read-only SELECT in each dialect.
@@ -1460,6 +1526,69 @@ def test_init_refuses_where_a_project_already_exists(dbt_project_dir: Path):
         transform.init_project(
             "fresh", "duckdb", path=str(repo / "warehouse.duckdb"), repo_root=repo
         )
+
+
+def test_demo_refuses_to_overwrite_an_existing_warehouse(tmp_path: Path, capsys):
+    """`dex demo` is create-only, and deliberately not confirmable.
+
+    The sibling of the init refusal above, for the one verb that writes a data
+    file rather than a project file. It is stricter than init on purpose: a
+    `--confirm` that could talk past this would put a real warehouse one typo
+    away from being replaced, and the fix (name another path) costs nothing.
+    """
+
+    import json
+
+    pytest.importorskip("duckdb")
+    from exmergo_dex_core.cli import main
+
+    existing = tmp_path / "production.duckdb"
+    existing.write_bytes(b"someone else's warehouse")
+
+    for argv in (["demo", str(existing)], ["demo", str(existing), "--confirm"]):
+        assert main(argv) == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "error"
+        assert payload["reason"] == "guard"
+        assert existing.read_bytes() == b"someone else's warehouse"
+
+
+def test_demo_creates_only_what_it_names_and_never_a_second_config(
+    tmp_path: Path, monkeypatch, capsys
+):
+    """Two artifacts, both reported, and never one that shadows a real project.
+
+    A `.dex/config.yml` written into a subdirectory of someone's repo would
+    silently capture every command run there, which is the same class of harm as
+    overwriting a file: a change they did not ask for and would not see.
+    """
+
+    import json
+
+    pytest.importorskip("duckdb")
+    from exmergo_dex_core.cli import main
+
+    monkeypatch.chdir(tmp_path)
+    assert main(["demo"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    on_disk = sorted(
+        str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*") if p.is_file()
+    )
+    assert on_disk == sorted(payload["data"]["created"])
+
+    # Now with a project config already above the target: the warehouse is still
+    # created, the config is not, and the envelope says which happened.
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "scratch").mkdir()
+    committed = tmp_path / ".dex" / "config.yml"
+    before = committed.read_text(encoding="utf-8")
+
+    assert main(["demo", "scratch/second.duckdb"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["data"]["created"] == ["scratch/second.duckdb"]
+    assert not (tmp_path / "scratch" / ".dex").exists()
+    assert committed.read_text(encoding="utf-8") == before
+    assert any("left untouched" in w for w in payload["warnings"])
 
 
 def test_init_never_falls_through_to_a_default_connector(tmp_path: Path, capsys):

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -25,12 +25,20 @@ from profiled, PII-cleared columns, bounded and capped by the query firewall.
 
 ## The command surface
 
-Capabilities, not final spelling. Implemented incrementally: `connect test`, the
-`explore` group, the authoring surface (`transform`, `semantic`), and the
+Capabilities, not final spelling. Implemented incrementally: `demo`, `connect test`,
+the `explore` group, the authoring surface (`transform`, `semantic`), and the
 `maintain` group are live; `viz preview` returns a valid `not_implemented`
 envelope until the Viz integration lands.
 
 ```
+dex demo [path]                   -> generate a seeded local DuckDB warehouse (7 tables,
+                                     29,512 rows) plus a .dex/config.yml beside it, so a
+                                     first run needs no warehouse and no credentials;
+                                     reports both under data.created and names what to
+                                     run next under data.next_steps. Create-only and not
+                                     confirmable: an existing target refuses, no
+                                     directory is ever created, and an existing config
+                                     at or above the target is left alone with a warning
 dex connect test                  -> {capabilities, dialect, read_only: true}
 dex explore inventory [--rank]    -> ranked object summary (counts, sizes; no rows)
 dex explore profile <objects>     -> column profiles + PII flags + candidate keys, grain, data-quality warnings

--- a/references/duckdb.md
+++ b/references/duckdb.md
@@ -2,7 +2,8 @@
 
 DuckDB is a first-class product connector and, at the same time, the engine behind
 dex's evals and benchmarks. One adapter, three uses: the zero-credential
-on-ramp, the dev and CI engine, and the eval and benchmark engine.
+on-ramp, the dev and CI engine, and the eval and benchmark engine. `dex demo`
+supplies the on-ramp's content, so that first use needs no warehouse of your own.
 
 ## Auth and target
 
@@ -25,10 +26,64 @@ live `--path` is typed in your shell, so it stays relative to the current direct
 ## Read-only and resource bounds
 
 DuckDB is always opened **read-only** (`read_only=True`). A read-only open of a
-nonexistent file fails by design: dex attaches to an existing analytical store, it
-never creates one. Because the work is free and local, there is no cost ceiling,
-only resource bounds: a memory limit and a thread cap (defaults: 2GB, 4 threads),
-overridable from config. The adapter (`adapters/duckdb.py`) owns all of this.
+nonexistent file fails by design: the adapter attaches to an existing analytical
+store, it never creates one, and there is no writable fallback to relax. Because the
+work is free and local, there is no cost ceiling, only resource bounds: a memory
+limit and a thread cap (defaults: 2GB, 4 threads), overridable from config. The
+adapter (`adapters/duckdb.py`) owns all of this.
+
+`dex demo` is the one place a DuckDB file is created, and it is deliberately not the
+adapter (see the next section).
+
+## The demo warehouse
+
+```bash
+dex demo            # -> ./dex_demo.duckdb and ./.dex/config.yml
+dex explore map     # no flags: the config demo wrote points at the file it made
+```
+
+`dex demo` generates a small e-commerce warehouse locally: 7 tables and 29,512 rows
+(`customers` 1,200, `products` 300, `orders` 5,000, `order_items` 14,000,
+`web_events` 9,000, `warehouse_locations` 12, and `returns`, which an interrupted
+load left empty). No credentials, no cloud account, no network. The path is
+positional and resolves against the working directory; `--path` is refused there,
+because everywhere else it names the warehouse dex reads.
+
+**Generated, not committed.** DuckDB's storage format has broken backward
+compatibility across releases before, so a committed file could stop opening for a
+user on a newer duckdb, and that failure would land on the first command a stranger
+ever runs. A generator builds against whatever duckdb resolved and cannot rot; it
+also weighs a few KB in the wheel rather than a binary that does not
+delta-compress.
+
+**Deterministic.** One pinned seed, a random stream restricted to primitives that
+are stable across CPython releases, and no wall-clock anywhere: every date is
+measured back from a fixed anchor. A test pins a sha256 over every generated cell,
+so a change that would silently move a count quoted in the READMEs fails CI instead.
+
+**Create-only, and off the connector path.** The generator writes a new file and
+refuses rather than replace one, with no `--confirm` that can talk past that, and it
+never creates a parent directory; it will not write a `.dex/config.yml` where a
+project at or above the target already has one, so it cannot shadow a real config
+with its own. It lives in `demo/warehouse.py`, imports `duckdb` directly, and
+reaches neither the adapter nor the SQL guard, so the read-only rule above keeps no
+branch that could be relaxed. The safety spine asserts that mechanically: one test
+scans the package for every `duckdb.connect(` and requires `read_only=True`
+everywhere except the generator, another opens a freshly generated file through the
+adapter and confirms a write is still refused.
+
+**Seeded to be realistically broken**, because a first run that reports a clean bill
+of health teaches nothing. `order_item_id` lost its uniqueness to a double-loaded
+batch; `sku` mixes numeric and md5-shaped ids from a merged catalogue;
+`web_events.customer_id` shares the CRM's column name and none of its values, so
+`--verify` collapses the inferred join at 100% orphans; `orders.placed_at` is a
+VARCHAR holding timestamps and `web_events.occurred_at` a BIGINT holding epoch
+milliseconds; `customers.email` and `full_name` are personal data, while
+`warehouse_locations.city` and its coordinates are PII false positives on a
+building, and `site_name` is de-rated below the block threshold by its own values.
+
+`generate_demo_warehouse` is exported from the package, so the Python API and
+`examples/quickstart.py` build the same fixture.
 
 ## Exact distinct counts
 

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -19,6 +19,13 @@ nothing else; read the envelope and decide the next step.
 uv run "${CLAUDE_SKILL_DIR}/scripts/run.py" <subcommand> [flags]
 ```
 
+If the user has no warehouse to point at and wants to see what dex does, `demo`
+generates one: a seeded local DuckDB warehouse plus the `.dex/config.yml` for it,
+with no credentials and no network, so every subcommand below then runs with no
+flags. It only ever creates, so it refuses rather than touch a file that already
+exists. Offer it rather than assuming it: a user who does have a warehouse wants
+that one read, not a fixture built beside it.
+
 Subcommands, in the usual order:
 
 1. `connect test --path <file.duckdb>` confirms a read-only connection and

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.4"
+DEX_CORE_VERSION = "1.6.5"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.4"
+DEX_CORE_VERSION = "1.6.5"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.4"
+DEX_CORE_VERSION = "1.6.5"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
Closes #301.

The packaging has described a "zero-credential DuckDB on-ramp" since the extras
were laid out, and it delivers one: a base install pulls no cloud client stack.
The on-ramp just had no content. To see dex do anything at all, a stranger had to
supply a warehouse, discover credentials, and accept a cost estimate against real
data. That is the highest-friction possible starting point, and for a read that
touches a metered connector it is the one a cautious person is least willing to
take on faith. The first run was doing double duty as an evaluation, and #296
records that `dex --help` had absorbed the onboarding job without being built for
it.

```
pip install "exmergo-dex-core[duckdb]"
dex demo
dex explore map
```

`dex demo` builds a small e-commerce DuckDB warehouse (7 tables, 29,512 rows) in
the directory you are standing in, plus a `.dex/config.yml` beside it, so
everything after it runs with no flags. It also lands in `dex --help` as the one
annotated verb, which is where #296 measured first contact actually happening.

## The data is seeded to be broken, on purpose

A first run that reports a clean bill of health teaches nothing. Every flaw below
is aimed at a detector that already exists, at thresholds read out of the code
rather than guessed, and every string here is real output from the dogfood run.

| Seeded flaw | What the user sees |
|---|---|
| `order_items` carries a batch loaded twice | `order_item_id is not unique: 13000 distinct over 14000 rows (~1000 duplicate rows); joins on it will fan out` |
| `products.sku` merges two catalogues | `sku is a candidate key but mixes value shapes: 90% numeric, 10% 32-character hexadecimal (md5-shaped); casting to a number or comparing numerically will silently drop the non-numeric group(s)` |
| `web_events.customer_id` is the vendor's id space, not the CRM's | inferred on the shared name, then `--verify` reports `shares a column name but 100% of values have no match; the shared name is not evidence of a shared key`, and confidence collapses 0.85 to 0.35 |
| `orders.placed_at` is text | `placed_at is declared VARCHAR but 100% of values match the %Y-%m-%d %H:%M:%S date format` |
| `web_events.occurred_at` is epoch millis | `occurred_at is declared BIGINT but 100% of values fall in the plausible unix-epoch-milliseconds range; implied date range 2026-01-01 to 2026-03-31` |
| `returns` is what an interrupted load leaves behind | `empty table (no rows)`, and its FK probe reports `no non-null keys` rather than a fake verdict |
| `customers.email`, `customers.full_name` | flagged at 0.95 and 0.75; `select email from customers` is refused, `select count(distinct email) from customers` returns 1200 |
| `warehouse_locations.city`, `latitude`, `longitude` | flagged at 0.70 and 0.60 on a distribution centre. Designed false positives, met on data nobody minds |
| `warehouse_locations.site_name` | 0.60 de-rated to 0.30 by its own closed all-caps vocabulary, so it runs with a warning: evidence moving in both directions in the same run |
| `products.product_name` | not flagged, because `product` is a non-person qualifier. The true negative beside the false positives |

Two placements are load-bearing rather than arbitrary. The mixed value shapes are
on `products.sku` and not on `order_items.order_item_id`, because the shape check
is gated on being a *candidate key* and `order_item_id` is deliberately not
unique, so it would never be looked at that way. And `warehouse_locations` has
twelve distinct cities and coordinates rather than five, because at five or fewer
the engine de-rates those categories below the block threshold, and the point of a
false positive here is to meet one that actually blocks.

`explore map` reports 7 objects, 6 PII columns, 5 inferred joins, and 5
data-quality findings. `explore diagram` renders the whole thing, with the
100%-orphan edge visibly weaker than the three proven ones and PII drawn as
category and confidence rather than hidden.

## Determinism is a contract, because the READMEs quote it

One pinned seed, a random stream restricted to `randrange`/`random` (stable across
CPython releases), and no wall clock anywhere: every date is measured back from a
fixed anchor, so the file does not change overnight. Money is built from integer
cents, never through a float, so binary rounding cannot drift a value.

`row_digest()` hashes every generated column and cell, and `tests/demo` pins the
sha256. An edit that would move a count printed in a README fails there instead of
shipping documentation that disagrees with what the user sees on screen. For a
tool whose claim is precision, that disagreement is worse than having no
quickstart at all. A separate test asserts no wall-clock call exists in the
generator's source, since a `date.today()` reproduces perfectly within one day and
would be the hardest version of this to notice.

## Create-only, and structurally off the connector write path

The safety story is the reason this is a separate module rather than a flag on the
adapter.

- **An existing target refuses, and is not confirmable.** `reason: guard`. A
  `--confirm` that could talk past it would put a real warehouse one typo away
  from being replaced, and naming another path costs nothing.
- **No directory is ever created.** A missing parent is `reason: request`.
- **An existing `.dex/config.yml` at or above the target is left untouched**, with
  a warning, and the printed commands switch to the explicit `--path` form. A
  second config in a subdirectory would silently capture every command run there,
  which is the same class of harm as an overwrite: a change the user did not ask
  for and would not see. Resolution reuses `resolve_dex_root`, the same walk every
  command uses to find its project, so the two cannot disagree.
- **`--path` is refused rather than honored or ignored.** It names the warehouse
  dex *reads* everywhere else, and this is the one command that writes one.
  Accepting and dropping it would be worse; that is how `--dataset` came to be
  silently lost.
- **The generator never touches a connector.** `demo/warehouse.py` imports
  `duckdb` directly and reaches neither `adapters.duckdb` nor the SQL guard, so
  the read-only open keeps no branch it could have taken, and `cli._run` routes
  `demo` without `ensure_dialect_available()` because it authors no SQL a guard
  has to clear. Table and column names in the DDL are module constants; every
  value goes in as a bound parameter.

Two safety-spine tests hold that mechanically rather than by argument:
`test_the_demo_generator_is_the_only_writable_duckdb_open` scans the package for
every `duckdb.connect(` and requires `read_only=True` outside the generator, then
walks the generator's import statements to prove it reaches no adapter or guard;
`test_a_generated_demo_warehouse_is_opened_read_only` generates a file and
confirms the adapter still refuses a write against it, because the moment it
exists it is user data. Two more in family 4 pin the create-only refusals and that
the command creates exactly the artifacts it names.

`cost.paradigm` stays `null` on a fresh directory. The demo opens no connector, and
`free_local` is DuckDB's positive answer about a connector that was actually
resolved, never a stand-in for having nothing to say; the first envelope a new user
reads is the worst place to start blurring that. The `next_steps` prose carries the
honest version instead: nothing bills here, and the same command on BigQuery or
Snowflake returns an estimate first.

## Rejected alternatives

- **Commit a `.duckdb`.** The storage format has broken backward compatibility
  before, so a stale file could fail on the first command a stranger ever runs.
  Binary blobs also do not delta-compress, so every regeneration is permanent
  history weight, and this fixture will grow as scenarios are added for
  `transform` and `maintain`.
- **Ship the file as data in the wheel.** The skills resolve the engine per
  version per environment, so anything in the wheel is fetched repeatedly, and
  excluding it would mean it does not ship with the product.
- **A separate demo repository.** Cloning a second repo before the first command
  is exactly the friction this removes.
- **Download from a release asset on first use.** Corporate proxies are common in
  the environments this is meant to reassure, and the first run is the one place
  that cannot afford to fail.
- **A refusal for the `[duckdb]`-less adapter path too.** Considered and dropped.
  A base install hits `ensure_dialect_available` first, which already names
  `exmergo-dex-core[duckdb]`, so the adapter's bare `ImportError` is not reachable
  in practice and a second error type for it would be speculative widening.
  `dex demo` raises its own `DemoDependencyError` naming the same extra, which is
  the path that is actually reachable first.

## Scope

A dbt project is out of scope per the issue: `transform init` already bootstraps
one, and `dex demo` can chain into it later if the demo needs to cover authoring or
drift.

## Files

**New.** `demo/__init__.py`, `demo/warehouse.py` (the generator and the only
writable DuckDB open in the engine), `demo/commands.py` (the shim, the config
wiring, and `next_steps`), `tests/demo/{conftest,test_warehouse,test_commands}.py`.

**Engine.** `cli.py` gains the `COMMAND_SURFACE` entry, the positional, the
`--help` line, and the route; `envelope.py` maps the three demo errors to
`guard`/`prerequisite`/`request` in both tiers of `_reason_overrides`;
`command_args._resolve_dex_root` becomes `resolve_dex_root`, since a second module
now legitimately asks the same question; `__init__.py` exports
`generate_demo_warehouse` and the error types. No `DexEngine` method: demo reaches
no warehouse, store, or project, so a method there would ignore every field the
class holds.

**Tests.** Four safety-spine additions; a `demo` branch in `test_cli_contract`'s
`_all_commands` pointing at a nonexistent directory, so the parametrized contract
test exercises the refusal instead of seeding a warehouse into the checkout; a
wheel-level `test_the_first_run_on_ramp_works_on_a_clean_install` that runs `demo`
then a bare `explore map` in an isolated environment with only `[duckdb]`, which is
the README's claim verified as a packaging claim; `examples/quickstart.py`
refactored onto the shared generator, so the packaging suite verifies it too.

**Docs.** `README.md` gains a "Try it in 60 seconds" section, the first CLI
invocation that file has ever shown. `packages/dex-core/README.md` gains a
first-run section and a `demo:` paragraph in Commands. `packages/dex-core-stub`,
`AGENTS.md` (contract row, skill mapping, and the guardrail-3 carve-out written
narrower than the rule it sits inside), `references/command-contract.md`,
`references/duckdb.md` (a full section, plus a precision fix: "never creates one"
is true of the *adapter*), `skills/explore/SKILL.md`, `CONTRIBUTING.md`,
`.gitignore`, and `ruff.toml` (a per-file ignore for the pinned RNG, with the
reason).

## Verification

Full suite green (2165 passed, 65 skipped), including the packaging marker. Ruff
check and format clean, `check_no_em_dashes.py` clean.

Dogfooded end to end from a built wheel in an isolated environment outside the
checkout, which is the claim the issue makes:

1. `dex --help` on a base install shows `demo` as the one annotated verb.
2. `dex demo` on a base install refuses with `reason: prerequisite`, naming
   `exmergo-dex-core[duckdb]`.
3. `dex demo` with `[duckdb]` only: two artifacts, nothing else on disk, no WAL.
4. `dex demo` again, and again with `--confirm`: `reason: guard`, file untouched.
5. `dex demo nope/x.duckdb`: `reason: request`, no directory created.
6. `dex demo scratch/x.duckdb` under an existing config inside a git repo:
   warehouse created, config untouched, warning raised, next steps use `--path`.
7. `dex demo --path other.duckdb`: refused, naming the positional form.
8. `dex explore map` with no flags: 7 objects, 6 PII columns, 5 joins, 5 findings.
9. `explore profile`, `explore relationships --verify`, the PII refusal, the
   allowed aggregate, the sub-threshold warning, and `explore diagram`, all
   reporting the strings quoted above.
10. The `explore` skill wrapper forwards `demo` unchanged (the DuckDB extra is
    already its default), so no wrapper change was needed.

Every number and column name in the README, the package README, the changelog, and
this description is taken from that output verbatim.
