### PR TITLE
A missing `uv` is a refusal that names the fix, not a traceback

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,14 @@ uv run python -m exmergo_dex_core <subcommand> [flags]
 uv run scripts/run.py <subcommand> [flags]
 ```
 
+Both forms need [`uv`](https://docs.astral.sh/uv/) on `PATH`: it is what installs
+and runs the engine, and no agent host installs it for you. Without it the shell
+reports `uv: command not found`, and the shipped wrapper run directly refuses with
+an error envelope (`reason: prerequisite`) naming the fix. The install is one line
+(`curl -LsSf https://astral.sh/uv/install.sh | sh`, or `brew install uv`, or
+`pipx install uv`); relay it to the user rather than reaching for another way to do
+the work, since every guardrail below lives in the engine.
+
 Install the engine with the connector extra you use: `exmergo-dex-core[duckdb]`
 for the zero-credential on-ramp, or `[snowflake]`, `[bigquery]`, `[databricks]`,
 `[postgres]`, `[redshift]`, or `[all]` for every optional capability at once. The shipped wrapper pins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A missing `uv` is a refusal that names the fix, not a traceback** ([#310]).
+  The skill wrappers shell into `uv run` to install and run the engine, and did so
+  with no guard, so on a machine without `uv` on `PATH` a first run ended in a raw
+  `FileNotFoundError`. Nothing said `uv` was required either: not the plugin
+  manifest, not the skill frontmatter, not the install sections of the READMEs. The
+  documented Claude Code path is two `/plugin` commands and then "the skills appear
+  and auto-trigger", so a user who followed it exactly could land on a stack trace,
+  and the person most likely to hit it is a Claude Code user rather than a Python
+  developer. dex collects no telemetry by design, which is what makes this worth
+  fixing pre-emptively: every user who hit it churned invisibly, and no report was
+  ever going to arrive.
+
+  The wrapper now checks for `uv` before it execs and, when it is absent, prints the
+  same envelope shape every other refusal uses (`status: error`,
+  `reason: prerequisite`) carrying the install command, and exits 1. It is the one
+  envelope built by hand rather than through `exmergo_dex_core.envelope`, since the
+  engine that would build it is exactly what has not been installed yet; a test
+  holds the two shapes in step. Invoked through `uv run`, the shell still fails
+  first with `command not found`, which no guard inside the script can catch, so
+  each `SKILL.md` now tells the agent what that message means, what to tell the user
+  to install, and not to reach for raw Python or a database CLI instead: the
+  guardrails live in the engine, so every other path is unguarded. The prerequisite
+  is stated up front in the README and in `AGENTS.md` for the any-agent path.
+
 ## [1.6.5] - 2026-08-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.6.6] - 2026-08-15
+
 ### Fixed
 
 - **`maintain check` carries each axis's findings in the command envelope**

--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ DuckDB is free and local, so nothing here asks you to confirm a spend. On BigQue
 or Snowflake the same commands return an estimate first and run only once you agree
 to it.
 
+## Prerequisite: `uv`
+
+dex installs and runs its engine through [`uv`](https://docs.astral.sh/uv/), so you
+need it on your `PATH` before either install below. Neither Claude Code nor the
+plugin installs it for you.
+```
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+`brew install uv` and `pipx install uv` work too. Nothing else is required: `uv`
+supplies the Python and the engine, with the connector extra chosen for you at
+runtime.
+
 ## Benchmarks
 
 We run `dex` on two public analytics-engineering benchmarks. Every run's raw

--- a/evals/tests/test_wrapper.py
+++ b/evals/tests/test_wrapper.py
@@ -3,14 +3,17 @@
 The wrapper is a stdlib-only PEP 723 script that runs before the engine is
 installed and decides which `exmergo-dex-core[<extra>]` to install. These tests
 guard the decoupling of the version pin from the connector extra: the version is
-pinned, the extra is resolved at runtime from the active connector. The script is
-not importable as a package module, so it is loaded via importlib (its
+pinned, the extra is resolved at runtime from the active connector. They also guard
+the missing-`uv` refusal, which is the one refusal the wrapper has to build itself
+because it happens before the engine (and so `exmergo_dex_core.envelope`) exists.
+The script is not importable as a package module, so it is loaded via importlib (its
 `if __name__ == "__main__"` guard means importing does not run `main()`).
 """
 
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -51,6 +54,102 @@ def test_pin_carries_no_extra(wrapper):
     assert "[" not in version and "]" not in version
     assert "@" not in version
     assert version.strip() == version and version
+
+
+# --- the missing-uv refusal --------------------------------------------------
+#
+# Parametrized over all three wrappers rather than resting on the byte-identity
+# test above: this guard is exactly the kind of thing a refactor drops from one
+# copy, and proving the behavior in each one costs nothing.
+
+
+def _run_without_uv(skill, monkeypatch, argv):
+    """Drive `main()` on a machine where uv is absent, and return (code, stdout).
+
+    `subprocess.call` is replaced with a raiser rather than a stub, so a guard
+    that let execution through fails loudly here instead of quietly shelling out
+    to a `uv` that is not there.
+    """
+
+    module = _load(skill)
+    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        module.subprocess,
+        "call",
+        lambda *a, **k: pytest.fail("the guard let execution reach uv"),
+    )
+    monkeypatch.setattr(module.sys, "argv", ["run.py", *argv])
+    code = module.main()
+    return code, module
+
+
+@pytest.mark.parametrize("skill", _SKILLS)
+def test_missing_uv_refuses_with_one_error_envelope(skill, monkeypatch, capsys):
+    code, _module = _run_without_uv(skill, monkeypatch, ["explore", "inventory"])
+    assert code == 1  # the engine's own exit code for an error envelope
+
+    out = capsys.readouterr().out
+    envelope = json.loads(out)  # exactly one object, or this raises
+    assert envelope["status"] == "error"
+    assert envelope["reason"] == "prerequisite"
+    assert set(envelope) == {
+        "status",
+        "data",
+        "cost",
+        "warnings",
+        "diffs",
+        "errors",
+        "reason",
+    }
+    assert envelope["cost"] == {"paradigm": None, "estimate": None, "ceiling": None}
+    assert envelope["data"] == {}
+
+
+@pytest.mark.parametrize("skill", _SKILLS)
+def test_missing_uv_message_names_uv_and_how_to_install_it(skill, monkeypatch, capsys):
+    # The whole point of the refusal: a user who is not a Python developer has to
+    # be able to act on it without reading our source.
+    _run_without_uv(skill, monkeypatch, ["connect", "test"])
+    message = json.loads(capsys.readouterr().out)["errors"][0]
+    assert "uv" in message
+    assert "astral.sh/uv/install.sh" in message
+
+
+def test_uv_present_still_execs_the_engine(monkeypatch, capsys):
+    # The guard must not fire on the ordinary path, and must not print anything
+    # of its own onto the single-envelope stdout the engine owns.
+    module = _load()
+    monkeypatch.setattr(module.shutil, "which", lambda _name: "/usr/local/bin/uv")
+    seen: list[list[str]] = []
+    monkeypatch.setattr(
+        module.subprocess, "call", lambda cmd, **_kwargs: seen.append(cmd) or 0
+    )
+    monkeypatch.setattr(module.sys, "argv", ["run.py", "explore", "inventory"])
+
+    assert module.main() == 0
+    assert capsys.readouterr().out == ""
+    assert seen and seen[0][:2] == ["uv", "run"]
+    assert seen[0][-2:] == ["explore", "inventory"]
+
+
+def test_refusal_matches_the_engines_envelope_shape(monkeypatch, capsys):
+    """The hand-built envelope must stay in step with the one the engine emits.
+
+    Skipped where the engine is not installed, which includes CI's
+    `uvx pytest evals -q` job: this is a local-dev and synced-environment guard
+    against the two shapes drifting apart, not a gate.
+    """
+
+    envelope_module = pytest.importorskip("exmergo_dex_core.envelope")
+
+    _run_without_uv("explore", monkeypatch, ["explore", "inventory"])
+    refusal = json.loads(capsys.readouterr().out)
+    engine_built = envelope_module.Envelope(
+        status=envelope_module.Status.ERROR,
+        errors=refusal["errors"],
+        reason=envelope_module.Reason.PREREQUISITE,
+    ).model_dump(mode="json")
+    assert refusal == engine_built
 
 
 # --- connector resolution (mirrors the engine's flag > config > duckdb order) ---

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -12,7 +12,11 @@ logic.
   against the pinned engine version, installing the connector extra it resolves at
   runtime (an explicit `--connector`, then the `connector:` in the `.dex/config.yml`
   found by walking up from the run directory to the git root, then DuckDB), so the
-  pin stays connector-neutral.
+  pin stays connector-neutral. `uv` is therefore a prerequisite, and the wrapper
+  holds the envelope contract even there: with no `uv` on `PATH` it refuses with a
+  `reason: prerequisite` error envelope naming the install command, rather than
+  failing the exec. It is the one refusal built by hand, because the engine that
+  would otherwise build it is what is missing.
 - The engine prints **exactly one** sanitized JSON envelope to stdout and nothing
   else. Diagnostics go to stderr.
 - The agent reads the envelope and decides the next step.

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -19,6 +19,13 @@ nothing else; read the envelope and decide the next step.
 uv run "${CLAUDE_SKILL_DIR}/scripts/run.py" <subcommand> [flags]
 ```
 
+dex runs its engine through `uv`, which is a prerequisite and is not installed by
+Claude Code. If the shell reports `uv: command not found`, stop and tell the user
+to install it (`curl -LsSf https://astral.sh/uv/install.sh | sh`, or
+`brew install uv`, or `pipx install uv`), then re-run. Never fall back to raw
+Python, `pip`, or a database CLI to do the work another way: the guardrails live in
+the engine, so any other path is unguarded.
+
 If the user has no warehouse to point at and wants to see what dex does, `demo`
 generates one: a seeded local DuckDB warehouse plus the `.dex/config.yml` for it,
 with no credentials and no network, so every subcommand below then runs with no

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -51,7 +51,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.5"
+DEX_CORE_VERSION = "1.6.6"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -8,6 +8,12 @@ The skill never re-implements logic. It forwards its arguments to the pinned
 `dex-core` engine and lets the engine print the sanitized JSON envelope. Run it
 with `uv run "${CLAUDE_SKILL_DIR}/scripts/run.py" <dex subcommand> ...`.
 
+`uv` is a hard prerequisite: it is what installs and runs the engine. When it is
+absent this wrapper refuses with an error envelope naming the install command,
+rather than letting the exec fail with a traceback. Invoked through `uv run` the
+shell fails first (`uv: command not found`), which is why each SKILL.md also tells
+the agent what that message means.
+
 Two execution modes, chosen automatically:
   - Monorepo checkout (this repo): `packages/dex-core` is found above the skill,
     so the engine runs from an editable local install. This is what makes the
@@ -35,7 +41,9 @@ scripts/prepare_release.sh before the tag; nothing else here changes per release
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -161,6 +169,33 @@ def _engine_spec(extras: str, skill_dir: Path | None = None) -> list[str]:
 
 def main() -> int:
     argv = sys.argv[1:]
+    if shutil.which("uv") is None:
+        # The one refusal that happens before the engine exists, so the envelope
+        # is hand-built: `exmergo_dex_core.envelope` is precisely what is not
+        # installed yet. The keys mirror Envelope/Cost and have to stay in step
+        # with them, and `prerequisite` is the engine's own classification for a
+        # missing dependency the user installs and retries (the same one
+        # DemoDependencyError and DialectDependencyError carry). A caller reads
+        # this exactly like any other refusal instead of parsing a traceback.
+        print(
+            json.dumps(
+                {
+                    "status": "error",
+                    "data": {},
+                    "cost": {"paradigm": None, "estimate": None, "ceiling": None},
+                    "warnings": [],
+                    "diffs": [],
+                    "errors": [
+                        "dex runs its engine through uv, which was not found on "
+                        "PATH. Install it with: "
+                        "curl -LsSf https://astral.sh/uv/install.sh | sh "
+                        "(or `brew install uv`, or `pipx install uv`), then re-run."
+                    ],
+                    "reason": "prerequisite",
+                }
+            )
+        )
+        return 1
     connector = _resolve_connector(argv, Path.cwd())
     # The connector extra is always installed; `explore cluster` adds the
     # scikit-learn [cluster] extra so the light default install stays light.

--- a/skills/maintain/SKILL.md
+++ b/skills/maintain/SKILL.md
@@ -40,6 +40,13 @@ mistaken for a clean bill.
 uv run "${CLAUDE_SKILL_DIR}/scripts/run.py" <subcommand> [flags]
 ```
 
+dex runs its engine through `uv`, which is a prerequisite and is not installed by
+Claude Code. If the shell reports `uv: command not found`, stop and tell the user
+to install it (`curl -LsSf https://astral.sh/uv/install.sh | sh`, or
+`brew install uv`, or `pipx install uv`), then re-run. Never fall back to diffing
+the warehouse against the project by hand instead: the drift axes and the baseline
+comparison live in the engine, so any other path is guesswork.
+
 - `maintain snapshot` captures or refreshes the baseline. Run it after a clean
   explore or transform session so later runs have a known-good reference. It pins
   the current `.dex/cache.json` (so the grain baseline is the exact-distinct

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -51,7 +51,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.5"
+DEX_CORE_VERSION = "1.6.6"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -8,6 +8,12 @@ The skill never re-implements logic. It forwards its arguments to the pinned
 `dex-core` engine and lets the engine print the sanitized JSON envelope. Run it
 with `uv run "${CLAUDE_SKILL_DIR}/scripts/run.py" <dex subcommand> ...`.
 
+`uv` is a hard prerequisite: it is what installs and runs the engine. When it is
+absent this wrapper refuses with an error envelope naming the install command,
+rather than letting the exec fail with a traceback. Invoked through `uv run` the
+shell fails first (`uv: command not found`), which is why each SKILL.md also tells
+the agent what that message means.
+
 Two execution modes, chosen automatically:
   - Monorepo checkout (this repo): `packages/dex-core` is found above the skill,
     so the engine runs from an editable local install. This is what makes the
@@ -35,7 +41,9 @@ scripts/prepare_release.sh before the tag; nothing else here changes per release
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -161,6 +169,33 @@ def _engine_spec(extras: str, skill_dir: Path | None = None) -> list[str]:
 
 def main() -> int:
     argv = sys.argv[1:]
+    if shutil.which("uv") is None:
+        # The one refusal that happens before the engine exists, so the envelope
+        # is hand-built: `exmergo_dex_core.envelope` is precisely what is not
+        # installed yet. The keys mirror Envelope/Cost and have to stay in step
+        # with them, and `prerequisite` is the engine's own classification for a
+        # missing dependency the user installs and retries (the same one
+        # DemoDependencyError and DialectDependencyError carry). A caller reads
+        # this exactly like any other refusal instead of parsing a traceback.
+        print(
+            json.dumps(
+                {
+                    "status": "error",
+                    "data": {},
+                    "cost": {"paradigm": None, "estimate": None, "ceiling": None},
+                    "warnings": [],
+                    "diffs": [],
+                    "errors": [
+                        "dex runs its engine through uv, which was not found on "
+                        "PATH. Install it with: "
+                        "curl -LsSf https://astral.sh/uv/install.sh | sh "
+                        "(or `brew install uv`, or `pipx install uv`), then re-run."
+                    ],
+                    "reason": "prerequisite",
+                }
+            )
+        )
+        return 1
     connector = _resolve_connector(argv, Path.cwd())
     # The connector extra is always installed; `explore cluster` adds the
     # scikit-learn [cluster] extra so the light default install stays light.

--- a/skills/transform/SKILL.md
+++ b/skills/transform/SKILL.md
@@ -17,6 +17,13 @@ writes only to the repo, as reviewable diffs, and runs against a dev target only
 uv run "${CLAUDE_SKILL_DIR}/scripts/run.py" <subcommand> [flags]
 ```
 
+dex runs its engine through `uv`, which is a prerequisite and is not installed by
+Claude Code. If the shell reports `uv: command not found`, stop and tell the user
+to install it (`curl -LsSf https://astral.sh/uv/install.sh | sh`, or
+`brew install uv`, or `pipx install uv`), then re-run. Never fall back to editing
+the dbt project by hand instead: the validation, the diffs, and the dev-target
+gating live in the engine, so any other path is unguarded.
+
 You author the dbt file content; the engine validates it, computes the diffs,
 and stores the proposal as a plan. Hand content over with `--edits-file <path>`
 (or `-` to read stdin), a JSON payload:

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -51,7 +51,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.5"
+DEX_CORE_VERSION = "1.6.6"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -8,6 +8,12 @@ The skill never re-implements logic. It forwards its arguments to the pinned
 `dex-core` engine and lets the engine print the sanitized JSON envelope. Run it
 with `uv run "${CLAUDE_SKILL_DIR}/scripts/run.py" <dex subcommand> ...`.
 
+`uv` is a hard prerequisite: it is what installs and runs the engine. When it is
+absent this wrapper refuses with an error envelope naming the install command,
+rather than letting the exec fail with a traceback. Invoked through `uv run` the
+shell fails first (`uv: command not found`), which is why each SKILL.md also tells
+the agent what that message means.
+
 Two execution modes, chosen automatically:
   - Monorepo checkout (this repo): `packages/dex-core` is found above the skill,
     so the engine runs from an editable local install. This is what makes the
@@ -35,7 +41,9 @@ scripts/prepare_release.sh before the tag; nothing else here changes per release
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -161,6 +169,33 @@ def _engine_spec(extras: str, skill_dir: Path | None = None) -> list[str]:
 
 def main() -> int:
     argv = sys.argv[1:]
+    if shutil.which("uv") is None:
+        # The one refusal that happens before the engine exists, so the envelope
+        # is hand-built: `exmergo_dex_core.envelope` is precisely what is not
+        # installed yet. The keys mirror Envelope/Cost and have to stay in step
+        # with them, and `prerequisite` is the engine's own classification for a
+        # missing dependency the user installs and retries (the same one
+        # DemoDependencyError and DialectDependencyError carry). A caller reads
+        # this exactly like any other refusal instead of parsing a traceback.
+        print(
+            json.dumps(
+                {
+                    "status": "error",
+                    "data": {},
+                    "cost": {"paradigm": None, "estimate": None, "ceiling": None},
+                    "warnings": [],
+                    "diffs": [],
+                    "errors": [
+                        "dex runs its engine through uv, which was not found on "
+                        "PATH. Install it with: "
+                        "curl -LsSf https://astral.sh/uv/install.sh | sh "
+                        "(or `brew install uv`, or `pipx install uv`), then re-run."
+                    ],
+                    "reason": "prerequisite",
+                }
+            )
+        )
+        return 1
     connector = _resolve_connector(argv, Path.cwd())
     # The connector extra is always installed; `explore cluster` adds the
     # scikit-learn [cluster] extra so the light default install stays light.


### PR DESCRIPTION
# A missing `uv` is a refusal that names the fix, not a traceback

Closes #310.

The skill wrappers shell into `uv run` to install and run the engine, and did so
with no guard, byte-identically in all three. On a machine without `uv` on `PATH`
the first run ended here:

```
$ PATH=/usr/bin:/bin python3 skills/explore/scripts/run.py explore inventory
Traceback (most recent call last):
  ...
FileNotFoundError: [Errno 2] No such file or directory: 'uv'
```

Nothing said `uv` was required either: not the plugin manifest, not the skill
frontmatter, not the install sections of either README. The documented Claude Code
path is two `/plugin` commands and then "the skills appear and auto-trigger", so a
user who followed it exactly could land on a stack trace, and the person most
likely to be standing there is a Claude Code user rather than a Python developer.

dex collects no telemetry by design, which is what makes this worth fixing
pre-emptively rather than on a report. Every user who hit it churned invisibly, and
the report was never going to arrive.

## Two failure surfaces, and only one of them is catchable

**The wrapper executed directly** (`python3 .../run.py`, the `AGENTS.md` any-agent
path, any host that calls the script) runs our code, so it can refuse. It now does:

```
$ PATH=/usr/bin:/bin python3 skills/explore/scripts/run.py explore inventory; echo "exit=$?"
{"status": "error", "data": {}, "cost": {"paradigm": null, "estimate": null, "ceiling": null},
 "warnings": [], "diffs": [], "errors": ["dex runs its engine through uv, which was not found
 on PATH. Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh (or `brew install
 uv`, or `pipx install uv`), then re-run."], "reason": "prerequisite"}
exit=1
```

**`uv run .../run.py`**, which is what every `SKILL.md` tells the agent to run,
fails in the shell with `uv: command not found` before a line of ours executes. No
guard inside the script can catch that, so the fix there is documentation aimed at
the agent rather than at the user: each `SKILL.md` now says what that message means,
what to tell the user to install, and not to work around it. That last clause is
the load-bearing one. An agent that cannot run the wrapper will otherwise reach for
raw Python or a database CLI, and every guardrail lives in the engine, so any other
path is unguarded. The three skills each name their own version of the wrong move
(raw SQL, hand-editing the dbt project, eyeballing drift) rather than sharing one
generic warning.

## The envelope shape is the engine's, not the issue's sketch

The issue body sketches `{"ok": false, "error": {"code": "uv_not_found", ...}}`,
which is not a shape dex has ever emitted; its prose asks for "the same sanitized
JSON envelope shape the engine emits", and that is the one above. Confirmed before
building. A caller reads this exactly like any other refusal instead of learning a
second format for one case.

`reason: prerequisite` is not a new classification either. It is what the engine
already assigns to a missing dependency the user installs and retries, the same
reason `DemoDependencyError` and `DialectDependencyError` carry through
`envelope._reason_overrides`.

This is the one envelope in the product built by hand rather than through
`exmergo_dex_core.envelope`, because the engine that would build it is precisely
what has not been installed yet. That is a real drift risk, so a test holds the two
in step: it constructs `Envelope(status=ERROR, errors=[...], reason=PREREQUISITE)`
and asserts the wrapper's literal equals its `model_dump(mode="json")`. It sits
behind `importorskip`, so it skips in CI's engine-less `uvx pytest evals` job and
runs everywhere the engine is present. Verified passing with the engine importable
rather than left to skip silently.

## Tests

In `evals/tests/test_wrapper.py`, the established home for wrapper tests.

- The refusal is proven in all three wrappers by behavior, parametrized over
  `_SKILLS`, not left to the existing byte-identity assertion. This guard is exactly
  the kind of thing a refactor drops from one copy, which the issue calls out.
- `subprocess.call` is patched to a raiser rather than a stub, so a guard that let
  execution through fails loudly here instead of quietly shelling out to a `uv` that
  is not there.
- Stdout parses as exactly one JSON object with exactly the seven envelope keys,
  `main()` returns 1 (the engine's own exit code for an error envelope), and the
  message names `uv` and an install command, since a user who is not a Python
  developer has to be able to act on it without reading our source.
- The ordinary path is covered too: with `uv` present the guard does not fire, the
  argv still begins `["uv", "run", ...]`, and nothing of the wrapper's own reaches
  the single-envelope stdout the engine owns.

## Files

**Engine.** None. The engine is untouched.

**Wrappers.** `skills/{explore,transform,maintain}/scripts/run.py`: `json` and
`shutil` added to the stdlib imports, the guard inline at the top of `main()`, and
a docstring paragraph stating the prerequisite. Edited once and copied, so the three
stay byte-identical. The wrapper's constraint is that it runs before the engine is
installed, not that it stays minimal, so two more stdlib imports cost nothing.

**Tests.** `evals/tests/test_wrapper.py`, five tests and a shared driver.

**Docs.** Each `SKILL.md` under "How to drive it"; `README.md` gains a
`## Prerequisite: uv` section covering both install paths, since `npx skills add`
needs it as much as the plugin does; `AGENTS.md` states it for the any-agent
contract, which documented `uv run` twice and never said so; `references/command-contract.md`
records that the envelope contract holds even on the one path that runs before the
engine exists; `CHANGELOG.md` under `[Unreleased] / Fixed`.

**Not changed.** `.claude-plugin/plugin.json` has no prerequisites field.
`scripts/prepare_release.sh` and `.github/workflows/release.yml` `sed` and `grep`
`DEX_CORE_VERSION`, which this does not move. The `.cursor` and `.windsurf` rule
files document `uv run python -m exmergo_dex_core` and defer to `AGENTS.md`.

## Out of scope, per the issue

Falling back to `python -m exmergo_dex_core` when the engine is already importable
and `uv` is absent. It carries its own questions (which interpreter, which extras,
how the pinned version is honoured), and a clear refusal that names what to install
is a complete fix for the reported failure.

Also considered and dropped: changing the documented invocation from `uv run` to
`python3`, which would make the guard reachable on the documented path. It trades a
missing-`uv` failure for a missing-`python3` one (a bare macOS without the Xcode
command line tools has only a stub), so it widens the blast radius to fix a message.

## Verification

- The issue's exact reproduction now returns the envelope above with `exit=1`.
- `uvx pytest evals -q`: 33 passed, 1 skipped (the engine cross-check). The same
  file under the engine: 28 passed, 0 skipped, so the cross-check ran and passed.
- `packages/dex-core`: 2178 passed, 65 skipped, unaffected.
- Ruff check and format clean; `check_no_em_dashes.py` clean.
- Happy path from a temp directory through two different wrappers: `demo` creates
  `dex_demo.duckdb` and `.dex/config.yml`, `explore inventory --rank` returns 7
  objects. No regression on a machine that has `uv`.
- `md5 skills/*/scripts/run.py` identical across the three.
