### PR TITLE
A statement the warehouse refuses is classified, names its object, and reports what it spent; profiling a non-PII string column no longer kills the statement on Redshift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **Profiling a non-PII string column no longer kills the statement on
+  Redshift** ([#310]). The declared-type-vs-content probe (#204) guarded every
+  `CAST` behind a length-bounded shape predicate inside a `CASE`, on the
+  premise that a dialect without `TRY_CAST` would then never evaluate the cast
+  for a row the `WHEN` excluded. Postgres honors that premise; Redshift does
+  not, and evaluates the branch for rows it never selects, so one ordinary
+  varchar status or category column was enough to fail the whole profiling
+  statement with `Invalid digit, Value 'p', Pos 0, Type: Long`. The probe
+  shipped in 1.6.2, so on Redshift that took down `explore profile`,
+  `explore relationships`, and `explore map`, plus the commands that profile
+  the object they name before running (`explore query`, `explore cluster`).
+
+  Every `CAST` the probe builds is now total: the argument is a `CASE` that
+  yields a digit-only string on every row of the column, so no evaluation
+  order can reach a cast with something it cannot parse, and the sentinel it
+  falls back to is rejected by every predicate built on the cast. The
+  measurements are unchanged, denominators included; the "shaped versus not
+  shaped" distinction the fractions need now comes from a separate uncast
+  expression instead of from the cast result being NULL. The fix is
+  dialect-agnostic and lands in the shared expression builder, so the standing
+  assumption about lazy `CASE` evaluation is gone from all six adapters, and an
+  offline invariant test asserts the shape on every one of them.
+
 - **`maintain check` carries each axis's findings in the command envelope**
   ([#279]). The top-level `data.findings` ranking could report drift while the
   adjacent per-axis result did not carry those findings, making an axis look

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   assumption about lazy `CASE` evaluation is gone from all six adapters, and an
   offline invariant test asserts the shape on every one of them.
 
+- **A statement the warehouse refuses is classified, names its object, and
+  reports what it spent** ([#310]). A server-side SQL error escaped the
+  adapters untranslated. Not being a `DexError`, it fell through every reason
+  override and arrived as `reason: internal` ("not a deliberate dex refusal")
+  with `data: {}`: nothing to branch on, no object named, and no spend, on a
+  connector that had already billed the seconds the statement ran before it
+  died. Every adapter now raises a typed `WarehouseQueryError` (exported from
+  the package root, `reason: execution_failure`) carrying the server's own
+  message and error code, trimmed to one line and capped; profiling names the
+  object the refused statement was reading; and an error envelope from a
+  metered connector reports the spend the ledger recorded, as the
+  budget-exhaustion path already did. The live suites now assert with a helper
+  that prints `errors` rather than an envelope repr pytest truncates, which is
+  what kept the Redshift message out of sixteen CI logs.
+
 - **`maintain check` carries each axis's findings in the command envelope**
   ([#279]). The top-level `data.findings` ranking could report drift while the
   adjacent per-axis result did not carry those findings, making an axis look

--- a/packages/dex-core/src/exmergo_dex_core/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/__init__.py
@@ -109,6 +109,7 @@ _EXPORTS = {
     "StoreContext": "storage",
     "StoreFactory": "storage",
     "StoreRequiredError": "errors",
+    "WarehouseQueryError": "errors",
     "generate_demo_warehouse": "demo",
     "render_er_mermaid": "explore.diagram",
     "to_envelope": "results",
@@ -143,6 +144,7 @@ if TYPE_CHECKING:  # what a type checker and an IDE see; never run
         RepoRootRequiredError,
         RequestError,
         StoreRequiredError,
+        WarehouseQueryError,
     )
     from .explore.cluster import ClusterDependencyError, ClusterError
     from .explore.commands import CacheRequiredError
@@ -249,6 +251,7 @@ __all__ = [
     "StoreContext",
     "StoreFactory",
     "StoreRequiredError",
+    "WarehouseQueryError",
     "__version__",
     "generate_demo_warehouse",
     "render_er_mermaid",

--- a/packages/dex-core/src/exmergo_dex_core/adapters/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/base.py
@@ -27,6 +27,7 @@ from math import ceil
 from typing import Protocol, runtime_checkable
 
 from ..envelope import Paradigm
+from ..errors import WarehouseQueryError
 
 
 @dataclass(frozen=True)
@@ -240,6 +241,30 @@ def blame(origin: str, error: type[Exception]):
         yield
     except error as exc:
         raise error(f"{exc} [from {origin}]") from exc
+
+
+# How much of a driver's error text survives into the envelope. Generous
+# enough for any real server message, short enough that a driver which appends
+# the whole statement (or a stack of context lines) cannot turn one refusal
+# into a wall of stdout.
+_SERVER_DETAIL_CAP = 400
+
+
+def warehouse_refusal(message: str, *, code: str | None = None) -> WarehouseQueryError:
+    """The typed error for one server-side statement failure.
+
+    Every adapter funnels through here so the envelope reads the same whichever
+    warehouse said no, and so the server's words get the same trim: first line
+    only (drivers append the statement, a caret diagram, or their whole error
+    payload after it) and capped. ``code`` is the connector's own error code
+    where it has one, which is what a caller looking the failure up needs.
+    """
+
+    first = next((ln.strip() for ln in message.splitlines() if ln.strip()), "")
+    detail = first or "the server gave no message"
+    if len(detail) > _SERVER_DETAIL_CAP:
+        detail = detail[:_SERVER_DETAIL_CAP].rstrip() + "..."
+    return WarehouseQueryError(f"{detail} [{code}]" if code else detail)
 
 
 def json_safe(value: object | None) -> object | None:

--- a/packages/dex-core/src/exmergo_dex_core/adapters/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/base.py
@@ -451,6 +451,15 @@ HEX_PATTERN = r"^[0-9a-fA-F]+$"
 # anything else is reported by its bare length instead of guessing further.
 _HEX_LENGTH_NAMES = {32: "md5", 40: "sha1", 64: "sha256"}
 
+# What a shape-gated CAST reads on every row the shape predicate rejects, so
+# the cast's argument is digit-only for the whole column and the cast is total
+# (see `type_contradiction_expressions`). It has to parse as an integer on
+# every dialect and be *rejected* by every predicate built on top of the cast:
+# the epoch ranges start in the year 2000 and the slash-component test asks for
+# > 12, so zero is evidence of nothing and a row that reaches the cast only
+# because the cast is unconditional can never be counted.
+_CAST_SENTINEL = "'0'"
+
 
 def type_contradiction_expressions(
     qcol: str,
@@ -463,16 +472,37 @@ def type_contradiction_expressions(
 ) -> list[str]:
     """Declared-type-vs-content aggregate expressions for one column.
 
-    Every CAST is guarded behind a length-bounded shape predicate inside a
-    CASE -- never combined with AND, which the SQL standard does not
-    guarantee to evaluate left-to-right -- so a non-numeric string never
-    reaches a CAST on a dialect with no ``TRY_CAST`` (Postgres, Redshift), and
-    the gating patterns are always length-bounded so the CAST itself can never
-    overflow BIGINT/INT64. Only fractions and translated-to-date integers
-    (read back and converted to a calendar date by the caller) ever leave the
-    engine through this path. ``qcol`` must already be quoted/escaped by the
-    calling adapter. Returns ``[]`` for a column that is neither string- nor
-    integer-typed (nothing to check).
+    Every CAST here is **total**: its argument is a CASE that yields a
+    digit-only string on every row of the column (the value where a
+    length-bounded shape predicate matches, ``_CAST_SENTINEL`` where it does
+    not), so the cast cannot raise whatever rows the dialect decides to
+    evaluate it for, and the length bound means it can never overflow
+    BIGINT/INT64 either.
+
+    The obvious shape is the opposite one, and it is a bug (#310). Guarding
+    the cast *inside* a CASE branch (``CASE WHEN <shape> THEN CAST(col AS
+    BIGINT) END``) reads as safe and is safe on Postgres, but Redshift
+    evaluates a branch's cast for rows the WHEN never selects, so a single
+    non-numeric string killed the whole profiling statement server-side with
+    ``Invalid digit, Value 'p', Pos 0, Type: Long``. The SQL standard does not
+    promise the lazy evaluation that guard needs, no offline test can catch a
+    dialect that disagrees, and so nothing here depends on it: correctness
+    comes from the cast's argument being castable for every row, which is a
+    property of the expression rather than of the engine's evaluation order.
+
+    What the sentinel cannot express is the difference between "not shaped"
+    and "shaped but out of range", and the fractions' denominators are exactly
+    that distinction (``ts_ep_s_{i}`` is the in-range share *of the
+    epoch-shaped rows*, not of the column). That comes from a second,
+    uncast expression whose NULL-ness is the denominator test, which is where
+    the CASE-returns-NULL trick belongs: it carries a string, so it can raise
+    nothing.
+
+    Only fractions and translated-to-date integers (read back and converted to
+    a calendar date by the caller) ever leave the engine through this path.
+    ``qcol`` must already be quoted/escaped by the calling adapter. Returns
+    ``[]`` for a column that is neither string- nor integer-typed (nothing to
+    check).
     """
 
     def fraction(value_expr: str, condition: str, alias: str) -> str:
@@ -483,6 +513,21 @@ def type_contradiction_expressions(
 
     def plain_fraction(pattern: str, alias: str) -> str:
         return fraction(qcol, regexp_predicate(qcol, pattern), alias)
+
+    def shaped(predicate: str) -> str:
+        """The column itself where the shape matches, NULL everywhere else:
+        the denominator test, uncast and so incapable of raising."""
+
+        return f"CASE WHEN {predicate} THEN {qcol} END"
+
+    def total_cast(predicate: str, inner: str) -> str:
+        """``inner`` as an integer, with the sentinel standing in wherever the
+        shape predicate does not match, so every row casts digits."""
+
+        return (
+            f"CAST(CASE WHEN {predicate} THEN {inner} "
+            f"ELSE {_CAST_SENTINEL} END AS {bigint_type})"
+        )
 
     exprs: list[str] = []
     if is_string:
@@ -499,34 +544,35 @@ def type_contradiction_expressions(
             fraction(qcol, slash_datetime_pred, f"ts_sl_dt_{i}"),
         ]
         slash_either = f"({slash_date_pred} OR {slash_datetime_pred})"
-        first_val = (
-            f"CASE WHEN {slash_either} THEN "
-            f"CAST(SUBSTR({qcol}, 1, 2) AS {bigint_type}) END"
-        )
-        second_val = (
-            f"CASE WHEN {slash_either} THEN "
-            f"CAST(SUBSTR({qcol}, 4, 2) AS {bigint_type}) END"
-        )
+        slash_shaped = shaped(slash_either)
+        first_val = total_cast(slash_either, f"SUBSTR({qcol}, 1, 2)")
+        second_val = total_cast(slash_either, f"SUBSTR({qcol}, 4, 2)")
         exprs += [
-            fraction(first_val, f"{first_val} > 12", f"ts_sl1_{i}"),
-            fraction(second_val, f"{second_val} > 12", f"ts_sl2_{i}"),
+            fraction(slash_shaped, f"{first_val} > 12", f"ts_sl1_{i}"),
+            fraction(slash_shaped, f"{second_val} > 12", f"ts_sl2_{i}"),
         ]
         seconds_shape = regexp_predicate(qcol, EPOCH_SECONDS_SHAPE_PATTERN)
         millis_shape = regexp_predicate(qcol, EPOCH_MILLIS_SHAPE_PATTERN)
-        seconds_val = (
-            f"CASE WHEN {seconds_shape} THEN CAST({qcol} AS {bigint_type}) END"
-        )
-        millis_val = f"CASE WHEN {millis_shape} THEN CAST({qcol} AS {bigint_type}) END"
+        seconds_shaped = shaped(seconds_shape)
+        millis_shaped = shaped(millis_shape)
+        seconds_val = total_cast(seconds_shape, qcol)
+        millis_val = total_cast(millis_shape, qcol)
     elif is_integer:
-        seconds_val = millis_val = qcol  # already numeric: no CAST, no overflow surface
+        # Already numeric: no CAST to make total, no overflow surface, and
+        # every non-null row is in the denominator.
+        seconds_shaped = millis_shaped = seconds_val = millis_val = qcol
     else:
         return []
 
     seconds_cond = f"{seconds_val} BETWEEN {EPOCH_SECONDS_LOW} AND {EPOCH_SECONDS_HIGH}"
     millis_cond = f"{millis_val} BETWEEN {EPOCH_MILLIS_LOW} AND {EPOCH_MILLIS_HIGH}"
     exprs += [
-        fraction(seconds_val, seconds_cond, f"ts_ep_s_{i}"),
-        fraction(millis_val, millis_cond, f"ts_ep_ms_{i}"),
+        fraction(seconds_shaped, seconds_cond, f"ts_ep_s_{i}"),
+        fraction(millis_shaped, millis_cond, f"ts_ep_ms_{i}"),
+        # The MIN/MAX branch value is the total cast, not the shaped string:
+        # the range condition already excludes the sentinel (zero is not a
+        # plausible epoch), so a dialect that evaluates the branch for every
+        # row computes a cast that cannot raise and reports only in-range rows.
         f"MIN(CASE WHEN {seconds_cond} THEN {seconds_val} END) AS ts_ep_s_mn_{i}",
         f"MAX(CASE WHEN {seconds_cond} THEN {seconds_val} END) AS ts_ep_s_mx_{i}",
         f"MIN(CASE WHEN {millis_cond} THEN {millis_val} END) AS ts_ep_ms_mn_{i}",
@@ -579,10 +625,11 @@ def key_shape_expressions(
     is valid input to a hex-charset pattern too), which is what keeps
     ``numeric_string_fraction`` directly reusable here unchanged and keeps
     the two buckets from double-counting the same value. Plain boolean
-    predicates ANDed together carry none of the CAST-ordering risk
-    ``type_contradiction_expressions`` has to guard against; nothing here
-    can raise. ``qcol`` must already be quoted/escaped by the calling
-    adapter.
+    predicates ANDed together cast nothing, so the total-CAST discipline
+    ``type_contradiction_expressions`` has to keep does not apply here and
+    nothing in these expressions can raise on any dialect, whatever it
+    chooses to evaluate. ``qcol`` must already be quoted/escaped by the
+    calling adapter.
     """
 
     numeric_pred = regexp_predicate(qcol, NUMERIC_PATTERN)

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -49,6 +49,7 @@ from .base import (
     temporal_units_for,
     type_contradiction_aggregate_kwargs,
     type_contradiction_expressions,
+    warehouse_refusal,
 )
 
 PARADIGM = "bytes_scanned"
@@ -1091,7 +1092,12 @@ class BigQueryAdapter:
                     "(server-side maximum_bytes_billed); raise --budget or "
                     "narrow the query"
                 ) from exc
-            raise
+            # Every other BadRequest is BigQuery refusing the statement itself
+            # (an invalid query, a type it will not coerce). Typed, so the
+            # envelope carries `execution_failure` and BigQuery's own words
+            # rather than the `internal` an untyped API exception falls
+            # through to.
+            raise warehouse_refusal(str(exc)) from exc
         except TimeoutError as exc:
             # concurrent.futures.TimeoutError is the builtin on Python 3.11+.
             self._cancel(job)

--- a/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
@@ -60,6 +60,7 @@ from .base import (
     temporal_units_for,
     type_contradiction_aggregate_kwargs,
     type_contradiction_expressions,
+    warehouse_refusal,
 )
 
 PARADIGM = "compute_time"
@@ -143,6 +144,22 @@ def _date_diff_expr(unit: str, later: str, earlier: str) -> str:
     # TIMESTAMPDIFF (not the days-only datediff) covers day/month/hour in one
     # spelling, unlike Spark SQL's native datediff (days only).
     return f"TIMESTAMPDIFF({unit.upper()}, {earlier}, {later})"
+
+
+def _is_server_error(exc: Exception) -> bool:
+    """Whether the driver labelled this "the warehouse answered with an error".
+
+    Matched on the class name along the MRO rather than with ``isinstance``:
+    the SQL driver is injected into this adapter rather than imported by it
+    (which is what lets the offline suite build the adapter without the
+    library installed), so there is no class object here to compare against.
+    ``ServerOperationError`` is databricks-sql-connector's class for a
+    server-side statement failure; its transport failures (``RequestError``,
+    ``OperationalError``) are deliberately excluded, because a connection that
+    died is not a statement the server refused.
+    """
+
+    return any(cls.__name__ == "ServerOperationError" for cls in type(exc).__mro__)
 
 
 def warehouse_http_path(value: str) -> str:
@@ -1293,6 +1310,13 @@ class DatabricksAdapter:
                 "remaining budget (STATEMENT_TIMEOUT); raise --budget or "
                 "narrow the work"
             )
+        if _is_server_error(exc):
+            # The warehouse answered with an error. Typed, so the envelope
+            # carries `execution_failure` and Databricks' own words rather
+            # than the `internal` an untyped driver exception falls through
+            # to. Transport failures are left alone deliberately: a connection
+            # that died is not a statement the server refused.
+            return warehouse_refusal(str(exc))
         return exc
 
     # --- helpers ------------------------------------------------------------------

--- a/packages/dex-core/src/exmergo_dex_core/adapters/duckdb.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/duckdb.py
@@ -13,7 +13,7 @@ import threading
 from pathlib import Path
 
 from ..envelope import Paradigm
-from ..errors import ConnectorError
+from ..errors import ConnectorError, WarehouseQueryError
 from ..guards.sql_guard import assert_select_only
 from .base import (
     ColumnAggregate,
@@ -35,6 +35,7 @@ from .base import (
     temporal_units_for,
     type_contradiction_aggregate_kwargs,
     type_contradiction_expressions,
+    warehouse_refusal,
 )
 
 
@@ -528,7 +529,10 @@ class DuckDBAdapter:
                     f"query exceeded {timeout_seconds:g}s and was interrupted; "
                     "narrow it (tighter filter, fewer columns) and retry"
                 ) from exc
-            raise
+            refusal = _refusal(exc)
+            if refusal is None:
+                raise
+            raise refusal from exc
         finally:
             watchdog.cancel()
 
@@ -545,12 +549,35 @@ class DuckDBAdapter:
         # Single read-only door for every query: parsed and refused if it is not a
         # SELECT, on top of the read-only connection.
         assert_select_only(sql, dialect=self.dialect)
-        return self._conn.execute(sql, params or []).fetchall()
+        try:
+            return self._conn.execute(sql, params or []).fetchall()
+        except Exception as exc:
+            refusal = _refusal(exc)
+            if refusal is None:
+                raise
+            raise refusal from exc
 
     def close(self) -> None:
         if self._conn is not None:
             self._conn.close()
             self._conn = None
+
+
+def _refusal(exc: Exception) -> WarehouseQueryError | None:
+    """The typed refusal for a statement DuckDB itself rejected, or ``None``
+    when the failure did not come from the database at all.
+
+    The local engine is still an engine that answers with errors, and it gets
+    the same treatment as the cloud connectors: a refused statement reads as
+    ``execution_failure`` carrying DuckDB's own words rather than falling
+    through to ``internal``. Anything that is not a ``duckdb.Error`` (an
+    interrupt, an out-of-memory kill) is left alone, so the caller re-raises it
+    as itself.
+    """
+
+    import duckdb
+
+    return warehouse_refusal(str(exc)) if isinstance(exc, duckdb.Error) else None
 
 
 def _quote_ident(name: str) -> str:

--- a/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
@@ -66,6 +66,7 @@ from .base import (
     temporal_units_for,
     type_contradiction_aggregate_kwargs,
     type_contradiction_expressions,
+    warehouse_refusal,
 )
 
 PARADIGM = "db_load"
@@ -1056,6 +1057,17 @@ class PostgresAdapter:
                 "the statement attempted a write and the session is read-only "
                 "by construction; dex never mutates the database"
             ) from exc
+        except self._pg_errors.DatabaseError as exc:
+            # Everything else the server refused, after the two failures with
+            # a better answer above. `sqlstate` is what separates a server
+            # answer from a connection that died mid-statement (psycopg raises
+            # OperationalError with none for the latter), and only the first
+            # is an execution failure; a dead connection stays untyped so it
+            # is not reported as SQL the server rejected.
+            self._record_elapsed(started, sql)
+            if getattr(exc, "sqlstate", None) is None:
+                raise
+            raise warehouse_refusal(str(exc), code=exc.sqlstate) from exc
         self._record_elapsed(started, sql)
         labels = [str(d.name) for d in cursor.description]
         types = [self._description_type(d) for d in cursor.description]

--- a/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
@@ -71,6 +71,7 @@ from .base import (
     temporal_units_for,
     type_contradiction_aggregate_kwargs,
     type_contradiction_expressions,
+    warehouse_refusal,
 )
 
 PARADIGM = "compute_time"
@@ -1198,7 +1199,16 @@ class RedshiftAdapter:
         message = str(exc).lower()
         timed_out = payload.get("C") == "57014" or "statement timeout" in message
         if not timed_out:
-            return exc
+            # Everything else the server refused. Typed rather than handed
+            # back unchanged: a driver exception is not a DexError, so it used
+            # to fall through every reason override and land on `internal`,
+            # which reads as a dex crash and buries the server's own diagnosis
+            # in an envelope with no reason, no object, and no spend. The
+            # payload's M and C are the message and the SQLSTATE; str(exc) is
+            # the whole payload dict, which is not for reading.
+            return warehouse_refusal(
+                str(payload.get("M") or exc), code=payload.get("C")
+            )
         if budget_bound:
             return OverCeilingError(
                 "the statement hit the server-side statement_timeout derived "

--- a/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
@@ -59,6 +59,7 @@ from .base import (
     temporal_units_for,
     type_contradiction_aggregate_kwargs,
     type_contradiction_expressions,
+    warehouse_refusal,
 )
 
 PARADIGM = "compute_time"
@@ -1187,7 +1188,13 @@ class SnowflakeAdapter:
                 f"query exceeded {timeout_seconds:g}s and was cancelled; "
                 "narrow it (tighter filter, fewer columns) and retry"
             )
-        return exc
+        # Everything else the server refused (a compilation error, a missing
+        # grant, an unsupported construct). Typed, so the envelope carries
+        # `execution_failure` and Snowflake's own words rather than the
+        # `internal` an untyped driver exception falls through to. No separate
+        # code: the driver already prefixes its message with the error number
+        # and the SQLSTATE.
+        return warehouse_refusal(message)
 
     @staticmethod
     def _description_type(description: Any) -> str:

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -21,6 +21,7 @@ so the contract, the wrappers, and the eval harness stay exercisable.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import sys
 
 from . import command_args
@@ -516,6 +517,10 @@ def main(argv: list[str] | None = None) -> int:
     # inside the handler, so a read taken right after `from_repo` would still
     # see no connector even on a run that went on to pick one.
     engine: DexEngine | None = None
+    # What the command actually billed, captured on the way out for the same
+    # reason the paradigm is: `close()` drops the adapter the gate hangs off,
+    # and it runs before the handlers below.
+    spend: dict | None = None
     # Building the engine is inside the handler, not before it: it reads the
     # config file and constructs the configured storage backend, and both can
     # refuse. Every agent wrapper expects exactly one envelope on stdout, so a
@@ -547,6 +552,12 @@ def main(argv: list[str] | None = None) -> int:
             # to name; taken in the `finally` so it reflects whatever the
             # handler resolved, auto-detect included, not just construction.
             paradigm = engine.paradigm
+            # Best-effort by design: a ledger that cannot be read must not
+            # replace the exception on its way out with a bookkeeping failure,
+            # which would lose the reason the command failed to report a
+            # number about it.
+            with contextlib.suppress(Exception):
+                spend = engine.settled_spend()
             engine.close()
     except env.SanitizationError:
         # A sanitization failure must never be swallowed: re-raise so it surfaces
@@ -559,6 +570,18 @@ def main(argv: list[str] | None = None) -> int:
         if paradigm is None and getattr(args, "connector", None):
             paradigm = paradigm_for(args.connector)
         envelope = env.error_for(exc, env.redact(str(exc)))
+
+    # A command that failed still spent what it spent. Only the two-phase
+    # refusals used to say so (budget exhaustion carries its own spend), so a
+    # statement that died mid-scan on a metered connector reported `data: {}`
+    # and read as a failure that cost nothing. Filled only where the handler
+    # did not already report it, so the richer partial-completion payload wins.
+    if (
+        envelope.status is env.Status.ERROR
+        and spend is not None
+        and "spend" not in envelope.data
+    ):
+        envelope.data["spend"] = spend
 
     # A guess the engine made on the caller's behalf (issue #199's run-directory
     # DuckDB auto-detect) must never be silent, so it rides into every envelope

--- a/packages/dex-core/src/exmergo_dex_core/command_args.py
+++ b/packages/dex-core/src/exmergo_dex_core/command_args.py
@@ -340,15 +340,34 @@ def stamp_spend(result: Result, adapter: Adapter) -> Result:
 
     gate = cost_gate(adapter)
     if gate is not None:
-        gate.settle()
+        spend = settled_spend(adapter)
         if result.cost.estimate is None:
             result.cost = gate.cost()
-        spend = gate.spend_summary()
-        display = getattr(adapter, "spend_display", None)
-        if display is not None:
-            spend.update(display())
         result.spend = spend
         # Settlement is the honest moment to say what did not bind: the command
         # has spent, and the caller is looking at the number.
         result.warnings = [*result.warnings, *gate.warnings()]
     return result
+
+
+def settled_spend(adapter: Adapter) -> dict | None:
+    """Settle the gate and read back what this command actually billed, in the
+    connector's own unit plus whatever translation the adapter adds.
+
+    Split out of :func:`stamp_spend` because the failure path needs the same
+    number and has no ``Result`` to stamp it onto: a command that died partway
+    still burned the seconds it burned, and an error envelope reporting nothing
+    tells a caller on a metered connector that its failure was free. ``None``
+    on a free connector, which has no gate and so no spend to report rather
+    than a row of zeroes.
+    """
+
+    gate = cost_gate(adapter)
+    if gate is None:
+        return None
+    gate.settle()
+    spend = gate.spend_summary()
+    display = getattr(adapter, "spend_display", None)
+    if display is not None:
+        spend.update(display())
+    return spend

--- a/packages/dex-core/src/exmergo_dex_core/engine.py
+++ b/packages/dex-core/src/exmergo_dex_core/engine.py
@@ -417,6 +417,31 @@ class DexEngine:
             return None
         return connect.paradigm_for(self.connector or self.config.connector)
 
+    def settled_spend(self) -> dict | None:
+        """What the command that just ran actually billed, settled and read
+        back from the gate, or ``None`` when nothing billed anything.
+
+        The success path reaches this through ``stamp_spend`` on the result;
+        this is the same number for a caller holding an exception instead,
+        which is why it lives on the engine rather than inside a command. An
+        adapter that was never opened has no gate and so no spend.
+        """
+
+        from .guards.cost_guard import spend_field
+
+        adapter = self._adapter_instance
+        gate = None if adapter is None else command_args.cost_gate(adapter)
+        if adapter is None or gate is None:
+            return None
+        spend = command_args.settled_spend(adapter)
+        # Nothing billed, nothing to report: a refusal that stopped before the
+        # first statement is free, and a spend block of zeroes on it would read
+        # as a claim about money where the honest answer is silence. The day's
+        # cumulative total rides along only when this command contributed to it.
+        if not spend or not spend.get(spend_field(gate.paradigm)):
+            return None
+        return spend
+
     def project_dir(self) -> Path:
         """The dbt project directory: the config pin wins, discovery is the default."""
 

--- a/packages/dex-core/src/exmergo_dex_core/envelope.py
+++ b/packages/dex-core/src/exmergo_dex_core/envelope.py
@@ -242,6 +242,7 @@ def _reason_overrides() -> list[tuple[type[BaseException], Reason]]:
         DexError,
         PrerequisiteError,
         RequestError,
+        WarehouseQueryError,
     )
     from .guards.dialect import DialectDependencyError
 
@@ -253,6 +254,7 @@ def _reason_overrides() -> list[tuple[type[BaseException], Reason]]:
         (PrerequisiteError, Reason.PREREQUISITE),  # CacheRequiredError, NoBaselineError
         (ConnectorError, Reason.CONNECTION),  # every *ConnectionError subclass
         (ConfigurationError, Reason.CONFIGURATION),
+        (WarehouseQueryError, Reason.EXECUTION_FAILURE),  # the server said no
         (RequestError, Reason.REQUEST),
         (DexError, Reason.REQUEST),  # generic fallback for any other deliberate refusal
         (ValueError, Reason.REQUEST),  # the pre-typed-error convention: bad input
@@ -310,6 +312,9 @@ def _reason_overrides() -> list[tuple[type[BaseException], Reason]]:
         (SemanticBackendError, Reason.CONFIGURATION),  # after SemanticQueryRefusedError
         (BuildFailedError, Reason.EXECUTION_FAILURE),
         (DbtRunError, Reason.EXECUTION_FAILURE),
+        # The statement ran and the server refused it: an execution failure for
+        # the same reason a failed dbt run is one, and never `internal`.
+        (WarehouseQueryError, Reason.EXECUTION_FAILURE),
         (RequestError, Reason.REQUEST),
         (DbtParseError, Reason.REQUEST),
         (PlanError, Reason.REQUEST),  # PlanNotFoundError

--- a/packages/dex-core/src/exmergo_dex_core/errors.py
+++ b/packages/dex-core/src/exmergo_dex_core/errors.py
@@ -113,6 +113,62 @@ class ConnectorError(DexError):
     """
 
 
+class WarehouseQueryError(DexError):
+    """A statement dex built ran against the warehouse and the server refused it.
+
+    Neither a refusal dex made nor a bug in dex: the guards cleared the
+    statement, the connection was open, and the server answered with an error.
+    For an engine whose whole job is issuing SQL to somebody else's warehouse
+    that is a first-class outcome, so it classifies as ``execution_failure``
+    (the operation ran and failed) instead of falling through ``reason_for``
+    to ``internal``, which says "not a deliberate dex refusal" and sends
+    whoever reads it looking for a crash. Every adapter raises this for a
+    server-side statement failure it cannot translate into something more
+    specific (a budget-derived timeout, a read-only violation), so a caller
+    branching on the reason gets the same answer from every connector.
+
+    ``detail`` is the server's own words, which is the whole diagnostic value:
+    the adapter trims them to one line and caps their length before they get
+    here, because a driver will happily append the statement, a caret diagram,
+    or its entire error payload. They can still quote the fragment of a value
+    that offended the server (``Invalid digit, Value 'p'``), the same way an
+    agent SQL failure's message already does; that is a diagnostic the server
+    volunteered, not a profile of the column, and suppressing it is what made
+    this class of failure undiagnosable in the first place.
+
+    The adapter knows the server's words but not what the statement was for;
+    only the caller that built it knows which object it was reading. So the
+    object is attached afterwards, by :meth:`naming`, rather than threaded
+    down through every adapter's execution seam.
+
+    It lives here rather than beside the code that raises it, which is this
+    module's usual rule, because six adapters raise this one class (there is no
+    "the code that raises it") and because ``envelope._reason_overrides`` has to
+    classify it from the tier of imports that works on an install with no
+    connector extra at all.
+    """
+
+    def __init__(self, detail: str, *, reading: str | None = None):
+        self.detail = detail
+        self.reading = reading
+        super().__init__(self._message())
+
+    def _message(self) -> str:
+        about = f" while reading {self.reading}" if self.reading else ""
+        return f"the warehouse refused a statement dex built{about}: {self.detail}"
+
+    def naming(self, identifier: str) -> WarehouseQueryError:
+        """This failure with the object it was reading named.
+
+        The first name wins: the innermost caller that knows one is the most
+        specific, so an outer handler re-naming it cannot make it vaguer.
+        """
+
+        if self.reading is not None:
+            return self
+        return WarehouseQueryError(self.detail, reading=identifier)
+
+
 class NoConnectorSelectedError(ConfigurationError):
     """Nothing named a connector: not a flag, not a path, not a config file.
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -35,6 +35,7 @@ from ..cache import (
     ValueDomain,
 )
 from ..config import PIIOverrideMatcher
+from ..errors import WarehouseQueryError
 from ..progress import ProgressReporter
 
 # approx_count_distinct error observed in practice reaches ~14% in both
@@ -720,33 +721,46 @@ def profile(
         ]
         scan_columns = [c for c in columns if c.name not in blob_excluded]
 
-        aggregates = {
-            a.name: a
-            for a in adapter.column_aggregates(
-                identifier,
-                scan_columns,
-                safe_min_max=safe,
-                shape_stats=shape,
-                type_stats=type_stats,
-                key_shape_stats=key_shape_stats,
-                temporal_stats=temporal_stats,
+        # The adapter knows what the server said and this loop knows which
+        # object it said it about, so a server-side refusal picks up the
+        # identifier on its way past: an envelope reading "the warehouse
+        # refused a statement dex built" is only actionable when it names the
+        # object, and a map run has a dozen of them in flight.
+        try:
+            aggregates = {
+                a.name: a
+                for a in adapter.column_aggregates(
+                    identifier,
+                    scan_columns,
+                    safe_min_max=safe,
+                    shape_stats=shape,
+                    type_stats=type_stats,
+                    key_shape_stats=key_shape_stats,
+                    temporal_stats=temporal_stats,
+                )
+            }
+            # Re-read the metadata after the aggregate scan: adapters whose
+            # inventory row counts are planner estimates (Postgres reltuples)
+            # upgrade to the exact COUNT(*) the scan just paid for, so
+            # uniqueness proofs and the dataset row count are exact. Free
+            # everywhere (cached or trivially cheap on the other adapters).
+            meta, _ = adapter.table_metadata(identifier)
+            aggregates = _escalate_near_unique(
+                adapter, identifier, meta.row_count, aggregates
             )
-        }
-        # Re-read the metadata after the aggregate scan: adapters whose
-        # inventory row counts are planner estimates (Postgres reltuples)
-        # upgrade to the exact COUNT(*) the scan just paid for, so uniqueness
-        # proofs and the dataset row count are exact. Free everywhere (cached
-        # or trivially cheap on the other adapters).
-        meta, _ = adapter.table_metadata(identifier)
-        aggregates = _escalate_near_unique(
-            adapter, identifier, meta.row_count, aggregates
-        )
-        composite_keys = _probe_composite_keys(
-            adapter, identifier, meta.row_count, aggregates
-        )
-        value_domains = _probe_value_domains(
-            adapter, identifier, meta.row_count, aggregates, prelim_pii, composite_keys
-        )
+            composite_keys = _probe_composite_keys(
+                adapter, identifier, meta.row_count, aggregates
+            )
+            value_domains = _probe_value_domains(
+                adapter,
+                identifier,
+                meta.row_count,
+                aggregates,
+                prelim_pii,
+                composite_keys,
+            )
+        except WarehouseQueryError as exc:
+            raise exc.naming(identifier) from exc
         composite_members = {c for pair in composite_keys for c in pair}
 
         profiles: list[ColumnProfile] = []

--- a/packages/dex-core/tests/adapters/test_connect_redshift.py
+++ b/packages/dex-core/tests/adapters/test_connect_redshift.py
@@ -486,9 +486,18 @@ def test_wall_clock_timeout_translates_to_timeout_error(fake_redshift_connection
 def test_a_wlm_cancel_is_not_blamed_on_the_budget(fake_redshift_connection):
     """WLM query-monitoring rules and admin kills also say "canceled"; only a
     statement_timeout kill (SQLSTATE 57014) may be translated into budget
-    advice, or the user is told to raise --budget for a refusal it cannot fix."""
+    advice, or the user is told to raise --budget for a refusal it cannot fix.
+
+    It is still a server-side refusal, so it comes back typed (#310) with the
+    server's own message and SQLSTATE, rather than as the raw driver exception
+    that used to classify as `internal`.
+    """
 
     from redshift_connector import error as rs_errors
+
+    from exmergo_dex_core.envelope import Reason, reason_for
+    from exmergo_dex_core.errors import WarehouseQueryError
+    from exmergo_dex_core.guards.cost_guard import OverCeilingError
 
     def resolve(sql):
         raise rs_errors.ProgrammingError(
@@ -501,12 +510,65 @@ def test_a_wlm_cancel_is_not_blamed_on_the_budget(fake_redshift_connection):
 
     fake_redshift_connection.row_resolver = resolve
     adapter = make_adapter(fake_redshift_connection, ceiling=600.0)
-    with pytest.raises(rs_errors.ProgrammingError, match="WLM"):
+    with pytest.raises(WarehouseQueryError, match="WLM") as caught:
         adapter.run_query(
             "SELECT count(*) FROM dexdb.shop.customers",
             max_rows=10,
             timeout_seconds=30.0,
         )
+    assert not isinstance(caught.value, (OverCeilingError, TimeoutError))
+    assert "XX000" in str(caught.value)
+    assert reason_for(caught.value) is Reason.EXECUTION_FAILURE
+
+
+def test_a_refused_profiling_statement_is_typed_named_and_still_billed(
+    fake_redshift_connection,
+):
+    """#310: the shape of the failure the invalid-digit bug produced live.
+
+    A server-side refusal mid-profile has to arrive as three things at once:
+    typed (so the envelope says `execution_failure`, not `internal`), carrying
+    the server's own diagnosis and SQLSTATE (so it can be read at all), and
+    named with the object being profiled (a map run has a dozen statements in
+    flight). The seconds it burned before dying are billed either way, and the
+    ledger has to hold them.
+    """
+
+    from redshift_connector import error as rs_errors
+
+    from exmergo_dex_core.envelope import Reason, reason_for
+    from exmergo_dex_core.errors import WarehouseQueryError
+    from exmergo_dex_core.explore.profile import profile
+
+    clock = fake_redshift_connection.clock
+
+    def resolve(sql):
+        if "n_total" not in sql:  # catalog lookups answer normally
+            return None
+        clock.now += 12.0
+        raise rs_errors.ProgrammingError(
+            {
+                "S": "ERROR",
+                "C": "22P02",
+                "M": "Invalid digit, Value 'p', Pos 0, Type: Long",
+            }
+        )
+
+    entries: list[dict] = []
+    fake_redshift_connection.row_resolver = resolve
+    adapter = make_adapter(fake_redshift_connection, record=entries.append)
+    with pytest.raises(WarehouseQueryError) as caught:
+        profile(adapter, ["dexdb.shop.customers"])
+
+    assert reason_for(caught.value) is Reason.EXECUTION_FAILURE
+    message = str(caught.value)
+    assert "Invalid digit" in message and "22P02" in message
+    assert "dexdb.shop.customers" in message
+    # str(exc) on the driver error is the whole payload dict; the envelope gets
+    # the server's message, not the driver's bookkeeping.
+    assert "'S':" not in message
+    assert adapter.cost_gate.spend_summary()["seconds_billed"] == pytest.approx(12.0)
+    assert [e["billed_seconds"] for e in entries] == [pytest.approx(12.0)]
 
 
 def test_a_dropped_connection_still_records_billed_seconds(

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -1030,3 +1030,117 @@ def test_duckdb_never_warns_about_a_cumulative_cap(duckdb_file: Path, capsys):
     assert main(["explore", "profile", "customers", "--path", str(duckdb_file)]) == 0
     payload = json.loads(capsys.readouterr().out)
     assert _session_warning(payload["warnings"]) == []
+
+
+# --- a statement the server refused (#310) ----------------------------------------
+#
+# Three defects met on this path and each hid the next: profiling built a CAST
+# Redshift refused, the driver's exception escaped untranslated so the envelope
+# said `internal` with no reason and no object, and the seconds already billed
+# were reported nowhere, so a failed metered command read as a free one. The
+# first is fixed in the SQL (see test_safety_spine); these pin the envelope the
+# other two produce, which is what makes any future one diagnosable from stdout.
+
+
+def test_a_refused_statement_reports_its_reason_its_object_and_its_spend(
+    fake_bq_client, monkeypatch, tmp_path, capsys
+):
+    from google.api_core import exceptions as api_exceptions
+
+    from exmergo_dex_core.cli import main
+    from exmergo_dex_core.engine import DexEngine
+
+    def opener(self, command=None, *, budget=None, confirmed=None):
+        # Cached on the engine the way the real funnel does it: the settlement
+        # that reads spend back on the way out reads the engine's held adapter,
+        # so an opener that handed out a fresh one per call would test nothing.
+        if self._adapter_instance is None:
+            self._adapter_instance = _adapter(
+                fake_bq_client, confirmed=True, budget=float(100 * MB)
+            )
+        return self._adapter_instance
+
+    monkeypatch.setattr(DexEngine, "_adapter", opener)
+    fake_bq_client.row_resolver = _aggregate_resolver
+
+    # The first object profiles and bills; the second meets a server refusal,
+    # which is the ordinary shape of this failure (one bad column in one table
+    # of many, on a run that has already spent).
+    original = BigQueryAdapter.column_aggregates
+
+    def refuse_the_second(self, identifier, columns, **kwargs):
+        if identifier.endswith("events"):
+            fake_bq_client.result_error = api_exceptions.BadRequest(
+                "Bad int64 value: pending"
+            )
+        return original(self, identifier, columns, **kwargs)
+
+    monkeypatch.setattr(BigQueryAdapter, "column_aggregates", refuse_the_second)
+
+    rc = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--connector",
+            "bigquery",
+            "explore",
+            "profile",
+            "customers",
+            "events",
+            "--confirm",
+            "--budget",
+            str(float(100 * MB)),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert payload["status"] == "error"
+    # Classified: the server ran the statement and refused it, which is not the
+    # `internal` an untyped driver exception used to fall through to.
+    assert payload["reason"] == Reason.EXECUTION_FAILURE.value
+    error = payload["errors"][0]
+    assert "Bad int64 value" in error  # the server's own diagnosis, verbatim
+    assert "test-proj.shop.events" in error  # and which object it was about
+    # Metered and failed is not the same as free: the first object's scan was
+    # billed and the envelope says so.
+    assert payload["data"]["spend"]["bytes_billed"] > 0
+    assert payload["cost"]["paradigm"] == Paradigm.BYTES_SCANNED.value
+
+
+def test_a_refusal_that_never_reached_the_warehouse_reports_no_spend(
+    fake_bq_client, monkeypatch, tmp_path, capsys
+):
+    """The other side of it: a command refused before the first statement
+    spent nothing, and a spend block of zeroes on that envelope would read as a
+    claim about money where silence is the honest answer."""
+
+    from exmergo_dex_core.cli import main
+    from exmergo_dex_core.engine import DexEngine
+
+    def opener(self, command=None, *, budget=None, confirmed=None):
+        if self._adapter_instance is None:
+            self._adapter_instance = _adapter(
+                fake_bq_client, confirmed=True, budget=float(1)
+            )
+        return self._adapter_instance
+
+    monkeypatch.setattr(DexEngine, "_adapter", opener)
+    rc = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--connector",
+            "bigquery",
+            "explore",
+            "profile",
+            "customers",
+            "--confirm",
+            "--budget",
+            "1",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["reason"] == Reason.GUARD.value
+    assert "spend" not in payload["data"]

--- a/packages/dex-core/tests/integration/conftest.py
+++ b/packages/dex-core/tests/integration/conftest.py
@@ -73,6 +73,25 @@ DBX_MAX_SECONDS = float(os.environ.get("DEX_TEST_DATABRICKS_MAX_SECONDS", "60"))
 RS_MAX_SECONDS = float(os.environ.get("DEX_TEST_REDSHIFT_MAX_SECONDS", "60"))
 
 
+def assert_ok(rc: int, envelope: dict) -> dict:
+    """Assert a live command succeeded, and say what the warehouse said if it
+    did not. Returns the envelope, so it reads inline.
+
+    The obvious spelling is ``assert rc == 0, envelope``, and it is why a live
+    Redshift failure cost sixteen CI runs to diagnose instead of five minutes
+    (#310): pytest elides the middle of a long assertion message, and the
+    middle of a profiling envelope is exactly where ``errors`` sits, so the
+    server's own message never once reached a CI log. Putting the errors
+    first, alone, makes the surviving line the one worth reading.
+    """
+
+    assert rc == 0, (
+        f"errors={envelope.get('errors')} reason={envelope.get('reason')} "
+        f"warnings={envelope.get('warnings')}"
+    )
+    return envelope
+
+
 def _snowflake_enabled() -> bool:
     return bool(
         os.environ.get("DEX_TEST_SNOWFLAKE_DATABASE")

--- a/packages/dex-core/tests/integration/test_bigquery_connect.py
+++ b/packages/dex-core/tests/integration/test_bigquery_connect.py
@@ -11,6 +11,8 @@ import yaml
 
 from exmergo_dex_core.cli import main
 
+from .conftest import assert_ok
+
 pytestmark = [pytest.mark.integration, pytest.mark.bigquery]
 
 PUBLIC_DATASETS = [
@@ -47,7 +49,7 @@ def test_connect_test_discovers_adc_and_reports_read_only(
 ):
     seed_repo(tmp_path, bq_project)
     rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     data = envelope["data"]
     assert data["connector"] == "bigquery"
     assert data["dialect"] == "bigquery"

--- a/packages/dex-core/tests/integration/test_bigquery_explore.py
+++ b/packages/dex-core/tests/integration/test_bigquery_explore.py
@@ -13,7 +13,7 @@ import pytest
 from exmergo_dex_core.cache import ColumnProfile, Dataset, DexCache
 from exmergo_dex_core.storage import FilesystemStore
 
-from .conftest import MAX_BYTES
+from .conftest import MAX_BYTES, assert_ok
 from .test_bigquery_connect import run_cli, seed_repo
 
 pytestmark = [pytest.mark.integration, pytest.mark.bigquery]
@@ -29,7 +29,7 @@ def test_inventory_is_free_and_ranked(tmp_path: Path, capsys, bq_project: str):
     rc, envelope = run_cli(
         ["--repo-root", str(tmp_path), "explore", "inventory", "--rank"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     identifiers = {o["identifier"] for o in envelope["data"]["objects"]}
     assert SHAKESPEARE in identifiers
     assert envelope["cost"]["paradigm"] == "bytes_scanned"
@@ -180,7 +180,7 @@ def test_unnest_of_a_function_derived_array_runs_live(
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     assert envelope["data"]["row_count"] == 3
 
     # The smuggle shape is refused statically, before any job is created.

--- a/packages/dex-core/tests/integration/test_bigquery_transform.py
+++ b/packages/dex-core/tests/integration/test_bigquery_transform.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from .conftest import MAX_BYTES, assert_unpivot_build, unpivot_fixture_edits
+from .conftest import MAX_BYTES, assert_ok, assert_unpivot_build, unpivot_fixture_edits
 from .test_bigquery_connect import run_cli, seed_repo
 
 pytestmark = [pytest.mark.integration, pytest.mark.bigquery]
@@ -43,7 +43,7 @@ def test_init_plan_apply_build_into_the_scratch_dataset(
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "init", "analytics"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     profiles = yaml.safe_load(
         (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
     )
@@ -139,13 +139,13 @@ def test_unpivot_json_object_macro_builds_live(
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "init", "analytics"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "macro", "unpivot_json_object"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     rc, envelope = run_cli(["--repo-root", root, "transform", "apply"], capsys)
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     edits_file = tmp_path / "edits.json"
     edits_file.write_text(
@@ -220,7 +220,7 @@ def test_a_missing_dev_dataset_warns_rather_than_refusing(
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "init", "analytics"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     # No model is authored, so the build creates nothing: the preflight's warning
     # is what is under test, not dbt's dataset creation.

--- a/packages/dex-core/tests/integration/test_databricks_connect.py
+++ b/packages/dex-core/tests/integration/test_databricks_connect.py
@@ -14,6 +14,8 @@ import yaml
 
 from exmergo_dex_core.cli import main
 
+from .conftest import assert_ok
+
 pytestmark = [pytest.mark.integration, pytest.mark.databricks]
 
 SAMPLE_SCOPE = "samples.tpch"
@@ -52,7 +54,7 @@ def test_connect_test_discovers_connection_and_reports_read_only(
 ):
     seed_repo(tmp_path, dbx_warehouse, dbx_scratch_catalog)
     rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     data = envelope["data"]
     assert data["connector"] == "databricks"
     assert data["dialect"] == "databricks"

--- a/packages/dex-core/tests/integration/test_databricks_explore.py
+++ b/packages/dex-core/tests/integration/test_databricks_explore.py
@@ -13,7 +13,7 @@ import pytest
 from exmergo_dex_core.cache import ColumnProfile, Dataset, DexCache
 from exmergo_dex_core.storage import FilesystemStore
 
-from .conftest import DBX_MAX_SECONDS
+from .conftest import DBX_MAX_SECONDS, assert_ok
 from .test_databricks_connect import SAMPLE_SCOPE, run_cli, seed_repo
 
 pytestmark = [pytest.mark.integration, pytest.mark.databricks]
@@ -31,7 +31,7 @@ def test_inventory_is_free_and_ranked(
     rc, envelope = run_cli(
         ["--repo-root", str(tmp_path), "explore", "inventory", "--rank"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     identifiers = {o["identifier"] for o in envelope["data"]["objects"]}
     assert REGION in identifiers
     assert envelope["cost"]["paradigm"] == "compute_time"
@@ -145,7 +145,7 @@ def test_firewalled_query_round_trip(
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     assert envelope["data"]["cells"] == [[5]]
     assert envelope["data"]["spend"]["seconds_billed"] >= 0
 
@@ -186,7 +186,7 @@ def test_lateral_view_explode_runs_live(
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     assert envelope["data"]["cells"] == [["a", 5], ["b", 5]]
 
 

--- a/packages/dex-core/tests/integration/test_databricks_transform.py
+++ b/packages/dex-core/tests/integration/test_databricks_transform.py
@@ -13,7 +13,12 @@ from pathlib import Path
 import pytest
 import yaml
 
-from .conftest import DBX_MAX_SECONDS, assert_unpivot_build, unpivot_fixture_edits
+from .conftest import (
+    DBX_MAX_SECONDS,
+    assert_ok,
+    assert_unpivot_build,
+    unpivot_fixture_edits,
+)
 from .test_databricks_connect import run_cli, seed_repo
 
 pytestmark = [pytest.mark.integration, pytest.mark.databricks]
@@ -71,7 +76,7 @@ def test_init_plan_apply_build_into_the_scratch_catalog(
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "init", "analytics"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     profiles = yaml.safe_load(
         (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
     )
@@ -182,7 +187,7 @@ def test_missing_dev_catalog_is_refused_before_the_cost_gate(
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "init", "analytics"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "build", "--target", "dev"], capsys
@@ -212,13 +217,13 @@ def test_unpivot_json_object_macro_builds_live(
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "init", "analytics"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "macro", "unpivot_json_object"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     rc, envelope = run_cli(["--repo-root", root, "transform", "apply"], capsys)
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     edits_file = tmp_path / "edits.json"
     edits_file.write_text(

--- a/packages/dex-core/tests/integration/test_postgres_connect.py
+++ b/packages/dex-core/tests/integration/test_postgres_connect.py
@@ -14,6 +14,8 @@ import yaml
 
 from exmergo_dex_core.cli import main
 
+from .conftest import assert_ok
+
 pytestmark = [pytest.mark.integration, pytest.mark.postgres]
 
 
@@ -49,7 +51,7 @@ def test_connect_test_discovers_connection_and_reports_read_only(
     monkeypatch.setenv("DATABASE_URL", pg_dsn)
     seed_repo(tmp_path)
     rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     data = envelope["data"]
     assert data["connector"] == "postgres"
     assert data["dialect"] == "postgres"

--- a/packages/dex-core/tests/integration/test_postgres_explore.py
+++ b/packages/dex-core/tests/integration/test_postgres_explore.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from .conftest import assert_ok
 from .test_postgres_connect import run_cli, seed_repo
 
 pytestmark = [pytest.mark.integration, pytest.mark.postgres]
@@ -26,7 +27,7 @@ def test_inventory_is_free_and_scoped(tmp_path: Path, capsys):
     rc, envelope = run_cli(
         ["--repo-root", str(tmp_path), "explore", "inventory"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     identifiers = {o["identifier"] for o in envelope["data"]["objects"]}
     assert any(i.endswith("app.customers") for i in identifiers)
     assert all(".app." in i for i in identifiers)
@@ -73,7 +74,7 @@ def test_confirmed_map_profiles_flags_pii_and_infers_the_missing_fk(
     rc, envelope = run_cli(
         ["--repo-root", str(tmp_path), "explore", "map", "--confirm"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     data = envelope["data"]
     assert data["profiled_count"] >= 6
     assert data["pii_column_count"] >= 3  # email, names, phone, address
@@ -117,7 +118,7 @@ def test_query_firewall_allows_measuring_and_refuses_pii_values(tmp_path: Path, 
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     assert envelope["data"]["row_count"] >= 1
 
     rc, envelope = run_cli(
@@ -160,7 +161,7 @@ def test_query_firewall_unnests_the_seeded_jsonb_column(tmp_path: Path, capsys):
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     keys = {row[0] for row in envelope["data"]["cells"]}
     assert {"weight_g", "in_stock"} <= keys
 

--- a/packages/dex-core/tests/integration/test_postgres_transform.py
+++ b/packages/dex-core/tests/integration/test_postgres_transform.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from .conftest import assert_unpivot_build, unpivot_fixture_edits
+from .conftest import assert_ok, assert_unpivot_build, unpivot_fixture_edits
 from .test_postgres_connect import run_cli, seed_repo
 
 pytestmark = [pytest.mark.integration, pytest.mark.postgres]
@@ -54,7 +54,7 @@ def test_init_and_build_write_only_the_dev_schema(
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     rendered = (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
     profile = yaml.safe_load(rendered)["analytics"]["outputs"]["dev"]
@@ -84,7 +84,7 @@ def test_init_and_build_write_only_the_dev_schema(
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     data = envelope["data"]
     assert data["success"] is True
     assert any(n["name"] == "stg_orders" for n in data["nodes"])
@@ -117,13 +117,13 @@ def test_unpivot_json_object_macro_builds_live(tmp_path: Path, capsys, dev_dsn):
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "macro", "unpivot_json_object"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     rc, envelope = run_cli(["--repo-root", root, "transform", "apply"], capsys)
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     edits_file = tmp_path / "edits.json"
     edits_file.write_text(
@@ -184,7 +184,7 @@ def test_an_unwritable_dev_schema_is_refused_before_the_cost_gate(
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "build", "--target", "dev"], capsys

--- a/packages/dex-core/tests/integration/test_redshift_connect.py
+++ b/packages/dex-core/tests/integration/test_redshift_connect.py
@@ -17,6 +17,8 @@ import yaml
 
 from exmergo_dex_core.cli import main
 
+from .conftest import assert_ok
+
 pytestmark = [pytest.mark.integration, pytest.mark.redshift]
 
 
@@ -57,7 +59,7 @@ def test_connect_test_discovers_connection_and_reports_read_only(
 ):
     seed_repo(tmp_path)
     rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     data = envelope["data"]
     assert data["connector"] == "redshift"
     assert data["dialect"] == "redshift"

--- a/packages/dex-core/tests/integration/test_redshift_explore.py
+++ b/packages/dex-core/tests/integration/test_redshift_explore.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from .conftest import RS_MAX_SECONDS
+from .conftest import RS_MAX_SECONDS, assert_ok
 from .test_redshift_connect import run_cli, seed_repo
 
 pytestmark = [pytest.mark.integration, pytest.mark.redshift]
@@ -28,7 +28,7 @@ def test_inventory_is_ungated_and_scoped(tmp_path: Path, capsys):
     rc, envelope = run_cli(
         ["--repo-root", str(tmp_path), "explore", "inventory"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     identifiers = {o["identifier"] for o in envelope["data"]["objects"]}
     assert any(i.endswith("app.customers") for i in identifiers)
     assert all(".app." in i for i in identifiers)
@@ -81,7 +81,7 @@ def test_confirmed_map_profiles_flags_pii_and_records_spend(tmp_path: Path, caps
     rc, envelope = run_cli(
         ["--repo-root", str(tmp_path), "explore", "map", "--confirm"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     data = envelope["data"]
     assert data["profiled_count"] >= 4
     assert data["pii_column_count"] >= 1  # the seeded email at minimum
@@ -118,7 +118,7 @@ def test_query_firewall_allows_measuring_and_refuses_pii_values(tmp_path: Path, 
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     assert envelope["data"]["row_count"] >= 1
 
     rc, envelope = run_cli(
@@ -160,7 +160,7 @@ def test_query_firewall_allows_measuring_and_refuses_pii_values(tmp_path: Path, 
 #         ],
 #         capsys,
 #     )
-#     assert rc == 0, envelope
+#     assert_ok(rc, envelope)
 #     assert envelope["data"]["row_count"] >= 1
 
 

--- a/packages/dex-core/tests/integration/test_redshift_transform.py
+++ b/packages/dex-core/tests/integration/test_redshift_transform.py
@@ -15,7 +15,12 @@ from pathlib import Path
 import pytest
 import yaml
 
-from .conftest import RS_MAX_SECONDS, assert_unpivot_build, unpivot_fixture_edits
+from .conftest import (
+    RS_MAX_SECONDS,
+    assert_ok,
+    assert_unpivot_build,
+    unpivot_fixture_edits,
+)
 from .test_redshift_connect import run_cli
 
 pytestmark = [pytest.mark.integration, pytest.mark.redshift]
@@ -73,7 +78,7 @@ def test_init_and_build_write_only_the_dev_schema(tmp_path: Path, capsys, dev_en
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     rendered = (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
     profile = yaml.safe_load(rendered)["analytics"]["outputs"]["dev"]
@@ -102,7 +107,7 @@ def test_init_and_build_write_only_the_dev_schema(tmp_path: Path, capsys, dev_en
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     data = envelope["data"]
     assert data["success"] is True
     assert any(n["name"] == "stg_orders" for n in data["nodes"])
@@ -139,13 +144,13 @@ def test_unpivot_json_object_macro_builds_live(tmp_path: Path, capsys, dev_env):
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "macro", "unpivot_json_object"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     rc, envelope = run_cli(["--repo-root", root, "transform", "apply"], capsys)
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     edits_file = tmp_path / "edits.json"
     edits_file.write_text(
@@ -218,7 +223,7 @@ def test_an_unwritable_dev_schema_is_refused_before_the_cost_gate(
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "build", "--target", "dev"], capsys

--- a/packages/dex-core/tests/integration/test_snowflake_connect.py
+++ b/packages/dex-core/tests/integration/test_snowflake_connect.py
@@ -13,6 +13,8 @@ import yaml
 
 from exmergo_dex_core.cli import main
 
+from .conftest import assert_ok
+
 pytestmark = [pytest.mark.integration, pytest.mark.snowflake]
 
 SAMPLE_SCOPE = "SNOWFLAKE_SAMPLE_DATA.TPCH_SF1"
@@ -53,7 +55,7 @@ def test_connect_test_discovers_connection_and_reports_read_only(
 ):
     seed_repo(tmp_path, sf_scratch_database, sf_warehouse, sf_connection_name)
     rc, envelope = run_cli(["--repo-root", str(tmp_path), "connect", "test"], capsys)
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     data = envelope["data"]
     assert data["connector"] == "snowflake"
     assert data["dialect"] == "snowflake"

--- a/packages/dex-core/tests/integration/test_snowflake_explore.py
+++ b/packages/dex-core/tests/integration/test_snowflake_explore.py
@@ -13,7 +13,7 @@ import pytest
 from exmergo_dex_core.cache import ColumnProfile, Dataset, DexCache
 from exmergo_dex_core.storage import FilesystemStore
 
-from .conftest import SF_MAX_SECONDS
+from .conftest import SF_MAX_SECONDS, assert_ok
 from .test_snowflake_connect import SAMPLE_SCOPE, run_cli, seed_repo
 
 pytestmark = [pytest.mark.integration, pytest.mark.snowflake]
@@ -32,7 +32,7 @@ def test_inventory_is_free_and_ranked(
     rc, envelope = run_cli(
         ["--repo-root", str(tmp_path), "explore", "inventory", "--rank"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     identifiers = {o["identifier"] for o in envelope["data"]["objects"]}
     assert REGION in identifiers
     assert envelope["cost"]["paradigm"] == "compute_time"
@@ -157,7 +157,7 @@ def test_firewalled_query_round_trip(
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     assert envelope["data"]["cells"] == [[5]]
     assert envelope["data"]["spend"]["seconds_billed"] >= 0
 
@@ -185,7 +185,7 @@ def test_flatten_of_a_parsed_json_literal_runs_live(
         ],
         capsys,
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     assert [row[0] for row in envelope["data"]["cells"]] == ["a", "b"]
 
 

--- a/packages/dex-core/tests/integration/test_snowflake_transform.py
+++ b/packages/dex-core/tests/integration/test_snowflake_transform.py
@@ -13,7 +13,12 @@ from pathlib import Path
 import pytest
 import yaml
 
-from .conftest import SF_MAX_SECONDS, assert_unpivot_build, unpivot_fixture_edits
+from .conftest import (
+    SF_MAX_SECONDS,
+    assert_ok,
+    assert_unpivot_build,
+    unpivot_fixture_edits,
+)
 from .test_snowflake_connect import run_cli, seed_repo
 
 pytestmark = [pytest.mark.integration, pytest.mark.snowflake]
@@ -50,7 +55,7 @@ def test_init_plan_apply_build_into_the_scratch_database(
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "init", "analytics"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     profiles = yaml.safe_load(
         (tmp_path / "analytics" / "profiles.yml").read_text(encoding="utf-8")
     )
@@ -157,13 +162,13 @@ def test_unpivot_json_object_macro_builds_live(
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "init", "analytics"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "macro", "unpivot_json_object"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
     rc, envelope = run_cli(["--repo-root", root, "transform", "apply"], capsys)
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     edits_file = tmp_path / "edits.json"
     edits_file.write_text(
@@ -222,7 +227,7 @@ def test_missing_dev_database_is_refused_before_the_cost_gate(
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "init", "analytics"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "build", "--target", "dev"], capsys
@@ -248,7 +253,7 @@ def test_config_drift_from_the_rendered_profile_is_refused(
     rc, envelope = run_cli(
         ["--repo-root", root, "transform", "init", "analytics"], capsys
     )
-    assert rc == 0, envelope
+    assert_ok(rc, envelope)
 
     config_path = tmp_path / ".dex" / "config.yml"
     config = yaml.safe_load(config_path.read_text(encoding="utf-8"))

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -30,6 +30,50 @@ def _memory_engine(**kwargs) -> DexEngine:
     return DexEngine(config=DexConfig(), store=MemoryStore(), **kwargs)
 
 
+def cast_arguments(sql: str) -> list[str]:
+    """Every CAST argument in one generated statement.
+
+    Matched by parenthesis balance rather than by regex: the arguments nest
+    (a CASE holding a SUBSTR), so a non-greedy match would stop at the wrong
+    close paren.
+    """
+
+    arguments = []
+    for start in (i for i in range(len(sql)) if sql.startswith("CAST(", i)):
+        depth, i = 1, start + len("CAST(")
+        while depth:
+            depth += {"(": 1, ")": -1}.get(sql[i], 0)
+            i += 1
+        arguments.append(sql[start + len("CAST(") : i - 1].rsplit(" AS ", 1)[0])
+    return arguments
+
+
+def assert_every_cast_is_total(sql: str) -> None:
+    """#310: every CAST in a generated aggregate must be castable for every row
+    of the column, not only for the rows a surrounding CASE would select.
+
+    Redshift evaluates a CASE branch's cast for rows the WHEN never selects,
+    so the shape that reads as safe (``CASE WHEN <digits> THEN CAST(col AS
+    BIGINT) END``) died server-side on any table with one non-numeric string
+    in a profiled column. The invariant that replaced it is structural and
+    dialect-independent: the cast's argument is itself a CASE that yields
+    digits on every row, so no evaluation order can reach the cast with
+    something it cannot parse.
+    """
+
+    from exmergo_dex_core.adapters.base import _CAST_SENTINEL
+
+    for argument in cast_arguments(sql):
+        assert argument.startswith("CASE WHEN "), (
+            f"a CAST argument is not shape-guarded, so a row that fails the "
+            f"shape predicate reaches it raw: {argument}"
+        )
+        assert argument.endswith(f"ELSE {_CAST_SENTINEL} END"), (
+            f"a CAST argument has no digit fallback, so it is NULL-or-value "
+            f"rather than total: {argument}"
+        )
+
+
 # --- Family 1: read-only against data; SELECT-only; prod-target refused -------
 
 
@@ -81,8 +125,65 @@ def test_generated_sql_is_select_only(duckdb_file: Path):
     assert "tp_d_2" in sql and "tg_d_2" in sql
     assert "tp_m_2" in sql and "tg_m_2" in sql
     assert "tp_h_2" in sql and "tg_h_2" in sql
+    assert_every_cast_is_total(sql)
     # Idempotent: passing it through the guard again must not raise.
     assert assert_select_only(sql) == sql
+
+
+def test_a_shape_gated_cast_never_reaches_a_non_numeric_value(tmp_path: Path):
+    """#310: the profiling aggregate must not depend on lazy CASE evaluation.
+
+    Redshift evaluates a CASE branch's cast for rows the WHEN never selects,
+    which killed `explore map` and `explore profile` on any table holding one
+    ordinary varchar status column, and no offline test could catch it because
+    every other dialect honors the guard. This reproduces that engine here: it
+    lifts each CAST argument out of the generated statement and casts it over
+    every row, which is exactly the work Redshift does eagerly. A raise is the
+    bug; the fixed shape casts digits on every row and cannot raise anywhere.
+    """
+
+    import duckdb
+
+    from exmergo_dex_core.adapters.base import ColumnMeta
+
+    path = tmp_path / "statuses.duckdb"
+    conn = duckdb.connect(str(path))
+    conn.execute("CREATE TABLE orders (id INTEGER, status VARCHAR)")
+    conn.executemany(
+        "INSERT INTO orders VALUES (?, ?)",
+        [(1, "pending"), (2, "shipped"), (3, None), (4, "1700000000")],
+    )
+    conn.close()
+
+    adapter = DuckDBAdapter(path)
+    try:
+        sql, _plan = adapter._build_aggregate_sql(
+            "statuses.main.orders",
+            [
+                ColumnMeta("id", "INTEGER", True, 0),
+                ColumnMeta("status", "VARCHAR", True, 1),
+            ],
+            safe={"id"},
+            shape=set(),
+            type_req={"id", "status"},
+            key_shape_req={"status"},
+            temporal_req=set(),
+        )
+        arguments = cast_arguments(sql)
+        assert arguments, "the aggregate should carry the epoch/slash casts to check"
+        for argument in arguments:
+            # No CASE around it: every row of the column reaches the cast, the
+            # way the hostile dialect does it. The interpolation is the
+            # generator's own output, which is what this asserts about (S608).
+            adapter._run_select(f"SELECT CAST({argument} AS BIGINT) FROM orders")  # noqa: S608
+        # The statement itself still runs, and still measures: 1 of the 3
+        # non-null values is epoch-shaped and in range.
+        (row,) = adapter._run_select(sql)
+        values = dict(zip([d[0] for d in adapter._conn.description], row, strict=True))
+        assert values["ts_ep_s_1"] == 1.0  # of the epoch-shaped rows, all in range
+        assert values["ts_ns_1"] == pytest.approx(1 / 3)  # of the non-null rows
+    finally:
+        adapter.close()
 
 
 def test_type_contradiction_note_carries_no_raw_value(tmp_path: Path):
@@ -1974,6 +2075,9 @@ def test_bigquery_generated_sql_is_select_only(fake_bq_client):
     assert "su_" in sql and "sp_" in sql and "st_" in sql
     # Declared-type-vs-content statistics (#204) ride the same statement too.
     assert "ts_ns_" in sql and "ts_ep_s_" in sql
+    # ...with every cast in them total, so no dialect can raise on a
+    # non-numeric string in a profiled column (#310).
+    assert_every_cast_is_total(sql)
     # Heterogeneous-key-shape statistics (#205) ride the same statement too.
     assert "ks_uuid_" in sql and "ks_hex_" in sql
     # Temporal-continuity statistics (#206) ride the same statement too,
@@ -2400,6 +2504,9 @@ def test_snowflake_generated_sql_is_select_only(fake_sf_connection):
     assert sql.lstrip().upper().startswith("SELECT")
     assert "su_" in sql and "sp_" in sql and "st_" in sql
     assert "ts_ns_" in sql and "ts_ep_s_" in sql
+    # ...with every cast in them total, so no dialect can raise on a
+    # non-numeric string in a profiled column (#310).
+    assert_every_cast_is_total(sql)
     assert "ks_uuid_" in sql and "ks_hex_" in sql
     # Temporal-continuity statistics (#206) ride the same statement too.
     assert "tc_da_" in sql and "tp_d_" in sql and "tg_h_" in sql
@@ -2694,6 +2801,9 @@ def test_databricks_generated_sql_is_select_only(fake_databricks):
     assert sql.lstrip().upper().startswith("SELECT")
     assert "su_" in sql and "sp_" in sql and "st_" in sql
     assert "ts_ns_" in sql and "ts_ep_s_" in sql
+    # ...with every cast in them total, so no dialect can raise on a
+    # non-numeric string in a profiled column (#310).
+    assert_every_cast_is_total(sql)
     assert "ks_uuid_" in sql and "ks_hex_" in sql
     # Temporal-continuity statistics (#206) ride the same statement too.
     assert "tc_da_" in sql and "tp_d_" in sql and "tg_h_" in sql
@@ -2922,6 +3032,9 @@ def test_postgres_generated_sql_is_select_only(fake_pg_connection):
     assert sql.lstrip().upper().startswith("SELECT")
     assert "su_" in sql and "sp_" in sql and "st_" in sql
     assert "ts_ns_" in sql and "ts_ep_s_" in sql
+    # ...with every cast in them total, so no dialect can raise on a
+    # non-numeric string in a profiled column (#310).
+    assert_every_cast_is_total(sql)
     assert "ks_uuid_" in sql and "ks_hex_" in sql
     # Temporal-continuity statistics (#206) ride the same statement too.
     assert "tc_da_" in sql and "tp_d_" in sql and "tg_h_" in sql
@@ -3180,6 +3293,9 @@ def test_redshift_generated_sql_is_select_only(fake_redshift_connection):
     assert sql.lstrip().upper().startswith("SELECT")
     assert "su_" in sql and "sp_" in sql and "st_" in sql
     assert "ts_ns_" in sql and "ts_ep_s_" in sql
+    # ...with every cast in them total, so no dialect can raise on a
+    # non-numeric string in a profiled column (#310).
+    assert_every_cast_is_total(sql)
     assert "ks_uuid_" in sql and "ks_hex_" in sql
     # Temporal-continuity statistics (#206) ride the same statement too.
     assert "tc_da_" in sql and "tp_d_" in sql and "tg_h_" in sql

--- a/references/redshift.md
+++ b/references/redshift.md
@@ -158,6 +158,19 @@ no TABLESAMPLE, so a sampling knob would be a lie; the budget is the only
 bound. Empty tables are inventoried from `pg_class` even though
 `SVV_TABLE_INFO` omits them.
 
+**Every `CAST` in a generated aggregate is total, and has to stay that way.**
+Redshift evaluates a `CASE` branch's cast for rows the `WHEN` never selects,
+so guarding a cast behind a shape predicate inside a `CASE` does not protect
+it: the declared-type-vs-content probe did exactly that and died on any table
+with one non-numeric string in a profiled column (`Invalid digit, Value 'p',
+Pos 0, Type: Long`). There is no `TRY_CAST` here and the Python UDF escape
+hatch is end-of-support after 2026-06-30, so the discipline is in the
+expression shape: a cast's argument is itself a `CASE` yielding a digit-only
+string on every row, with a sentinel every predicate built on the cast
+rejects. It is enforced offline for all six adapters (see
+`assert_every_cast_is_total`), because no unit test can catch a dialect that
+disagrees with the standard about evaluation order.
+
 ## dbt builds
 
 `transform init` renders a `type: redshift` dev profile from whichever


### PR DESCRIPTION
## What this changes

`explore map --confirm` and `explore profile --confirm` fail against Redshift on
any table with a non-PII string column, and have since 1.6.2. Three defects sit
on that path and each one hid the next. This fixes all three.

### 1. The profiling aggregate no longer depends on lazy CASE evaluation

`type_contradiction_expressions` guarded every `CAST` behind a length-bounded
shape predicate inside a `CASE`, on the premise that a dialect without
`TRY_CAST` would then never evaluate the cast for a row the `WHEN` excluded.
Postgres honors that premise. Redshift does not: it evaluates the branch for
rows it never selects, so one ordinary varchar status or category column was
enough to fail the whole statement with `Invalid digit, Value 'p', Pos 0,
Type: Long`.

Every `CAST` the probe builds is now total. Its argument is a `CASE` that
yields a digit-only string on every row, so no evaluation order can reach a
cast with something it cannot parse:

    CAST(CASE WHEN "status" ~ '^-?[0-9]{1,10}$' THEN "status" ELSE '0' END AS BIGINT)

The sentinel is rejected by every predicate built on the cast (the epoch ranges
start in 2000, the slash-component test asks for `> 12`), so a row that reaches
the cast only because the cast is unconditional is never counted as evidence.
The "shaped versus not shaped" distinction the fractions' denominators need
moved to a separate uncast expression, which carries a string and so cannot
raise. One change in the shared expression builder covers all six adapters and
removes the standing assumption about lazy `CASE` evaluation everywhere.

Measurements are unchanged, denominators included.

### 2. A statement the warehouse refuses is now classified and named

A server-side SQL error escaped the adapters untranslated. Not being a
`DexError`, it fell through every entry in `_reason_overrides()` and arrived as
`reason: internal` ("not a deliberate dex refusal") with `data: {}`. Same class
of misclassification as #252.

Every adapter now raises a typed `WarehouseQueryError`, exported from the
package root and mapped to `reason: execution_failure`, carrying the server's
own message and error code trimmed to one line and capped. Redshift reads `M`
and `C` out of the driver payload rather than stringifying the whole dict.
Postgres gates on `sqlstate` and Databricks on `ServerOperationError`, so a
connection that died mid-statement is not reported as SQL the server rejected.
Profiling attaches the object name at the one place that knows it, since a map
run has a dozen statements in flight.

### 3. A failed billed command reports what it spent

`_record_elapsed` runs in a `finally`, so the wasted compute reached
`.dex/spend.jsonl` correctly, but the error envelope carried `data: {}`. On a
metered connector a caller reading only the envelope saw a failure that
appeared to cost nothing. Any error envelope now reports the settled spend,
as the budget-exhaustion path already did. Nothing billed means no spend block,
so a refusal that never reached the warehouse still says nothing rather than
claiming a zero.

### Also

The live suites assert through a new `assert_ok(rc, envelope)` helper that
prints `errors`, `reason`, and `warnings`. `assert rc == 0, envelope` is why
this took sixteen CI runs to diagnose: pytest elides the middle of a long
assertion message, and the middle of a profiling envelope is where `errors`
sits, so the Redshift message never once reached a CI log. 35 call sites across
all five connectors.

## Evidence

The offline suite passed before this change too, so the tests are the argument
here as much as the code is.

**The fix reproduces the bug offline.** A new test lifts each `CAST` argument
out of the generated statement and casts it over every row unconditionally,
which is exactly the work Redshift does eagerly. Under the old shape it raises
on DuckDB; under the new one it cannot raise anywhere. Alongside it,
`assert_every_cast_is_total` asserts the structural invariant on all six
adapters' generated SQL. Reverting the expression change fails 7 tests.

**The fix is behavior-preserving.** Old and new expressions were run side by
side on DuckDB across 12 fixtures (pure text, mixed epoch and text, MDY, DMY,
ambiguous slash dates, boundary epochs, all-null, empty table). All 14 aliases
agree on every fixture. End to end, `dex demo` plus `explore map` produces a
cache byte-identical to the pre-change run apart from `updated_at`, including
both of the demo warehouse's designed type-contradiction findings.

**The envelope defects are pinned.** A Redshift adapter test drives a real
`Invalid digit` payload through profiling and asserts the failure is typed,
carries the message and SQLSTATE, names the object, and still bills its
seconds to the ledger. A CLI-level test drives a refusal mid-profile on a
metered connector and asserts `reason`, the server's words, the object, and
`data.spend`, with its counterpart asserting that a refusal which never reached
the warehouse reports no spend at all.

## Not done here

**This needs the live Redshift suite to confirm it.** I have no credentials for
that workgroup, so the fix is unverified against a real Redshift. The offline
evidence above is as close as it gets. The residual risk is narrow: it is that
Redshift also pushes a cast down into `CASE` branches, which would defeat the
sentinel shape too. That is not its documented behavior and this is the
standard workaround for it, but only a green Redshift job proves it.

Separately, and left alone deliberately: `epoch_seconds_fraction` is measured
over the epoch-shaped rows, so a column that is half digits and half `pending`
reports "100% of values fall in the plausible unix-epoch range". That reads
wrong, but it is pre-existing and identical before and after this change, and
moving a detection threshold is not this fix's job. Worth its own issue.

## Related issues

Closes #310.

## Checklist

- [x] Tests pass (`uv run pytest` in `packages/dex-core`): 2197 passed, 65
      skipped. The 4 deselected `test_packaging.py` cases install wheels from
      PyPI and GitHub and cannot run on this machine (TLS trust store); the
      other 13 packaging tests pass.
- [x] Eval scoring-core tests pass (`uvx pytest evals`): 26 passed
- [x] If a safety path is touched, the spine still holds: read-only against
      data, cost-guarded, PII flagged not surfaced, propose-don't-impose. The
      generated SQL is still SELECT-only in every dialect, the aggregates still
      emit fractions rather than values, and spend now appears on more
      envelopes rather than fewer.
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free (checked in CI)
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or
      fixtures. One judgment call worth review: `WarehouseQueryError` passes the
      server's message through to the envelope, and a server message can quote
      the fragment of a value that offended it (`Invalid digit, Value 'p'`).
      That matches what an agent SQL failure already surfaces, and suppressing
      it is what made this class of failure undiagnosable. The class docstring
      states the tradeoff.
