### PR TITLE
SCRUM-1067-A PII refusal names the override entry that would clear it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **A PII refusal names the exact override entry that would clear the
+  column** ([#217]). The firewall's refusal was correct, and so is a name
+  detector flagging `account_name` on a table of companies or a team name in
+  a sports dataset; the false positive is the design working, and a human
+  reviewing it is the intended next step. But the message offered only two
+  routes, a measuring aggregate or dropping the column, both of which mean
+  not getting the answer. The third route, a reviewed `pii_overrides` entry,
+  existed and was never mentioned, and the cost of that omission was not the
+  override itself but the interval before anyone learned it existed: in
+  practice the caller opened a raw SQL client instead, where neither the
+  firewall nor the PII policy applies at all.
+
+  The refusal now says, for each blocking column, the exact entry that would
+  clear it, in flow-mapping YAML ready to paste under `pii_overrides:` in
+  `.dex/config.yml`: the fully qualified form always, and a scope-glob
+  pattern form alongside it when the same column name is flagged at the same
+  category on another dataset, which is the actual evidence a wider scope is
+  worth suggesting rather than a guess at how far a naming convention
+  reaches. The suggested scope is never wider than the schema that evidence
+  came from; a caller who knows it reaches further widens the glob
+  themselves. Both forms are text in the message, exactly like the existing
+  aggregate guidance beside them: nothing is applied, nothing changes about
+  what the query returns, and the entry is built from the column's identity
+  (dataset, column, category) alone, the same structural guarantee
+  `PIIFlag` itself already makes, so no value can appear in it by
+  construction.
+
+  The open question the issue posed, whether to suppress the suggestion for
+  the highest-severity categories, is answered no: nothing in the engine
+  ranks `PIICategory` by severity today, the block threshold is deliberately
+  uniform across every category on record, and the suggestion is inert text
+  a human must still copy, edit, and commit, exactly as much friction for
+  `credential` as for `name`. Inventing a severity tier to special-case here
+  would be new, untested policy with no existing basis, not a fix.
+
 ## [1.6.6] - 2026-08-15
 
 ### Fixed

--- a/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/query_firewall.py
@@ -41,11 +41,18 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from typing import NamedTuple
 
 import sqlglot
 from sqlglot import expressions as exp
 
-from ..cache import CACHE_SCHEMA_VERSION, Dataset, DexCache, match_identifier
+from ..cache import (
+    CACHE_SCHEMA_VERSION,
+    Dataset,
+    DexCache,
+    PIICategory,
+    match_identifier,
+)
 from ..config import QueryLimits
 from ..errors import DexError
 from . import PII_BLOCK_CONFIDENCE
@@ -193,12 +200,28 @@ _QUERY_ROOTS = tuple(
     if isinstance(c, type)
 )
 
+
 # A derived source (CTE, subquery, set operation) is represented by its output
 # taints: output column name (lowered) -> the flagged columns whose values can
-# reach it, each a (label, confidence) pair. Presence taints; whether a taint
-# blocks or merely warns is decided once, at the projection root, against
-# PII_BLOCK_CONFIDENCE. A physical source is the cached Dataset itself.
-_Taint = tuple[str, float]
+# reach it. Presence taints; whether a taint blocks or merely warns is decided
+# once, at the projection root, against PII_BLOCK_CONFIDENCE. A physical source
+# is the cached Dataset itself.
+#
+# `identifier` and `column` (alongside the display `label` and `confidence`)
+# are what let a blocking refusal name the exact `pii_overrides` entry that
+# would clear the column (issue #217): the label alone is the short table name
+# only, which is not enough to build a fully-qualified override safely (two
+# datasets can share a short name), so the fully-qualified identifier has to
+# ride along on the taint itself rather than being reconstructed later from a
+# string two datasets could both match.
+class _Taint(NamedTuple):
+    label: str
+    confidence: float
+    identifier: str
+    column: str
+    category: PIICategory
+
+
 _Outputs = dict[str, set[_Taint]]
 _Source = Dataset | dict
 
@@ -261,6 +284,51 @@ def recovery_hints(offending: list[str], cache: DexCache) -> list[str]:
     return sorted(suggestions)
 
 
+def _recurs_elsewhere(cache: DexCache, taint: _Taint) -> bool:
+    """Whether another dataset in the cache also flags a same-named column at
+    the same category, which is the evidence that a pattern override (a scope
+    glob, not one entry per table) is worth suggesting rather than a guess at
+    how far a naming convention actually reaches."""
+
+    return any(
+        dataset.identifier != taint.identifier
+        and any(
+            col.name.lower() == taint.column.lower()
+            and col.pii is not None
+            and col.pii.category == taint.category
+            for col in dataset.columns
+        )
+        for dataset in cache.datasets
+    )
+
+
+def _override_suggestion(taint: _Taint, cache: DexCache) -> str:
+    """The exact ``pii_overrides`` entry that would clear ``taint``'s column,
+    ready to paste into ``.dex/config.yml`` (issue #217).
+
+    Column identity only, in flow-mapping YAML so it fits inline in the
+    refusal's own prose: a fully-qualified path for the exact form, a bare
+    name and scope for the pattern form. Never a value: the taint carries
+    only what :class:`~..cache.PIIFlag` itself does (category and
+    confidence), the same structural guarantee that flag makes.
+
+    The pattern form is offered only when :func:`_recurs_elsewhere` finds the
+    same column name flagged at the same category on another dataset; the
+    suggested scope is that dataset's own schema (its identifier with the
+    table segment replaced by ``*``), never wider than what was actually
+    observed, so a caller who wants it to reach further widens the glob
+    themselves rather than dex guessing a blast radius nothing here proves.
+    """
+
+    exact = f"`- {{column: {taint.identifier}.{taint.column}}}`"
+    clause = f"for {taint.label}: {exact}"
+    if _recurs_elsewhere(cache, taint):
+        scope = taint.identifier.rsplit(".", 1)[0] + ".*"
+        pattern = f"`- {{column_name: {taint.column}, scope: {scope}}}`"
+        clause += f" (or, since it recurs across tables, {pattern})"
+    return clause
+
+
 def assert_query_shape(sql: str, *, dialect: str = "duckdb") -> exp.Expression:
     """Prove a statement is one read-only SELECT and return its parsed root.
 
@@ -306,9 +374,11 @@ def inspect_query(
     outputs = _query_outputs(root, {}, known, tables, dialect)
 
     flagged = {taint for taints in outputs.values() for taint in taints}
-    offending = sorted(
-        {label for label, conf in flagged if conf >= PII_BLOCK_CONFIDENCE}
+    blocking = sorted(
+        (t for t in flagged if t.confidence >= PII_BLOCK_CONFIDENCE),
+        key=lambda t: t.label,
     )
+    offending = [t.label for t in blocking]
     if offending:
         message = (
             "the projection would carry values from PII-flagged column(s): "
@@ -326,7 +396,9 @@ def inspect_query(
             )
         message += (
             " A column reviewed as not PII can be cleared durably with a "
-            "pii_overrides entry in .dex/config.yml."
+            "pii_overrides entry in .dex/config.yml, e.g. "
+            + "; ".join(_override_suggestion(t, cache) for t in blocking)
+            + "."
         )
         if cache.schema_version < CACHE_SCHEMA_VERSION and any(
             "(name)" in label for label in offending
@@ -338,11 +410,11 @@ def inspect_query(
         raise QueryRefusedError(message)
 
     warnings = [
-        f"{label} is PII-flagged at confidence {conf:g}, below the "
+        f"{t.label} is PII-flagged at confidence {t.confidence:g}, below the "
         f"{PII_BLOCK_CONFIDENCE:g} block threshold, so the projection ran. If "
         "its values are personal data, drop the column; if it is reviewed as "
         "not PII, record a pii_overrides entry in .dex/config.yml."
-        for label, conf in sorted(flagged)
+        for t in sorted(flagged, key=lambda t: t.label)
     ]
 
     new_sql, row_cap, capped = _apply_limit(root, limits.max_rows, dialect)
@@ -512,7 +584,15 @@ def _column_taint(dataset: Dataset, column_name: str) -> set[_Taint]:
                 return set()
             table = dataset.identifier.rsplit(".", 1)[-1]
             label = f"{table}.{col.name} ({col.pii.category.value})"
-            return {(label, col.pii.confidence)}
+            return {
+                _Taint(
+                    label,
+                    col.pii.confidence,
+                    dataset.identifier,
+                    col.name,
+                    col.pii.category,
+                )
+            }
     raise QueryRefusedError(
         f"column '{column_name}' is not in the profiled cache for "
         f"'{dataset.identifier}'; the cache may be stale, re-run `explore map`"

--- a/packages/dex-core/tests/guards/test_query_firewall.py
+++ b/packages/dex-core/tests/guards/test_query_firewall.py
@@ -335,6 +335,137 @@ def test_refusal_points_at_the_override_path(cache: DexCache):
     assert ".dex/config.yml" in message
 
 
+# --- issue #217: the refusal names the override that would clear it -----------
+
+
+def test_refusal_names_the_exact_override_entry(cache: DexCache):
+    """Acceptance: a PII refusal includes the exact override entry for the
+    named column, ready to paste under `pii_overrides:`."""
+
+    message = _refusal("SELECT NAME FROM RAW_HOSTS", cache)
+    assert "- {column: db.main.RAW_HOSTS.NAME}" in message
+
+
+def test_refusal_omits_the_pattern_form_when_the_column_does_not_recur(
+    cache: DexCache,
+):
+    # NAME is flagged only on RAW_HOSTS in this cache; nothing here suggests a
+    # wider scope is safe, so no pattern form is offered.
+    message = _refusal("SELECT NAME FROM RAW_HOSTS", cache)
+    assert "column_name:" not in message
+    assert "scope:" not in message
+
+
+@pytest.fixture
+def recurring_cache() -> DexCache:
+    """The same column name, flagged at the same category, on two tables in
+    one schema: the shape a pattern override actually fits."""
+
+    return DexCache(
+        datasets=[
+            Dataset(
+                identifier="db.main.RAW_HOSTS",
+                columns=[
+                    ColumnProfile(
+                        name="NAME",
+                        data_type="VARCHAR",
+                        pii=PIIFlag(category="name", confidence=0.6),
+                    ),
+                ],
+            ),
+            Dataset(
+                identifier="db.main.RAW_GUESTS",
+                columns=[
+                    ColumnProfile(
+                        name="NAME",
+                        data_type="VARCHAR",
+                        pii=PIIFlag(category="name", confidence=0.6),
+                    ),
+                ],
+            ),
+        ]
+    )
+
+
+def test_refusal_includes_the_pattern_form_when_the_column_recurs(
+    recurring_cache: DexCache,
+):
+    """Acceptance: the pattern form is included when the column shape
+    suggests it recurs across tables."""
+
+    message = _refusal("SELECT NAME FROM RAW_HOSTS", recurring_cache)
+    assert "- {column: db.main.RAW_HOSTS.NAME}" in message
+    assert "- {column_name: NAME, scope: db.main.*}" in message
+    assert "recurs across tables" in message
+
+
+def test_pattern_scope_is_never_wider_than_the_recurring_column_s_own_schema(
+    recurring_cache: DexCache,
+):
+    # The suggested scope is this column's own schema with the table wild-
+    # carded, not a blanket "*": dex never claims a wider blast radius than
+    # the evidence (another flagged dataset in the same schema) supports.
+    message = _refusal("SELECT NAME FROM RAW_HOSTS", recurring_cache)
+    assert "scope: db.main.*" in message
+    assert "scope: *" not in message
+
+
+def test_recurrence_requires_the_same_category_not_just_the_same_name():
+    # Two columns sharing a name but flagged under different categories are
+    # not the same convention; suggesting a shared scope would be a guess.
+    cache = DexCache(
+        datasets=[
+            Dataset(
+                identifier="db.main.RAW_HOSTS",
+                columns=[
+                    ColumnProfile(
+                        name="CODE",
+                        data_type="VARCHAR",
+                        pii=PIIFlag(category="name", confidence=0.6),
+                    ),
+                ],
+            ),
+            Dataset(
+                identifier="db.main.RAW_ORDERS",
+                columns=[
+                    ColumnProfile(
+                        name="CODE",
+                        data_type="VARCHAR",
+                        pii=PIIFlag(category="government_id", confidence=0.9),
+                    ),
+                ],
+            ),
+        ]
+    )
+    message = _refusal("SELECT CODE FROM RAW_HOSTS", cache)
+    assert "column_name:" not in message
+
+
+def test_refusal_suggests_one_entry_per_blocking_column(cache: DexCache):
+    """Two columns refused together each get their own named suggestion, not
+    one blended entry."""
+
+    extended = DexCache(
+        datasets=[
+            Dataset(
+                identifier=cache.datasets[0].identifier,
+                columns=[
+                    *cache.datasets[0].columns,
+                    ColumnProfile(
+                        name="EMAIL",
+                        data_type="VARCHAR",
+                        pii=PIIFlag(category="email", confidence=0.9),
+                    ),
+                ],
+            ),
+            *cache.datasets[1:],
+        ]
+    )
+    message = _refusal("SELECT NAME, EMAIL FROM RAW_HOSTS", extended)
+    assert "- {column: db.main.RAW_HOSTS.NAME}" in message
+    assert "- {column: db.main.RAW_HOSTS.EMAIL}" in message
+
+
 def test_stale_cache_refusal_hints_at_reprofiling():
     from exmergo_dex_core.cache import CACHE_SCHEMA_VERSION
 

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -867,6 +867,39 @@ def test_firewall_threshold_boundary_and_warning_carry_no_values():
     assert "AFRICA" not in warning and "@" not in warning
 
 
+def test_pii_refusal_s_suggested_override_carries_no_value():
+    # Issue #217: the refusal now names the exact pii_overrides entry that
+    # would clear the column. That entry is built from the dataset identifier,
+    # the column name, and the category only, the same structural guarantee
+    # PIIFlag itself makes (no value field exists anywhere to leak one).
+    from exmergo_dex_core.cache import ColumnProfile, Dataset, DexCache, PIIFlag
+    from exmergo_dex_core.config import QueryLimits
+    from exmergo_dex_core.guards.query_firewall import (
+        QueryRefusedError,
+        inspect_query,
+    )
+
+    cache = DexCache(
+        datasets=[
+            Dataset(
+                identifier="db.main.region",
+                columns=[
+                    ColumnProfile(
+                        name="r_name",
+                        data_type="VARCHAR",
+                        pii=PIIFlag(category="name", confidence=0.9),
+                    ),
+                ],
+            )
+        ]
+    )
+    with pytest.raises(QueryRefusedError) as excinfo:
+        inspect_query("SELECT r_name FROM region", cache, QueryLimits())
+    message = str(excinfo.value)
+    assert "column: db.main.region.r_name" in message
+    assert "AFRICA" not in message and "@" not in message
+
+
 def test_pii_override_is_config_only_and_survives_reprofiling(tmp_path: Path):
     # A hand-edit to the cache is overwritten by the next profile; only the
     # committed config entry durably clears a reviewed column, and the clear is


### PR DESCRIPTION
Closes : https://github.com/exmergo/dex/issues/217
The query firewall's PII refusal offered only two routes (aggregate or drop the column); the third route, a reviewed pii_overrides entry, existed and was never mentioned, so in practice callers opened a raw SQL client instead, where neither the firewall nor the PII policy applies.
The refusal now names, for each blocking column, the exact pii_overrides entry that would clear it, in flow-mapping YAML ready to paste into .dex/config.yml: the fully-qualified exact form always, plus a scope-glob pattern form when the same column name is flagged at the same category on another dataset.
The suggested scope is never wider than the schema that evidence came from (the dataset's own identifier with the table segment wildcarded); a caller who knows it reaches further widens the glob themselves.
Widened the internal _Taint type in guards/query_firewall.py from (label, confidence) to carry the fully-qualified identifier, column name, and category too, since the short table name in the display label alone isn't enough to build a safe, unambiguous override (two datasets can share a short name).
The suggestion is text in the message only, built from column identity (dataset, column, category) alone, the same structural guarantee PIIFlag itself makes, so no value can appear in it by construction. Nothing is applied automatically.
Answered the issue's open question (suppress for high-severity categories?) as no, documented in the CHANGELOG: nothing in the engine ranks PIICategory by severity today, the block threshold is deliberately uniform, and the suggestion is inert text a human must still copy/edit/commit regardless of category.

Before the fix: 
<img width="1647" height="92" alt="image" src="https://github.com/user-attachments/assets/4b748671-b82e-4c8b-a360-da58b3e7d15f" />
After : 
<img width="1642" height="137" alt="image" src="https://github.com/user-attachments/assets/b6de20c1-dbb5-4fd1-9954-cb97562a977f" />
