### PR TITLE
SCRUM-1069-explore profile: detect cumulative and snapshot measures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **`explore profile --check-cumulative` detects a running total or
+  point-in-time snapshot measure** ([#219]). A numeric column holding a
+  running total, an account balance, or a subscription's current MRR
+  profiles identically to one holding a per-row increment: same type, same
+  null fraction, same uniqueness. Summing it across rows is a common and
+  severely damaging misreading, and it silently inflates every aggregate
+  built on top of it.
+
+  The signal is structural: within an entity (a repeating, id-shaped column
+  that is not itself the table's own key) ordered by a temporal column, a
+  cumulative or snapshot measure almost never decreases from one observation
+  to the next, while a genuine per-row increment has natural ups and downs.
+  Measuring that needs a window-function scan over the table, so it sits on
+  the gated side of the free-versus-gated split: opt-in via
+  `--check-cumulative`, priced and confirmed the same way `--verify` prices
+  relationship overlap probes. The base profile always completes and is
+  returned first; the check runs as a second, individually skippable phase
+  against what the base scan already proved, and never blocks it. A table
+  missing an entity key or a temporal column is skipped with a note, not
+  silently reported as clean, and only fractions and observation counts ever
+  leave the engine, never a measure's value.
+
 ## [1.6.6] - 2026-08-15
 
 ### Fixed

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -259,6 +259,16 @@ def _build_parser() -> argparse.ArgumentParser:
                     sp.add_argument(
                         "--verify", action="store_true", default=argparse.SUPPRESS
                     )
+                # A running total or point-in-time snapshot profiles identically
+                # to a per-row increment; telling them apart needs a window-
+                # function scan over the table, so it is opt-in and priced like
+                # --verify rather than part of the always-free base profile.
+                if group == "explore" and name == "profile":
+                    sp.add_argument(
+                        "--check-cumulative",
+                        action="store_true",
+                        default=argparse.SUPPRESS,
+                    )
                 # Force a full re-profile even when the cache holds a fresh,
                 # schema-matching profile for a requested object (the default is
                 # skip-if-cached; --refresh is the escape hatch when the source

--- a/packages/dex-core/src/exmergo_dex_core/command_args.py
+++ b/packages/dex-core/src/exmergo_dex_core/command_args.py
@@ -271,6 +271,79 @@ def verify_handshake(
     return None
 
 
+def cumulative_handshake(
+    command: str,
+    adapter: Adapter,
+    estimate: float,
+    *,
+    candidate_count: int,
+    object_count: int,
+) -> ConfirmationRequest | None:
+    """The mid-command checkpoint for the cumulative-measure phase on billed
+    connectors, ``--check-cumulative``'s analogue of :func:`verify_handshake`.
+
+    The window-function probe can only be priced once profiling finds an
+    entity/temporal pair to test, so this runs after inference on an
+    already-confirmed command: the probes are dry-run priced (free), and only
+    when that estimate does not fit what remains of the confirmed budget does
+    it return the request, which the caller carries on its result as
+    ``pending_confirmation``. Otherwise the confirmed budget already covers
+    the check and the command proceeds in one pass.
+
+    A request rather than a raise, unlike :func:`billed_handshake`: the
+    profiles up to this point are already paid for, and raising would discard
+    them and bill the user twice for the same scan.
+    """
+
+    gate = cost_gate(adapter)
+    if gate is None or candidate_count == 0:
+        return None
+    try:
+        gate.preflight_phase(estimate)
+    except ConfirmationRequiredError as exc:
+        per_table = {"(cumulative-measure probes)": estimate}
+        describe = getattr(adapter, "describe_estimate", None)
+        if describe is not None:
+            data = {"command": command, **describe(estimate, per_table)}
+        else:
+            data = {
+                "command": command,
+                "estimated_bytes": estimate,
+                "per_table_bytes": per_table,
+            }
+        data.update(
+            {
+                "phase": "check-cumulative",
+                "candidate_count": candidate_count,
+                "object_count": object_count,
+                "hint": (
+                    f"found {candidate_count} entity/temporal candidate(s) "
+                    f"across {object_count} object(s); checking them all for "
+                    f"cumulative measures is estimated at {estimate:.0f} "
+                    f"{gate.paradigm.value} beyond what remains of the "
+                    "confirmed budget. Profiles are already saved to the "
+                    "exploration cache; re-run the same command with "
+                    f"--confirm --budget {math.ceil(exc.cost.estimate)} to "
+                    "profile and check in one pass (a re-run re-profiles "
+                    "first)"
+                ),
+            }
+        )
+        if (
+            gate.session_ceiling is not None
+            and gate.session_ceiling - gate.session_spent < exc.cost.estimate
+        ):
+            data.setdefault("notes", [])
+            data["notes"] = [
+                *data["notes"],
+                "the session budget is the binding ceiling; raising --budget "
+                "alone will not unlock this, raise the session budget in "
+                ".dex/config.yml instead",
+            ]
+        return ConfirmationRequest(cost=exc.cost, data=data)
+    return None
+
+
 def sample_handshake(
     command: str,
     adapter: Adapter,

--- a/packages/dex-core/src/exmergo_dex_core/engine.py
+++ b/packages/dex-core/src/exmergo_dex_core/engine.py
@@ -641,11 +641,16 @@ class DexEngine:
         *objects: str,
         refresh: bool = False,
         use_project: bool = False,
+        check_cumulative: bool = False,
     ) -> ProfileResult:
         from .explore import commands as explore
 
         return explore.profile(
-            self, list(objects), refresh=refresh, use_project=use_project
+            self,
+            list(objects),
+            refresh=refresh,
+            use_project=use_project,
+            check_cumulative=check_cumulative,
         )
 
     def relationships(

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -65,6 +65,7 @@ from ..progress import ProgressReporter
 from ..results import BudgetExhaustedError, ConfirmationRequest, to_envelope
 from ..storage import CacheUnreadableError, Document, ExploreStore, readable_cache
 from . import cluster as cluster_mod
+from . import cumulative as cumulative_mod
 from . import diagram as diagram_mod
 from . import inventory as inventory_mod
 from . import profile as profile_mod
@@ -202,6 +203,45 @@ def _verify_estimate(
     total = sum(
         query_estimate(sql)
         for sql in rel_mod.probe_statements(candidates, adapter.dialect)
+    )
+    return total, len(candidates), len(objects)
+
+
+def _cumulative_candidates(
+    datasets: list[Dataset],
+) -> tuple[list[tuple[Dataset, cumulative_mod.CumulativeCandidate]], list[str]]:
+    """Every dataset with an eligible entity/temporal/measure shape, paired
+    with the one candidate :func:`cumulative.find_candidate` chose for it, plus
+    the notes (skips, untested alternatives) each dataset contributed."""
+
+    candidates: list[tuple[Dataset, cumulative_mod.CumulativeCandidate]] = []
+    notes: list[str] = []
+    for dataset in datasets:
+        candidate, dataset_notes = cumulative_mod.find_candidate(dataset)
+        notes.extend(f"{dataset.identifier}: {note}" for note in dataset_notes)
+        if candidate is not None:
+            candidates.append((dataset, candidate))
+    return candidates, notes
+
+
+def _cumulative_estimate(
+    adapter: Adapter,
+    candidates: list[tuple[Dataset, cumulative_mod.CumulativeCandidate]],
+) -> tuple[float, int, int]:
+    """Free dry-run pricing of the window-function probes ``--check-cumulative``
+    would run, plus the candidate/object counts for the checkpoint payload;
+    zero-cost on free adapters or when nothing qualifies to probe.
+
+    Mirrors :func:`_verify_estimate`'s shape so the two opt-in probe phases
+    report cost the same way."""
+
+    objects = {dataset.identifier for dataset, _ in candidates}
+    query_estimate = getattr(adapter, "query_estimate", None)
+    if query_estimate is None or not candidates:
+        return 0.0, len(candidates), len(objects)
+    total = sum(
+        query_estimate(sql)
+        for sql in cumulative_mod.probe_statements(candidates, adapter.dialect)
     )
     return total, len(candidates), len(objects)
 
@@ -472,13 +512,18 @@ def profile(
     *,
     refresh: bool = False,
     use_project: bool = False,
+    check_cumulative: bool = False,
 ) -> ProfileResult:
     """Profile the named objects, reusing fresh cached profiles where they exist.
 
     Raises :class:`~..results.ConfirmationRequired` on a billed connector before
     anything is scanned. ``refresh`` forces a re-scan of objects the cache would
     otherwise serve; ``use_project`` folds the dbt project's declared joins,
-    grain, and metric lineage into the result.
+    grain, and metric lineage into the result. With ``check_cumulative``, every
+    profiled dataset with an eligible entity/temporal shape is probed for
+    measures that look like a running total or point-in-time snapshot; this
+    probe is priced only after profiling knows what to test, which is why it
+    can come back as ``pending_confirmation`` rather than raising.
     """
 
     store = engine.store
@@ -530,7 +575,7 @@ def profile(
     # query` on that table must work without a second warehouse scan. Only the
     # freshly profiled are merged; the reused already live in the cache untouched,
     # and prior relationships are preserved because profile runs no inference pass.
-    profiled, _cache, locator, persist_note = _profile_into_cache(
+    profiled, cache, locator, persist_note = _profile_into_cache(
         store, adapter, config, defs, stale, prior, now
     )
 
@@ -549,6 +594,75 @@ def profile(
             f"unchanged, profiled within {window:g}h); pass --refresh to force "
             "re-profiling"
         )
+
+    # Cumulative-measure check: opt-in and priced only once profiling knows
+    # what to test, so it runs after the base profile is already saved and can
+    # come back pending rather than discarding it.
+    cumulative_pending: ConfirmationRequest | None = None
+    if check_cumulative:
+        candidates, candidate_notes = _cumulative_candidates(datasets)
+        notes.extend(candidate_notes)
+        if candidates:
+            probe_cost, candidate_count, object_count = _cumulative_estimate(
+                adapter, candidates
+            )
+            cumulative_pending = command_args.cumulative_handshake(
+                "explore profile",
+                adapter,
+                probe_cost,
+                candidate_count=candidate_count,
+                object_count=object_count,
+            )
+            if cumulative_pending is None:
+                # A fresh-cached dataset here is `_split_fresh_stale`'s deep
+                # copy, not the object `cache.datasets` carries forward, so a
+                # note appended only to `dataset` would show in this result
+                # but never reach the save below. Resolve the cache's own
+                # object by identifier and append there too, guarding against
+                # a double append on the freshly profiled path, where they are
+                # the same object.
+                cache_by_id = {d.identifier: d for d in cache.datasets}
+                measured = 0
+                try:
+                    for dataset, candidate in candidates:
+                        fractions = cumulative_mod.measure_fractions(
+                            adapter,
+                            dataset.identifier,
+                            candidate,
+                            timeout_seconds=config.query.timeout_seconds,
+                        )
+                        cache_entry = cache_by_id.get(dataset.identifier)
+                        for text in cumulative_mod.cumulative_measure_notes(
+                            candidate, fractions
+                        ):
+                            # Idempotent: re-running the check on a dataset a
+                            # prior run already flagged must not pile up the
+                            # same sentence again.
+                            if text not in dataset.data_quality:
+                                dataset.data_quality.append(text)
+                            if (
+                                cache_entry is not None
+                                and cache_entry is not dataset
+                                and text not in cache_entry.data_quality
+                            ):
+                                cache_entry.data_quality.append(text)
+                            notes.append(f"{dataset.identifier}: {text}")
+                        measured += 1
+                except OverCeilingError:
+                    notes.append(
+                        f"budget exhausted after checking {measured} of "
+                        f"{len(candidates)} candidate(s) for cumulative "
+                        "measures; checked results are saved; raise --budget "
+                        "and re-run to finish (a re-run re-profiles first)"
+                    )
+                finally:
+                    locator = store.save_cache(cache, now=now)
+            else:
+                notes.append(
+                    "cumulative-measure check saved unverified; the check "
+                    "awaits confirmation (see hint)"
+                )
+
     result = ProfileResult(
         datasets=datasets,
         profiled_count=len(profiled),
@@ -557,6 +671,7 @@ def profile(
         updated_at=now.isoformat(),
         notes=notes,
         warnings=_override_mismatches(datasets, config.pii_overrides),
+        pending_confirmation=cumulative_pending,
     )
     return command_args.stamp_spend(result, adapter)
 
@@ -568,6 +683,7 @@ def cmd_profile(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
             args.objects,
             refresh=getattr(args, "refresh", False),
             use_project=getattr(args, "use_project", False),
+            check_cumulative=getattr(args, "check_cumulative", False),
         )
     )
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/cumulative.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/cumulative.py
@@ -1,0 +1,292 @@
+"""Explore: cumulative and snapshot measure detection (issue #219).
+
+A numeric column holding a running total or a point-in-time snapshot (a
+season-to-date score, a subscription's current MRR, an account balance, an
+inventory level) profiles identically to one holding a per-row increment:
+same type, same null fraction, same uniqueness, same min/max shape. Summing
+it across rows is a common and severely damaging misreading, and it is
+detectable from data.
+
+The signal: within an entity (a repeating, id-shaped column that is not
+itself the table's own key) ordered by a temporal column, a cumulative or
+snapshot measure almost never decreases from one observation to the next. A
+per-row increment, by contrast, has natural ups and downs. Measuring that
+needs a real scan (a window function over the table), so this sits on the
+gated side of the free-versus-gated split: opt-in via ``--check-cumulative``,
+priced and confirmed the same way ``--verify`` prices relationship overlap
+probes. The base profile always completes and is returned first; this runs
+as a second, individually skippable phase against what the base scan already
+proved, never blocking it.
+
+Only fractions and observation counts ever leave the engine. The probe is
+aggregate-only (``COUNT``/``CASE WHEN``); no row's measure value is ever
+projected, only compared and counted.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from ..adapters.base import Adapter, is_temporal_type
+from ..cache import ColumnProfile, Dataset
+from .profile import is_numeric_type
+from .relationships import _is_id_shaped
+
+# A fraction of within-entity consecutive decreases at or below this, over
+# enough observations, is read as "does not decrease" -- strong evidence of a
+# cumulative or snapshot measure -- rather than "happened not to decrease
+# yet". Small non-zero values still qualify: a snapshot can fall (a balance
+# after a withdrawal, MRR after a downgrade) without being a per-row
+# increment; what a genuine increment has that a snapshot does not is *many*
+# decreases, not zero exactly.
+_DECREASE_FRACTION_CEILING = 0.05
+# Below this many within-entity observations there is not enough evidence
+# either way; the column is skipped rather than reported on a handful of
+# rows. Mirrors this codebase's other "not enough evidence, fail closed"
+# floors (e.g. the temporal-alignment and heterogeneous-key checks).
+_MIN_OBSERVATIONS = 20
+
+
+class CumulativeCandidate(NamedTuple):
+    """One (entity, temporal) pair this dataset's shape supports, and every
+    eligible measure column paired with it. Only one pair is ever chosen per
+    dataset; see :func:`find_candidate`."""
+
+    entity: str
+    temporal: str
+    measures: list[str]
+
+
+def _is_single_column_key(col: ColumnProfile) -> bool:
+    return bool(col.is_unique) and col.null_fraction in (0.0, None)
+
+
+def _is_entity_key(col: ColumnProfile) -> bool:
+    """An id-shaped column that is *not itself, alone,* a proven key: a
+    partition of exactly one row per key could never show a within-entity
+    sequence, so a real entity key must repeat.
+
+    Deliberately not excluded for merely appearing in some *composite* proven
+    key: an entity column commonly pairs with the measure itself to look
+    "unique" (a snapshot that keeps changing per entity rarely repeats a
+    value), which is a coincidence of the data, not evidence the entity
+    column fails to repeat on its own.
+    """
+
+    if col.pii is not None:
+        return False
+    if not _is_id_shaped(col.name):
+        return False
+    return not _is_single_column_key(col)
+
+
+def _is_temporal_candidate(col: ColumnProfile) -> bool:
+    return col.pii is None and is_temporal_type(col.data_type)
+
+
+def _is_measure_candidate(col: ColumnProfile) -> bool:
+    """A numeric, non-key, non-id-shaped, non-PII column: the acceptance
+    criterion's auto-increment id is excluded here (it is a proven
+    single-column key, whatever its name), and an ordinary foreign key is
+    excluded by shape (id-shaped names are never measures). Not excluded for
+    merely appearing in a composite key, for the same reason
+    :func:`_is_entity_key` is not: pairing with the entity is the coincidence
+    a real running total or snapshot produces, not disqualifying evidence.
+    """
+
+    if col.pii is not None:
+        return False
+    if not is_numeric_type(col.data_type):
+        return False
+    if _is_id_shaped(col.name):
+        return False
+    return not _is_single_column_key(col)
+
+
+def find_candidate(dataset: Dataset) -> tuple[CumulativeCandidate | None, list[str]]:
+    """The one (entity, temporal) pair this dataset's shape supports, paired
+    with every eligible measure column, or ``None`` when an entity key or a
+    temporal column is missing outright -- the acceptance criterion that a
+    table lacking either is skipped, not silently reported as clean.
+
+    Returns ``(candidate, notes)``: ``notes`` states the skip when there is
+    one, and names any additional entity/temporal candidate this dataset had
+    that was not tested, so narrowing to one pair is never silent.
+
+    Where more than one entity or temporal candidate exists, the pair that is
+    also the table's own proven composite key wins -- the strongest possible
+    evidence that this table really is one row per entity per period.
+    Failing that, the first of each, in column order.
+    """
+
+    entities = [c.name for c in dataset.columns if _is_entity_key(c)]
+    temporals = [c.name for c in dataset.columns if _is_temporal_candidate(c)]
+
+    if not entities or not temporals:
+        missing = []
+        if not entities:
+            missing.append("entity key")
+        if not temporals:
+            missing.append("temporal column")
+        return None, [
+            "cumulative-measure check skipped: no "
+            + " or ".join(missing)
+            + " found; detecting a running total needs both"
+        ]
+
+    composite_pair = next(
+        (
+            (e, t)
+            for key in dataset.composite_keys
+            for e in entities
+            for t in temporals
+            if e in key and t in key
+        ),
+        None,
+    )
+    entity, temporal = composite_pair or (entities[0], temporals[0])
+
+    measures = [
+        c.name
+        for c in dataset.columns
+        if c.name not in (entity, temporal) and _is_measure_candidate(c)
+    ]
+
+    notes: list[str] = []
+    skipped_entities = [e for e in entities if e != entity]
+    skipped_temporals = [t for t in temporals if t != temporal]
+    if skipped_entities or skipped_temporals:
+        skipped = ", ".join(skipped_entities + skipped_temporals)
+        notes.append(
+            f"cumulative-measure check tested only {entity} x {temporal}; "
+            f"also eligible but not tested: {skipped}"
+        )
+    if not measures:
+        notes.append(
+            f"cumulative-measure check skipped: {entity} x {temporal} has an "
+            "entity key and a temporal column but no eligible numeric "
+            "measure column"
+        )
+        return None, notes
+    return CumulativeCandidate(entity, temporal, measures), notes
+
+
+def probe_sql(identifier: str, candidate: CumulativeCandidate) -> str:
+    """Aggregate-only SQL (DuckDB-flavored; transpiled per dialect by
+    :func:`probe_statements`) computing, for every measure in one pass, the
+    fraction of within-entity consecutive observations where the value
+    decreased. Never projects a measure's own value: each is only compared,
+    inside a ``CASE WHEN``, to its own lag."""
+
+    table = _quote_identifier(identifier)
+    entity = _quote_part(candidate.entity)
+    temporal = _quote_part(candidate.temporal)
+
+    lag_cols = []
+    counts = []
+    for i, measure in enumerate(candidate.measures):
+        m = _quote_part(measure)
+        cur, prev = f"m_{i}", f"p_{i}"
+        lag_cols.append(
+            f"{m} AS {cur}, LAG({m}) OVER (PARTITION BY {entity} "
+            f"ORDER BY {temporal}) AS {prev}"
+        )
+        counts.append(
+            f"COUNT(CASE WHEN {prev} IS NOT NULL AND {cur} IS NOT NULL "
+            f"THEN 1 END) AS obs_{i}, "
+            f"COUNT(CASE WHEN {prev} IS NOT NULL AND {cur} IS NOT NULL "
+            f"AND {cur} < {prev} THEN 1 END) AS dec_{i}"
+        )
+
+    return (
+        "WITH lagged AS (SELECT "  # noqa: S608
+        + ", ".join(lag_cols)
+        + f" FROM {table}) SELECT "
+        + ", ".join(counts)
+        + " FROM lagged"
+    )
+
+
+def probe_statements(
+    datasets_and_candidates: list[tuple[Dataset, CumulativeCandidate]], dialect: str
+) -> list[str]:
+    """The exact SQL :func:`measure_fractions` will run, one statement per
+    dataset, in the adapter's dialect. Exists so a billed caller can dry-run
+    the probes for a cost estimate before confirming the spend."""
+
+    return [
+        _transpile_probe(probe_sql(dataset.identifier, candidate), dialect)
+        for dataset, candidate in datasets_and_candidates
+    ]
+
+
+def measure_fractions(
+    adapter: Adapter,
+    identifier: str,
+    candidate: CumulativeCandidate,
+    *,
+    timeout_seconds: float = 30.0,
+) -> dict[str, tuple[float, int]]:
+    """Run one probe and return, per measure, ``(decrease_fraction,
+    observations)``. A measure with zero within-entity observations (every
+    row is its entity's first, or every prior value was null) is omitted
+    rather than reported at a meaningless 0/0."""
+
+    sql = _transpile_probe(probe_sql(identifier, candidate), adapter.dialect)
+    result = adapter.run_query(sql, max_rows=1, timeout_seconds=timeout_seconds)
+    values = dict(zip(result.columns, result.cells[0], strict=True))
+    fractions: dict[str, tuple[float, int]] = {}
+    for i, measure in enumerate(candidate.measures):
+        obs = int(values[f"obs_{i}"] or 0)
+        if obs <= 0:
+            continue
+        decreases = int(values[f"dec_{i}"] or 0)
+        fractions[measure] = (decreases / obs, obs)
+    return fractions
+
+
+def cumulative_measure_notes(
+    candidate: CumulativeCandidate, fractions: dict[str, tuple[float, int]]
+) -> list[str]:
+    """A data-quality observation per measure that never (or almost never)
+    decreases within an entity over time: the consequence named, never a
+    value. Silent for a measure with too little evidence, or whose decreases
+    are too common to read as a running total."""
+
+    notes = []
+    for measure in candidate.measures:
+        result = fractions.get(measure)
+        if result is None:
+            continue
+        fraction, observations = result
+        if observations < _MIN_OBSERVATIONS or fraction > _DECREASE_FRACTION_CEILING:
+            continue
+        notes.append(
+            f"{measure} looks cumulative or a point-in-time snapshot: over "
+            f"{observations} consecutive observations within "
+            f"{candidate.entity}, ordered by {candidate.temporal}, only "
+            f"{fraction:.1%} decreased; summing it across rows multiplies "
+            "the true value -- take the latest value per entity, or "
+            "difference consecutive values to recover the increment"
+        )
+    return notes
+
+
+def _transpile_probe(sql: str, dialect: str) -> str:
+    """Render the DuckDB-flavored probe in the active connector's dialect.
+    Identity on DuckDB itself, matching ``relationships._transpile_probe``."""
+
+    if dialect == "duckdb":
+        return sql
+    import sqlglot
+
+    return sqlglot.transpile(sql, read="duckdb", write=dialect)[0]
+
+
+def _quote_identifier(identifier: str) -> str:
+    return ".".join(_quote_part(p) for p in identifier.split("."))
+
+
+def _quote_part(name: str) -> str:
+    escaped = name.replace('"', '""')
+    return f'"{escaped}"'

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -840,6 +840,84 @@ def test_verify_handshake_uses_the_adapters_estimate_description():
     assert pending.cost.estimate == 13.0
 
 
+def test_cumulative_handshake_uses_the_adapters_estimate_description():
+    # `--check-cumulative`'s phase checkpoint, exercised the same way as
+    # `verify_handshake` above: a connector that speaks credits/seconds
+    # describes its own estimate, and the checkpoint payload keeps that shape
+    # while overlaying the check-cumulative phase fields.
+    gate = CostGate(
+        paradigm=Paradigm.COMPUTE_TIME,
+        ceiling=10.0,
+        session_ceiling=None,
+        session_spent=0.0,
+        confirmed=True,
+        connector="snowflake",
+        command="explore profile",
+    )
+    gate.charge(8.0)
+
+    class StubAdapter:
+        cost_gate = gate
+
+        def describe_estimate(self, estimate, per_table):
+            return {
+                "estimated_seconds": estimate,
+                "per_table_seconds": per_table,
+                "notes": ["seconds are a coarse translation"],
+            }
+
+    from exmergo_dex_core import command_args
+
+    pending = command_args.cumulative_handshake(
+        "explore profile", StubAdapter(), 5.0, candidate_count=2, object_count=2
+    )
+    # A request, not a raise: the profiles this phase follows are already paid for.
+    assert pending is not None
+    assert pending.data["estimated_seconds"] == 5.0
+    assert pending.data["per_table_seconds"] == {"(cumulative-measure probes)": 5.0}
+    assert pending.data["phase"] == "check-cumulative"
+    assert pending.data["candidate_count"] == 2
+    assert pending.data["object_count"] == 2
+    assert "notes" in pending.data
+    assert pending.cost.estimate == 13.0
+
+
+def test_cumulative_handshake_stays_none_on_a_free_connector_or_no_candidates():
+    from exmergo_dex_core import command_args
+
+    class FreeAdapter:
+        cost_gate = None
+
+    assert (
+        command_args.cumulative_handshake(
+            "explore profile", FreeAdapter(), 5.0, candidate_count=1, object_count=1
+        )
+        is None
+    )
+
+    gate = CostGate(
+        paradigm=Paradigm.COMPUTE_TIME,
+        ceiling=10.0,
+        session_ceiling=None,
+        session_spent=0.0,
+        confirmed=True,
+        connector="snowflake",
+        command="explore profile",
+    )
+
+    class BilledAdapter:
+        cost_gate = gate
+
+    # Nothing eligible to probe: no checkpoint to ask for even on a billed
+    # connector, so this never blocks a run whose profile found no candidate.
+    assert (
+        command_args.cumulative_handshake(
+            "explore profile", BilledAdapter(), 5.0, candidate_count=0, object_count=0
+        )
+        is None
+    )
+
+
 def test_duckdb_map_verify_stays_confirmation_free(duckdb_file: Path, capsys):
     from exmergo_dex_core.cli import main
 

--- a/packages/dex-core/tests/explore/test_cumulative.py
+++ b/packages/dex-core/tests/explore/test_cumulative.py
@@ -1,0 +1,482 @@
+"""explore profile --check-cumulative: cumulative and snapshot measure
+detection (issue #219).
+
+A running total or a point-in-time snapshot profiles identically to a
+per-row increment (same type, null fraction, uniqueness, min/max), and
+summing it across rows is a common and damaging misreading. The signal is
+structural: within an entity ordered by a temporal column, such a measure
+almost never decreases. These tests cover the pure eligibility functions,
+the probe SQL and its transpile, and the end-to-end detection pipeline
+against a real DuckDB table.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.cache import ColumnProfile, Dataset, PIICategory, PIIFlag
+from exmergo_dex_core.cli import main
+from exmergo_dex_core.explore.cumulative import (
+    CumulativeCandidate,
+    cumulative_measure_notes,
+    find_candidate,
+    measure_fractions,
+    probe_sql,
+    probe_statements,
+)
+
+
+def _run(argv: list[str], capsys) -> dict:
+    rc = main(argv)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0, payload
+    assert payload["status"] == "ok", payload
+    return payload
+
+
+def _col(name: str, data_type: str, **kwargs) -> ColumnProfile:
+    return ColumnProfile(name=name, data_type=data_type, **kwargs)
+
+
+# --- eligibility: entity / temporal / measure candidates ---------------------
+
+
+def test_find_candidate_pairs_the_id_shaped_repeating_column_with_the_date():
+    dataset = Dataset(
+        identifier="db.main.balances",
+        columns=[
+            _col("account_id", "INTEGER", is_unique=False, null_fraction=0.0),
+            _col("snapshot_date", "DATE", is_unique=False, null_fraction=0.0),
+            _col("balance", "DOUBLE", is_unique=False, null_fraction=0.0),
+        ],
+    )
+    candidate, notes = find_candidate(dataset)
+    assert candidate == CumulativeCandidate("account_id", "snapshot_date", ["balance"])
+    assert notes == []
+
+
+def test_find_candidate_excludes_an_auto_increment_id_from_measures():
+    """A proven single-column key is never a measure, whatever it is named
+    (the acceptance criterion): only the genuine running-total column is
+    offered as a candidate measure."""
+
+    dataset = Dataset(
+        identifier="db.main.events",
+        columns=[
+            _col("event_id", "INTEGER", is_unique=True, null_fraction=0.0),
+            _col("account_id", "INTEGER", is_unique=False, null_fraction=0.0),
+            _col("event_date", "DATE", is_unique=False, null_fraction=0.0),
+            _col("running_total", "DOUBLE", is_unique=False, null_fraction=0.0),
+        ],
+    )
+    candidate, notes = find_candidate(dataset)
+    assert candidate is not None
+    assert candidate.entity == "account_id"
+    assert candidate.measures == ["running_total"]
+    assert notes == []
+
+
+def test_find_candidate_does_not_exclude_a_column_for_pairing_into_a_composite_key():
+    """An entity naturally pairs with its own evolving measure to look
+    unique (a drifting balance rarely repeats per account), which is the
+    coincidence a real running total or snapshot produces -- not evidence
+    that the entity or measure fails its own eligibility. Regression for a
+    bug where composite-key membership wrongly excluded both."""
+
+    dataset = Dataset(
+        identifier="db.main.balances",
+        columns=[
+            _col("account_id", "INTEGER", is_unique=False, null_fraction=0.0),
+            _col("snapshot_date", "DATE", is_unique=False, null_fraction=0.0),
+            _col("balance", "DOUBLE", is_unique=False, null_fraction=0.0),
+        ],
+        composite_keys=[["account_id", "balance"]],
+    )
+    candidate, _notes = find_candidate(dataset)
+    assert candidate is not None
+    assert candidate.entity == "account_id"
+    assert candidate.measures == ["balance"]
+
+
+def test_find_candidate_prefers_the_pair_that_is_the_proven_composite_key():
+    dataset = Dataset(
+        identifier="db.main.balances",
+        columns=[
+            _col("account_id", "INTEGER", is_unique=False, null_fraction=0.0),
+            _col("region_id", "INTEGER", is_unique=False, null_fraction=0.0),
+            _col("snapshot_date", "DATE", is_unique=False, null_fraction=0.0),
+            _col("as_of_ts", "TIMESTAMP", is_unique=False, null_fraction=0.0),
+            _col("balance", "DOUBLE", is_unique=False, null_fraction=0.0),
+        ],
+        composite_keys=[["region_id", "as_of_ts"]],
+    )
+    candidate, notes = find_candidate(dataset)
+    assert candidate is not None
+    assert (candidate.entity, candidate.temporal) == ("region_id", "as_of_ts")
+    assert any("tested only region_id x as_of_ts" in n for n in notes)
+    assert "account_id" in notes[0] and "snapshot_date" in notes[0]
+
+
+@pytest.mark.parametrize(
+    ("columns", "expected_missing"),
+    [
+        (
+            [_col("amount", "DOUBLE", is_unique=False, null_fraction=0.0)],
+            "entity key or temporal column",
+        ),
+        (
+            [
+                _col("account_id", "INTEGER", is_unique=False, null_fraction=0.0),
+                _col("amount", "DOUBLE", is_unique=False, null_fraction=0.0),
+            ],
+            "temporal column",
+        ),
+        (
+            [
+                _col("snapshot_date", "DATE", is_unique=False, null_fraction=0.0),
+                _col("amount", "DOUBLE", is_unique=False, null_fraction=0.0),
+            ],
+            "entity key",
+        ),
+    ],
+)
+def test_find_candidate_states_grammatically_correct_skip_when_a_shape_is_missing(
+    columns, expected_missing
+):
+    dataset = Dataset(identifier="db.main.plain", columns=columns)
+    candidate, notes = find_candidate(dataset)
+    assert candidate is None
+    assert len(notes) == 1
+    assert f"no {expected_missing} found" in notes[0]
+    # No article ever precedes the bare noun ("an entity key", "a temporal
+    # column"): the missing-shape phrase must read as a plain noun list.
+    assert "no an " not in notes[0]
+    assert "no a " not in notes[0]
+
+
+def test_find_candidate_skips_with_a_note_when_no_measure_column_is_eligible():
+    dataset = Dataset(
+        identifier="db.main.pairs",
+        columns=[
+            _col("account_id", "INTEGER", is_unique=False, null_fraction=0.0),
+            _col("snapshot_date", "DATE", is_unique=False, null_fraction=0.0),
+        ],
+    )
+    candidate, notes = find_candidate(dataset)
+    assert candidate is None
+    assert any("no eligible numeric measure column" in n for n in notes)
+
+
+def test_find_candidate_excludes_pii_columns_from_every_role():
+    dataset = Dataset(
+        identifier="db.main.pii",
+        columns=[
+            _col(
+                "account_id",
+                "INTEGER",
+                is_unique=False,
+                null_fraction=0.0,
+                pii=PIIFlag(category=PIICategory.NAME, confidence=0.9),
+            ),
+            _col("snapshot_date", "DATE", is_unique=False, null_fraction=0.0),
+            _col("balance", "DOUBLE", is_unique=False, null_fraction=0.0),
+        ],
+    )
+    candidate, notes = find_candidate(dataset)
+    assert candidate is None
+    assert any("no entity key found" in n for n in notes)
+
+
+def test_find_candidate_excludes_an_ordinary_foreign_key_from_measures_by_shape():
+    """An id-shaped column is never treated as a measure even when numeric
+    and non-unique -- an ordinary foreign key, not a running total."""
+
+    dataset = Dataset(
+        identifier="db.main.orders",
+        columns=[
+            _col("customer_id", "INTEGER", is_unique=False, null_fraction=0.0),
+            _col("order_date", "DATE", is_unique=False, null_fraction=0.0),
+            _col("product_id", "INTEGER", is_unique=False, null_fraction=0.0),
+            _col("running_total", "DOUBLE", is_unique=False, null_fraction=0.0),
+        ],
+    )
+    candidate, _notes = find_candidate(dataset)
+    assert candidate is not None
+    assert candidate.measures == ["running_total"]
+
+
+# --- probe SQL: authored once, transpiled per dialect -------------------------
+
+
+def test_probe_sql_never_projects_a_measure_value_only_lag_and_compare():
+    candidate = CumulativeCandidate("account_id", "snapshot_date", ["balance", "mrr"])
+    sql = probe_sql("db.main.balances", candidate)
+    assert "LAG(" in sql
+    assert "PARTITION BY" in sql and "ORDER BY" in sql
+    # Only COUNT/CASE WHEN comparisons leave the WITH clause; no bare SELECT
+    # of a measure column outside the lag computation.
+    assert sql.count("COUNT(") == 4  # obs + dec, per measure
+    assert '"balance"' in sql and '"mrr"' in sql
+
+
+def test_probe_statements_transpiles_to_postgres_and_stays_select_only():
+    import sqlglot
+
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    candidate = CumulativeCandidate("account_id", "snapshot_date", ["balance"])
+    dataset = Dataset(identifier="dexdb.app.balances", columns=[])
+    statements = probe_statements([(dataset, candidate)], "postgres")
+    assert len(statements) == 1
+    sql = statements[0]
+    assert_select_only(sql, dialect="postgres")
+    parsed = sqlglot.parse_one(sql, read="postgres")
+    assert parsed is not None
+    assert "balances" in sql
+
+
+def test_probe_statements_is_identity_on_duckdb():
+    candidate = CumulativeCandidate("account_id", "snapshot_date", ["balance"])
+    dataset = Dataset(identifier="db.main.balances", columns=[])
+    [sql] = probe_statements([(dataset, candidate)], "duckdb")
+    assert sql == probe_sql(dataset.identifier, candidate)
+
+
+# --- measure_fractions / cumulative_measure_notes: pure aggregation ----------
+
+
+class _StubAdapter:
+    """Just the surface `measure_fractions` touches: one canned aggregate row."""
+
+    dialect = "duckdb"
+
+    def __init__(self, columns: list[str], row: list):
+        self._columns = columns
+        self._row = row
+
+    def run_query(self, sql: str, *, max_rows: int, timeout_seconds: float):
+        from exmergo_dex_core.adapters.base import QueryResult
+
+        return QueryResult(
+            columns=self._columns,
+            types=["BIGINT"] * len(self._columns),
+            cells=[self._row],
+            truncated=False,
+        )
+
+
+def test_measure_fractions_omits_a_measure_with_zero_observations():
+    candidate = CumulativeCandidate("account_id", "snapshot_date", ["balance", "delta"])
+    adapter = _StubAdapter(
+        columns=["obs_0", "dec_0", "obs_1", "dec_1"],
+        row=[100, 3, 0, 0],
+    )
+    fractions = measure_fractions(adapter, "db.main.balances", candidate)
+    assert set(fractions) == {"balance"}
+    assert fractions["balance"] == (0.03, 100)
+
+
+@pytest.mark.parametrize(
+    ("fraction", "observations", "expect_note"),
+    [
+        (0.0, 780, True),  # never decreases, plenty of evidence
+        (0.03, 100, True),  # a real snapshot can fall a little
+        (0.05, 100, True),  # exactly at the ceiling still qualifies
+        (0.051, 100, False),  # just over the ceiling: too many decreases
+        (0.25, 1000, False),  # a genuine per-row increment
+        (0.0, 19, False),  # not enough observations, even at zero decreases
+    ],
+)
+def test_cumulative_measure_notes_decisions(fraction, observations, expect_note):
+    candidate = CumulativeCandidate("account_id", "snapshot_date", ["balance"])
+    notes = cumulative_measure_notes(candidate, {"balance": (fraction, observations)})
+    assert bool(notes) is expect_note
+    if expect_note:
+        assert "balance" in notes[0]
+        assert "cumulative" in notes[0] or "snapshot" in notes[0]
+        # The rate is reported as a percentage; the raw fraction never appears.
+        assert f"{fraction:.1%}" in notes[0]
+
+
+def test_cumulative_measure_notes_silent_for_a_measure_with_no_evidence():
+    candidate = CumulativeCandidate("account_id", "snapshot_date", ["balance"])
+    assert cumulative_measure_notes(candidate, {}) == []
+
+
+# --- end-to-end: a real DuckDB table, genuine cumulative vs. incrementing ----
+
+
+def _build_account_activity(path: Path) -> None:
+    duckdb = pytest.importorskip("duckdb")
+    conn = duckdb.connect(str(path))
+    conn.execute(
+        "CREATE TABLE account_activity ("
+        "event_id INTEGER, account_id INTEGER, event_date DATE, "
+        "balance DOUBLE, daily_txn DOUBLE)"
+    )
+    rows = []
+    event_id = 1
+    for account in range(1, 6):
+        balance = 1000.0
+        for day in range(160):  # 5 accounts * 160 days = 800 rows, 795 observations
+            # A running total: goes up almost every day, one small dip.
+            delta = -50.0 if day == 80 else 10.0
+            balance += delta
+            # A genuine per-row increment: naturally goes up and down.
+            txn = 20.0 if day % 2 == 0 else -15.0
+            event_date = date(2024, 1, 1) + timedelta(days=day)
+            rows.append((event_id, account, event_date, balance, txn))
+            event_id += 1
+    conn.executemany("INSERT INTO account_activity VALUES (?, ?, ?, ?, ?)", rows)
+    conn.close()
+
+
+def test_end_to_end_flags_the_genuinely_cumulative_column_and_spares_the_increment(
+    tmp_path: Path,
+):
+    path = tmp_path / "activity.duckdb"
+    _build_account_activity(path)
+
+    from exmergo_dex_core.adapters.duckdb import DuckDBAdapter
+    from exmergo_dex_core.explore.profile import profile as run_profile
+
+    adapter = DuckDBAdapter(path)
+    try:
+        identifiers = [m.identifier for m in adapter.list_objects()]
+        [dataset] = run_profile(adapter, identifiers)
+        candidate, notes = find_candidate(dataset)
+        assert candidate is not None
+        assert notes == []
+        assert set(candidate.measures) == {"balance", "daily_txn"}
+        assert "event_id" not in candidate.measures
+
+        fractions = measure_fractions(adapter, dataset.identifier, candidate)
+        measure_notes = cumulative_measure_notes(candidate, fractions)
+    finally:
+        adapter.close()
+
+    joined = " ".join(measure_notes)
+    assert "balance" in joined and "looks cumulative" in joined
+    assert "daily_txn" not in joined
+
+
+def test_check_cumulative_flag_annotates_the_profile_and_persists_the_note(
+    tmp_path: Path, capsys
+):
+    path = tmp_path / "activity.duckdb"
+    _build_account_activity(path)
+
+    data = _run(
+        [
+            "explore",
+            "profile",
+            "account_activity",
+            "--check-cumulative",
+            "--path",
+            str(path),
+        ],
+        capsys,
+    )["data"]
+    [dataset] = data["datasets"]
+    assert any("looks cumulative" in n for n in dataset["data_quality"])
+
+    # Re-running plain `explore profile` (served from cache) still carries the
+    # note: the check-cumulative phase persisted it, not just returned it.
+    data = _run(
+        ["explore", "profile", "account_activity", "--path", str(path)], capsys
+    )["data"]
+    [dataset] = data["datasets"]
+    assert any("looks cumulative" in n for n in dataset["data_quality"])
+
+
+def test_check_cumulative_is_silent_without_the_flag(tmp_path: Path, capsys):
+    path = tmp_path / "activity.duckdb"
+    _build_account_activity(path)
+
+    data = _run(
+        ["explore", "profile", "account_activity", "--path", str(path)], capsys
+    )["data"]
+    [dataset] = data["datasets"]
+    assert not any("cumulative" in n for n in dataset["data_quality"])
+
+
+def test_check_cumulative_persists_a_note_on_an_already_fresh_cached_dataset(
+    tmp_path: Path, capsys
+):
+    """Regression: a dataset served from the freshness cache is a deep copy
+    (`_split_fresh_stale.model_copy`), not the object the cache write carries
+    forward. Appending a note only to that copy would show it in this run's
+    payload but lose it the moment the cache saves -- exactly the case a
+    plain profile first, then `--check-cumulative` second, hits."""
+
+    path = tmp_path / "activity.duckdb"
+    _build_account_activity(path)
+
+    # Plain profile first: caches the object with no check-cumulative note.
+    data = _run(
+        ["explore", "profile", "account_activity", "--path", str(path)], capsys
+    )["data"]
+    assert data["cache_hit_count"] == 0
+    assert data["profiled_count"] == 1
+
+    # Second call is served from the freshness cache (profiled_count == 0),
+    # which is exactly the path that lost the note.
+    data = _run(
+        [
+            "explore",
+            "profile",
+            "account_activity",
+            "--check-cumulative",
+            "--path",
+            str(path),
+        ],
+        capsys,
+    )["data"]
+    assert data["cache_hit_count"] == 1
+    assert data["profiled_count"] == 0
+    [dataset] = data["datasets"]
+    assert any("looks cumulative" in n for n in dataset["data_quality"])
+
+    # And it must have actually reached the persisted cache, not just this
+    # run's in-memory payload.
+    data = _run(
+        ["explore", "profile", "account_activity", "--path", str(path)], capsys
+    )["data"]
+    [dataset] = data["datasets"]
+    assert any("looks cumulative" in n for n in dataset["data_quality"])
+
+
+def test_check_cumulative_run_twice_does_not_duplicate_the_note(tmp_path: Path, capsys):
+    """Regression: running `--check-cumulative` again on a dataset a prior
+    run already flagged must not pile up a second copy of the same
+    sentence. The check is idempotent whether the dataset was freshly
+    profiled this run or served from the freshness cache."""
+
+    path = tmp_path / "activity.duckdb"
+    _build_account_activity(path)
+
+    argv = [
+        "explore",
+        "profile",
+        "account_activity",
+        "--check-cumulative",
+        "--path",
+        str(path),
+    ]
+    _run(argv, capsys)
+    data = _run(argv, capsys)["data"]
+    [dataset] = data["datasets"]
+    cumulative_notes = [n for n in dataset["data_quality"] if "looks cumulative" in n]
+    assert len(cumulative_notes) == 1
+
+    # And the duplicate-free state is what actually persisted.
+    data = _run(
+        ["explore", "profile", "account_activity", "--path", str(path)], capsys
+    )["data"]
+    [dataset] = data["datasets"]
+    cumulative_notes = [n for n in dataset["data_quality"] if "looks cumulative" in n]
+    assert len(cumulative_notes) == 1


### PR DESCRIPTION
Closes : https://github.com/exmergo/dex/issues/219
`explore profile --check-cumulative` (#219): flags a numeric column that
looks like a running total, an account balance, or a point-in-time
snapshot instead of a per-row increment. This shape profiles identically
to an ordinary measure (same type, null fraction, uniqueness), so summing
it downstream is a common and severely damaging misreading that nothing
else in `explore profile` catches.

## How it works

- Signal: within an entity (a repeating, id-shaped column that is not
  itself the table's key) ordered by a temporal column, a cumulative or
  snapshot measure almost never decreases from one observation to the
  next. A genuine per-row increment has natural ups and downs.
- The probe is a single aggregate-only, window-function query authored
  once in DuckDB SQL and transpiled per connector dialect via sqlglot
  (mirrors `relationships.py`'s overlap-probe pattern). No row's measure
  value ever leaves the engine, only comparison counts.
- Priced and gated like `--verify`: the base profile always completes
  and saves first; the check runs as a second, individually skippable
  phase, dry-run priced only once profiling knows what to test, and can
  come back as `pending_confirmation` on a billed connector rather than
  discarding already-paid-for work.
- A table missing an entity key or a temporal column is skipped with an
  explicit note, never silently reported as clean.

## Bugs found and fixed during manual testing

Two real bugs surfaced while exercising this against a live DuckDB file
(not caught by the initial test pass, since it always exercised a fresh
scan):

- A dataset served from the freshness cache is a deep copy, not the
  object the cache write carries forward, so a note appended only to it
  showed in that run's output but never reached disk. Fixed by resolving
  the cache's own object by identifier before appending.
- Running the check again on an already-flagged dataset duplicated the
  same sentence. Fixed by making the append idempotent (skip if the exact
  text is already present).

Both are covered by dedicated regression tests, plus manual stress
testing across multiple objects in one call, `--refresh` combined with
the flag, a first-ever call already using the flag, and a table with no
eligible shape.

<img width="1645" height="193" alt="image" src="https://github.com/user-attachments/assets/2353ff82-04c2-44cb-9e2b-b405b4c4aa6d" />
balance correctly flagged as cumulative, purely from its shape in the data.