### PR TITLE
SCRUM-1159-adapters: get_dialect raises on an unrecognized connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`get_dialect` now raises on an unrecognized connector instead of
+  silently parsing every subsequent statement as DuckDB** ([#319]). A
+  hyphenated BigQuery project id, the shape BigQuery itself hands out and
+  the exact form `explore query` and `explore inventory` print back, parses
+  as subtraction under the DuckDB dialect. `explore query` and the query
+  firewall already resolve and thread the connector's own dialect into
+  every parse, so a hyphenated project id has parsed correctly in the
+  BigQuery dialect since early in the project. The one remaining way to
+  still hit that failure was a connector-name mismatch: `.dex/config.yml`'s
+  `connector` field is a plain string with no enum validation, and
+  `get_dialect` silently fell back to DuckDB on anything it did not
+  recognize, producing a policy-refusal-shaped message that actually points
+  at a SQL parser and names neither the mismatch nor the fix.
+
+  `get_dialect` now raises the same way `get_adapter` already does for the
+  same condition, so a connector-name mismatch fails loudly at the point it
+  happens instead of silently picking the wrong dialect. Regression tests
+  lock in that a hyphenated project id (fully-quoted-per-part, backtick-
+  wrapped-as-one-identifier, and the bare unquoted form copied verbatim
+  from an `explore query` `tables` entry or an `explore inventory`
+  `identifier`) parses correctly in every spelling and reaches the cost
+  handshake.
+
 ## [1.6.6] - 2026-08-15
 
 ### Fixed

--- a/packages/dex-core/src/exmergo_dex_core/adapters/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/__init__.py
@@ -55,10 +55,20 @@ def get_adapter(connector: str, **kwargs: Any):
 
 
 def get_dialect(connector: str) -> str:
-    """The SQLGlot dialect for ``connector``, defaulting to DuckDB for unknown
-    names so parsing has a deterministic fallback."""
+    """The SQLGlot dialect for ``connector``.
 
-    return _DIALECTS.get(connector, "duckdb")
+    Raises rather than defaulting to DuckDB on an unrecognized name: a silent
+    fallback here means every subsequent SQL parse silently reads the wrong
+    dialect (a hyphenated BigQuery project id parses as subtraction, for
+    example), producing a confusing parse-error refusal that never mentions
+    the real cause. ``get_adapter`` already raises on the same condition; this
+    matches it instead of being the one caller that stays lenient.
+    """
+
+    try:
+        return _DIALECTS[connector]
+    except KeyError:
+        raise ValueError(f"unknown connector '{connector}'") from None
 
 
 # Connectors that bill nothing for a scan. Kept beside the dialect map and for

--- a/packages/dex-core/tests/adapters/test_connect_bigquery.py
+++ b/packages/dex-core/tests/adapters/test_connect_bigquery.py
@@ -845,7 +845,17 @@ def test_get_adapter_wires_bigquery(fake_bq_client):
 def test_get_dialect_resolves_without_clients():
     assert get_dialect("bigquery") == "bigquery"
     assert get_dialect("duckdb") == "duckdb"
-    assert get_dialect("nonsense") == "duckdb"
+
+
+def test_get_dialect_raises_on_an_unrecognized_connector():
+    """A silent fallback to DuckDB here would misparse every subsequent SQL
+    statement in the wrong dialect (issue #319: a hyphenated BigQuery project
+    id reads as subtraction under the DuckDB dialect) while reporting a
+    generic parse error that never names the real cause. Raising matches
+    `get_adapter`'s existing convention for the same condition."""
+
+    with pytest.raises(ValueError, match="unknown connector 'nonsense'"):
+        get_dialect("nonsense")
 
 
 # --- project resolution (connect.py) -----------------------------------------------

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -413,6 +413,32 @@ def test_unconfirmed_query_returns_estimate_and_logs(
     assert json.loads(log_lines[-1])["decision"] == "needs_confirmation"
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Issue #319: a hyphenated project id, both fully-quoted-per-part and
+        # backtick-wrapped-as-one-identifier, plus the bare unquoted form
+        # copied verbatim out of an `explore inventory` identifier or an
+        # `explore query` `tables` entry. All three must parse in the
+        # connector's own dialect and reach the cost handshake rather than
+        # a "could not parse query" refusal on the hyphen.
+        "SELECT COUNT(*) AS n FROM `test-proj`.`shop`.`customers`",
+        "SELECT COUNT(*) AS n FROM `test-proj.shop.customers`",
+        "SELECT COUNT(*) AS n FROM test-proj.shop.customers",
+    ],
+)
+def test_a_hyphenated_project_id_parses_in_every_spelling(
+    fake_bq_client, route_adapter, tmp_path, sql
+):
+    _seed_query_cache(tmp_path)
+    route_adapter(fake_bq_client)
+    envelope = _dispatch(tmp_path, subcommand="query", sql=sql)
+    # A parse failure on the hyphen would come back as an `error` envelope
+    # (`reason: guard`) naming a SQL parser, not this cost checkpoint.
+    assert envelope.status.value == "needs_confirmation"
+    assert envelope.cost.estimate == 10 * MB
+
+
 def _clusterable_client():
     """A fake warehouse whose `customers` carries numeric non-key columns.
 


### PR DESCRIPTION
Closes : https://github.com/exmergo/dex/issues/319 
The issue's proposal assumes `explore query` parses agent SQL without the connector's dialect, so a hyphen reads as subtraction under a generic/DuckDB parse. That's not what's happening here: `explore query` already resolves `dialect get_dialect(connector)` and threads it into every `sqlglot` call in the query firewall, and has done so since very early in the project, before the 1.6.3 the issue was filed against.

Verified through the real dispatch path, not just the parser in isolation, against a fake BigQuery client whose project id is itself
hyphenated:

```json {"status": "needs_confirmation", "data": {"command": "explore query", "per_table_bytes"{"myproject.my_dataset.my_table": 31457280.0, ...}, ...}} All three spellings the issue names reach needs_confirmation cleanly: `my-project.my_dataset.my_table`, `my-project`.`my_dataset`.`my_table`, and the bare unquoted form copied verbatim from an explore inventory identifier or explore query tables entry.

So this PR does not add a dialect= parameter anywhere, that's already there. If the reporter can still reproduce the original failure against a real BigQuery connection, the fix would be something else, most likely a connector-name mismatch (see below), and I'd want their exact command and .dex/config.yml connector value to find it.

What fixed : 
One real gap: get_dialect() in adapters/__init__.py silently returned "duckdb" for any connector name it didn't recognize. That's exactly this failure mode waiting to happen — .dex/config.yml's connector field is a plain string with no enum validation, so a typo or an alias drift would silently parse every statement in the wrong dialect and produce this exact confusing error (a policy-refusal shape pointing at what looks like a SQL parser).

Before:

<img width="1587" height="110" alt="image" src="https://github.com/user-attachments/assets/4a177a07-55cf-493d-b061-717b247a9a90" />

>>> get_dialect("nonsense")
duckdb
After:

<img width="1580" height="265" alt="image" src="https://github.com/user-attachments/assets/e3fe97e2-4ba0-4d81-b46f-a5129b683e86" />

>>> get_dialect("nonsense")
ValueError: unknown connector 'nonsense'get_dialect now raises the same way get_adapter already does for the same condition, so a connector-name mismatch fails loudly at the point it happens instead of quietly picking the wrong dialect.