### PR TITLE
SCRUM-1161-explore(query): state the exact shortfall on a mid-batch refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **A mid-batch `explore query` refusal states exactly how much more budget
+  finishes the batch** ([#321]). BigQuery bills at least its per-query floor
+  no matter how little a statement reads, so an N-statement call needs at
+  least `N x 10,485,760` bytes of headroom; the multi-statement estimate
+  already reserves that (summed per-statement, since each floors on its own
+  distinct tables), and confirming at that estimate already completes every
+  statement for a batch that genuinely reads almost nothing. What can still
+  strand the tail is the same execution-time variance [#320] fixes within
+  one statement, here compounding across several: each statement's real
+  bill sits just far enough above its own floor that the shortfall only
+  surfaces once several statements have already run and billed.
+
+  A refusal partway through a batch already keeps and reports every
+  statement that completed, since it has been paid for; it now also states,
+  in the same refusal, exactly how many bytes finishing the remaining
+  statements needs, computed the same way the original estimate was, so a
+  caller re-running with a wider `--budget` picks the right number the
+  first time rather than guessing again after a second partial run.
+
 - **`get_dialect` now raises on an unrecognized connector instead of
   silently parsing every subsequent statement as DuckDB** ([#319]). A
   hyphenated BigQuery project id, the shape BigQuery itself hands out and

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -1350,6 +1350,8 @@ def _execute(
         except ConfirmationRequiredError:
             raise
         except Exception as exc:
+            if isinstance(exc, OverCeilingError):
+                exc = _with_batch_shortfall(exc, shared.adapter, batch, statement)
             entry = {
                 "sql": statement.inspected.sql,
                 "decision": "failed",
@@ -1396,6 +1398,49 @@ def _execute(
         if statement.inspected.warnings:
             entry["pii_warnings"] = statement.inspected.warnings
         ledger(statement, entry)
+
+
+def _with_batch_shortfall(
+    exc: OverCeilingError,
+    adapter: Adapter,
+    batch: list[_Statement],
+    statement: _Statement,
+) -> OverCeilingError:
+    """Name exactly how much more this batch needs to finish, not just why
+    this one statement hit the wall (issue #321).
+
+    BigQuery bills at least its per-query floor no matter how little a
+    statement reads, so an N-statement call needs at least ``N x`` that floor
+    of headroom; that arithmetic is fully knowable the moment inference finds
+    the remaining statements, which is exactly what this recomputes. A caller
+    who otherwise has to raise ``--budget`` and guess again now sees the
+    number the first guess would have needed. Already-completed statements
+    are unaffected: their results are kept exactly as :func:`_execute`
+    already keeps them, so a wider budget on re-run does not re-pay for them.
+
+    A no-op (returns ``exc`` unchanged) for a lone, non-batch statement,
+    where "the remaining budget is below the floor" already says everything
+    there is to say, and when the adapter cannot price a dry run at all.
+    """
+
+    if len(batch) == 1:
+        return exc
+    remaining = [s for s in batch if s.index >= statement.index and s.live]
+    query_estimate = getattr(adapter, "query_estimate", None)
+    if query_estimate is None or not remaining:
+        return exc
+    extra = sum(query_estimate(s.inspected.sql) for s in remaining)
+    gate = command_args.cost_gate(adapter)
+    unit = gate.paradigm.value if gate is not None else "bytes"
+    wrapped = OverCeilingError(
+        f"{exc}. Completing the remaining {len(remaining)} statement(s) in "
+        f"this batch needs at least {extra:,.0f} more {unit}; the "
+        "statement(s) already run above are saved, so a wider --budget on "
+        "re-run does not re-pay for them",
+        cost=exc.cost,
+    )
+    wrapped.__cause__ = exc
+    return wrapped
 
 
 def _batch_marks(statement: _Statement, size: int) -> dict:

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -625,6 +625,99 @@ def test_a_cold_batch_prices_the_shared_scan_and_every_statement_together(
     assert any("no usable profile" in note for note in envelope.data["notes"])
 
 
+# --- issue #321: the multi-statement per-query floor, and a mid-batch shortfall --
+#
+# BigQuery bills at least its per-query floor no matter how little a statement
+# reads, so an N-statement call needs at least N x that floor of headroom.
+# These tests pin that the estimate already reserves it (acceptance criterion
+# 1), that confirming at exactly that estimate completes every statement in
+# the "reads almost nothing" case the issue describes (acceptance criterion
+# 2), and that a real per-statement billing overage that still strands the
+# tail states the exact extra budget needed to finish, rather than leaving a
+# caller to guess a second time.
+
+
+def _seven_statements_against_customers() -> list[str]:
+    table = "`test-proj`.`shop`.`customers`"
+    return [f"SELECT COUNT(*) AS n{i} FROM {table}" for i in range(7)]  # noqa: S608
+
+
+def test_a_seven_statement_batch_reserves_at_least_n_times_the_floor(
+    fake_bq_client, route_adapter, tmp_path
+):
+    _seed_query_cache(tmp_path)
+    route_adapter(fake_bq_client)
+    envelope = _dispatch(
+        tmp_path, subcommand="query", sql=_seven_statements_against_customers()
+    )
+    assert envelope.status.value == "needs_confirmation"
+    assert envelope.cost.estimate >= 7 * 10 * MB
+    assert envelope.cost.estimate == 70 * MB
+
+
+def test_confirming_at_that_estimate_completes_every_statement(
+    fake_bq_client, route_adapter, tmp_path
+):
+    _seed_query_cache(tmp_path)
+    fake_bq_client.row_resolver = lambda sql: [{"n": 1}]
+    route_adapter(fake_bq_client)
+    statements = _seven_statements_against_customers()
+    unconfirmed = _dispatch(tmp_path, subcommand="query", sql=statements)
+    estimate = unconfirmed.cost.estimate
+
+    envelope = _dispatch(
+        tmp_path,
+        subcommand="query",
+        sql=statements,
+        confirm=True,
+        budget=estimate,
+    )
+    assert envelope.status.value == "ok"
+    assert [r["status"] for r in envelope.data["results"]] == ["ok"] * 7
+
+
+def test_a_mid_batch_shortfall_states_the_exact_extra_budget_needed(
+    fake_bq_client, route_adapter, tmp_path
+):
+    """Each statement's real bill sits just above its own floor, and the dry
+    run under-reports enough that the *estimate* floors to exactly the
+    per-query minimum (masking the gap) while the *real* bill stays above
+    it -- the same execution-time variance issue #320 hits within one
+    statement, compounding here across a batch until the tail is stranded.
+    """
+
+    _seed_query_cache(tmp_path)
+    fake_bq_client.tables["test-proj.shop.customers"].num_bytes = int(10.6 * MB)
+    fake_bq_client.dry_run_underestimate = 0.98
+    fake_bq_client.row_resolver = lambda sql: [{"n": 1}]
+    route_adapter(fake_bq_client)
+    statements = _seven_statements_against_customers()
+    unconfirmed = _dispatch(tmp_path, subcommand="query", sql=statements)
+    estimate = unconfirmed.cost.estimate
+
+    envelope = _dispatch(
+        tmp_path,
+        subcommand="query",
+        sql=statements,
+        confirm=True,
+        budget=estimate,
+    )
+    assert envelope.status.value == "error"
+    results = envelope.data["results"]
+    statuses = [r["status"] for r in results]
+    # Earlier statements completed and are saved; only the tail is stranded.
+    assert statuses.count("ok") >= 1
+    assert "failed" in statuses
+    failed = next(r for r in results if r["status"] == "failed")
+    assert "is below BigQuery's" in failed["error"]
+    assert "needs at least" in failed["error"]
+    assert "bytes_scanned" in failed["error"]
+    assert "does not re-pay for them" in failed["error"]
+    # The already-completed statements' real results are still there.
+    ok_results = [r for r in results if r["status"] == "ok"]
+    assert all(r["cells"] == [[1]] for r in ok_results)
+
+
 def test_duckdb_explore_stays_confirmation_free(duckdb_file: Path, capsys):
     # The regression guard for the free path: no gate, no handshake, free cost.
     from exmergo_dex_core.cli import main


### PR DESCRIPTION
Closes : #321 
("a multi-statement call strands its last statement, because the estimate reserves one 10 MB floor for the whole batch") and fixes the real, narrower gap found. What shipped is not the issue's literal proposal, because the literal bug doesn't reproduce.

## What I found
The issue's headline claim doesn't reproduce on this codebase. A 7-statement batch, each statement reading almost nothing, already gets `estimated_bytes == 7 x 10,485,760` (summed per-statement, since each already floors on its own distinct tables via `query_estimate`), and confirming at exactly that estimate already completes all 7 statements. Both acceptance criteria hold today for that literal scenario.

Pushing further, the same execution-time billing variance #320 fixes within one statement also applies across a batch: if each statement's real bill sits just far enough above its own floor, and the dry run under-reports enough that the *estimate* still floors to exactly the per-query minimum (masking the gap) while the *real* bill stays above it, the shortfall compounds across the batch until the tail is stranded after several statements have already run and billed. I reproduced this exactly (6 of 7 statements succeed, the 7th fails just under the floor).

This is a real, narrower gap than the issue's literal framing, and it's why #320 and #321 are siblings: same underlying mechanism, one hitting a single multi-table statement's own cap, the other hitting a multi-statement batch's cumulative total.

## The fix
`_execute` already keeps and reports every statement that completed before a cost-guard refusal, since it's already been paid for that part of the existing design is sound and unchanged. What was missing: the refusal for the failed statement said *why* it failed, but not what it would take to *finish*.

A mid-batch `OverCeilingError` now recomputes, from the same `query_estimate` the original handshake used, exactly how many more bytes complete every remaining (not-yet-run) statement, and states that in the same refusal:
> "...raise --budget or narrow the work. Completing the remaining 1 statement(s) in this batch needs at least 10,892,606 more bytes_scanned; the statement(s) already run above are saved, so a wider --budget on re-run does not re-pay for them."

A caller now sets the right `--budget` on the first re-run instead of raising it by a guess and possibly hitting the same wall again. A no-op for a lone, non-batch statement, where the existing message already says everything there is to say.

Before the fix : 
<img width="1558" height="162" alt="image" src="https://github.com/user-attachments/assets/8c4e6f1e-4ca2-4ba8-b8e6-1ab84cf82296" />
After the fix : 
<img width="1548" height="155" alt="image" src="https://github.com/user-attachments/assets/789d6b4e-b3e3-4395-acae-e33e13fc292e" />
 the error now continues: "Completing the remaining 1 statement(s) in this batch needs at least 10,892,606 more bytes_scanned; the statement(s) already run above are saved, so a wider --budget on re-run does not re-pay for them."
