### PR TITLE
PlacingProject assertion improvements

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.6.6",
+  "version": "1.7.0",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-25
+
 ### Added
 
 - **ClickHouse connector, self-hosted** ([#188]). The seventh connector, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,94 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   shipped `unpivot_json_object` macro, whose ClickHouse implementation uses
   `ARRAY JOIN` because there is no lateral join.
 
+- **A project format's write tier is asserted at the strength it is used, and
+  `load()` is declared** ([#328]). A second format reached tier 3 and
+  `PlacingProject` in full, passed the whole conformance suite, and still could
+  not have completed a single `maintain reconcile`. Two gaps, one seam: what the
+  write tier requires was not what its contract asserted.
+
+  **`load()` is now a declared member of `PlacingProject`**, with the shape its
+  callers need stated on it: `ProjectView` (`root`, and `files` keyed the way
+  `edit_path` keys) and `SourceFileView` (`content`, `sha256`). Nothing declared
+  it before, and two callers used it anyway, so a format implementing the four
+  declared methods and omitting this one passed conformance and raised
+  `AttributeError: load` on the first real reconcile, after the tier said 3 and
+  after the gate let it through. It sits beside the two methods that share its
+  keyspace rather than on tier 3, for the reason `PlacingProject` is beside the
+  tiers at all: these protocols are `runtime_checkable`, so a method added to
+  tier 3 demotes every format that has not implemented it, and this requirement
+  is not tier 3's to state. Nothing outside the placement path calls `load()`,
+  so a format that receives edits and does not place them never needed a view.
+
+  The two view protocols are deliberately not `runtime_checkable` and nothing
+  calls `isinstance` against them: on a data protocol that only asks whether the
+  attribute names exist, which reads as a type check and is not one. The
+  conformance suite makes that check instead, with a message naming the missing
+  member and what it costs. `isinstance(view, DbtProjectView)` stays where it is,
+  because it asks whether a view is dbt's surface rather than whether it is a
+  view.
+
+  **Three assertions join the write contract**, each catching a defect that
+  passed it before, and all three are silent failures where the apply reports
+  success. A conflict now has to refuse the whole edit set rather than the
+  conflicting edit within it, which is the worst of them: landing the clean half
+  leaves the project matching neither the proposal nor what the human had, while
+  the apply reports itself refused, so nothing records which half arrived. A
+  create pinned to no prior content has to be refused when a file has appeared at
+  that path since, rather than overwriting whole the file somebody wrote during
+  review. And `write_edits` has to honor the surface its format declared,
+  asserted on the case a string-prefix comparison gets wrong, where
+  `declarations` admits `declarations_backup/`.
+
+  The first of those is worth an optional hook, `a_clean_edit(project)`, which
+  returns an unconflicted edit and a callable reading its target. Without it the
+  assertion can only ask what `write_edits` reported, so a writer that lands half
+  a set and reports nothing written still passes; with it, the project itself is
+  read. No new mandatory hook, so a downstream suite that was green stays
+  runnable, and the new assertions compose from what implementers already supply.
+
+  **A format holding part of `PlacingProject` is now told which member it is
+  missing.** The gate asks for the protocol structurally rather than probing for
+  one method, so the answer for a partial format is the advisory degradation a
+  narrower format has always got, on the `transform plan` path as well as
+  reconcile's, and the message names `load()` rather than sending the implementer
+  back to the two methods they already wrote.
+
+### Changed
+
+- **`transform apply` re-checks containment against the surface the format
+  declares, before the plan reaches the writer** ([#328]). The hashes are
+  re-checked at apply because a plan is a stored artifact that sits through a
+  human review, and the surface is exactly as much a plan-time fact as they are.
+  The shipped format re-checks inside its own writer; a second format was
+  trusted to. A stored edit whose path falls outside the declared surface is now
+  a `PlanError` naming the path and the surface, and `--confirm` is not a way
+  past it: confirmation is the handshake for a human edit somebody can look at
+  and accept, and nobody accepts a write outside the region the format itself
+  declared.
+
+- **The dbt format declares the four root manifests it authors, not just its
+  model and macro paths** ([#328]). `editing_surface()` omitted `packages.yml`,
+  `dependencies.yml`, `dbt_project.yml` and `profiles.yml` on the grounds that
+  dbt's own writer allowed them by name. With a second consumer re-checking that
+  declaration at apply, a surface narrower than the writer is not a modest claim:
+  it refuses the project config, the profiles and the package manifests, every
+  one of which is a path dex authors through a plan. What a format declares has
+  to be what its writer will take.
+
 ### Fixed
+
+- **A project format that places an edit and cannot be read no longer raises
+  from inside a command** ([#328]). `plans.plan` and `transform`'s authored-plan
+  path both decided whether to route through the format by probing for
+  `editing_surface`, then called `load()`, which no protocol declared. A format
+  holding one without the other reached that line and raised `AttributeError`
+  mid-command. Both now ask for `PlacingProject` structurally, so the format
+  falls back to the pre-seam behavior and carries a warning naming the member it
+  is missing. On the plan path that fallback is dbt's project and dbt's surface,
+  which refuses an edit the format placed in its own keyspace while naming dbt's
+  paths, so the gap rides along on the refusal to explain why dbt's surface was
+  the one consulted.
 
 - **A `DATETIME` column no longer reports its hour continuity as clean when it
   was never measured** ([#188]). `is_date_only_type` claimed any type containing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,6 +373,18 @@ the code that produced the graph is, so an edit written into the reduction is
 overwritten on the next run. `maintain reconcile` reads that declaration, and your
 format gets advisory proposals and no stored plan, by contract rather than by luck.
 
+If you do serve it, `PlacingProject` is what carries a proposal to your write path,
+and it is three methods rather than two: `load()` reads the keyspace an edit is
+pinned against, `edit_path()` names a key in it, and `editing_surface()` declares the
+region those keys may fall in. They go together because none of them answers
+anything alone, and a format holding two of the three places nothing at all. Mix
+`PlacingProjectContract` in beside your tier-3 contract: it checks that the three
+agree, that the view carries the `root`, `content` and `sha256` a pinned edit needs,
+and that your own writer refuses a path outside the surface you declared, including
+the sibling case a string-prefix comparison lets through. Supplying its optional
+`a_clean_edit(project)` hook is what upgrades the all-or-nothing assertion from
+asking what your writer reported to reading what your project holds.
+
 Decide it by asking which artifact an edit would land in, not where your project came
 from. Those questions come apart more often than the graph example suggests: an asset
 graph carries neither column names nor join keys, so a format over one reads its
@@ -384,7 +396,10 @@ serve this tier for that channel while still refusing to author a model.
 that are not obvious from the signatures.
 
 Formats contributed here run the same suite: see
-`packages/dex-core/tests/adapters/test_project_parity.py`.
+`packages/dex-core/tests/adapters/test_project_parity.py` for the shipped format, and
+`packages/dex-core/tests/adapters/test_project_conformance.py` for a format that is
+neither dbt nor a directory, driven through the contract and then broken on purpose,
+one defect per assertion.
 
 ## Linting and formatting (Ruff)
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
@@ -61,16 +61,17 @@ running the suite needs.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
 import pytest
 
-from ..dbt_project import ProjectDefinitions
+from ..dbt_project import EditOp, ProjectDefinitions
 from ..maintain.snapshot import Snapshot
 from .project import ExploreProject, ProjectContext, tier_of
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
     from typing import Any
 
     from ..maintain.snapshot import SemanticLayer, TransformLayer
@@ -84,6 +85,38 @@ __all__ = [
     "ProjectFactoryContract",
     "SemanticProjectContract",
 ]
+
+
+def _probe_content(path: str) -> str:
+    """Content for an edit that must never land, commented for the file it names.
+
+    A refusal is what is being asserted, so nothing should ever read this. It is
+    still written as a comment in the target's own language, because a format
+    that parses what it is handed before refusing it should refuse it for the
+    reason under test rather than for being unparseable.
+    """
+
+    marker = "-- " if path.endswith(".sql") else "# "
+    return f"{marker}dex conformance probe: this must never be written\n"
+
+
+def _edit_like(template: Any, **changes: Any) -> Any:
+    """A copy of an edit the format was handed, with fields replaced.
+
+    The assertions below vary one field of a real edit (its path, or the hash it
+    is pinned to) rather than constructing one, so what reaches ``write_edits``
+    is the same shape dex passes it everywhere. Every caller in the engine passes
+    ``Edit`` or ``PlanEdit``, which is what makes this safe to assume.
+    """
+
+    copier = getattr(template, "model_copy", None)
+    assert copier is not None, (
+        "the edits returned by an_edit_against_a_changed_target() are not dex's "
+        f"`Edit`/`PlanEdit` models but {type(template).__name__}. write_edits() is "
+        "called with those models from every path in the engine, so the hook has "
+        "to stage what the format will really be handed"
+    )
+    return copier(update=changes)
 
 
 class ExploreProjectContract:
@@ -600,9 +633,20 @@ class EditableProjectContract(MaintainProjectContract):
     stage that scenario cannot detect it either, and a format that cannot detect it
     overwrites work silently, which is the one failure this seam exists to prevent.
 
-    **The two write assertions have to be read as a pair.** Refusing an unconfirmed
-    conflict is satisfied trivially by a ``write_edits`` that never writes anything,
-    so the confirmed case is what rules that out. Neither is worth much alone.
+    **The first two write assertions have to be read as a pair.** Refusing an
+    unconfirmed conflict is satisfied trivially by a ``write_edits`` that never
+    writes anything, so the confirmed case is what rules that out. Neither is worth
+    much alone.
+
+    **The pair rules out a writer that never writes. It does not rule out a writer
+    that writes too much**, which is the direction the rest of the assertions
+    cover: an apply that lands the clean half of a refused edit set, and a create
+    pinned to no prior content that overwrites a file which appeared during
+    review. Both leave the project holding something nobody proposed, both report
+    themselves as a clean refusal, and neither is visible to a contract that
+    stages one edit and asks only what came back. Supplying
+    :meth:`a_clean_edit` upgrades the first from checking what the writer said to
+    checking what the project holds.
 
     **Deliberately not asserted here: which directory the edits land in.**
     ``project_dir`` is a slot for the formats keyed by one, so an assertion about it
@@ -637,6 +681,33 @@ class EditableProjectContract(MaintainProjectContract):
             "read_target), staging the case the write tier exists to get right: a "
             "human edited the target after the plan pinned its content"
         )
+
+    def a_clean_edit(self, project: Any) -> tuple[Any, Any] | None:
+        """An edit that is *not* in conflict, and a callable reading its target.
+
+        Optional, and worth supplying. It is the oracle for
+        :meth:`test_a_refused_apply_leaves_every_target_alone`: without it that
+        assertion can only ask what ``write_edits`` *reported*, so a writer that
+        writes half an edit set and says it wrote nothing still passes. With it,
+        the target is read directly and the claim is checked against the project.
+
+        Return ``(edit, read_target)``, where ``edit`` is pinned truthfully
+        against current content (it must be clean, since the conflict under test
+        is the other one) and ``read_target`` is a zero-argument callable
+        returning what its target holds right now. Any value that compares equal
+        to itself will do.
+
+        ``project`` is the one :meth:`an_edit_against_a_changed_target` just
+        staged, and the edit has to be valid against *that* project rather than
+        against a fresh one: both edits are written through it in a single call,
+        and the reader has to be looking at the same place the write lands.
+
+        Returning ``None`` falls back to an edit derived from the staged
+        conflict's own path, which is inside your surface by construction (it is
+        a sibling of a path you already accept) and needs nothing from you.
+        """
+
+        return None
 
     def test_satisfies_the_editable_tier(self) -> None:
         assert tier_of(self.make_project()) >= 3
@@ -682,6 +753,115 @@ class EditableProjectContract(MaintainProjectContract):
             "write_edits() left the target unchanged with confirmed=True. The "
             "override is what a human reaches for after reading the conflict "
             "diffs, so a format that refuses either way has no apply path"
+        )
+
+    def test_a_refused_apply_leaves_every_target_alone(self) -> None:
+        """A conflict refuses the apply, not the conflicting edit within it.
+
+        ``write_edits`` is all-or-nothing, and the edit set is the unit. A writer
+        that lands the clean edits and holds back the conflicting one leaves the
+        project in a state neither the proposal nor the human intended, with no
+        record of which half arrived: the plan reads as refused, the tree does
+        not match it, and the diffs a reviewer was shown describe a change that
+        partly happened.
+
+        It is the failure worth catching most and the one a single-edit set
+        cannot see, which is why this stages two. The clean edit goes first, so a
+        writer working through the set in order reaches it before it discovers
+        the conflict.
+        """
+
+        project, project_dir, edits, read_target = (
+            self.an_edit_against_a_changed_target()
+        )
+        staged = list(edits)
+        assert staged, (
+            "an_edit_against_a_changed_target() returned no edits, so there is no "
+            "conflict staged and nothing here can be asserted"
+        )
+        supplied = self.a_clean_edit(project)
+        if supplied is None:
+            template = staged[0]
+            sibling = PurePosixPath(template.path)
+            clean_path = str(sibling.with_name(f"dex_conformance_clean_{sibling.name}"))
+            clean = _edit_like(
+                template,
+                path=clean_path,
+                old_content_hash=None,
+                op=EditOp.UPSERT,
+                new_content=_probe_content(clean_path),
+            )
+            read_clean = None
+        else:
+            clean, read_clean = supplied
+
+        before = read_target()
+        before_clean = read_clean() if read_clean is not None else None
+
+        result = project.write_edits([clean, *staged], project_dir)
+
+        assert read_target() == before, (
+            "write_edits() overwrote the conflicting target inside a mixed edit "
+            "set, with confirmed left at its default"
+        )
+        assert not getattr(result, "written", []), (
+            "write_edits() refused an unconfirmed conflict and still reported "
+            f"{list(getattr(result, 'written', []))} as written. The apply is "
+            "all-or-nothing: one conflict refuses the whole set, so the clean "
+            "edits beside it do not land either"
+        )
+        if read_clean is not None:
+            assert read_clean() == before_clean, (
+                "write_edits() wrote the clean edit while refusing the "
+                "conflicting one beside it. That leaves the project matching "
+                "neither the proposal nor what the human had, and the apply "
+                "reports itself as refused, so nothing records which half landed"
+            )
+
+    def test_a_create_pinned_absent_refuses_a_target_that_now_exists(self) -> None:
+        """``old_content_hash=None`` is a claim about the target, and it is checked.
+
+        A create is pinned to nothing because there was nothing there when the
+        plan was made. If a file has appeared at that path since, the claim is
+        false and the write is exactly the overwrite this tier exists to refuse:
+        the human who created it during review loses the whole file rather than
+        the lines that diverged.
+
+        A writer that reads ``None`` as "nothing to compare, go ahead" passes
+        every other assertion here, because in the staged conflict the pinned
+        hash is a real one.
+        """
+
+        project, project_dir, edits, read_target = (
+            self.an_edit_against_a_changed_target()
+        )
+        staged = list(edits)
+        assert staged, (
+            "an_edit_against_a_changed_target() returned no edits, so there is no "
+            "target to re-pin and nothing here can be asserted"
+        )
+        template = staged[0]
+        before = read_target()
+        create = _edit_like(
+            template,
+            old_content_hash=None,
+            op=EditOp.UPSERT,
+            new_content=_probe_content(template.path),
+        )
+
+        result = project.write_edits([create], project_dir)
+
+        assert read_target() == before, (
+            "write_edits() honored an edit pinned to no prior content over a "
+            "target that exists, overwriting it whole. A pin of None says the "
+            "file was absent at plan time; a file being there now is a conflict, "
+            "not a create. (If the target your hook stages does not exist, the "
+            "hook is not staging the case it documents.)"
+        )
+        assert not getattr(result, "written", []), (
+            "write_edits() reported the create as written over an existing "
+            "target, so the caller marks the plan applied and no one is asked "
+            "about the file that appeared"
         )
 
     def test_the_write_result_reports_what_happened(self) -> None:
@@ -731,13 +911,146 @@ class PlacingProjectContract:
     not this one gets advisory proposals and no stored plan, which is the same
     outcome as declining the tier.
 
-    **What this asserts is that your two answers agree.** Each is checkable alone
-    and neither is interesting alone: ``edit_path`` names a file, and
-    ``editing_surface`` says which region files may be named in. A format placing
-    an edit outside its own declared surface builds a proposal the plan store then
-    refuses, and the refusal reads as dex declining rather than as the format
-    contradicting itself, which is a bad afternoon to debug from the outside.
+    **What this asserts is that your three answers agree.** Each is checkable
+    alone and none is interesting alone: ``load`` reads a keyspace, ``edit_path``
+    names a key in it, and ``editing_surface`` says which region those keys may
+    fall in. A format placing an edit outside its own declared surface builds a
+    proposal the plan store then refuses, and the refusal reads as dex declining
+    rather than as the format contradicting itself, which is a bad afternoon to
+    debug from the outside.
+
+    **Placement presupposes tier 3, and this checks that first**, the way
+    :class:`SemanticProjectContract` checks tier 2. Every assertion below needs
+    either the write path or the staged conflict that
+    :class:`EditableProjectContract` stages, so a format mixing this in alone
+    would meet an error about a missing attribute where the thing to say is that
+    the contract is missing its other half.
     """
+
+    def _staged_conflict(self) -> tuple[Any, Any, Any, Any]:
+        """The tier-3 hook, with a message when this mixin is used on its own."""
+
+        hook = getattr(self, "an_edit_against_a_changed_target", None)
+        assert hook is not None, (
+            "the assertions here write through your format, so they need the "
+            "tier-3 hook an_edit_against_a_changed_target(). Mix "
+            "EditableProjectContract in beside this contract, which is how "
+            "placement is meant to be run: a format that places and cannot "
+            "receive an edit has nowhere for the placement to lead"
+        )
+        return hook()
+
+    def test_placement_presupposes_the_editable_tier(self) -> None:
+        assert tier_of(self.make_project()) >= 3, (
+            "a format that places an edit has to reach tier 3, because placement "
+            "is where a proposal is carried to `write_edits`. Implement the write "
+            "tier, or drop this mixin: placing an edit a format cannot receive "
+            "describes a path that stops halfway"
+        )
+
+    def test_the_view_pins_what_an_edit_is_written_against(self) -> None:
+        """``load()`` answers with the keyspace the other two members describe.
+
+        This is what ``transform plan`` pins each edit against and what
+        ``reconcile`` reads before it extends a declaration. Three things are
+        needed and each fails silently in its own way when it is absent:
+        ``root``, which the plan records as the directory it was pinned against;
+        ``content``, which the diff a human reviews is built from; and
+        ``sha256``, without which every existing file pins as a create, so a
+        one-line change is rendered as a whole-file overwrite and the apply that
+        follows conflicts on a file nobody touched.
+
+        The hash need only be consistent with what your own writer re-checks. It
+        is your keyspace, and dex compares your value against your value.
+        """
+
+        view = self.make_project().load()
+
+        root = getattr(view, "root", None)
+        assert isinstance(root, str) and root, (
+            "load() returned a view with no `root`. A plan records the directory "
+            "its edits were pinned against, and reads it from here"
+        )
+        files = getattr(view, "files", None)
+        assert isinstance(files, Mapping), (
+            "load() returned a view whose `files` is not a mapping. It has to be "
+            "keyed the way edit_path() keys, because that is how a placed edit is "
+            f"looked up: got {type(files).__name__}"
+        )
+
+        project, _project_dir, edits, _read_target = self._staged_conflict()
+        staged = list(edits)
+        assert staged, "an_edit_against_a_changed_target() returned no edits"
+        target = staged[0].path
+        entry = project.load().files.get(target)
+        assert entry is not None, (
+            f"load().files has no entry for '{target}', which is the path your own "
+            "hook staged an edit against. dex looks a placed path up in this "
+            "mapping: absent, it pins the edit as a create, renders a whole-file "
+            "diff, and conflicts at apply on a file nobody edited"
+        )
+        assert isinstance(getattr(entry, "content", None), str), (
+            f"the entry for '{target}' carries no `content` string, so no diff "
+            "can be built for a human to review"
+        )
+        sha = getattr(entry, "sha256", None)
+        assert isinstance(sha, str) and sha, (
+            f"the entry for '{target}' carries no `sha256`, so the edit pinned "
+            "against it pins nothing. A create is what a pin of None means, and "
+            "an existing file that pins as a create is one an apply overwrites "
+            "whole"
+        )
+
+    def test_write_edits_refuses_a_path_outside_the_declared_surface(self) -> None:
+        """Your writer honors the surface you declared, not just your placements.
+
+        Containment is checked at plan time and re-checked before dex hands a
+        stored plan to your writer, but ``write_edits`` is a public method of
+        your format and is reachable directly, so the surface has to hold there
+        too. What is asserted is the case a prefix comparison gets wrong: a
+        sibling that merely starts with the same characters. ``declarations``
+        admits ``declarations/orders.yml`` and does not admit
+        ``declarations_backup/orders.yml``, and a format matching by string
+        prefix accepts both while passing every other assertion here.
+
+        Refusing by raising and refusing by writing nothing are both refusals.
+        """
+
+        project, project_dir, edits, read_target = self._staged_conflict()
+        surface = [str(prefix) for prefix in project.editing_surface()]
+        if not surface:
+            pytest.skip(
+                "this format declares no editing surface, so it already refuses "
+                "every edit and there is no sibling prefix to probe"
+            )
+        staged = list(edits)
+        assert staged, "an_edit_against_a_changed_target() returned no edits"
+        outside = f"{surface[0]}_dex_conformance_outside/probe.yml"
+        before = read_target()
+        escaping = _edit_like(
+            staged[0],
+            path=outside,
+            old_content_hash=None,
+            op=EditOp.UPSERT,
+            new_content=_probe_content(outside),
+        )
+
+        try:
+            result = project.write_edits([escaping], project_dir)
+        except Exception:
+            return
+
+        assert not getattr(result, "written", []), (
+            f"write_edits() wrote '{outside}', which editing_surface() does not "
+            f"admit ({', '.join(surface)}). Prefixes match by path segment, so a "
+            "sibling that shares the first characters is outside the surface. A "
+            "format matching by string prefix admits the whole neighborhood of "
+            "every region it owns"
+        )
+        assert read_target() == before, (
+            f"write_edits() left '{outside}' unwritten but moved another target "
+            "while doing it"
+        )
 
     def placeable_model(self) -> str:
         """A warehouse table your format would place an edit for.
@@ -757,10 +1070,13 @@ class PlacingProjectContract:
     def test_satisfies_the_placing_protocol(self) -> None:
         from .project import PlacingProject
 
-        assert isinstance(self.make_project(), PlacingProject), (
+        project = self.make_project()
+        from .project import placement_gap
+
+        assert isinstance(project, PlacingProject), placement_gap(project) or (
             "the format does not satisfy PlacingProject, so reconcile has no path "
             "to plan an edit against and every proposal it makes stays advisory. "
-            "Both `edit_path` and `editing_surface` are required"
+            "All three of `load`, `edit_path` and `editing_surface` are required"
         )
 
     def test_it_places_at_least_one_kind(self) -> None:

--- a/packages/dex-core/src/exmergo_dex_core/adapters/project.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/project.py
@@ -75,6 +75,9 @@ __all__ = [
     "ProjectAdapter",
     "ProjectContext",
     "ProjectFactory",
+    "ProjectView",
+    "SourceFileView",
+    "placement_gap",
     "tier_of",
 ]
 
@@ -211,9 +214,60 @@ class EditableProject(MaintainProject, Protocol):
         ...
 
 
+class SourceFileView(Protocol):
+    """One entry in a project view: the content an edit is pinned against.
+
+    Two members, because two are what the callers read. ``sha256`` is what an
+    edit is pinned to at plan time and re-checked against at apply time, so a
+    view that omits it hashes every existing file as absent, which renders a
+    one-line change as a whole-file create and turns the next apply into a
+    conflict on a file nobody touched. ``content`` is what the diff is built
+    against and what ``reconcile`` reads before it extends a declaration.
+
+    A format is free to carry more (the shipped ``SourceFile`` also carries its
+    own ``path``); nothing here reads it.
+    """
+
+    content: str
+    sha256: str
+
+
+class ProjectView(Protocol):
+    """What :meth:`PlacingProject.load` returns: the format's keyspace, read once.
+
+    ``files`` is keyed exactly the way :meth:`PlacingProject.edit_path` keys and
+    :meth:`PlacingProject.editing_surface` prefixes. That is the whole point of
+    the type: the three members describe one keyspace, and a format whose view
+    is keyed differently from its placements pins every edit as a create.
+
+    ``root`` is what the plan records as the directory its edits were pinned
+    against, relative to the repository root where that subtraction is possible
+    and verbatim where it is not (``transform.plans`` falls back to the string).
+    A format keyed by a directory returns it; a format keyed by something else
+    returns whatever identifies its root, and the plan carries that.
+
+    **Neither this nor** :class:`SourceFileView` **is** ``runtime_checkable``,
+    and nothing calls ``isinstance`` against them. An isinstance check on a data
+    protocol only asks whether the attribute names exist, which is exactly the
+    check :class:`~.conformance.PlacingProjectContract` makes with a message
+    naming the missing member and what breaks without it. These exist to be
+    read and to annotate, not to gate.
+    """
+
+    root: str
+    files: Mapping[str, SourceFileView]
+
+
 @runtime_checkable
 class PlacingProject(Protocol):
-    """Optional beside tier 3: where a proposed edit lands.
+    """Optional beside tier 3: the keyspace a proposed edit lands in.
+
+    Three members describing one thing: :meth:`load` reads the keyspace,
+    :meth:`edit_path` names a key in it, :meth:`editing_surface` says which
+    region of it the format owns. They are here together because none of them
+    is answerable alone. A key is a key into a view; a surface is a region of
+    the same space; and a view nobody places into is a read dex has no use for
+    on this path.
 
     Tier 3 says a format *can* receive an edit. It does not say where the edit
     goes, and ``maintain reconcile`` decides that before it consults the format:
@@ -233,14 +287,48 @@ class PlacingProject(Protocol):
     PlacingProject)`` is checkable, and a format that cannot place an edit
     cannot accidentally claim it can.
 
-    **Separate from** :class:`EditableProject` **rather than a method on it.**
+    **Separate from** :class:`EditableProject` **rather than methods on it.**
     The tiers are ``runtime_checkable``, so a method added to tier 3 silently
     demotes every format that has not implemented it yet: ``tier_of`` would
     start answering 2 where it answered 3, and the write path would close for
     exactly the implementers who were already passing. Beside it, the answer for
     a format that has not implemented this is "tier 3, placement unknown", which
     is the truth and is what the caller warns about.
+
+    That is also why :meth:`load` is here rather than on tier 3, which is where
+    a reader first looks for it. Nothing calls it outside this path: both
+    callers reach it only for a format that places, so requiring it of tier 3
+    would demote formats that never needed it, to state a requirement that is
+    not theirs. A format holding some of these three and not the others places
+    nothing at all, and :func:`placement_gap` is what names the one that is
+    missing instead of leaving it to surface as ``AttributeError`` from inside
+    a command the tier check already let through.
     """
+
+    def load(self) -> ProjectView:
+        """Read the project into the keyspace the other two members describe.
+
+        Two callers, and between them they need every member of
+        :class:`ProjectView`. ``transform.plans`` pins each edit to the
+        ``sha256`` of the file at ``files[edit_path(...)]``, and records
+        ``root`` as the directory the plan was pinned against.
+        ``maintain.reconcile`` reads ``files[...].content`` to extend a
+        declaration it is about to propose an edit to, and refuses to guess
+        where the key is absent.
+
+        **Cheap enough to call once per command, and fresh enough to be worth
+        calling.** A project is an artifact a previous command may have just
+        rewritten, so a view cached across commands is a wrong drift report.
+        Memoizing within one instance is the shipped format's answer (see
+        :meth:`DbtProject.load`), and it is a good one precisely because dex
+        builds one project per command.
+
+        Raising is the honest answer when there is no project to read, and the
+        callers handle it: ``reconcile`` turns it into a refusal naming the
+        format. Tier 1 is the channel with the never-raises promise, and this
+        is not it.
+        """
+        ...
 
     def edit_path(self, kind: EditKind, model: str) -> str | None:
         """Where an edit of ``kind`` for ``model`` lives, or ``None``.
@@ -405,6 +493,64 @@ def tier_of(project: object) -> int:
     return 0
 
 
+#: Each :class:`PlacingProject` member, and the one clause that says what dex
+#: cannot do without it. Read by :func:`placement_gap`, which names only the
+#: members a format is actually missing.
+_PLACEMENT_MEMBERS = {
+    "load": (
+        "`load()` returns the view an edit is pinned against: `root`, and "
+        "`files` keyed the way `edit_path` keys, each entry carrying `content` "
+        "and `sha256`"
+    ),
+    "edit_path": (
+        "`edit_path(kind, model)` answers where an edit of that kind for that "
+        "warehouse table lives, or None to decline the kind"
+    ),
+    "editing_surface": (
+        "`editing_surface()` declares the prefixes those paths must stay inside"
+    ),
+}
+
+
+def placement_gap(project: object) -> str | None:
+    """Which :class:`PlacingProject` member a nearly-placing format is missing.
+
+    Placement is satisfied structurally, so a format holding two of the three
+    members places nothing, and the warning its caller would otherwise reach for
+    ("this format does not say where a proposed edit lands") is false of a
+    format that answers ``edit_path`` and cannot be read. Worse, it sends the
+    implementer to the member they already wrote.
+
+    ``None`` in the two cases where there is nothing to add: a format that
+    places has no gap, and a format declaring none of the three is declining
+    placement outright, which is a complete answer the caller already describes.
+
+    This exists because of what the alternative was. A format implementing the
+    declared members and omitting the undeclared one passed the whole
+    conformance suite and then raised ``AttributeError`` on the first real
+    reconcile: after the tier said 3, after the gate let it through, in a
+    command someone ran.
+    """
+
+    if isinstance(project, PlacingProject):
+        return None
+    missing = [
+        member
+        for member in _PLACEMENT_MEMBERS
+        if getattr(project, member, None) is None
+    ]
+    if len(missing) == len(_PLACEMENT_MEMBERS):
+        return None
+    named = getattr(project, "name", type(project).__name__)
+    listed = ", ".join(f"`{member}()`" for member in missing)
+    details = " ".join(f"{_PLACEMENT_MEMBERS[member]}." for member in missing)
+    return (
+        f"the '{named}' project format implements part of PlacingProject and is "
+        f"missing {listed}, so it places no edit at all and every proposal stays "
+        f"advisory. {details}"
+    )
+
+
 class DbtProject:
     """The dbt implementation of the project seam.
 
@@ -478,6 +624,10 @@ class DbtProject:
     def load(self) -> DbtProjectView:
         """Load the project into an in-memory view, once per instance.
 
+        ``DbtProjectView`` is the shipped :class:`ProjectView`: its ``files`` are
+        keyed by the project-relative paths :meth:`edit_path` returns, and its
+        ``SourceFile`` entries are the shipped :class:`SourceFileView`.
+
         Raises ``DbtProjectError`` when there is no project to load, which is what
         every caller of ``dbt_project.load`` already expects. Tier 1 is the channel
         with the never-raises promise.
@@ -544,18 +694,25 @@ class DbtProject:
         return None if suffix is None else f"models/staging/stg_{model}.{suffix}"
 
     def editing_surface(self) -> list[str]:
-        """The project's configured model and macro paths, read from the view.
+        """Everything dbt's own writer accepts: the model and macro paths, and
+        the four root manifests it admits by name.
 
         Read rather than assumed: a project that configures ``model-paths`` away
         from ``models`` moves its editing surface with it, and the containment
-        check has always honored that. This returns what the engine computed for
-        itself before the seam existed, so routing dbt through the seam changes
-        nothing about which paths dbt admits.
+        check has always honored that.
 
-        The root manifests ``contained_path`` allows by name are not listed here.
-        They are a dbt fact about dbt's own project root rather than a region of
-        the surface, and the check keeps applying them on the dbt path.
+        The root manifests are listed even though they are files rather than
+        regions, because ``transform.plans`` re-checks a stored plan against this
+        declaration before handing it to the writer. A declaration narrower than
+        what the writer accepts is not a modest one: it refuses the project
+        config, the profiles, and the package manifests at apply, every one of
+        which is a path dex authors through a plan. What a format declares here
+        has to be what its writer will take.
         """
 
         view = self.load()
-        return list(view.model_paths) + list(view.macro_paths)
+        return (
+            list(view.model_paths)
+            + list(view.macro_paths)
+            + sorted(dbt_project._ALLOWED_ROOT_FILES)
+        )

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -729,7 +729,7 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
     coincidence survivable.
     """
 
-    from ..adapters.project import PlacingProject
+    from ..adapters.project import PlacingProject, placement_gap
     from ..transform import plans as plans_mod
     from . import reconcile as reconcile_mod
 
@@ -773,14 +773,23 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
             "actually defined"
         )
     elif not isinstance(editable, PlacingProject):
+        # A format holding some of `PlacingProject` and not the rest gets told
+        # which member is missing, because the general message below would send
+        # it to the ones it already wrote. That is the difference between the
+        # gap being reported here and it surfacing as `AttributeError` from
+        # inside the reconcile the tier check already let through.
         warnings.append(
-            f"the '{editable.name}' project format implements the write tier, but "
-            "does not say where a proposed edit lands, so reconcile has no path to "
-            "plan an edit against and every proposal below is advisory. A format "
-            "reaches this path by implementing `PlacingProject`: `edit_path` "
-            "answers where an edit of a given kind goes and may decline a kind by "
-            "answering None, and `editing_surface` declares the region those "
-            "paths must stay inside"
+            placement_gap(editable)
+            or (
+                f"the '{editable.name}' project format implements the write tier, "
+                "but does not say where a proposed edit lands, so reconcile has no "
+                "path to plan an edit against and every proposal below is "
+                "advisory. A format reaches this path by implementing "
+                "`PlacingProject`: `load` returns the view an edit is pinned "
+                "against, `edit_path` answers where an edit of a given kind goes "
+                "and may decline a kind by answering None, and `editing_surface` "
+                "declares the region those paths must stay inside"
+            )
         )
     else:
         try:

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -27,6 +27,7 @@ import yaml
 
 from .. import command_args
 from .. import envelope as env
+from ..adapters.project import PlacingProject, placement_gap
 from ..dbt_project import ApplyResult as PlanApplyResult
 from ..dbt_project import EditOp
 from ..errors import DexError
@@ -34,7 +35,7 @@ from ..results import to_envelope
 from ..storage import Store, readable_cache
 from . import plans as plans_mod
 from . import semantic as semantic_mod
-from .plans import EditKind, PlanEdit
+from .plans import EditKind, PlanEdit, PlanError
 from .results import (
     ApplyResult,
     BuildResult,
@@ -519,7 +520,10 @@ def apply(engine: DexEngine, plan_id: str | None = None) -> ApplyResult:
 def cmd_apply(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     try:
         return to_envelope(apply(engine, getattr(args, "argument", None)))
-    except ValueError as exc:
+    except (ValueError, PlanError) as exc:
+        # `PlanError` is the apply-time containment refusal, which is a refusal
+        # the caller can act on rather than a failure, so it gets the same named
+        # envelope every other refusal on this path gets.
         return env.error_for(exc)
 
 
@@ -1047,19 +1051,37 @@ def _make_plan(engine: DexEngine, intent: str, edits: list[PlanEdit]) -> PlanRes
     # that function's own fallback (discovery from the repo root) would not
     # honor. For dbt the two agree by construction: its view loads the same
     # resolved directory `project_dir()` returns.
-    declares_surface = getattr(editable, "editing_surface", None) is not None
-    stored, diffs, warnings = plans_mod.plan(
-        intent,
-        edits,
-        None if declares_surface else engine.project_dir(),
-        repo_root,
-        store=engine.require_full_store("storing a semantic plan"),
-        # Agent-authored edits, which is the caller `editing_surface` exists for:
-        # there is no placement to compare a path against here, only the surface
-        # the format admits to owning. A format declining the write tier is
-        # `None` and validates against dbt's surface as before.
-        project_format=editable,
-    )
+    #
+    # Asked structurally: the branch turns on the format having a whole keyspace
+    # (a view to pin against, and a surface to check in), and a format holding
+    # one without the other has neither. `placement_gap` names the member it is
+    # missing, on the plan path as well as on reconcile's, because this is the
+    # other command that would otherwise fall silently back to dbt's discovery
+    # and refuse with "no dbt project found" in a repository that has none.
+    places = isinstance(editable, PlacingProject)
+    gap = placement_gap(editable)
+    try:
+        stored, diffs, warnings = plans_mod.plan(
+            intent,
+            edits,
+            None if places else engine.project_dir(),
+            repo_root,
+            store=engine.require_full_store("storing a semantic plan"),
+            # Agent-authored edits, which is the caller `editing_surface` exists
+            # for: there is no placement to compare a path against here, only the
+            # surface the format admits to owning. A format declining the write
+            # tier is `None` and validates against dbt's surface as before.
+            project_format=editable,
+        )
+    except DexError as exc:
+        # A format with a placement gap fell back to dbt's project and dbt's
+        # surface, so a refusal here names dbt's paths for an edit the format
+        # placed in its own keyspace, which reads as dex refusing the format's
+        # own file. The gap is what explains it, and it is the reason there was a
+        # fallback at all.
+        if gap is None:
+            raise
+        raise type(exc)(f"{exc}. {gap}") from exc
     return PlanResult(
         plan_id=stored.plan_id,
         intent=stored.intent,
@@ -1068,7 +1090,7 @@ def _make_plan(engine: DexEngine, intent: str, edits: list[PlanEdit]) -> PlanRes
             stored.plan_id
         ),
         diffs=diffs,
-        warnings=warnings,
+        warnings=[*warnings, gap] if gap else warnings,
     )
 
 

--- a/packages/dex-core/src/exmergo_dex_core/transform/plans.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/plans.py
@@ -153,14 +153,23 @@ def plan(
     if not edits:
         raise PlanError("a plan needs at least one edit")
 
-    # A format that declares no surface is not routed through this seam at all:
-    # it goes down the path it went down before the seam existed, loading the dbt
-    # project and validating against dbt's paths. That is a deliberate fallback
-    # rather than an oversight. Such a format cannot place an edit either (the
-    # placement seam and the surface are declared together), so the edits reaching
-    # here are dbt-shaped and dbt's view is the right thing to pin them against.
-    declares_surface = getattr(project_format, "editing_surface", None)
-    if project_format is not None and declares_surface is not None:
+    # A format that does not place is not routed through this seam at all: it goes
+    # down the path it went down before the seam existed, loading the dbt project
+    # and validating against dbt's paths. That is a deliberate fallback rather than
+    # an oversight, and the edits reaching here are dbt-shaped, so dbt's view is the
+    # right thing to pin them against.
+    #
+    # Asked structurally rather than by probing for `editing_surface`, because the
+    # branch needs `load()` as well and a format holding one without the other used
+    # to reach this line and raise `AttributeError` from inside it. `PlacingProject`
+    # is the object that says all three are there; `placement_gap` is what tells an
+    # implementer which one is not.
+    #
+    # Late import: `adapters.project` reads this module's `EditKind`.
+    from ..adapters.project import PlacingProject
+
+    places = isinstance(project_format, PlacingProject)
+    if places:
         view = project_format.load()
         project = Path(project_dir) if project_dir else Path(getattr(view, "root", "."))
     else:
@@ -173,7 +182,7 @@ def plan(
     # this from becoming the `isinstance(project, DbtProject)` gate the seam
     # exists to remove.
     dbt_shaped = isinstance(view, DbtProjectView)
-    surface = [] if dbt_shaped else list(declares_surface())
+    surface = [] if dbt_shaped or not places else list(project_format.editing_surface())
 
     warnings: list[str] = []
     pinned: list[PlanEdit] = []
@@ -344,13 +353,34 @@ def apply(
     accepted it, and the tier-3 ``write_edits`` the format implemented would
     never be reached. A plan a format could store and not apply is not a write
     path.
+
+    Raises ``PlanError`` when a stored edit falls outside the surface the format
+    declares, before anything is handed to the writer. Confirmation does not
+    override it.
     """
+
+    from ..adapters.project import PlacingProject
 
     stored = store.load_plan(plan_id)
     project = Path(repo_root) / stored.project_dir
     if project_format is None:
         result = write_edits(list(stored.edits), project, confirmed=confirmed)
     else:
+        # Containment is re-checked here, against the surface the format declares
+        # now, for the same reason the hashes are re-checked: a plan is a stored
+        # artifact that sat through a human review, and what it was validated
+        # against at plan time is not what it is being written into. The shipped
+        # format re-checks inside its own writer; a second format is otherwise
+        # trusted to, and this is the one guarantee that is not a format's to
+        # decide.
+        #
+        # A hard refusal rather than a conflict: `confirmed` is the handshake for
+        # a human edit someone can look at and accept, and no one accepts a write
+        # outside the surface the format itself declared.
+        if isinstance(project_format, PlacingProject):
+            surface = list(project_format.editing_surface())
+            for edit in stored.edits:
+                contained_key(edit.path, surface)
         result = project_format.write_edits(
             list(stored.edits), project, confirmed=confirmed
         )

--- a/packages/dex-core/tests/adapters/test_project_conformance.py
+++ b/packages/dex-core/tests/adapters/test_project_conformance.py
@@ -1,0 +1,372 @@
+"""The seam as a second format meets it: a project that is not a directory.
+
+`test_project_parity.py` runs the shipped contract against the shipped format,
+which shares an author with the protocol and so cannot show whether the contract
+is implementable by someone reading only what is published. This file builds a
+format that is neither dbt nor a filesystem, and then breaks it on purpose.
+
+Two shapes matter here and are covered nowhere else:
+
+- **A tier-3 format keyed by its own keyspace.** dbt's view is a directory tree,
+  so every path in it is also a real path, and the two are impossible to tell
+  apart from inside the contract. Here the keys are a namespace and nothing else,
+  which is the case ``edit_path`` and ``editing_surface`` were widened for.
+- **A contract that catches what it claims to.** Each defect below passed the
+  contract as it stood: an apply that lands the clean half of a refused set, a
+  create pinned to no prior content overwriting a file that appeared during
+  review, containment by string prefix, and a format missing the member no
+  protocol declared. A conformance suite that only proves a correct format
+  correct has not been shown to do anything.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from exmergo_dex_core.adapters.conformance import (
+    EditableProjectContract,
+    PlacingProjectContract,
+)
+from exmergo_dex_core.dbt_project import (
+    ApplyResult,
+    Conflict,
+    Edit,
+    EditOp,
+    ProjectDefinitions,
+    content_hash,
+)
+from exmergo_dex_core.maintain.snapshot import (
+    SemanticLayer,
+    SourceTable,
+    TransformLayer,
+)
+from exmergo_dex_core.transform.plans import EditKind, PlanError, contained_key
+
+_DECLARATION = "declarations/orders.yml"
+_ORIGINAL = "version: 2\nmodels:\n  - name: orders\n"
+_PROPOSED = "version: 2\nmodels:\n  - name: orders\n    tests: [unique]\n"
+_HUMAN = "version: 2\nmodels:\n  - name: orders  # mine\n"
+_NOTE = "models are reduced from a graph, so only the declarations are files"
+
+
+class KeyspaceFile:
+    """One entry in the view: content, and the hash the writer re-checks."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.sha256 = content_hash(content)
+
+
+class KeyspaceView:
+    """A root that names nothing on disk, and files keyed by declaration."""
+
+    def __init__(self, root: str, files: dict[str, KeyspaceFile]) -> None:
+        self.root = root
+        self.files = files
+
+
+class ViewlessKeyspaceProject:
+    """Tier 3 and placing in every member a protocol used to declare.
+
+    The split between this and :class:`KeyspaceProject` is the first defect
+    rather than an abstraction: this is the format the seam let through, passing
+    the whole suite and raising ``AttributeError: load`` on the first reconcile a
+    user ran. Everything below is shared because everything below was fine.
+
+    Its models come from a graph it never reads here; its declarations are files
+    someone wrote, held in memory because nothing about this format is a
+    directory. That is the shape tier 3 is for: an edit lands in the half that is
+    hand-authored, and the reduced half declines.
+    """
+
+    name = "keyspace"
+
+    def __init__(self, files: dict[str, str] | None = None) -> None:
+        self.files = dict(files or {})
+
+    # --- tiers 1 and 2 --------------------------------------------------------
+
+    def definitions(self) -> ProjectDefinitions:
+        return ProjectDefinitions(
+            present=True,
+            built_relation_names=["orders"] if self.files else [],
+            notes=[_NOTE],
+        )
+
+    def transform_layer(self) -> TransformLayer:
+        return TransformLayer(
+            models=["orders"] if self.files else [],
+            sources=[SourceTable(source_name="raw", table="orders")],
+            notes=[_NOTE],
+        )
+
+    def semantic_layer(self) -> SemanticLayer:
+        return SemanticLayer(notes=[_NOTE])
+
+    # --- placement and the write path -----------------------------------------
+
+    def edit_path(self, kind: EditKind, model: str) -> str | None:
+        # No authored model SQL: that half is the reduction, and writing into it
+        # would edit an artifact the next run regenerates.
+        return f"declarations/{model}.yml" if kind is EditKind.SCHEMA_YML else None
+
+    def editing_surface(self) -> list[str]:
+        return ["declarations"]
+
+    def _contain(self, path: str) -> None:
+        contained_key(path, self.editing_surface())
+
+    def write_edits(
+        self, edits: Any, project_dir: Any = None, *, confirmed: bool = False
+    ) -> ApplyResult:
+        """Hash-checked and all-or-nothing, in a keyspace rather than a tree."""
+
+        staged: list[tuple[str, Edit]] = []
+        conflicts: list[Conflict] = []
+        for edit in edits:
+            self._contain(edit.path)
+            current = self.files.get(edit.path)
+            found = content_hash(current) if current is not None else None
+            if found != edit.old_content_hash:
+                conflicts.append(
+                    Conflict(
+                        path=edit.path,
+                        expected_sha256=edit.old_content_hash,
+                        found_sha256=found,
+                    )
+                )
+            staged.append((edit.path, edit))
+
+        if conflicts and not confirmed:
+            return ApplyResult(written=[], diffs=[], conflicts=conflicts)
+
+        written: list[str] = []
+        for path, edit in staged:
+            if edit.op is EditOp.DELETE:
+                self.files.pop(path, None)
+            else:
+                self.files[path] = edit.new_content
+            written.append(path)
+        return ApplyResult(written=written, diffs=[], conflicts=conflicts)
+
+
+class KeyspaceProject(ViewlessKeyspaceProject):
+    """The whole seam: the keyspace can be read, placed into, and written."""
+
+    def load(self) -> KeyspaceView:
+        return KeyspaceView(
+            root="graph://orders",
+            files={key: KeyspaceFile(content) for key, content in self.files.items()},
+        )
+
+
+# --- the four defects, one per assertion that now exists ----------------------
+
+
+class PartialWriter(KeyspaceProject):
+    """Refuses the conflicting edit and writes the rest of the set.
+
+    The worst of them: the project ends up matching neither the proposal nor what
+    the human had, the apply reports itself refused, and nothing records which
+    half landed.
+    """
+
+    def write_edits(
+        self, edits: Any, project_dir: Any = None, *, confirmed: bool = False
+    ) -> ApplyResult:
+        conflicts, written = [], []
+        for edit in edits:
+            self._contain(edit.path)
+            current = self.files.get(edit.path)
+            found = content_hash(current) if current is not None else None
+            if found != edit.old_content_hash and not confirmed:
+                conflicts.append(
+                    Conflict(
+                        path=edit.path,
+                        expected_sha256=edit.old_content_hash,
+                        found_sha256=found,
+                    )
+                )
+                continue
+            self.files[edit.path] = edit.new_content
+            written.append(edit.path)
+        return ApplyResult(written=written, diffs=[], conflicts=conflicts)
+
+
+class SilentPartialWriter(PartialWriter):
+    """Writes half the set and reports nothing written.
+
+    The reason :meth:`a_clean_edit` is worth supplying. Asking the result what it
+    wrote catches the honest partial writer above; only reading the target
+    catches this one, and both leave the same project behind.
+    """
+
+    def write_edits(
+        self, edits: Any, project_dir: Any = None, *, confirmed: bool = False
+    ) -> ApplyResult:
+        result = super().write_edits(edits, project_dir, confirmed=confirmed)
+        if result.conflicts and not confirmed:
+            return ApplyResult(
+                written=[], diffs=result.diffs, conflicts=result.conflicts
+            )
+        return result
+
+
+class TrustingCreator(KeyspaceProject):
+    """Reads a pin of ``None`` as "nothing to compare against, go ahead".
+
+    Every other assertion passes, because in the staged conflict the pinned hash
+    is a real one and this only mishandles the create.
+    """
+
+    def write_edits(
+        self, edits: Any, project_dir: Any = None, *, confirmed: bool = False
+    ) -> ApplyResult:
+        creates = [e for e in edits if e.old_content_hash is None]
+        rest = [e for e in edits if e.old_content_hash is not None]
+        for edit in creates:
+            self._contain(edit.path)
+            self.files[edit.path] = edit.new_content
+        result = super().write_edits(rest, project_dir, confirmed=confirmed)
+        return ApplyResult(
+            written=[e.path for e in creates] + result.written,
+            diffs=result.diffs,
+            conflicts=result.conflicts,
+        )
+
+
+class PrefixContainer(KeyspaceProject):
+    """Containment by string prefix, so `declarations` admits its neighbors."""
+
+    def _contain(self, path: str) -> None:
+        if not any(path.startswith(prefix) for prefix in self.editing_surface()):
+            raise PlanError(f"outside the surface: '{path}'")
+
+
+class HashlessView(KeyspaceProject):
+    """A view whose entries carry content and no hash.
+
+    Nothing raises. Every existing file pins as a create, so a one-line change is
+    rendered as a whole-file overwrite and the apply that follows conflicts on a
+    file nobody edited.
+    """
+
+    def load(self) -> KeyspaceView:
+        view = super().load()
+        for entry in view.files.values():
+            del entry.sha256
+        return view
+
+
+class _KeyspaceContract(PlacingProjectContract, EditableProjectContract):
+    """The same few lines a third party writes, over a swappable format."""
+
+    project_cls: type[ViewlessKeyspaceProject] = KeyspaceProject
+
+    def make_project(self) -> Any:
+        return self.project_cls()
+
+    def make_unreadable_project(self) -> None:
+        # A format reduced from objects already in memory has no unparseable
+        # state, which is the case the hook's default exists for.
+        return None
+
+    def placeable_model(self) -> str:
+        return "orders"
+
+    def an_edit_against_a_changed_target(self) -> tuple[Any, Any, Any, Any]:
+        project = self.project_cls({_DECLARATION: _ORIGINAL})
+        edit = Edit(
+            path=_DECLARATION,
+            new_content=_PROPOSED,
+            old_content_hash=content_hash(_ORIGINAL),
+        )
+        # The human, arriving after the plan pinned the hash above.
+        project.files[_DECLARATION] = _HUMAN
+        return project, None, [edit], lambda: project.files.get(_DECLARATION)
+
+    def a_clean_edit(self, project: Any) -> tuple[Any, Any]:
+        # Supplied rather than left to the derived default, so the assertion asks
+        # what the project holds instead of what the writer said it wrote.
+        beside = "declarations/customers.yml"
+        edit = Edit(
+            path=beside,
+            new_content="version: 2\nmodels:\n  - name: customers\n",
+            old_content_hash=None,
+        )
+        return edit, lambda: project.files.get(beside)
+
+
+class TestKeyspaceProject(_KeyspaceContract):
+    """A format that is not dbt and not a directory, run through the contract."""
+
+
+@pytest.mark.parametrize(
+    ("format_cls", "assertion"),
+    [
+        (
+            PartialWriter,
+            "test_a_refused_apply_leaves_every_target_alone",
+        ),
+        (
+            SilentPartialWriter,
+            "test_a_refused_apply_leaves_every_target_alone",
+        ),
+        (
+            TrustingCreator,
+            "test_a_create_pinned_absent_refuses_a_target_that_now_exists",
+        ),
+        (
+            PrefixContainer,
+            "test_write_edits_refuses_a_path_outside_the_declared_surface",
+        ),
+        (
+            ViewlessKeyspaceProject,
+            "test_satisfies_the_placing_protocol",
+        ),
+        (
+            HashlessView,
+            "test_the_view_pins_what_an_edit_is_written_against",
+        ),
+    ],
+)
+def test_the_contract_catches_the_defect(
+    format_cls: type[ViewlessKeyspaceProject], assertion: str
+) -> None:
+    """Each defect fails the assertion that exists for it, by name.
+
+    Run directly rather than through a collected subclass: what is under test is
+    that the assertion fails, so a failing test is the passing outcome. The
+    message matters as much as the failure, which is why each defect is named for
+    what it does to somebody's project rather than for the method it overrides.
+    """
+
+    case = type("Mutated", (_KeyspaceContract,), {"project_cls": format_cls})()
+
+    with pytest.raises(AssertionError):
+        getattr(case, assertion)()
+
+
+def test_a_format_missing_load_is_diagnosed_rather_than_left_to_crash() -> None:
+    """The gap is named at the seam, not met as ``AttributeError`` in a command.
+
+    This is the format the issue behind these assertions describes: four declared
+    methods implemented in full, the undeclared one absent, tier 3 answered, the
+    gate passed, and the failure arriving inside a reconcile someone ran.
+    """
+
+    from exmergo_dex_core.adapters.project import (
+        EditableProject,
+        PlacingProject,
+        placement_gap,
+    )
+
+    project = ViewlessKeyspaceProject()
+
+    assert isinstance(project, EditableProject)
+    assert not isinstance(project, PlacingProject)
+    gap = placement_gap(project)
+    assert gap is not None and "`load()`" in gap
+    assert "edit_path" not in gap.split("missing")[1].split(".")[0]

--- a/packages/dex-core/tests/adapters/test_project_parity.py
+++ b/packages/dex-core/tests/adapters/test_project_parity.py
@@ -30,6 +30,8 @@ from exmergo_dex_core.adapters.project import (
     DbtProject,
     EditableProject,
     ProjectContext,
+    ProjectView,
+    SourceFileView,
     tier_of,
 )
 from exmergo_dex_core.config import DexConfig
@@ -44,6 +46,7 @@ from exmergo_dex_core.maintain.snapshot import (
     TransformLayer,
 )
 from exmergo_dex_core.storage import MemoryStore
+from exmergo_dex_core.transform.plans import PlanError, contained_key
 
 _PROJECT_YML = (
     'name: dex_test\nversion: "1.0.0"\nprofile: dex_test\nmodel-paths: ["models"]\n'
@@ -90,6 +93,27 @@ def _staged_conflict(root: Path):
     )
 
 
+def _clean_edit(root: Path):
+    """An edit beside the staged conflict that is not itself in conflict.
+
+    Supplied so the all-or-nothing assertion asks what the project holds rather
+    than what the writer reported holding: a writer that lands this one while
+    refusing the conflict answers the result honestly and still leaves the tree
+    matching nothing anybody proposed.
+    """
+
+    target = root / "analytics" / "models" / "stg_orders.sql"
+    edit = dbt_project.Edit(
+        path="models/stg_orders.sql",
+        new_content="select 1 as order_id\n",
+        old_content_hash=None,
+    )
+    return (
+        edit,
+        lambda: target.read_text(encoding="utf-8") if target.is_file() else None,
+    )
+
+
 class TestDbtProject(
     DeclaringProjectContract,
     SemanticProjectContract,
@@ -108,6 +132,9 @@ class TestDbtProject(
 
     def an_edit_against_a_changed_target(self):
         return _staged_conflict(self.root)
+
+    def a_clean_edit(self, project):
+        return _clean_edit(self.root)
 
     def placeable_model(self) -> str:
         # The warehouse table, not `stg_orders`: dbt's scaffold prefix is applied
@@ -259,6 +286,9 @@ class TestDbtProjectFactory(ProjectFactoryContract, EditableProjectContract):
     def an_edit_against_a_changed_target(self):
         return _staged_conflict(self.root)
 
+    def a_clean_edit(self, project):
+        return _clean_edit(self.root)
+
 
 class _PathlessProject:
     """A tier-2 format reduced from objects rather than files.
@@ -296,6 +326,47 @@ class TestPathlessProject(MaintainProjectContract):
 
     def make_project(self) -> _PathlessProject:
         return _PathlessProject()
+
+
+def test_the_dbt_view_is_the_shipped_project_view(tmp_path: Path):
+    """`DbtProjectView` implements `ProjectView`, member for member.
+
+    The two protocols are not `runtime_checkable`, deliberately: an isinstance
+    check on a data protocol only asks whether the names exist, which reads as a
+    type check and is not one. Asserting against the declared members rather than
+    a hand-written list is what keeps this honest if a member is ever added, since
+    the shipped format has to grow it too or this fails.
+    """
+
+    view = DbtProject(tmp_path, _project(tmp_path)).load()
+
+    for member in ProjectView.__annotations__:
+        assert hasattr(view, member), f"DbtProjectView has no `{member}`"
+    entry = view.files["models/stg_customers.sql"]
+    for member in SourceFileView.__annotations__:
+        assert hasattr(entry, member), f"SourceFile has no `{member}`"
+
+
+def test_the_dbt_editing_surface_admits_everything_its_writer_accepts(tmp_path: Path):
+    """The declaration and the writer agree, which `transform apply` now needs.
+
+    Containment is re-checked against this list before a stored plan reaches the
+    writer, so a surface narrower than what the writer takes refuses the project
+    config, the profiles and the package manifests at apply. Every one of those is
+    a path dex authors through a plan.
+    """
+
+    project = _project(tmp_path)
+    surface = DbtProject(tmp_path, project).editing_surface()
+
+    for path in (
+        "models/stg_customers.sql",
+        "macros/m.sql",
+        *dbt_project._ALLOWED_ROOT_FILES,
+    ):
+        contained_key(path, surface)
+    with pytest.raises(PlanError):
+        contained_key("models_backup/stg_customers.sql", surface)
 
 
 def test_a_pathless_format_declines_the_write_tier():

--- a/packages/dex-core/tests/maintain/test_project_format.py
+++ b/packages/dex-core/tests/maintain/test_project_format.py
@@ -35,7 +35,7 @@ from exmergo_dex_core.maintain.snapshot import (
     SourceTable,
     TransformLayer,
 )
-from exmergo_dex_core.transform.plans import EditKind
+from exmergo_dex_core.transform.plans import EditKind, contained_key
 
 _NOTE = "models are assets in an orchestrated graph, so no file backs a definition"
 
@@ -188,8 +188,13 @@ class SidecarView:
         self.files = files
 
 
-class SidecarGraphProject(GraphProject):
-    """Tier 3 for one channel only, which is the shape #258 is about.
+class ViewlessSidecarProject(GraphProject):
+    """Tier 3 for one channel only, and no way to read the keyspace it places in.
+
+    Split out from :class:`SidecarGraphProject` rather than written twice: the
+    only difference is `load()`, which is the member a second format implemented
+    without being asked to and dex called anyway. Everything below is what a
+    format got right and still could not complete a reconcile with.
 
     The models are a reduction of a running graph and cannot receive an authored
     staging model. The declared keys live in a hand-written YAML sidecar that
@@ -211,18 +216,6 @@ class SidecarGraphProject(GraphProject):
     def _root(self) -> Path:
         return Path(self.context.repo_root or ".")
 
-    def load(self) -> SidecarView:
-        root = self._root()
-        files = {}
-        for path in sorted(root.glob("declarations/*.yml")):
-            content = path.read_text(encoding="utf-8")
-            files[f"declarations/{path.name}"] = SourceFile(
-                path=f"declarations/{path.name}",
-                content=content,
-                sha256=content_hash(content),
-            )
-        return SidecarView(str(root), files)
-
     def edit_path(self, kind: EditKind, model: str) -> str | None:
         if kind is EditKind.SCHEMA_YML:
             return f"declarations/{model}.yml"
@@ -236,6 +229,10 @@ class SidecarGraphProject(GraphProject):
         root = Path(project_dir) if project_dir else self._root()
         conflicts, staged = [], []
         for edit in edits:
+            # The writer honors the surface the format declared, rather than
+            # trusting whoever built the edit to have honored it. `write_edits`
+            # is a public method, so the plan-time check is not the only door.
+            contained_key(edit.path, self.editing_surface())
             target = root / edit.path
             current = target.read_text(encoding="utf-8") if target.is_file() else None
             found = content_hash(current) if current is not None else None
@@ -256,6 +253,27 @@ class SidecarGraphProject(GraphProject):
         return ApplyResult(
             written=[e.path for _, e in staged], diffs=[], conflicts=conflicts
         )
+
+
+class SidecarGraphProject(ViewlessSidecarProject):
+    """The whole seam: the sidecar can be read as well as placed into and written.
+
+    `load()` is what carries the declarations dex pins an edit against and reads
+    before it proposes one. It lives here rather than on the base above only so
+    the base can stand in for the format that omits it.
+    """
+
+    def load(self) -> SidecarView:
+        root = self._root()
+        files = {}
+        for path in sorted(root.glob("declarations/*.yml")):
+            content = path.read_text(encoding="utf-8")
+            files[f"declarations/{path.name}"] = SourceFile(
+                path=f"declarations/{path.name}",
+                content=content,
+                sha256=content_hash(content),
+            )
+        return SidecarView(str(root), files)
 
 
 @pytest.fixture
@@ -495,6 +513,75 @@ def test_an_authored_edit_is_pinned_and_applied_where_the_format_put_it(
     assert applied["data"]["written"] == [_SIDECAR]
     assert "unique" in (authored_repo / _SIDECAR).read_text(encoding="utf-8")
     assert not (authored_repo / "analytics" / _SIDECAR).exists()
+
+
+@pytest.fixture
+def viewless_repo(maintain_repo, monkeypatch):
+    """The same repository, wired to the format that cannot be read."""
+
+    module = types.ModuleType("dex_viewless_format")
+    module.viewless_project = ViewlessSidecarProject
+    monkeypatch.setitem(sys.modules, "dex_viewless_format", module)
+
+    config = maintain_repo.root / ".dex" / "config.yml"
+    config.write_text(
+        config.read_text(encoding="utf-8")
+        + "project:\n  format: dex_viewless_format:viewless_project\n",
+        encoding="utf-8",
+    )
+    sidecar = maintain_repo.root / _SIDECAR
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(_SIDECAR_CONTENT, encoding="utf-8")
+    return maintain_repo
+
+
+def test_a_format_that_cannot_be_read_degrades_and_names_the_member(viewless_repo):
+    """The gap arrives as a warning, not as `AttributeError` mid-command.
+
+    This is the format the write tier let all the way through: it implements
+    every declared method, omits the one no protocol declared, answers tier 3,
+    passes the gate, and then raised from inside a reconcile someone ran. What it
+    gets now is what a narrower format has always got, advisory proposals and a
+    warning, and the warning names the member rather than sending the
+    implementer to the two they already wrote.
+    """
+
+    _grain_drift(viewless_repo)
+
+    rc, payload = viewless_repo.dex("maintain", "reconcile", "grain")
+
+    assert rc == 0 and payload["status"] == "ok", payload.get("errors")
+    assert payload["data"].get("plan_id") is None
+    assert not payload.get("diffs")
+    warning = next(w for w in payload["warnings"] if "PlacingProject" in w)
+    assert "`load()`" in warning
+    # And not sent to the members it already implements.
+    named = warning.split("missing")[1].split(".")[0]
+    assert "edit_path" not in named and "editing_surface" not in named
+
+
+def test_an_authored_plan_against_an_unreadable_format_says_so(viewless_repo, tmp_path):
+    """`transform plan` is the other caller, and it used to fall back silently.
+
+    The format is not asked for a view it cannot produce, so dex goes back to
+    discovering a dbt project, which is what every caller predating the seam
+    gets. That fallback is the right behavior and a baffling refusal on its own:
+    the edit is turned down for being outside *dbt's* model paths, when the
+    format placed it inside the surface it declared, so the message describes a
+    project the author was not editing. The gap rides along to say why dbt's
+    surface was the one consulted.
+    """
+
+    payload_file = _authored_edit(tmp_path, _AUTHORED)
+
+    rc, payload = viewless_repo.dex(
+        "transform", "plan", "add a unique test", "--edits-file", str(payload_file)
+    )
+
+    assert rc != 0
+    reported = json.dumps(payload["errors"])
+    assert "outside" in reported
+    assert "`load()`" in reported and "PlacingProject" in reported
 
 
 def test_a_placing_format_still_declines_the_staging_model_channel(sidecar_repo):

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -1515,6 +1515,108 @@ def test_apply_refuses_to_overwrite_a_human_edit(dbt_project_dir: Path):
     assert model.read_text(encoding="utf-8") == "select 99 as id -- hand-tuned\n"
 
 
+def test_one_conflict_refuses_the_whole_plan_not_the_conflicting_edit(
+    dbt_project_dir: Path,
+):
+    """An apply is all-or-nothing across the plan, and the edit set is the unit.
+
+    Landing the clean edits beside a refused one leaves the project matching
+    neither the proposal nor what the human had, while the apply reports itself
+    refused, so nothing records which half arrived. The single-file refusal above
+    cannot see that: with one edit in the plan there is no clean half to land.
+    """
+
+    from exmergo_dex_core import transform
+
+    touched = dbt_project_dir / "models" / "staging" / "stg_customers.sql"
+    untouched = dbt_project_dir / "models" / "marts" / "fct_orders.sql"
+    edits = [
+        transform.PlanEdit(
+            path="models/marts/fct_orders.sql",
+            kind=transform.EditKind.MODEL_SQL,
+            new_content="select 1 as order_id\n",
+        ),
+        transform.PlanEdit(
+            path="models/staging/stg_customers.sql",
+            kind=transform.EditKind.MODEL_SQL,
+            new_content="select 1 as id\n",
+        ),
+    ]
+    planned, _diffs, _warnings = transform.plan(
+        "two edits, one of which a human will touch",
+        edits,
+        dbt_project_dir,
+        repo_root=dbt_project_dir.parent,
+        store=FilesystemStore(dbt_project_dir.parent),
+    )
+    model_existed = untouched.exists()
+    touched.write_text("select 99 as id -- hand-tuned\n", encoding="utf-8")
+
+    result = transform.apply(
+        planned.plan_id,
+        dbt_project_dir.parent,
+        store=FilesystemStore(dbt_project_dir.parent),
+    )
+
+    assert result.written == []
+    assert result.conflicts
+    assert touched.read_text(encoding="utf-8") == "select 99 as id -- hand-tuned\n"
+    assert untouched.exists() == model_existed, (
+        "the clean edit landed while the conflicting one beside it was refused"
+    )
+
+
+def test_a_stored_plan_cannot_escape_the_surface_its_format_declares(
+    dbt_project_dir: Path,
+):
+    """Containment is re-checked at apply, and confirmation does not override it.
+
+    A plan is a stored artifact that sits through a human review, so what it was
+    validated against at plan time is not what it is being written into. The
+    hashes are re-checked for that reason and the surface now is too: a path
+    outside what the format declares is refused before anything reaches the
+    writer, and unlike a conflict there is nobody who can accept it.
+    """
+
+    import json as _json
+
+    from exmergo_dex_core import transform
+    from exmergo_dex_core.adapters.project import DbtProject
+
+    store = FilesystemStore(dbt_project_dir.parent)
+    planned, _diffs, _warnings = transform.plan(
+        "a plan to tamper with",
+        [
+            transform.PlanEdit(
+                path="models/staging/stg_customers.sql",
+                kind=transform.EditKind.MODEL_SQL,
+                new_content="select 1 as id\n",
+            )
+        ],
+        dbt_project_dir,
+        repo_root=dbt_project_dir.parent,
+        store=store,
+    )
+    # The plan is rewritten where it sits, which is the only way to reach apply
+    # with a path plan-time containment would have refused.
+    stored_path = dbt_project_dir.parent / ".dex" / "plans" / f"{planned.plan_id}.json"
+    stored = _json.loads(stored_path.read_text(encoding="utf-8"))
+    stored["edits"][0]["path"] = "models_backup/stg_customers.sql"
+    stored_path.write_text(_json.dumps(stored), encoding="utf-8")
+    escaped = dbt_project_dir / "models_backup" / "stg_customers.sql"
+
+    for confirmed in (False, True):
+        with pytest.raises(transform.PlanError, match="editing surface"):
+            transform.apply(
+                planned.plan_id,
+                dbt_project_dir.parent,
+                store=store,
+                confirmed=confirmed,
+                project_format=DbtProject(dbt_project_dir.parent, dbt_project_dir),
+            )
+    assert not escaped.exists()
+
+
 def test_apply_refuses_to_delete_a_human_edited_file(dbt_project_dir: Path):
     # Propose-don't-impose extends to removal: a delete never silently drops a
     # file a human touched after the plan was made.

--- a/packages/dex-core/tests/transform/test_apply.py
+++ b/packages/dex-core/tests/transform/test_apply.py
@@ -226,6 +226,35 @@ def test_reapply_is_a_noop(dbt_project_dir: Path, tmp_path: Path, capsys):
     assert envelope["data"]["written"] == []
 
 
+def test_apply_refuses_a_stored_plan_that_escapes_the_editing_surface(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    """The refusal reaches the caller as a named refusal, not a stack trace.
+
+    Containment is re-checked before the plan reaches the writer, and the failure
+    is a `PlanError`, which this command has to report the way it reports every
+    other refusal: an error envelope naming the path and the surface. It is not a
+    conflict, so `--confirm` is not a way past it.
+    """
+
+    plan_id = _make_plan(
+        tmp_path, capsys, "models/staging/stg_customers.sql", "select 1 as id\n"
+    )
+    stored_path = tmp_path / ".dex" / "plans" / f"{plan_id}.json"
+    stored = json.loads(stored_path.read_text(encoding="utf-8"))
+    stored["edits"][0]["path"] = "models_backup/stg_customers.sql"
+    stored_path.write_text(json.dumps(stored), encoding="utf-8")
+
+    rc, envelope = _run(
+        ["--repo-root", str(tmp_path), "transform", "apply", plan_id, "--confirm"],
+        capsys,
+    )
+
+    assert rc != 0 and envelope["status"] == "error"
+    assert "editing surface" in json.dumps(envelope["errors"])
+    assert not (dbt_project_dir / "models_backup" / "stg_customers.sql").exists()
+
+
 def test_apply_conflict_needs_confirmation_then_confirm_overrides(
     dbt_project_dir: Path, tmp_path: Path, capsys
 ):

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -231,7 +231,12 @@ replace) inlines a literal credential, so no secret ever reaches the diff.
 - `transform apply [plan-id]` re-hashes every file first. A file edited by a
   human after the plan was made is a **conflict**: nothing is written, the
   divergence is returned as diffs with `needs_confirmation`, and only an explicit
-  `--confirm` overrides it. A clean apply is all-or-nothing. With no plan id it
+  `--confirm` overrides it. An apply is all-or-nothing across the whole plan: one
+  conflict refuses the set, so the clean edits beside it do not land either. The
+  stored paths are re-checked against the project format's editing surface at the
+  same time, and a path outside it is refused outright rather than surfaced for
+  confirmation, since nobody can accept a write into a region the format says it
+  does not own. With no plan id it
   applies the latest unapplied plan of any kind (semantic plans included; `emit
   dbt` remains the semantic-scoped spelling). `transform plans` lists what is
   stored, pending and applied.

--- a/references/project.md
+++ b/references/project.md
@@ -41,13 +41,18 @@ implementation is complete rather than partial.
 implemented.
 
 One protocol sits beside the tiers rather than in them, `PlacingProject`, and
-reaching `reconcile`'s write path means implementing it as well as tier 3. It is
-described under [Where an edit lands](#where-an-edit-lands-and-what-you-own)
-below. It is beside rather than on tier 3 because these protocols are
-`runtime_checkable`: a method added to tier 3 would demote every format that has
-not implemented it yet, so `tier_of` would start answering 2 where it answered 3
-and the write path would close for exactly the implementers who were already
-passing.
+reaching `reconcile`'s write path means implementing it as well as tier 3. Its three
+methods are `load()`, `edit_path()` and `editing_surface()`, and they are described
+under [Where an edit lands](#where-an-edit-lands-and-what-you-own) below. It is
+beside rather than on tier 3 because these protocols are `runtime_checkable`: a
+method added to tier 3 would demote every format that has not implemented it yet, so
+`tier_of` would start answering 2 where it answered 3 and the write path would close
+for exactly the implementers who were already passing.
+
+That is also why `load()` is there rather than on tier 3, which is where you would
+look for it first. Nothing outside the placement path calls it: both callers reach it
+only for a format that places, so asking it of tier 3 would demote formats that never
+needed it in order to state a requirement that is not theirs.
 
 **Tier 1 is where the value is concentrated, and it is easy to underestimate.**
 Declared keys and declared joins reach dex through `definitions()` and through no
@@ -120,13 +125,17 @@ those two.
 
 Tier 3 says your format *can* receive an edit. It does not say where the edit goes,
 and reconcile decides that before it consults you. `PlacingProject` is where you
-answer, and reaching the write path means implementing both of its methods.
+answer, and reaching the write path means implementing all three of its methods.
 
 ```python
+from exmergo_dex_core.adapters.project import ProjectView
 from exmergo_dex_core.transform.plans import EditKind
 
 
 class MyProject:  # ... tier 3 methods as above
+    def load(self) -> ProjectView:
+        return MyView(root=self.root, files=self.declarations())
+
     def edit_path(self, kind: EditKind, model: str) -> str | None:
         if kind is EditKind.SCHEMA_YML:
             return f"declarations/{model}.yml"
@@ -135,6 +144,35 @@ class MyProject:  # ... tier 3 methods as above
     def editing_surface(self) -> list[str]:
         return ["declarations"]
 ```
+
+The three describe one keyspace, and none of them is answerable alone. A key is a key
+into a view; a surface is a region of the same space; and a view nobody places into is
+a read dex has no use for on this path. A format holding two of the three places
+nothing at all, and dex says which one is missing rather than leaving it to surface as
+`AttributeError` from inside a command the tier check already let through.
+
+`load()` reads the keyspace, once per command, and returns a `ProjectView`:
+
+| member | type | what breaks without it |
+|---|---|---|
+| `root` | `str` | the plan has no directory to record its edits as pinned against |
+| `files` | `Mapping[str, SourceFileView]` | a placed path resolves to nothing |
+| `files[k].content` | `str` | no diff can be built for a human to review |
+| `files[k].sha256` | `str` | every existing file pins as a create, so a one-line change renders as a whole-file overwrite and the next apply conflicts on a file nobody touched |
+
+`files` is keyed exactly the way `edit_path` keys and `editing_surface` prefixes,
+which is the whole point of the type. `root` is what the plan records as the directory
+it was pinned against, relative to the repository root where that subtraction is
+possible and verbatim where it is not, so a format keyed by something other than a
+directory returns whatever identifies its root and the plan carries that. The hash need
+only be consistent with what your own writer re-checks: it is your keyspace, and dex
+compares your value against your value.
+
+`ProjectView` and `SourceFileView` are declared protocols and neither is
+`runtime_checkable`. Nothing calls `isinstance` against them, because an isinstance
+check on a data protocol only asks whether the attribute names exist, which reads as a
+type check and is not one. `PlacingProjectContract` makes that check instead, with a
+message naming the missing member and what it costs.
 
 `edit_path(kind, model)` says where an edit of that kind for that table lives. Two
 things about it are easy to get wrong. `model` is the warehouse table the finding is
@@ -162,6 +200,22 @@ admitting all of them, which is the same statement declining tier 3 makes.
 
 This is containment, which is a safety property and stays mandatory. What the seam
 moved is who declares the surface, not whether there is one.
+
+**Honor it in your writer too, and expect dex to re-check it.** Containment is
+checked when a plan is stored, and re-checked against this declaration before dex
+hands a stored plan to `write_edits`, for the same reason the hashes are re-checked:
+a plan is a stored artifact that sits through a human review, so what it was
+validated against then is not what it is being written into. That refusal is a hard
+one, and `confirmed` is not a way past it. Nobody accepts a write outside the surface
+the format itself declared. Your own writer still has to check, because `write_edits`
+is a public method of your format and dex is not its only caller, and the conformance
+suite asserts the case a prefix comparison gets wrong.
+
+**Declare what your writer accepts, not less.** The shipped dbt format lists its
+model and macro paths *and* the four root manifests it authors by name, because a
+declaration narrower than the writer is not a modest one: it refuses the project
+config, the profiles and the package manifests at apply, every one of which is a path
+dex authors through a plan.
 
 **One thing dex still spells its own way.** The `unique` test edit finds your model
 inside the placed file by the file's own name (`declarations/orders.yml` means a
@@ -338,26 +392,64 @@ Two hooks are worth overriding beyond `make_project`:
 Tier 3 adds one more hook, and unlike the two above it is **not optional**.
 `an_edit_against_a_changed_target()` returns a project, a directory, an edit set
 pinned to content that has since moved, and a callable reading what the target holds
-now. Two assertions use it: an unconfirmed write must leave the target alone, and a
-confirmed one must go through. They only mean something as a pair, since a
-`write_edits` that never writes satisfies the first on its own. The hook raises
-rather than skipping because the excuse that justifies skipping
+now. It raises rather than skipping because the excuse that justifies skipping
 `make_unreadable_project` does not apply here. A format may genuinely have no
 unparseable state, but a format that reached tier 3 writes into a source of truth a
 human can also edit, so the case where the human got there first exists for all of
 them.
+
+Four assertions are built from it. An unconfirmed write must leave the target alone
+and a confirmed one must go through, and those two only mean something as a pair,
+since a `write_edits` that never writes satisfies the first on its own. **That pair
+rules out a writer that never writes; it does not rule out a writer that writes too
+much**, which is what the other two are for:
+
+- **A conflict refuses the apply, not the conflicting edit within it.** The edit set
+  is the unit. A writer that lands the clean edits and holds back the conflicting one
+  leaves the project matching neither the proposal nor what the human had, while the
+  apply reports itself refused, so nothing records which half arrived. A single-edit
+  set cannot see this, which is why the assertion stages two.
+- **A create pinned to no prior content is refused when the target now exists.**
+  `old_content_hash=None` is a claim that the file was absent at plan time. If one is
+  there now, the claim is false and honoring it costs the human who created it during
+  review the whole file rather than the lines that diverged. A writer reading `None`
+  as "nothing to compare, go ahead" passes every other assertion, because in the
+  staged conflict the pinned hash is a real one.
+
+One optional hook is worth supplying beside them. **`a_clean_edit(project)`** returns
+an edit that is not in conflict, pinned truthfully against the project the conflict
+hook just staged, and a callable reading its target. Without it the all-or-nothing
+assertion can only ask what `write_edits` *reported*, so a writer that lands half an
+edit set and reports nothing written still passes; with it, the target is read
+directly and the claim is checked against the project. Returning `None` falls back to
+an edit derived from the staged conflict's own path, which is inside your surface by
+construction and needs nothing from you.
 
 `PlacingProjectContract`, mixed in beside it, has one hook that is likewise not
 optional. `placeable_model()` returns a warehouse table your format would place an
 edit for, spelled as the warehouse spells it rather than as your format names the
 model derived from it, because that is how reconcile's findings arrive and it is the
 thing `edit_path` is most often gotten wrong on. The assertions are cheap and mostly
-about your two answers agreeing: at least one kind places somewhere, every path
+about your three answers agreeing: at least one kind places somewhere, every path
 `edit_path` returns is inside `editing_surface()`, and the surface itself stays
-within the project. The middle one is the reason the contract exists, since a
+within the project. That middle one is a reason the contract exists, since a
 placement outside your own declared surface builds a proposal the plan store then
 refuses, and from the outside that reads as dex declining rather than as the format
 contradicting itself.
+
+Two more come from `load()` being part of the same keyspace. The view has to carry
+`root` and `files`, and the entry behind a path your own hook staged an edit against
+has to carry `content` and `sha256`, each of which fails silently in its own way
+when it is absent. And `write_edits` has to refuse a path outside the surface you
+declared: what is asserted is the case a prefix comparison gets wrong, a sibling that
+merely starts with the same characters, since a format matching by string prefix
+admits the whole neighborhood of every region it owns while passing everything else.
+Refusing by raising and refusing by writing nothing both count.
+
+Placement presupposes tier 3, and the contract checks that first, the way
+`SemanticProjectContract` checks tier 2. Mix it in beside `EditableProjectContract`:
+the assertions here write through your format, and placing an edit a format cannot
+receive describes a path that stops halfway.
 
 The suite needs only pytest: no dialect engine, no connector. A packaging test keeps
 it that way.
@@ -467,3 +559,14 @@ reduced from a running graph has no directory, a hosted one has service coordina
 and a contract shaped around dbt would have left both unbuildable. The nullable
 slots plus verbatim `options` are what let a format that is keyed by nothing at all
 be named the same way.
+
+**Declaring `load()` on tier 3.** It is where a reader looks for it, and it is the
+protocol the method's callers are typed against, so it was the obvious home. It is
+the wrong one twice over. These protocols are `runtime_checkable`, so a method added
+to tier 3 demotes every format that has not implemented it, which is the argument
+that put `PlacingProject` beside the tiers in the first place; and the requirement is
+not tier 3's to state, because nothing outside the placement path calls `load()`. A
+format that receives edits and does not place them never needed a view, and would
+have been demoted to say otherwise. Beside the two methods that share its keyspace,
+it demotes only formats that were already going to fail, and it fails them into the
+advisory degradation the gate was written to give.

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -51,7 +51,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.6"
+DEX_CORE_VERSION = "1.7.0"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -51,7 +51,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.6"
+DEX_CORE_VERSION = "1.7.0"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -51,7 +51,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.6.6"
+DEX_CORE_VERSION = "1.7.0"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
Closes #328.

A second format reached tier 3 and `PlacingProject` in full, passed the whole
conformance suite, and could not have completed a single `maintain reconcile`.
Both halves of that are the same statement from different sides: what the write
tier requires is not what its contract asserted, and what its callers call is not
what its protocols declared.

Filed as one issue and fixed as one, for the reason the reporter gave. The fixes
are separable; the premise is not.

## `load()` is declared, and it is declared on `PlacingProject`

Two callers used it and no protocol named it. `transform/plans.py` calls it to
pin each edit and resolve the project root; `maintain/commands.py` calls it before
reconcile builds a proposal. `DbtProject` has one, so nothing in-tree noticed. A
format implementing the four declared methods and omitting this one passed
conformance and raised `AttributeError: load` on the first real reconcile, after
the tier said 3 and after the gate let it through.

The issue proposes declaring it on `EditableProject`. It is on `PlacingProject`
instead, and that is the one place this PR departs from what was asked for.

Both call sites reach `load()` only for a format that places:
`maintain/commands.py` sits in the `else` branch under
`isinstance(editable, PlacingProject)`, and `plans.plan` enters the format branch
only when a surface is declared. So the requirement is not tier 3's to state. A
format that receives edits and does not place them never needed a view, and
declaring the method on tier 3 would have demoted it to say otherwise, which is
precisely the argument already written into `PlacingProject`'s own docstring for
why it sits beside the tiers rather than on them. Beside the two methods that
share its keyspace, `load()` demotes only formats that were already going to
fail, and it fails them into the advisory degradation the gate was written to
give.

The shape is pinned, which the issue asked about rather than assumed:
`ProjectView` (`root`, `files`) and `SourceFileView` (`content`, `sha256`),
declared as protocols and deliberately not `runtime_checkable`. Nothing calls
`isinstance` against them, because on a data protocol that only asks whether the
attribute names exist, which reads as a type check and is not one. The
conformance suite makes that check with a message naming the missing member and
what it costs. `isinstance(view, DbtProjectView)` survives untouched: it asks
whether a view is dbt's surface, not whether it is a view, and the comment beside
it now says so.

## Three assertions, and the hook that makes one of them real

Every defect in the reporter's mutation table now fails, and the mutants are in
the tree:

| defect | before | now fails |
|---|---|---|
| writes the non-conflicting edits while refusing the conflicting one | pass | `test_a_refused_apply_leaves_every_target_alone` |
| the same, reporting nothing written | pass | the same, via `a_clean_edit` |
| a create pinned `None` overwrites a file that appeared during review | pass | `test_a_create_pinned_absent_refuses_a_target_that_now_exists` |
| containment by string prefix | pass | `test_write_edits_refuses_a_path_outside_the_declared_surface` |
| `load()` missing | pass | `test_satisfies_the_placing_protocol` |
| a view with no `sha256` | pass | `test_the_view_pins_what_an_edit_is_written_against` |

No new mandatory hook. The assertions compose from what implementers already
supply: the clean edit is derived as a sibling of the staged conflict's own path,
so it is inside the surface by construction, and the create-over-existing case is
the staged edit re-pinned to `None`. A downstream suite that was green stays
runnable, and gets the new assertions for free.

One optional hook is worth supplying, and dbt supplies it in-repo:
`a_clean_edit(project)` returns an unconflicted edit and a callable reading its
target. Without it the all-or-nothing assertion can only ask what `write_edits`
*reported*, which catches an honest partial writer and not a quiet one. The
`SilentPartialWriter` mutant exists to prove the difference.

## Containment is re-checked where dex controls the call

The issue argues for asserting containment because `write_edits` is reachable
directly. The same argument says dex should not be trusting it on the path dex
controls either: `plans.apply` handed a stored plan straight to the format's
writer, so for a second format containment was enforced once, at plan time, by
the code that stored the plan. The hashes are re-checked at apply because a plan
is a stored artifact that sits through a human review. The surface is exactly as
much a plan-time fact as they are.

It is a hard refusal rather than a conflict, and `--confirm` is not a way past
it. Confirmation is the handshake for a human edit somebody can look at and
accept; nobody accepts a write into a region the format says it does not own.

This surfaced one thing worth flagging: dbt's `editing_surface()` omitted the four
root manifests its own writer allows by name, on the grounds that the check kept
applying them on the dbt path. With a second consumer reading that declaration, a
surface narrower than the writer refuses the project config, the profiles and the
package manifests at apply. It now declares what it accepts.

## The partial format is diagnosed rather than left to crash

Two call sites decided whether to route through a format by probing for
`editing_surface` and then called `load()`. Both now ask for `PlacingProject`
structurally, and `placement_gap()` names the member a partial format is missing,
because the warning those callers would otherwise emit ("does not say where a
proposed edit lands") is false of a format that answers `edit_path` and cannot be
read, and sends the implementer to the methods they already wrote.

On the `transform plan` path the fallback is dbt's project and dbt's surface,
which refuses an edit the format placed in its own keyspace while naming dbt's
paths. The gap rides along on that refusal, so the message explains why dbt's
surface was the one consulted.

## What proves it

`tests/adapters/test_project_conformance.py` is new: a tier-3 and placing format
that is neither dbt nor a directory, keyed by its own keyspace, driven through
the full suite, and then broken six ways, one per assertion. It is the project
analogue of `tests/storage/test_conformance.py`, and it needed writing for the
same reason: the shipped format shares an author with the protocol.

`SidecarGraphProject`, the second-format double the reconcile end-to-end tests
write through, wrote `root / edit.path` with no containment check at all. dex's
own model of a second format carried defect three. Fixed, and its `load()` is
split into a subclass so the base can stand in for the format that omits one.

The safety spine gains the two system-level statements the contract now asserts
per format: one conflict refuses the whole plan, and a stored plan cannot escape
the surface its format declares even with `--confirm`.

## Notes for review

- The atomicity and create-pinned-`None` assertions live on
  `EditableProjectContract` rather than `PlacingProjectContract`, which is a
  change from the agreed plan. They need only the tier-3 hook, so putting them
  with placement would have left them unrun for a tier-3 format that does not
  place, and both defects are write-tier defects. Only the two that genuinely
  read `editing_surface` or `load()` sit with placement. Easy to move if you
  disagree.
- `plans.apply` now loads the dbt project twice on a dbt apply: once for
  `editing_surface()` (memoized on the instance) and once inside
  `dbt_project.write_edits`. Accepted rather than reintroducing an
  `isinstance(DbtProject)` shortcut, which is the check the seam removed.
- This adds a public protocol member and a new refusal at apply. A patch number
  understates it.
