### PR TITLE
`transform` authors snapshots and seeds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,10 +99,16 @@ Authored content reaches the engine through `--edits-file <path>` (or `-` for
 stdin): a JSON payload of `{"edits": [{"path", "kind", "op", "content"}, ...]}`
 with `kind` one of `model_sql`, `schema_yml`, `semantic_yml`, `packages_yml` (the
 guarded way to author the project-root `packages.yml`/`dependencies.yml`, so
-declaring a dbt package is a reviewable diff too), `macro_sql`, `project_yml`
-(the project-root `dbt_project.yml`), or `profiles_yml` (the project-root
-`profiles.yml`, secret-guarded so a credential never enters the diff: reference
-secrets via `{{ env_var('NAME') }}`). `op` is `upsert` (create or update, the
+declaring a dbt package is a reviewable diff too), `macro_sql`, `snapshot_sql`
+(one `{% snapshot %}` block under the project's snapshot paths, its `config()`
+naming a `unique_key` and a strategy), `seed_csv` (a small reference CSV under
+the seed paths, capped at 5,000 rows and 1 MiB and refused when a column name
+looks like personal data, since a seed puts values into a diff and a diff goes
+into git), `project_yml` (the project-root `dbt_project.yml`), or `profiles_yml`
+(the project-root `profiles.yml`, secret-guarded so a credential never enters the
+diff: reference secrets via `{{ env_var('NAME') }}`). Each kind is confined to
+its own path family, and `schema_yml` is accepted beside a snapshot or a seed as
+well as beside a model. `op` is `upsert` (create or update, the
 default, carrying `content`) or `delete` (remove the file, no `content`); a
 delete is a reviewable diff too, guarded so the plan is refused if any surviving
 file still `ref()`s a deleted model, and a rename is one plan (delete old, create

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,68 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **`transform` authors dbt snapshots** ([#210]). A `snapshot_sql` edit kind, and
+  `snapshot-paths` read from `dbt_project.yml` with dbt's own default. Before
+  this, `transform plan` refused a snapshot file as "outside the project's model
+  paths", which was self-contradicting from the caller's side: a snapshot **is**
+  the dbt project surface, and slowly-changing-dimension capture is one of the
+  more common things an analytics engineer is asked to add. The only way to add
+  one was to leave the plan-then-apply path and write the file by hand, which
+  dropped the reviewable diff, the hash pinning and the conflict detection for
+  exactly the kind of change that most deserves them.
+
+  Validation is layered the way the macro kind's is. Structurally: exactly one
+  `{% snapshot %}` / `{% endsnapshot %}` block with nothing loose outside it, a
+  `config()` inside it naming a `unique_key` and a `strategy` of `timestamp` or
+  `check` along with the field that strategy cannot work without (`updated_at`
+  or `check_cols`), and a body that is a single read-only SELECT once its jinja
+  is stripped, the same guard a model gets. Each refusal names the fix rather
+  than the rule. Behind that, dbt's own parser runs at plan time and is the
+  authoritative gate, degrading to a warning where dbt is not installed.
+
+  `dbt build` runs snapshots natively, so nothing new has to be run after an
+  apply, and a snapshot writes a table, so it is priced in the cost handshake
+  like a model.
+
+- **`transform` authors dbt seeds** ([#211]). A `seed_csv` edit kind confined to
+  `seed-paths`, so moving a small reference mapping out of hard-coded SQL is a
+  reviewable diff like every other change instead of a hand-written file outside
+  the guardrail.
+
+  A seed is validated as CSV: it parses, the header is present and every column
+  is named, no two columns collide case-insensitively (warehouses fold
+  identifier case), and every row carries one field per column, with the refusal
+  naming the row and the column at fault. Two caps bound it, 5,000 data rows and
+  1 MiB, because a multi-megabyte CSV in a plan diff is unreadable in review,
+  which is the one thing a reviewable diff is for; over either, the refusal names
+  the cap and points at loading the data into the warehouse and `source()`-ing it.
+
+  **A seed is the first edit kind that puts values, not logic, into a diff**, and
+  a diff goes into git and stays there. So a seed's header is read two ways:
+  through the same name-and-type PII detector `explore` profiles warehouse
+  columns with, and against the flags already in the `.dex/` cache, where a
+  column a human has reviewed and cleared has already stopped being flagged. A
+  hit at or above the block threshold refuses, and the refusal names the exact
+  `pii_overrides` entry that would clear the column, carrying its name and
+  category and never a value. The refusal fires inside validation, which runs
+  before any diff is built, so a refused seed's values never enter a diff, agent
+  context, or git; a safety-spine assertion pins the ordering rather than only
+  the outcome.
+
+  Two limits are stated rather than papered over. Detection reads names and
+  types and never values, everywhere in dex, so a seed column named `code` full
+  of email addresses passes this gate. And the detector's generic `*_name` match
+  is one it explicitly calls provisional (on a warehouse column `explore` refines
+  it against value shape, up or down); dex never reads a seed's values, so that
+  refinement cannot run and the match warns instead of blocking. Every explicit
+  pattern (email, phone, address, government id, and the rest) still blocks, as
+  does a `*_name` column the cache has already flagged for real.
+
+  `dbt build` runs seeds natively, so applying and building is all it takes. A
+  seed loads a local CSV and scans nothing, so it stays deliberately unpriced.
+
 ### Changed
 
 - **`explore map` returns the map, not a receipt for it** ([#202]). The command
@@ -52,7 +114,53 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   it. Found by dogfooding the demo warehouse, and now asserted: every count in
   the payload reconciles with the objects it sits next to.
 
+- **The project view now loads all four of dbt's authored path families**
+  ([#210], [#211]). Loading snapshots and seeds is what makes them authorable: a
+  file dex can write but does not load hashes as absent, so a later edit to it
+  registers as a create and the apply after it conflicts on a file nobody
+  touched. The scan is per-family now rather than one global suffix filter
+  (`.sql`/`.yml`/`.yaml` under model, macro and snapshot paths, `.csv` plus YAML
+  under seed paths), so a stray CSV elsewhere in the repo is still nobody's
+  fixture to hash.
+
+  That widening moved what `maintain` fingerprints, which is the part that would
+  otherwise have broken quietly. Two derivations read "the things this project
+  builds" out of the file list by taking every `.sql` and using its filename;
+  loading snapshots would have made snapshots models there, and seeds would have
+  been missed entirely. Both are now scoped to the families that actually produce
+  a dbt node: `.sql` under model and snapshot paths, `.csv` under seed paths.
+  Macros counted as models before and no longer do, which is a fix rather than a
+  regression (a macro builds no relation and is `ref()`-able by nobody) but is a
+  behavior change worth naming. A baseline pinned before this lands reports no
+  phantom drift, because no detector diffs the file set or the model list; a test
+  pins that with a pre-change baseline.
+
+  Deleting a snapshot or a seed is now guarded like deleting a model, since both
+  are `ref()`-able. The seed half was a real hole: `.csv` never matched the
+  `.endswith(".sql")` test the guard made, so deleting a seed a model still
+  `ref()`s would have been accepted and broken the build.
+
+- **An edit's kind and its location must agree, across every family.** The rule
+  that kept a macro out of `models/` is now a table over the four families and
+  the file suffix, and it refuses in both directions naming both fixes (move the
+  file, or relabel the kind). `schema_yml` is admitted beside a snapshot and a
+  seed as well as beside a model, because that is where dbt expects a snapshot's
+  tests and a seed's column types declared. Macro-path behavior is unchanged.
+
 ### Fixed
+
+- **`transform plan` refuses on its own terms before it hands anything to dbt's
+  parser** ([#210], [#211]). The parse gate runs before the plan is stored, and
+  `shadow_parse` copies the project into a temp directory *with the edits written
+  into it*. Once snapshots and seeds joined that gate, a seed refused for
+  carrying personal data had already reached disk and a dbt subprocess by the
+  time the refusal fired, and dbt's message stood in for dex's own
+  ("Encountered unknown tag 'snapshot'" in place of "a snapshot_sql edit must
+  live under the project's snapshot paths"). The refusing half of plan-time
+  validation is now shared between `plans.plan` and the command, which runs it
+  first, on the same principle the profiles secret-guard already followed. Found
+  by dogfooding, and now pinned by a spine test that fails if the parser is ever
+  reached with a PII-flagged seed.
 
 - **Databricks: `explore profile` and `explore map` crashed on any real value
   domain.** The value-domain probe reads back a `collect_list`, which is an

--- a/packages/dex-core/src/exmergo_dex_core/adapters/project.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/project.py
@@ -694,7 +694,7 @@ class DbtProject:
         return None if suffix is None else f"models/staging/stg_{model}.{suffix}"
 
     def editing_surface(self) -> list[str]:
-        """Everything dbt's own writer accepts: the model and macro paths, and
+        """Everything dbt's own writer accepts: every authored path family, and
         the four root manifests it admits by name.
 
         Read rather than assumed: a project that configures ``model-paths`` away
@@ -711,8 +711,5 @@ class DbtProject:
         """
 
         view = self.load()
-        return (
-            list(view.model_paths)
-            + list(view.macro_paths)
-            + sorted(dbt_project._ALLOWED_ROOT_FILES)
-        )
+        families = [path for _name, paths in view.path_families() for path in paths]
+        return families + sorted(dbt_project._ALLOWED_ROOT_FILES)

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -57,6 +57,19 @@ _ALLOWED_ROOT_FILES = frozenset(
     {"packages.yml", "dependencies.yml", PROJECT_FILE, PROFILES_FILE}
 )
 
+# What each of dbt's authored path families can hold. Models and snapshots are
+# SQL plus their properties YAML; macros are jinja plus their properties YAML;
+# seeds are CSV data plus the YAML that declares their column types. The scan is
+# per-family rather than one global suffix filter because ".csv" is only a seed
+# anywhere else it is somebody's fixture, and a fixture is not dex's to hash.
+_YAML_SUFFIXES = frozenset({".yml", ".yaml"})
+_FAMILY_SUFFIXES: dict[str, frozenset[str]] = {
+    "model": _YAML_SUFFIXES | {".sql"},
+    "macro": _YAML_SUFFIXES | {".sql"},
+    "snapshot": _YAML_SUFFIXES | {".sql"},
+    "seed": _YAML_SUFFIXES | {".csv"},
+}
+
 
 class DbtProjectError(ProjectError):
     """The dbt format's refusal, and the shipped implementation of ``ProjectError``.
@@ -79,9 +92,15 @@ class SourceFile(BaseModel):
 class DbtProjectView(BaseModel):
     """The in-memory view of a dbt project.
 
-    ``files`` holds every ``*.sql``/``*.yml``/``*.yaml`` under the model paths:
-    the surface transform edits. ``manifest`` is the compiled artifact when the
-    project has been compiled; a fresh project loads fine without one.
+    ``files`` holds the editable surface: the source files under each of dbt's
+    four authored path families, each scanned for the suffixes that family can
+    hold (see :data:`_FAMILY_SUFFIXES`). ``manifest`` is the compiled artifact
+    when the project has been compiled; a fresh project loads fine without one.
+
+    A file that is *not* in ``files`` hashes as absent, so a later edit to it
+    registers as a create and the apply that follows conflicts on a file nobody
+    touched. That is why the scan covers every family dex can author into, not
+    only the ones it reads for definitions.
     """
 
     root: str
@@ -89,8 +108,27 @@ class DbtProjectView(BaseModel):
     profile_name: str
     model_paths: list[str] = Field(default_factory=lambda: ["models"])
     macro_paths: list[str] = Field(default_factory=lambda: ["macros"])
+    snapshot_paths: list[str] = Field(default_factory=lambda: ["snapshots"])
+    seed_paths: list[str] = Field(default_factory=lambda: ["seeds"])
     files: dict[str, SourceFile] = Field(default_factory=dict)
     manifest: dict[str, Any] | None = None
+
+    def path_families(self) -> list[tuple[str, list[str]]]:
+        """Every authored path family, as ``(name, configured paths)``.
+
+        One place to add the next family, and the order is the order a path is
+        matched against when deciding which family it belongs to: the specific
+        families first, models last as the catch-all. Two families configured to
+        the same directory is a project mistake dex does not adjudicate; the
+        first listed wins and the containment message names all four.
+        """
+
+        return [
+            ("macro", list(self.macro_paths)),
+            ("snapshot", list(self.snapshot_paths)),
+            ("seed", list(self.seed_paths)),
+            ("model", list(self.model_paths)),
+        ]
 
 
 class TargetInfo(BaseModel):
@@ -221,23 +259,46 @@ def load(project_dir: Path | str = ".") -> DbtProjectView:
     if not project_name:
         raise DbtProjectError(f"{project_file} has no 'name'")
     model_paths = list(raw.get("model-paths", ["models"]))
-    # dbt's own default when the key is absent, so a skeleton project's first
-    # scaffolded macro lands where dbt will look for it.
+    # dbt's own defaults when a key is absent, so a skeleton project's first
+    # scaffolded macro, snapshot, or seed lands where dbt will look for it.
     macro_paths = list(raw.get("macro-paths", ["macros"]))
+    snapshot_paths = list(raw.get("snapshot-paths", ["snapshots"]))
+    seed_paths = list(raw.get("seed-paths", ["seeds"]))
+
+    # Suffixes unioned per directory rather than per family, so a project that
+    # points two families at one directory gets both sets scanned instead of
+    # whichever happened to be visited last.
+    scan: dict[str, set[str]] = {}
+    for family, paths in (
+        ("model", model_paths),
+        ("macro", macro_paths),
+        ("snapshot", snapshot_paths),
+        ("seed", seed_paths),
+    ):
+        for configured in paths:
+            scan.setdefault(configured, set()).update(_FAMILY_SUFFIXES[family])
 
     files: dict[str, SourceFile] = {}
-    for model_path in model_paths + macro_paths:
-        base = root / model_path
+    for configured, suffixes in scan.items():
+        base = root / configured
         if not base.is_dir():
             continue
         for path in sorted(base.rglob("*")):
-            if path.suffix not in {".sql", ".yml", ".yaml"} or not path.is_file():
+            if path.suffix not in suffixes or not path.is_file():
                 continue
             # Posix-separated regardless of OS: every consumer of `files` keys
             # (transform_layer's model-name parsing, scaffolded model paths,
             # this module's own backed_relation_names) assumes "/".
             rel = path.relative_to(root).as_posix()
-            content = path.read_text(encoding="utf-8")
+            try:
+                content = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                # A seed saved in a legacy encoding is the realistic case, and
+                # loading the project is a prerequisite for every command,
+                # explore included. Skipping the file costs a spurious conflict
+                # if someone later edits it through dex; raising would cost them
+                # the whole engine.
+                continue
             files[rel] = SourceFile(
                 path=rel, content=content, sha256=content_hash(content)
             )
@@ -271,6 +332,8 @@ def load(project_dir: Path | str = ".") -> DbtProjectView:
         profile_name=raw.get("profile", project_name),
         model_paths=model_paths,
         macro_paths=macro_paths,
+        snapshot_paths=snapshot_paths,
+        seed_paths=seed_paths,
         files=files,
         manifest=manifest,
     )
@@ -491,9 +554,7 @@ def write_edits(
     conflicts: list[Conflict] = []
     diffs: list[dict[str, Any]] = []
     for edit in edits:
-        target_path = contained_path(
-            root, edit.path, view.model_paths, view.macro_paths
-        )
+        target_path = contained_path(root, edit.path, view)
         current = (
             target_path.read_text(encoding="utf-8") if target_path.is_file() else None
         )
@@ -535,19 +596,20 @@ def write_edits(
     return ApplyResult(written=written, diffs=diffs, conflicts=conflicts)
 
 
-def contained_path(
-    root: Path,
-    rel_path: str,
-    model_paths: list[str],
-    macro_paths: list[str] | None = None,
-) -> Path:
+def contained_path(root: Path, rel_path: str, view: DbtProjectView) -> Path:
     """Resolve an edit path and refuse anything outside the project's editing
     surface.
 
     Writes are confined to the repo, and within the repo to the dbt editing
-    surface: model SQL, schema.yml, and semantic YAML live under the model
-    paths, and macros under the macro paths. Escapes (absolute paths, ``..``)
-    are refused outright.
+    surface: model SQL, schema.yml and semantic YAML under the model paths,
+    macros under the macro paths, snapshots under the snapshot paths, seeds
+    under the seed paths, plus the root manifests dbt keeps at the project root.
+    Escapes (absolute paths, ``..``) are refused outright.
+
+    The families are read off the view rather than passed positionally. Four of
+    them is where a positional list stops being readable, and every caller
+    already holds a view: the writer loads one, and both plan-time callers were
+    handed one.
     """
 
     candidate = Path(rel_path)
@@ -559,15 +621,67 @@ def contained_path(
     # name (still inside the project, still not an arbitrary escape).
     if resolved.parent == root_resolved and resolved.name in _ALLOWED_ROOT_FILES:
         return root / candidate
-    allowed = list(model_paths) + list(macro_paths or [])
-    for allowed_path in allowed:
-        base = (root_resolved / allowed_path).resolve()
-        if resolved == base or base in resolved.parents:
-            return root / candidate
-    raise DbtProjectError(
-        f"edit path '{rel_path}' is outside the project's model and macro "
-        f"paths ({', '.join(allowed)}); dex edits only the dbt project surface"
+    if path_family(root, rel_path, view) is not None:
+        return root / candidate
+    listed = ", ".join(
+        f"{name} ({', '.join(paths) or 'none'})" for name, paths in view.path_families()
     )
+    raise DbtProjectError(
+        f"edit path '{rel_path}' is outside the project's authored paths "
+        f"[{listed}]; dex edits only the dbt project surface"
+    )
+
+
+def path_family(root: Path, rel_path: str, view: DbtProjectView) -> str | None:
+    """Which authored family ``rel_path`` falls in, or ``None`` for none of them.
+
+    The other half of containment: containment asks whether a path is inside the
+    surface at all, and this asks *which* part of it, which is what decides
+    whether the edit's declared kind belongs there. Both answer from the same
+    traversal so they can never disagree about where a directory ends.
+    """
+
+    resolved = (root / Path(rel_path)).resolve()
+    root_resolved = root.resolve()
+    for name, paths in view.path_families():
+        for configured in paths:
+            base = (root_resolved / configured).resolve()
+            if resolved == base or base in resolved.parents:
+                return name
+    return None
+
+
+def node_files(view: DbtProjectView) -> dict[str, SourceFile]:
+    """The files that become a dbt node named after the file, keyed by path.
+
+    A model, a snapshot and a seed each build a relation dbt names after the
+    file and each is ``ref()``-able; a macro, a schema.yml and a semantic YAML
+    build nothing. Every derivation that reads "the things this project builds"
+    out of the file list goes through here, so widening the load to a new family
+    cannot quietly turn its files into models by filename.
+    """
+
+    nodes: dict[str, SourceFile] = {}
+    for path, source in view.files.items():
+        family = path_family(Path(view.root), path, view)
+        if (family in ("model", "snapshot") and path.endswith(".sql")) or (
+            family == "seed" and path.endswith(".csv")
+        ):
+            nodes[path] = source
+    return nodes
+
+
+def node_name(path: str) -> str:
+    """The dbt node name a node file builds: its stem, case preserved.
+
+    dbt names a model, snapshot or seed after the file, ignoring the
+    directories above it, which is why two same-named files in different
+    subdirectories are a dbt error rather than two nodes. Case is preserved
+    because ``ref()`` matches it; callers comparing against warehouse
+    identifiers lower it themselves.
+    """
+
+    return path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
 
 
 # --- Read view: what the project declares -------------------------------------
@@ -610,11 +724,7 @@ def backed_relation_names(view: DbtProjectView) -> set[str]:
     risk a cycle.
     """
 
-    names = {
-        path.rsplit("/", 1)[-1][: -len(".sql")].lower()
-        for path in view.files
-        if path.endswith(".sql")
-    }
+    names = {node_name(path).lower() for path in node_files(view)}
     for parsed, _path in yaml_documents(view):
         for src in parsed.get("sources") or []:
             if not isinstance(src, dict):

--- a/packages/dex-core/src/exmergo_dex_core/explore/profile.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/profile.py
@@ -292,15 +292,20 @@ def detect_pii(column_name: str, data_type: str) -> PIIFlag | None:
     patterns remain string-only.
     """
 
-    flag, _generic = _classify_pii(column_name, data_type)
+    flag, _generic = classify_pii(column_name, data_type)
     return flag
 
 
-def _classify_pii(column_name: str, data_type: str) -> tuple[PIIFlag | None, bool]:
+def classify_pii(column_name: str, data_type: str) -> tuple[PIIFlag | None, bool]:
     """The detector plus a marker for the generic `*_name` match.
 
-    The marker tells :func:`profile` which flags are eligible for value-shape
-    refinement. It is deliberately a return value and never persisted: keying
+    The marker says the flag is **provisional**: it is the one match
+    :func:`profile` refines against value shape, up to person-name confidence or
+    down to reference-vocabulary confidence. A caller that cannot run that
+    refinement (nothing that reads names without values can) needs to know it is
+    holding an unrefined guess rather than a verdict, which is why this is
+    public and :func:`detect_pii` is the front door for callers that do not
+    care. It is deliberately a return value and never persisted: keying
     eligibility on the flag itself (e.g. its confidence value) would couple the
     shape rules to the base-confidence table.
     """
@@ -721,7 +726,7 @@ def profile(
 
         # Decide min/max safety BEFORE querying, from name + type, so the adapter
         # never even computes a suppressed extreme.
-        classified = {c.name: _classify_pii(c.name, c.data_type) for c in columns}
+        classified = {c.name: classify_pii(c.name, c.data_type) for c in columns}
         prelim_pii = {name: flag for name, (flag, _g) in classified.items()}
         overridden: dict[str, PIICategory] = {}
         for c in columns:

--- a/packages/dex-core/src/exmergo_dex_core/maintain/snapshot.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/snapshot.py
@@ -37,6 +37,8 @@ from ..dbt_project import (
     DbtProjectView,
     content_hash,
     metric_inputs,
+    node_files,
+    node_name,
     physical_column,
     semantic_yaml_entries,
     yaml_documents,
@@ -277,15 +279,24 @@ def warehouse_from_metadata(adapter: Adapter) -> WarehouseBaseline:
 
 
 def transform_layer(view: DbtProjectView) -> TransformLayer:
-    """Fingerprint the transformation layer from the project view."""
+    """Fingerprint the transformation layer from the project view.
+
+    ``models`` is every node the project builds and names after its file: a
+    model, a snapshot, or a seed. It reads that from ``node_files`` rather than
+    from every ``.sql`` in the view, which is what keeps a macro (jinja, builds
+    nothing, ``ref()``-able by no one) from counting as a model and a snapshot
+    or seed from being missed now that both are loaded.
+
+    ``files`` stays the whole editable surface: it is a change fingerprint of
+    what a human can edit, not a node list, and nothing compares it across
+    snapshots to raise a finding.
+    """
 
     models: list[str] = []
     model_sources: dict[str, list[str]] = {}
     model_refs: dict[str, list[str]] = {}
-    for path, source in view.files.items():
-        if not path.endswith(".sql"):
-            continue
-        model = path.rsplit("/", 1)[-1][: -len(".sql")]
+    for path, source in node_files(view).items():
+        model = node_name(path)
         models.append(model)
         source_calls = sorted(
             {

--- a/packages/dex-core/src/exmergo_dex_core/transform/build.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/build.py
@@ -260,9 +260,7 @@ def shadow_parse(
             ),
         )
         for edit in edits:
-            edit_path = contained_path(
-                shadow, edit.path, view.model_paths, view.macro_paths
-            )
+            edit_path = contained_path(shadow, edit.path, view)
             if edit.op is EditOp.DELETE:
                 # Remove it from the copy so the parse runs against the true
                 # post-deletion tree: a surviving ref() to it fails dbt's parse.

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -28,6 +28,7 @@ import yaml
 from .. import command_args
 from .. import envelope as env
 from ..adapters.project import PlacingProject, placement_gap
+from ..config import pii_override_paths
 from ..dbt_project import ApplyResult as PlanApplyResult
 from ..dbt_project import EditOp
 from ..errors import DexError
@@ -206,9 +207,11 @@ def plan(
     """Turn authored edits into a stored plan of reviewable diffs.
 
     ``scaffold`` prepends staging skeletons built from the exploration cache.
-    Deletes and project/profile edits are gated by dbt's own parser here rather
-    than at build time, because a broken ``dbt_project.yml`` breaks everything
-    and an orphaning delete is cheaper to catch before it is stored.
+    Deletes, project and profile edits, snapshots and seeds are gated by dbt's
+    own parser here rather than at build time, because a broken
+    ``dbt_project.yml`` breaks everything, an orphaning delete is cheaper to
+    catch before it is stored, and a snapshot's config and a seed's CSV are
+    shapes dbt's parser knows and a regex only approximates.
 
     ``attribute_rows`` controls the row-population report (see
     :mod:`.row_attribution`), which runs after the plan is stored so that nothing
@@ -229,10 +232,22 @@ def plan(
 
     parse_notes: list[str] = []
     has_delete = any(e.op is EditOp.DELETE for e in edits)
-    has_config = any(
-        e.kind in (EditKind.PROJECT_YML, EditKind.PROFILES_YML) for e in edits
+    # dbt's own parser is a far better gate than a regex on the two kinds whose
+    # shape it fully owns: it resolves a snapshot's config against the project
+    # and reads a seed's CSV the way it will at build time. It is the
+    # authoritative check behind the structural one in `validate`, and it
+    # degrades to a warning where dbt is not installed.
+    parser_owned = any(
+        e.kind
+        in (
+            EditKind.PROJECT_YML,
+            EditKind.PROFILES_YML,
+            EditKind.SNAPSHOT_SQL,
+            EditKind.SEED_CSV,
+        )
+        for e in edits
     )
-    if has_delete or has_config:
+    if has_delete or parser_owned:
         # The secret-guard runs first, so an inlined credential is never handed
         # to the dbt subprocess.
         from ..dbt_project import load as load_project
@@ -242,6 +257,23 @@ def plan(
         project = engine.project_dir()
         view = load_project(project)
         assert_profiles_safe(view, edits)
+        # dex's own refusals run before the subprocess, for the same reason the
+        # secret-guard above does: the parse copies the project with these edits
+        # written into it, so a seed refused for carrying personal data must not
+        # reach disk or a subprocess first, and dbt's message for a misfiled
+        # snapshot ("Encountered unknown tag 'snapshot'") must not stand in for
+        # the one that names the fix. Warnings are dropped here on purpose;
+        # `plans.plan` produces them again and is what the caller sees.
+        overrides = pii_override_paths(engine.config.pii_overrides)
+        cache = readable_cache(engine.store) if _has_seed(edits) else None
+        for edit in edits:
+            plans_mod.admit_edit(
+                edit,
+                view,
+                project,
+                cache=cache if edit.kind is EditKind.SEED_CSV else None,
+                pii_overrides=overrides,
+            )
         # Refuse an orphaning delete with a precise, dbt-independent message
         # before the subprocess runs (which would otherwise report the same
         # danglers as a lower-level parse error). This is the always-available
@@ -1067,6 +1099,10 @@ def _make_plan(engine: DexEngine, intent: str, edits: list[PlanEdit]) -> PlanRes
             None if places else engine.project_dir(),
             repo_root,
             store=engine.require_full_store("storing a semantic plan"),
+            # The reviewed columns a human has already cleared, so the seed
+            # gate's refusal can be lifted the same documented way every other
+            # PII refusal is.
+            pii_overrides=pii_override_paths(engine.config.pii_overrides),
             # Agent-authored edits, which is the caller `editing_surface` exists
             # for: there is no placement to compare a path against here, only the
             # surface the format admits to owning. A format declining the write
@@ -1166,6 +1202,16 @@ def _semantic_plan(
         result.warnings.append(parse_warning)
     result.warnings.extend(parse_deprecations)
     return result
+
+
+def _has_seed(edits: list[PlanEdit]) -> bool:
+    """Whether the exploration cache is worth reading for this payload.
+
+    The cache is a stored document and only the seed gate has any use for it, so
+    a plan with no seed in it never pays to load one.
+    """
+
+    return any(e.kind is EditKind.SEED_CSV and e.op is EditOp.UPSERT for e in edits)
 
 
 def _edits_from_payload(

--- a/packages/dex-core/src/exmergo_dex_core/transform/plans.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/plans.py
@@ -33,6 +33,9 @@ from ..dbt_project import (
     contained_path,
     content_hash,
     find_project,
+    node_files,
+    node_name,
+    path_family,
     write_edits,
 )
 from ..dbt_project import (
@@ -65,6 +68,13 @@ class EditKind(str, Enum):
     # A macro definition under the project's macro paths, the surface widened
     # for scaffolded and hand-repaired macros alike.
     MACRO_SQL = "macro_sql"
+    # A snapshot block under the project's snapshot paths, and a seed's CSV data
+    # under its seed paths. Both build a relation dbt names after the file and
+    # both are ref()-able, which is why each is confined to its own family the
+    # way a macro is: a snapshot filed under models/ is parsed as a model and
+    # fails the build, and a seed filed anywhere else is never loaded at all.
+    SNAPSHOT_SQL = "snapshot_sql"
+    SEED_CSV = "seed_csv"
     # dbt project-root config: the project settings and the connection profiles.
     # Each governs the whole project (a wider blast radius than a single model),
     # so each is pinned by name to the one root file it may target, and
@@ -121,6 +131,177 @@ def contained_key(rel_path: str, surface: list[str]) -> str:
     )
 
 
+# Which kind may be authored where, keyed by dbt's authored path family and then
+# by file suffix. dbt decides all of it: a `.sql` under the snapshot paths is
+# parsed as a snapshot block and nothing else, a seed is loaded only from a
+# `.csv` under the seed paths, and the properties YAML that declares a seed's
+# column types or a snapshot's tests belongs beside the thing it describes.
+#
+# `schema_yml` is admitted under the snapshot and seed families for exactly that
+# reason, and deliberately *not* under macros: macro properties YAML is a
+# different document shape, dex has never authored one, and a test pins both
+# directions of today's macro rule. Widening that is a live behavior change and
+# belongs in its own change, not smuggled in beside two new kinds.
+_PLACEMENT: dict[str, dict[str, frozenset[EditKind]]] = {
+    "macro": {".sql": frozenset({EditKind.MACRO_SQL})},
+    "snapshot": {
+        ".sql": frozenset({EditKind.SNAPSHOT_SQL}),
+        ".yml": frozenset({EditKind.SCHEMA_YML}),
+        ".yaml": frozenset({EditKind.SCHEMA_YML}),
+    },
+    "seed": {
+        ".csv": frozenset({EditKind.SEED_CSV}),
+        ".yml": frozenset({EditKind.SCHEMA_YML}),
+        ".yaml": frozenset({EditKind.SCHEMA_YML}),
+    },
+    "model": {
+        ".sql": frozenset({EditKind.MODEL_SQL}),
+        ".yml": frozenset({EditKind.SCHEMA_YML, EditKind.SEMANTIC_YML}),
+        ".yaml": frozenset({EditKind.SCHEMA_YML, EditKind.SEMANTIC_YML}),
+    },
+}
+
+
+def _home_families() -> dict[EditKind, str]:
+    """The one family each kind belongs to, where it has one.
+
+    Derived from :data:`_PLACEMENT` so the two can never drift: a kind exactly
+    one family admits lives there, and a kind several admit (``schema_yml``) has
+    no single home and is judged by where it actually landed instead.
+    """
+
+    families: dict[EditKind, set[str]] = {}
+    for family, by_suffix in _PLACEMENT.items():
+        for kinds in by_suffix.values():
+            for kind in kinds:
+                families.setdefault(kind, set()).add(family)
+    return {
+        kind: next(iter(found)) for kind, found in families.items() if len(found) == 1
+    }
+
+
+_HOME_FAMILY: dict[EditKind, str] = _home_families()
+
+# The project-root manifests. Each governs the whole project rather than sitting
+# in a path family, and each is pinned to its own filename separately, so the
+# family table has nothing to say about them.
+_ROOT_KINDS = frozenset(
+    {EditKind.PACKAGES_YML, EditKind.PROJECT_YML, EditKind.PROFILES_YML}
+)
+
+
+def assert_kind_placement(
+    edit: PlanEdit, family: str | None, view: DbtProjectView
+) -> None:
+    """Refuse an edit whose kind and location disagree, in either direction.
+
+    ``family`` is what :func:`~..dbt_project.path_family` made of the edit's
+    path, and ``None`` means containment admitted it as a project-root manifest,
+    which the family table does not govern.
+
+    Both directions matter and they fail differently. A kind in the wrong family
+    is told where its family is; a file in a family that does not admit its kind
+    is told which kinds that family admits for that suffix. Either way the
+    message names the fix rather than the rule.
+    """
+
+    if family is None or edit.kind in _ROOT_KINDS:
+        return
+    suffix = PurePosixPath(edit.path).suffix.lower()
+    admitted = _PLACEMENT[family].get(suffix, frozenset())
+    home = _HOME_FAMILY.get(edit.kind)
+    if home is not None and home != family:
+        configured = dict(view.path_families()).get(home) or []
+        # Both halves, because either one is a complete fix and only the caller
+        # knows which they meant: move the file, or relabel the kind.
+        instead = (
+            f"; a {suffix} file there is "
+            + " or ".join(sorted(k.value for k in admitted))
+            if admitted
+            else ""
+        )
+        raise PlanError(
+            f"a {edit.kind.value} edit must live under the project's {home} "
+            f"paths ({', '.join(configured) or 'none configured'}), got "
+            f"'{edit.path}', which is a {family} path{instead}"
+        )
+    if edit.kind in admitted:
+        return
+    if not admitted:
+        holds = "; ".join(
+            f"{ext} -> {', '.join(sorted(k.value for k in kinds))}"
+            for ext, kinds in sorted(_PLACEMENT[family].items())
+        )
+        named = suffix or "suffixless"
+        raise PlanError(
+            f"'{edit.path}' is under a {family} path, which holds {holds}; "
+            f"dex authors no '{named}' file there"
+        )
+    raise PlanError(
+        f"'{edit.path}' is under a {family} path but the edit kind is "
+        f"{edit.kind.value}; use "
+        f"{' or '.join(sorted(k.value for k in admitted))} for a {suffix} file "
+        "there"
+    )
+
+
+def admit_edit(
+    edit: PlanEdit,
+    view: DbtProjectView,
+    project: Path,
+    *,
+    cache: Any = None,
+    pii_overrides: Any = None,
+) -> list[str]:
+    """Every check that can refuse one dbt-shaped edit, and the warnings it
+    raises. Stores nothing, writes nothing, reads no subprocess.
+
+    Containment, kind-and-location agreement, the root-manifest pinning, and the
+    per-kind content validation, in that order, which is the order the refusals
+    read best in: where a file may live, then whether this kind may live there,
+    then whether the content is what that kind promises.
+
+    Split out of :func:`plan` because it has a second caller, and the order that
+    caller needs it in is the point. ``transform plan`` hands snapshots, seeds
+    and the config kinds to dbt's own parser before it stores anything, and dbt
+    parses a *copy of the project with the edit written into it*. Running that
+    first would mean a seed refused for carrying personal data had already been
+    written to disk and read by a subprocess, and it would mean dbt's message
+    ("Encountered unknown tag 'snapshot'") reaching the caller in place of dex's
+    ("a snapshot_sql edit must live under the project's snapshot paths"). dex
+    refuses on its own terms first; dbt's parser is the backstop behind it.
+    """
+
+    resolved = contained_path(project, edit.path, view).resolve()
+    assert_kind_placement(edit, path_family(project, edit.path, view), view)
+
+    # The one root file each config kind may target. Both the kind and the path
+    # must agree: a config kind aimed elsewhere, or one of these files reached
+    # by any other kind, is refused.
+    project_resolved = project.resolve()
+    root_config = {
+        EditKind.PROJECT_YML: (project_resolved / "dbt_project.yml").resolve(),
+        EditKind.PROFILES_YML: (project_resolved / "profiles.yml").resolve(),
+    }
+    if edit.kind in root_config and resolved != root_config[edit.kind]:
+        raise PlanError(
+            f"a {edit.kind.value} edit must target the project's "
+            f"{root_config[edit.kind].name}, got '{edit.path}'"
+        )
+    target_kind = {target: kind for kind, target in root_config.items()}.get(resolved)
+    if target_kind is not None and edit.kind is not target_kind:
+        raise PlanError(
+            f"'{edit.path}' is a project config file but the edit kind is "
+            f"{edit.kind.value}; use {target_kind.value} for it"
+        )
+
+    # A delete has no content to structurally validate; the whole-plan guard
+    # verifies the post-deletion project instead.
+    if edit.op is not EditOp.UPSERT:
+        return []
+    return validate_edit(edit, cache=cache, pii_overrides=pii_overrides)
+
+
 def plan(
     intent: str,
     edits: list[PlanEdit],
@@ -129,6 +310,7 @@ def plan(
     *,
     store: Store,
     project_format: EditableProject | None = None,
+    pii_overrides: Any = None,
 ) -> tuple[TransformPlan, list[dict[str, Any]], list[str]]:
     """Validate agent-authored edits and store them as a plan. Writes no project file.
 
@@ -148,6 +330,12 @@ def plan(
     while placing into a format's own keyspace hashes an existing file as absent,
     which renders a one-line change as a whole-file create and turns the next
     apply into a conflict on a file nobody touched.
+
+    ``pii_overrides`` is the reviewed-columns matcher from the engine config,
+    read only by the seed gate. Absent (a host calling this directly, a test),
+    the gate still runs on the seed's own header and on whatever the exploration
+    cache already flagged; an override is what a human uses to clear a column,
+    not what makes the check happen.
     """
 
     if not edits:
@@ -187,78 +375,59 @@ def plan(
     warnings: list[str] = []
     pinned: list[PlanEdit] = []
     diffs: list[dict[str, Any]] = []
-    project_resolved = project.resolve()
-    macro_bases = (
-        [(project_resolved / mp).resolve() for mp in view.macro_paths]
-        if dbt_shaped
-        else []
-    )
-    # The one root file each config kind may target, resolved once. Both the
-    # kind and the path must agree: a config kind aimed elsewhere, or one of
-    # these files reached by any other kind, is refused.
-    root_config = (
-        {
-            EditKind.PROJECT_YML: (project_resolved / "dbt_project.yml").resolve(),
-            EditKind.PROFILES_YML: (project_resolved / "profiles.yml").resolve(),
-        }
-        if dbt_shaped
-        else {}
-    )
-    config_targets = {target: kind for kind, target in root_config.items()}
+    # Read at most once, and only when a seed is actually in the plan: the cache
+    # is a stored document, and every other kind has no use for it.
+    cached: list[Any] = []
+
+    def seed_cache() -> Any:
+        if not cached:
+            from ..storage import CacheUnreadableError, readable_cache
+
+            try:
+                cached.append(readable_cache(store))
+            except CacheUnreadableError as exc:
+                # An unreadable cache narrows the seed's PII gate to the header
+                # detector rather than stopping the plan. Said out loud, because
+                # a check that quietly got weaker is worse than one that failed.
+                cached.append(None)
+                warnings.append(
+                    f"the exploration cache could not be read ({exc}), so a "
+                    "seed's columns were checked against their own names only, "
+                    "not against columns a profile already flagged"
+                )
+        return cached[0]
+
     for edit in edits:
         # Containment is checked at plan time as well as at write time, so a bad
         # path is refused before it ever becomes a stored proposal. Which surface
         # it is checked against is the format's to say; that it is checked at all
         # is not.
         if dbt_shaped:
-            resolved = contained_path(
-                project, edit.path, view.model_paths, view.macro_paths
-            ).resolve()
-            # Kind and surface must agree: a macro written into models/ would be
-            # parsed as a model and fail the build, and a model written into
-            # macros/ would silently never become a model.
-            in_macros = any(
-                resolved == base or base in resolved.parents for base in macro_bases
+            warnings.extend(
+                admit_edit(
+                    edit,
+                    view,
+                    project,
+                    cache=seed_cache() if edit.kind is EditKind.SEED_CSV else None,
+                    pii_overrides=pii_overrides,
+                )
             )
-            if edit.kind is EditKind.MACRO_SQL and not in_macros:
-                raise PlanError(
-                    f"a macro_sql edit must live under the project's macro paths "
-                    f"({', '.join(view.macro_paths)}), got '{edit.path}'"
-                )
-            if edit.kind is not EditKind.MACRO_SQL and in_macros:
-                raise PlanError(
-                    f"'{edit.path}' is under a macro path but the edit kind is "
-                    f"{edit.kind.value}; use macro_sql for macro files"
-                )
-            if edit.kind in root_config and resolved != root_config[edit.kind]:
-                raise PlanError(
-                    f"a {edit.kind.value} edit must target the project's "
-                    f"{root_config[edit.kind].name}, got '{edit.path}'"
-                )
-            target_kind = config_targets.get(resolved)
-            if target_kind is not None and edit.kind is not target_kind:
-                raise PlanError(
-                    f"'{edit.path}' is a project config file but the edit kind is "
-                    f"{edit.kind.value}; use {target_kind.value} for it"
-                )
         else:
-            # The three checks above read dbt's project layout (its macro paths,
+            # `admit_edit`'s checks read dbt's project layout (its path families,
             # its root manifests) to decide whether a kind and its location
             # agree. Another format's layout makes no such claim, and asserting
             # dbt's over it would refuse exactly the edits this seam exists to
             # allow. Agreement there is the format's own, expressed through what
             # `edit_path` places and what `write_edits` accepts.
             contained_key(edit.path, surface)
+            if edit.op is EditOp.UPSERT:
+                warnings.extend(validate_edit(edit))
         current = view.files.get(edit.path)
         if edit.op is EditOp.DELETE and current is None:
             raise PlanError(
                 f"nothing to delete at '{edit.path}': the file is not part of "
                 "the project (it may already be gone, or the path is wrong)"
             )
-        # A delete has no content to structurally validate; the guard that runs
-        # after this loop verifies the post-deletion project instead.
-        if edit.op is EditOp.UPSERT:
-            warnings.extend(validate_edit(edit))
         # The profiles secret-guard, current side: validate_edit covers the
         # proposed content, but the diff also surfaces the removed (on-disk)
         # content, so a pre-existing inlined credential is refused before any
@@ -409,12 +578,13 @@ def validate_deletions(view: DbtProjectView, edits: list[PlanEdit]) -> list[str]
     if not delete_paths:
         return []
 
-    macro_prefixes = tuple(f"{mp}/" for mp in view.macro_paths)
-    deleted_models = {
-        Path(path).stem
-        for path in delete_paths
-        if path.endswith(".sql") and not path.startswith(macro_prefixes)
-    }
+    # A snapshot and a seed are ref()-able exactly as a model is, so deleting
+    # one while a surviving model still ref()s it breaks the build the same way.
+    # `node_files` is what says which of the deleted paths build a node at all,
+    # which is why a macro is excluded and a seed's `.csv` is included: the
+    # `.endswith(".sql")` test this used to make would have missed every seed.
+    nodes = node_files(view)
+    deleted_models = {node_name(path) for path in delete_paths if path in nodes}
     if not deleted_models:
         return []
 

--- a/packages/dex-core/src/exmergo_dex_core/transform/validate.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/validate.py
@@ -132,6 +132,22 @@ _MACRO_OPEN = re.compile(r"\{%-?\s*macro\s+\w+\s*\(")
 _MACRO_CLOSE = re.compile(r"\{%-?\s*endmacro\s*-?%\}")
 _MACRO_BLOCK = re.compile(r"\{%-?\s*macro\s.*?\{%-?\s*endmacro\s*-?%\}", re.DOTALL)
 
+# Snapshot delimiters, on the same principle as the macro ones. A snapshot file
+# holds exactly one block: dbt names the snapshot after the block, not the file,
+# and a second block in one file is a build-time surprise nobody reading the
+# filename would expect.
+_SNAPSHOT_OPEN = re.compile(r"\{%-?\s*snapshot\s+\w+\s*-?%\}")
+_SNAPSHOT_CLOSE = re.compile(r"\{%-?\s*endsnapshot\s*-?%\}")
+_SNAPSHOT_BLOCK = re.compile(
+    r"\{%-?\s*snapshot\s.*?\{%-?\s*endsnapshot\s*-?%\}", re.DOTALL
+)
+_CONFIG_CALL = re.compile(r"\{\{-?\s*config\s*\(", re.DOTALL)
+# The strategies dbt ships, and the field each one cannot work without: a
+# timestamp strategy compares an updated-at column, a check strategy compares a
+# named column list. Naming the required field in the refusal is the difference
+# between "invalid snapshot" and a fix the caller can apply.
+_SNAPSHOT_STRATEGY_FIELDS = {"timestamp": "updated_at", "check": "check_cols"}
+
 
 def strip_jinja(sql: str) -> str:
     """Reduce a dbt model to plain SQL for the SELECT-only check.
@@ -178,8 +194,342 @@ def strip_jinja(sql: str) -> str:
     return "\n".join(lines).strip()
 
 
-def validate_edit(edit: PlanEdit) -> list[str]:
-    """Validate one edit for its kind. Returns warnings; raises on a hard failure."""
+# A seed is data entering git, and it stays there. dbt itself warns against
+# large seeds (it INSERTs them row by row), and a multi-megabyte CSV in a plan
+# diff is a different kind of object from a twenty-row lookup: it is unreadable
+# in review, which is the one thing the diff exists for. Module constants rather
+# than config, the same call `explore`'s own caps make; a project that genuinely
+# needs a bigger reference table wants a warehouse table, not a seed.
+MAX_SEED_ROWS = 5_000
+MAX_SEED_BYTES = 1 << 20
+
+
+def validate_snapshot(path: str, content: str) -> None:
+    """Refuse a snapshot file dbt could not build, naming the fix.
+
+    Structural, in the same spirit as the macro check: exactly one
+    ``{% snapshot %}`` block, a ``config()`` inside it carrying the fields the
+    chosen strategy cannot work without, and a body that is a single read-only
+    SELECT once its jinja is stripped. dbt's own parser is the authoritative
+    gate (``transform plan`` runs it); this is the always-available one that
+    still works on a machine where dbt is not installed, and it is the one that
+    can say *which* field is missing.
+    """
+
+    opens = len(_SNAPSHOT_OPEN.findall(content))
+    closes = len(_SNAPSHOT_CLOSE.findall(content))
+    if opens == 0:
+        raise EditValidationError(
+            f"{path}: a snapshot_sql edit needs a "
+            "{% snapshot name %} ... {% endsnapshot %} block"
+        )
+    if opens != closes:
+        raise EditValidationError(
+            f"{path}: unbalanced snapshot block "
+            f"({opens} snapshot, {closes} endsnapshot)"
+        )
+    if opens > 1:
+        raise EditValidationError(
+            f"{path}: a snapshot file holds exactly one snapshot block, found "
+            f"{opens}; dbt names the snapshot after the block, so put each one "
+            "in its own file"
+        )
+    block = _SNAPSHOT_BLOCK.search(content)
+    if block is None:
+        raise EditValidationError(
+            f"{path}: could not read the snapshot block; it must open with "
+            "{% snapshot name %} and close with {% endsnapshot %}"
+        )
+    outside = _JINJA_COMMENT.sub("", content.replace(block.group(0), ""))
+    if outside.strip():
+        raise EditValidationError(
+            f"{path}: a snapshot file holds one snapshot block and jinja "
+            "comments; found loose content outside it"
+        )
+
+    inner = block.group(0)
+    config_call = _CONFIG_CALL.search(inner)
+    if config_call is None:
+        raise EditValidationError(
+            f"{path}: the snapshot block needs a {{{{ config(...) }}}} call "
+            "naming unique_key and strategy"
+        )
+    config_args, config_end = _balanced_call(inner, config_call.end())
+    if config_args is None:
+        raise EditValidationError(
+            f"{path}: the snapshot's config(...) call is never closed"
+        )
+    if not re.search(r"\bunique_key\s*=", config_args):
+        raise EditValidationError(
+            f"{path}: the snapshot's config needs a unique_key, the column "
+            "dbt tracks each row by (e.g. unique_key='id')"
+        )
+    strategy = re.search(r"\bstrategy\s*=\s*['\"](\w+)['\"]", config_args)
+    if strategy is None:
+        raise EditValidationError(
+            f"{path}: the snapshot's config needs a strategy of "
+            + " or ".join(f"'{name}'" for name in sorted(_SNAPSHOT_STRATEGY_FIELDS))
+        )
+    name = strategy.group(1)
+    required = _SNAPSHOT_STRATEGY_FIELDS.get(name)
+    if required is None:
+        raise EditValidationError(
+            f"{path}: unknown snapshot strategy '{name}'; dbt ships "
+            + " and ".join(f"'{s}'" for s in sorted(_SNAPSHOT_STRATEGY_FIELDS))
+        )
+    if not re.search(rf"\b{required}\s*=", config_args):
+        raise EditValidationError(
+            f"{path}: a '{name}' strategy snapshot needs {required} in its "
+            "config ("
+            + (
+                "the column that changes when a row does"
+                if name == "timestamp"
+                else "the columns to compare, or 'all'"
+            )
+            + ")"
+        )
+
+    # Past the config call's own closing `}}` (whitespace-control marker and
+    # all), so what is left is the query and nothing else.
+    body = re.sub(r"^\s*-?\s*\}\}", "", inner[config_end:])
+    body = _SNAPSHOT_CLOSE.sub("", body)
+    stripped = strip_jinja(body)
+    if not stripped:
+        raise EditValidationError(
+            f"{path}: the snapshot block has no query; it needs a SELECT over "
+            "the source it captures"
+        )
+    try:
+        assert_select_only(stripped)
+    except Exception as exc:
+        raise EditValidationError(f"{path}: {exc}") from exc
+
+
+def _balanced_call(text: str, start: int) -> tuple[str | None, int]:
+    """The argument text of a call whose opening paren was just consumed, and
+    the offset just past its closing paren.
+
+    Naive about parens inside string literals, which only ever costs a refusal
+    on a snapshot nobody writes (a quoted paren in a config argument), never an
+    admission.
+    """
+
+    depth = 1
+    for offset in range(start, len(text)):
+        if text[offset] == "(":
+            depth += 1
+        elif text[offset] == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start:offset], offset + 1
+    return None, len(text)
+
+
+def validate_seed(
+    path: str,
+    content: str,
+    *,
+    cache: object | None = None,
+    pii_overrides: object | None = None,
+) -> list[str]:
+    """Refuse a seed dbt could not load, one too large to review, or one whose
+    columns look like PII. Returns warnings.
+
+    The PII gate is the part that is new in kind rather than in degree. Every
+    other edit kind puts *logic* into a reviewable diff; a seed puts **values**
+    into one, and a diff goes into git and stays there. So a seed's header is
+    read two ways: through the same name-and-type detector `explore` profiles
+    warehouse columns with, and against the PII flags already in the `.dex/`
+    cache, which is where a column a human reviewed and cleared has already
+    stopped being flagged. A hit at or above the block threshold refuses; a
+    weaker one, and the detector's own provisional generic-name match, warns.
+
+    **What this cannot see:** dex detects PII from names and types, never from
+    values, everywhere. A seed column named ``code`` holding email addresses
+    passes this gate. That is the standing limit of the whole PII subsystem
+    rather than a gap in this check, and value inspection is a separate axis.
+    """
+
+    import csv
+    import io
+
+    size = len(content.encode("utf-8"))
+    if size > MAX_SEED_BYTES:
+        raise EditValidationError(
+            f"{path}: seed is {size / 1024:.0f} KiB, over the "
+            f"{MAX_SEED_BYTES // 1024} KiB cap; a seed that large is data, not "
+            "a lookup: load it into the warehouse and source() it instead"
+        )
+
+    try:
+        rows = list(csv.reader(io.StringIO(content)))
+    except csv.Error as exc:
+        raise EditValidationError(f"{path}: could not parse as CSV: {exc}") from exc
+    if not rows:
+        raise EditValidationError(
+            f"{path}: a seed needs a header row naming its columns"
+        )
+    header = [column.strip() for column in rows[0]]
+    if not header or not any(header):
+        raise EditValidationError(
+            f"{path}: the header row is empty; a seed's first row names its columns"
+        )
+    for index, column in enumerate(header, start=1):
+        if not column:
+            raise EditValidationError(
+                f"{path}: header column {index} has no name; dbt needs every "
+                "seed column named"
+            )
+    seen: dict[str, int] = {}
+    for index, column in enumerate(header, start=1):
+        # Case-insensitively: most warehouses fold identifier case, so two
+        # headers differing only in case collide once the seed is loaded.
+        lowered = column.lower()
+        if lowered in seen:
+            raise EditValidationError(
+                f"{path}: duplicate column '{column}' at header columns "
+                f"{seen[lowered]} and {index}; seed columns must be unique "
+                "(case-insensitively, since warehouses fold identifier case)"
+            )
+        seen[lowered] = index
+
+    data_rows = rows[1:]
+    if len(data_rows) > MAX_SEED_ROWS:
+        raise EditValidationError(
+            f"{path}: seed has {len(data_rows)} data rows, over the "
+            f"{MAX_SEED_ROWS} row cap; a seed that long is data, not a lookup: "
+            "load it into the warehouse and source() it instead"
+        )
+    for number, row in enumerate(data_rows, start=2):
+        if len(row) != len(header):
+            raise EditValidationError(
+                f"{path}: row {number} breaks at column "
+                f"{min(len(row), len(header)) + 1}: it has {len(row)} "
+                f"{'field' if len(row) == 1 else 'fields'} where the header "
+                f"names {len(header)}; every row needs one field per column"
+            )
+
+    return _seed_pii_warnings(path, header, cache=cache, pii_overrides=pii_overrides)
+
+
+def _seed_pii_warnings(
+    path: str,
+    header: list[str],
+    *,
+    cache: object | None,
+    pii_overrides: object | None,
+) -> list[str]:
+    """The two detections, unioned at the strongest confidence per column.
+
+    The header detector is what catches a seed built by hand; the cache lookup
+    is what catches a seed built from a warehouse column a profile already
+    flagged, including one whose name the author changed on the way in only in
+    case. Neither reads a value.
+    """
+
+    from ..cache import PIIFlag
+    from ..explore.profile import classify_pii
+    from ..guards import PII_BLOCK_CONFIDENCE
+
+    seed = path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+    cached: dict[str, PIIFlag] = {}
+    for dataset in getattr(cache, "datasets", None) or []:
+        for column in dataset.columns:
+            if column.pii is None:
+                continue
+            known = cached.get(column.name.lower())
+            if known is None or column.pii.confidence > known.confidence:
+                cached[column.name.lower()] = column.pii
+
+    blocked: list[tuple[str, PIIFlag]] = []
+    warned: list[tuple[str, PIIFlag, str]] = []
+    for column in header:
+        # A seed column has no warehouse identifier, so the override path is the
+        # dbt name of the thing being authored: `<seed>.<column>`, which is what
+        # the suggested entry below spells out.
+        if pii_overrides is not None and f"{seed}.{column}" in pii_overrides:
+            continue
+        # A seed's values are text on the way in, so the type-gated detectors
+        # are asked about the only type a CSV column can have.
+        detected, provisional = classify_pii(column, "varchar")
+        from_cache = cached.get(column.lower())
+        # The cache's flag has already been through value-shape refinement on a
+        # real profile, so it is a verdict wherever it exists and outranks the
+        # header guess at equal confidence.
+        candidates = [
+            (from_cache, False, "a profile already flagged this column name"),
+            (detected, provisional, "the column name matches a PII pattern"),
+        ]
+        strongest = max(
+            (c for c in candidates if c[0] is not None),
+            key=lambda c: c[0].confidence,
+            default=None,
+        )
+        if strongest is None:
+            continue
+        flag, unrefined, why = strongest
+        if unrefined:
+            # The generic `*_name` match is the one flag the detector itself
+            # calls provisional: on a warehouse column `explore` refines it
+            # against value shape, up or down. dex never reads a seed's values,
+            # so that refinement cannot run here, and blocking on an
+            # unrefined guess would claim a certainty the detector disclaims.
+            # It warns instead, loudly, and every non-generic pattern (email,
+            # phone, national id, address) still blocks.
+            warned.append((column, flag, "unrefined"))
+        elif flag.confidence >= PII_BLOCK_CONFIDENCE:
+            blocked.append((column, flag))
+        else:
+            warned.append((column, flag, why))
+
+    if blocked:
+        detail = "; ".join(
+            f"'{column}' looks like {flag.category.value} "
+            f"(confidence {flag.confidence:g}), cleared by "
+            f"`- {{column: {seed}.{column}}}`"
+            for column, flag in blocked
+        )
+        raise EditValidationError(
+            f"{path}: a seed's values land in git and stay there, and this one "
+            f"has columns that look like personal data: {detail}. If the review "
+            "says otherwise, add that entry under pii_overrides in "
+            ".dex/config.yml and re-plan. Only names and types were read; no "
+            "value was."
+        )
+
+    warnings: list[str] = []
+    for column, flag, why in warned:
+        if why == "unrefined":
+            warnings.append(
+                f"{path}: '{column}' matches the generic name pattern, which "
+                "dex refines against values on a warehouse column and cannot "
+                "refine on a seed (it never reads a seed's values); if these "
+                "are people's names, do not commit them"
+            )
+        else:
+            warnings.append(
+                f"{path}: '{column}' may hold {flag.category.value} "
+                f"(confidence {flag.confidence:g}, under the "
+                f"{PII_BLOCK_CONFIDENCE:g} block threshold, {why}); a seed's "
+                "values are committed, so check this column before applying"
+            )
+    return warnings
+
+
+def validate_edit(
+    edit: PlanEdit,
+    *,
+    cache: object | None = None,
+    pii_overrides: object | None = None,
+) -> list[str]:
+    """Validate one edit for its kind. Returns warnings; raises on a hard failure.
+
+    ``cache`` and ``pii_overrides`` are the exploration cache and the reviewed
+    columns a human has cleared, and only the seed gate reads them. They are
+    optional because most callers have no seed in hand, and a seed validated
+    without a cache still gets the header detector: the cache widens the check,
+    it is not what makes it run.
+    """
 
     from .plans import EditKind
 
@@ -203,6 +553,22 @@ def validate_edit(edit: PlanEdit) -> list[str]:
                 f"{edit.path}: a macro file holds only macro definitions and "
                 "jinja comments; found loose content outside them"
             )
+    elif edit.kind is EditKind.SNAPSHOT_SQL:
+        validate_snapshot(edit.path, edit.new_content)
+    elif edit.kind is EditKind.SEED_CSV:
+        # Ahead of the YAML branch below, which would otherwise report a CSV as
+        # invalid YAML, and ahead of anything that builds a diff: the refusal
+        # this can raise is the one thing standing between a seed's values and
+        # the transcript, since the envelope sanitizer walks `data` and never
+        # `diffs`.
+        warnings.extend(
+            validate_seed(
+                edit.path,
+                edit.new_content,
+                cache=cache,
+                pii_overrides=pii_overrides,
+            )
+        )
     elif edit.kind is EditKind.MODEL_SQL:
         stripped = strip_jinja(edit.new_content)
         if not stripped:

--- a/packages/dex-core/tests/adapters/test_project_parity.py
+++ b/packages/dex-core/tests/adapters/test_project_parity.py
@@ -362,6 +362,12 @@ def test_the_dbt_editing_surface_admits_everything_its_writer_accepts(tmp_path: 
     for path in (
         "models/stg_customers.sql",
         "macros/m.sql",
+        # Every authored family, not only the two that predate them: a plan the
+        # writer accepts and this declaration refuses would be refused at apply
+        # after passing at plan.
+        "snapshots/snap_customers.sql",
+        "seeds/country_vat.csv",
+        "seeds/schema.yml",
         *dbt_project._ALLOWED_ROOT_FILES,
     ):
         contained_key(path, surface)

--- a/packages/dex-core/tests/maintain/test_reconcile.py
+++ b/packages/dex-core/tests/maintain/test_reconcile.py
@@ -312,4 +312,8 @@ def test_the_no_format_fallback_answers_exactly_what_dbt_answers():
     staged = "models/staging/stg_orders"
     assert _placed(None, EditKind.MODEL_SQL, "orders") == f"{staged}.sql"
     assert _placed(None, EditKind.SCHEMA_YML, "orders") == f"{staged}.yml"
-    assert _placed(None, EditKind.MACRO_SQL, "orders") is None
+    # `None` is a complete answer, not a gap: reconcile proposes staging models
+    # and their schema.yml, and a kind it does not propose gets no path this
+    # class would be inventing.
+    for unplaced in (EditKind.MACRO_SQL, EditKind.SNAPSHOT_SQL, EditKind.SEED_CSV):
+        assert _placed(None, unplaced, "orders") is None

--- a/packages/dex-core/tests/maintain/test_transform_layer_scope.py
+++ b/packages/dex-core/tests/maintain/test_transform_layer_scope.py
@@ -1,0 +1,85 @@
+"""What counts as a node in the transform layer, and what an existing baseline
+does the first time it is checked after the project view widened.
+
+Loading snapshots and seeds is what makes them authorable, and it also moves
+what `maintain` fingerprints: both derivations that read "the things this
+project builds" used to take every `.sql` in the view by filename, which turned
+macros into models and would now turn snapshots into them too. Scoping those to
+the families that actually produce dbt nodes is the fix; this is where the
+consequence for a baseline pinned before it is pinned down.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from exmergo_dex_core.dbt_project import load as load_project
+from exmergo_dex_core.maintain.snapshot import transform_layer
+
+SNAPSHOT = """{% snapshot snap_orders %}
+{{ config(unique_key='order_id', strategy='timestamp', updated_at='ordered_at') }}
+select * from {{ ref('stg_orders') }}
+{% endsnapshot %}
+"""
+
+MACRO = "{% macro cents_to_dollars(column) %}({{ column }} / 100){% endmacro %}\n"
+
+SEED = "status_code,label\nP,placed\nS,shipped\n"
+
+
+def _populate(root: Path) -> None:
+    (root / "snapshots").mkdir(exist_ok=True)
+    (root / "snapshots" / "snap_orders.sql").write_text(SNAPSHOT, encoding="utf-8")
+    (root / "macros").mkdir(exist_ok=True)
+    (root / "macros" / "cents_to_dollars.sql").write_text(MACRO, encoding="utf-8")
+    (root / "seeds").mkdir(exist_ok=True)
+    (root / "seeds" / "status_labels.csv").write_text(SEED, encoding="utf-8")
+
+
+def test_a_node_is_a_model_a_snapshot_or_a_seed_and_never_a_macro(maintain_repo):
+    _populate(maintain_repo.root)
+    layer = transform_layer(load_project(maintain_repo.root))
+
+    # A snapshot and a seed each build a relation dbt names after the file and
+    # each is ref()-able, so both are nodes. A macro builds nothing and never
+    # was one, though it was counted as one before the families were scoped.
+    assert set(layer.models) == {"stg_orders", "snap_orders", "status_labels"}
+    assert "cents_to_dollars" not in layer.models
+
+    # The file fingerprint stays the whole editable surface: it is a change
+    # fingerprint over what a human can edit, not a node list.
+    assert "macros/cents_to_dollars.sql" in layer.files
+    assert "seeds/status_labels.csv" in layer.files
+
+    # And a snapshot's ref() is recorded like a model's, which is what carries a
+    # warehouse finding through to the snapshot standing on it.
+    assert layer.model_refs["snap_orders"] == ["stg_orders"]
+
+
+def test_a_baseline_pinned_before_the_widening_reports_no_phantom_drift(
+    maintain_repo,
+):
+    """The risk this change carries, checked rather than assumed.
+
+    A baseline pinned before snapshots and seeds were loaded holds a smaller
+    file set and a models list that counted macros. Adding those files must read
+    as "nothing drifted", because no detector diffs the file set or the model
+    list: they feed `orphan_relation` and the semantic dangling-reference check,
+    both of which ask whether a *warehouse* table is still backed by the project.
+    """
+
+    maintain_repo.snapshot()
+
+    # A pre-change baseline also counted macro filenames as models. Injected
+    # rather than described, so the assertion is about the real shape.
+    baseline_path = maintain_repo.root / ".dex" / "snapshot.json"
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    baseline["transform_layer"]["models"].append("cents_to_dollars")
+    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+
+    _populate(maintain_repo.root)
+
+    rc, payload = maintain_repo.dex("maintain", "check")
+    assert rc == 0 and payload["status"] == "ok"
+    assert payload["data"]["finding_count"] == 0, payload["data"]["findings"]

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -918,6 +918,130 @@ def test_pii_refusal_s_suggested_override_carries_no_value():
     assert "AFRICA" not in message and "@" not in message
 
 
+def test_a_seed_s_pii_refusal_fires_before_any_diff_is_built(dbt_project_dir: Path):
+    """A seed is the first edit kind that puts **values** into a reviewable diff,
+    and a diff goes into git and stays there.
+
+    Two things have to hold, and only one of them is the refusal. The other is
+    its position: ``plan`` validates every edit before it builds a single diff,
+    because the envelope sanitizer walks ``data`` and never ``diffs``. If the
+    order were the other way round, a refused seed's values would already be in
+    the diff list, and from there in the transcript. So this asserts the
+    ordering, not just the outcome: nothing was stored, nothing was written, and
+    the message that comes back carries the column name and never a value.
+    """
+
+    from exmergo_dex_core import transform
+    from exmergo_dex_core.transform.validate import EditValidationError
+
+    store = FilesystemStore(dbt_project_dir.parent)
+    a_person = "someone@example.com"
+    with pytest.raises(EditValidationError) as excinfo:
+        transform.plan(
+            "a lookup built from customer data",
+            [
+                transform.PlanEdit(
+                    path="seeds/contacts.csv",
+                    kind=transform.EditKind.SEED_CSV,
+                    new_content=f"id,email\n1,{a_person}\n",
+                )
+            ],
+            dbt_project_dir,
+            repo_root=dbt_project_dir.parent,
+            store=store,
+        )
+    message = str(excinfo.value)
+    assert "'email' looks like email" in message
+    assert a_person not in message
+    # Nothing was stored (the plan never got made) and nothing was written.
+    assert store.list_plans() == []
+    assert not (dbt_project_dir / "seeds" / "contacts.csv").exists()
+
+
+def test_a_refused_seed_never_reaches_a_dbt_subprocess(
+    dbt_project_dir: Path, tmp_path: Path, monkeypatch, capsys
+):
+    """The PII gate runs before the parse, not after it.
+
+    `transform plan` hands snapshots, seeds and the config kinds to dbt's own
+    parser before it stores anything, and that parser reads a *copy of the
+    project with the edit written into it*. Parsing first would put a refused
+    seed's values on disk and through a subprocess before the gate ever fired,
+    which is the same failure the profiles secret-guard is ordered against.
+
+    Found by dogfooding, not by the suite: every unit test called the validator
+    directly and so could not see what the command layer did first.
+    """
+
+    import importlib
+    import json as _json
+
+    from exmergo_dex_core.cli import main
+
+    build_mod = importlib.import_module("exmergo_dex_core.transform.build")
+
+    def refuse_to_run(*args, **kwargs):
+        raise AssertionError("dbt was handed the seed before it was refused")
+
+    monkeypatch.setattr(build_mod, "shadow_parse", refuse_to_run)
+
+    payload = tmp_path / "edits.json"
+    payload.write_text(
+        _json.dumps(
+            {
+                "edits": [
+                    {
+                        "path": "seeds/contacts.csv",
+                        "kind": "seed_csv",
+                        "content": "id,email\n1,someone@example.com\n",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "a lookup built from customer data",
+            "--edits-file",
+            str(payload),
+        ]
+    )
+    envelope = _json.loads(capsys.readouterr().out)
+    assert rc != 0
+    assert "'email' looks like email" in envelope["errors"][0]
+    assert "someone@example.com" not in _json.dumps(envelope)
+
+
+def test_a_seed_over_the_size_cap_refuses_rather_than_writes(dbt_project_dir: Path):
+    # The other half of "a seed is data entering git": a multi-megabyte CSV is
+    # unreadable in review, which is the one thing a reviewable diff is for.
+    from exmergo_dex_core import transform
+    from exmergo_dex_core.transform.validate import MAX_SEED_ROWS, EditValidationError
+
+    store = FilesystemStore(dbt_project_dir.parent)
+    with pytest.raises(EditValidationError, match="row cap"):
+        transform.plan(
+            "far too much data",
+            [
+                transform.PlanEdit(
+                    path="seeds/big.csv",
+                    kind=transform.EditKind.SEED_CSV,
+                    new_content="code\n" + "x\n" * (MAX_SEED_ROWS + 1),
+                )
+            ],
+            dbt_project_dir,
+            repo_root=dbt_project_dir.parent,
+            store=store,
+        )
+    assert store.list_plans() == []
+    assert not (dbt_project_dir / "seeds" / "big.csv").exists()
+
+
 def test_pii_override_is_config_only_and_survives_reprofiling(tmp_path: Path):
     # A hand-edit to the cache is overwritten by the next profile; only the
     # committed config entry durably clears a reviewed column, and the clear is
@@ -1698,6 +1822,45 @@ def test_a_stored_plan_cannot_escape_the_surface_its_format_declares(
                 project_format=DbtProject(dbt_project_dir.parent, dbt_project_dir),
             )
     assert not escaped.exists()
+
+
+def test_an_authored_kind_cannot_land_outside_its_own_path_family(
+    dbt_project_dir: Path,
+):
+    """Writes are confined to the repo, and within the repo to the part of the
+    dbt surface the kind belongs to.
+
+    Containment alone is not enough once there are four families: a snapshot
+    written into ``models/`` is inside the surface and still wrong, because dbt
+    parses it as a model and the build fails. So the kind and its location have
+    to agree, in both directions, and neither confirmation nor a re-plan can
+    talk past it.
+    """
+
+    from exmergo_dex_core import transform
+
+    store = FilesystemStore(dbt_project_dir.parent)
+    misplaced = [
+        (
+            transform.EditKind.SNAPSHOT_SQL,
+            "models/staging/snap_customers.sql",
+            "snapshot paths",
+        ),
+        (transform.EditKind.SEED_CSV, "models/staging/lookup.csv", "seed paths"),
+        (transform.EditKind.SEED_CSV, "macros/lookup.csv", "seed paths"),
+        (transform.EditKind.SNAPSHOT_SQL, "seeds/snap.sql", "snapshot paths"),
+    ]
+    for kind, path, named in misplaced:
+        with pytest.raises(transform.PlanError, match=named):
+            transform.plan(
+                "misfiled",
+                [transform.PlanEdit(path=path, kind=kind, new_content="id\n1\n")],
+                dbt_project_dir,
+                repo_root=dbt_project_dir.parent,
+                store=store,
+            )
+        assert not (dbt_project_dir / path).exists()
+    assert store.list_plans() == []
 
 
 def test_apply_refuses_to_delete_a_human_edited_file(dbt_project_dir: Path):

--- a/packages/dex-core/tests/transform/test_dbt_project.py
+++ b/packages/dex-core/tests/transform/test_dbt_project.py
@@ -259,10 +259,13 @@ def test_write_edits_all_or_nothing_across_a_delete_and_an_upsert(
     [
         "../outside.sql",
         "models/../../escape.sql",
-        "seeds/data.yml",
+        # Inside the project, outside every authored family: the surface is the
+        # four path families plus the root manifests, not the whole repo.
+        "analyses/scratch.sql",
+        "target/compiled.sql",
     ],
 )
-def test_write_edits_refuses_paths_outside_model_paths(
+def test_write_edits_refuses_paths_outside_the_authored_families(
     dbt_project_dir: Path, bad_path: str
 ):
     edit = Edit(path=bad_path, new_content="x\n", old_content_hash=None)

--- a/packages/dex-core/tests/transform/test_macro.py
+++ b/packages/dex-core/tests/transform/test_macro.py
@@ -11,7 +11,11 @@ from pathlib import Path
 import pytest
 
 from exmergo_dex_core.cli import main
-from exmergo_dex_core.dbt_project import DbtProjectError, contained_path
+from exmergo_dex_core.dbt_project import (
+    DbtProjectError,
+    DbtProjectView,
+    contained_path,
+)
 from exmergo_dex_core.storage import FilesystemStore
 from exmergo_dex_core.transform.plans import EditKind, PlanEdit, PlanError
 from exmergo_dex_core.transform.plans import plan as make_plan
@@ -214,13 +218,16 @@ def test_plan_warns_when_a_model_calls_the_missing_macro(
 def test_contained_path_admits_macros_and_still_refuses_escapes(tmp_path: Path):
     root = tmp_path / "proj"
     root.mkdir()
-    assert contained_path(root, "macros/x.sql", ["models"], ["macros"])
+    view = DbtProjectView(
+        root=str(root), project_name="p", profile_name="p", model_paths=["models"]
+    )
+    assert contained_path(root, "macros/x.sql", view)
     with pytest.raises(DbtProjectError):
-        contained_path(root, "../macros/x.sql", ["models"], ["macros"])
+        contained_path(root, "../macros/x.sql", view)
     with pytest.raises(DbtProjectError):
-        contained_path(root, str(tmp_path / "macros" / "x.sql"), ["models"], ["macros"])
+        contained_path(root, str(tmp_path / "macros" / "x.sql"), view)
     with pytest.raises(DbtProjectError):
-        contained_path(root, "scripts/x.sql", ["models"], ["macros"])
+        contained_path(root, "scripts/x.sql", view)
 
 
 def test_custom_macro_paths_are_honored(dbt_project_dir: Path, tmp_path: Path, capsys):

--- a/packages/dex-core/tests/transform/test_seed_edit.py
+++ b/packages/dex-core/tests/transform/test_seed_edit.py
@@ -1,0 +1,385 @@
+"""`seed_csv` end to end: CSV shape, the size caps, containment to the seed
+paths, and the PII gate.
+
+The gate is the reason this kind is different in kind rather than in degree from
+every other one: a seed puts **values** into a reviewable diff, and a diff goes
+into git and stays there. So the refusal has to fire before any diff exists,
+which is what :mod:`tests.test_safety_spine` asserts; here we pin the behavior
+and the wording of the fix it names.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.cache import (
+    ColumnProfile,
+    Dataset,
+    DexCache,
+    PIICategory,
+    PIIFlag,
+)
+from exmergo_dex_core.cli import main
+from exmergo_dex_core.config import PIIOverride, pii_override_paths
+from exmergo_dex_core.dbt_project import DbtProjectError, node_files
+from exmergo_dex_core.dbt_project import load as load_project
+from exmergo_dex_core.storage import FilesystemStore
+from exmergo_dex_core.transform.plans import EditKind, PlanEdit, PlanError
+from exmergo_dex_core.transform.plans import plan as make_plan
+from exmergo_dex_core.transform.validate import (
+    MAX_SEED_BYTES,
+    MAX_SEED_ROWS,
+    EditValidationError,
+    validate_edit,
+    validate_seed,
+)
+
+SEED = "country_code,currency,vat_rate\nIT,EUR,0.22\nFR,EUR,0.20\nUS,USD,0.00\n"
+
+
+def _run(argv: list[str], capsys) -> tuple[int, dict]:
+    rc = main(argv)
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1, "exactly one line on stdout"
+    return rc, json.loads(out)
+
+
+def _edits_file(tmp_path: Path, *entries: dict) -> Path:
+    payload = tmp_path / "edits.json"
+    payload.write_text(json.dumps({"edits": list(entries)}), encoding="utf-8")
+    return payload
+
+
+def _seed(content: str = SEED, path: str = "seeds/country_vat.csv") -> PlanEdit:
+    return PlanEdit(path=path, kind=EditKind.SEED_CSV, new_content=content)
+
+
+def _cache_flagging(column: str, category: PIICategory, confidence: float) -> DexCache:
+    return DexCache(
+        connector="duckdb",
+        datasets=[
+            Dataset(
+                identifier="db.main.customers",
+                columns=[
+                    ColumnProfile(
+                        name=column,
+                        data_type="VARCHAR",
+                        pii=PIIFlag(category=category, confidence=confidence),
+                    )
+                ],
+            )
+        ],
+    )
+
+
+# --- CSV shape -------------------------------------------------------------------
+
+
+def test_a_well_formed_seed_validates():
+    assert validate_edit(_seed()) == []
+
+
+@pytest.mark.parametrize(
+    ("content", "fix_named"),
+    [
+        pytest.param("", "header row", id="empty"),
+        pytest.param("\n", "header row is empty", id="blank_header"),
+        pytest.param("a,,c\n1,2,3\n", "header column 2 has no name", id="unnamed"),
+        pytest.param("code,CODE\n1,2\n", "duplicate column", id="duplicate"),
+        pytest.param("a,b\n1,2\n3\n", "row 3 breaks at column 2", id="short_row"),
+        pytest.param("a,b\n1,2,3\n", "row 2 breaks at column 3", id="long_row"),
+    ],
+)
+def test_a_malformed_seed_names_the_row_and_column_at_fault(
+    content: str, fix_named: str
+):
+    with pytest.raises(EditValidationError, match=fix_named):
+        validate_edit(_seed(content))
+
+
+def test_the_row_cap_is_enforced_and_named():
+    oversized = "code\n" + "x\n" * (MAX_SEED_ROWS + 1)
+    with pytest.raises(EditValidationError, match=f"over the {MAX_SEED_ROWS} row cap"):
+        validate_edit(_seed(oversized))
+    # And exactly at the cap is fine: the refusal is for going over, not near.
+    assert validate_edit(_seed("code\n" + "x\n" * MAX_SEED_ROWS)) == []
+
+
+def test_the_byte_cap_is_enforced_and_named():
+    wide = "code\n" + ("x" * 200 + "\n") * 6_000
+    assert len(wide.encode("utf-8")) > MAX_SEED_BYTES
+    with pytest.raises(
+        EditValidationError, match=f"over the {MAX_SEED_BYTES // 1024} KiB cap"
+    ):
+        validate_edit(_seed(wide))
+
+
+# --- the PII gate ----------------------------------------------------------------
+
+
+def test_a_pii_named_column_is_refused_and_the_refusal_carries_no_value():
+    content = "id,email\n1,someone@example.com\n2,other@example.com\n"
+    with pytest.raises(EditValidationError) as excinfo:
+        validate_edit(_seed(content))
+    message = str(excinfo.value)
+    assert "'email' looks like email" in message
+    # The whole point: the column name and its category, never a value.
+    assert "someone@example.com" not in message
+    assert "other@example.com" not in message
+
+
+def test_the_refusal_names_the_override_that_clears_the_column():
+    with pytest.raises(EditValidationError) as excinfo:
+        validate_edit(_seed("id,email\n1,a@b.c\n"))
+    assert "`- {column: country_vat.email}`" in str(excinfo.value)
+    assert "pii_overrides" in str(excinfo.value)
+
+
+def test_the_named_override_actually_clears_it():
+    overrides = pii_override_paths([PIIOverride(column="country_vat.email")])
+    assert validate_edit(_seed("id,email\n1,a@b.c\n"), pii_overrides=overrides) == []
+
+
+def test_a_column_the_cache_already_flagged_is_refused_by_name():
+    # The seed's own header says nothing (`ref_code` matches no pattern); the
+    # cache is what knows this column carries personal data.
+    cache = _cache_flagging("ref_code", PIICategory.GOVERNMENT_ID, 0.9)
+    with pytest.raises(
+        EditValidationError, match="'ref_code' looks like government_id"
+    ):
+        validate_edit(_seed("ref_code,label\nA,x\n"), cache=cache)
+
+
+def test_a_cache_flag_matches_a_header_case_insensitively():
+    cache = _cache_flagging("ref_code", PIICategory.GOVERNMENT_ID, 0.9)
+    with pytest.raises(EditValidationError, match="REF_CODE"):
+        validate_edit(_seed("REF_CODE,label\nA,x\n"), cache=cache)
+
+
+def test_a_sub_threshold_cache_flag_warns_rather_than_refuses():
+    cache = _cache_flagging("ref_code", PIICategory.NAME, 0.3)
+    warnings = validate_edit(_seed("ref_code,label\nA,x\n"), cache=cache)
+    assert warnings and "under the 0.5 block threshold" in warnings[0]
+
+
+def test_the_provisional_generic_name_match_warns_rather_than_refuses():
+    # `country_name` matches the generic `*_name` pattern, which the detector
+    # itself calls provisional: on a warehouse column `explore` refines it
+    # against value shape, and dex never reads a seed's values, so blocking on
+    # it would claim a certainty the detector disclaims.
+    warnings = validate_seed(
+        "seeds/countries.csv", "country_code,country_name\nIT,Italy\n"
+    )
+    assert warnings and "cannot refine on a seed" in warnings[0]
+
+
+def test_an_explicit_person_name_pattern_still_refuses():
+    # The generic match is provisional; `full_name` is not a guess.
+    with pytest.raises(EditValidationError, match="'full_name' looks like name"):
+        validate_seed("seeds/people.csv", "id,full_name\n1,x\n")
+
+
+def test_detection_reads_names_and_types_and_never_values():
+    # The standing limit of the whole PII subsystem, stated rather than papered
+    # over: a column named `code` holding email addresses passes this gate.
+    assert validate_seed("seeds/x.csv", "code\nsomeone@example.com\n") == []
+
+
+# --- containment, kind agreement, and the project view ---------------------------
+
+
+def test_a_seed_plans_applies_and_lands_as_a_create_diff(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    payload = _edits_file(
+        tmp_path,
+        {"path": "seeds/country_vat.csv", "kind": "seed_csv", "content": SEED},
+        {
+            "path": "seeds/schema.yml",
+            "kind": "schema_yml",
+            "content": (
+                "version: 2\n"
+                "seeds:\n"
+                "  - name: country_vat\n"
+                "    config:\n"
+                "      column_types:\n"
+                "        vat_rate: double\n"
+            ),
+        },
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "add the VAT lookup",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+    assert envelope["data"]["paths"] == ["seeds/country_vat.csv", "seeds/schema.yml"]
+    created = {d["path"]: d for d in envelope["diffs"]}["seeds/country_vat.csv"]
+    assert created["op"] == "create"
+    assert "IT,EUR,0.22" in created["unified"]
+
+    rc, envelope = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+    assert rc == 0, envelope["errors"]
+    assert (dbt_project_dir / "seeds" / "country_vat.csv").read_text() == SEED
+
+
+def test_custom_seed_paths_are_honored(dbt_project_dir: Path, tmp_path: Path):
+    project_yml = dbt_project_dir / "dbt_project.yml"
+    project_yml.write_text(
+        project_yml.read_text(encoding="utf-8") + 'seed-paths: ["reference"]\n',
+        encoding="utf-8",
+    )
+    store = FilesystemStore(tmp_path)
+    stored, _diffs, _warnings = make_plan(
+        "add the lookup",
+        [_seed(path="reference/country_vat.csv")],
+        dbt_project_dir,
+        tmp_path,
+        store=store,
+    )
+    assert stored.edits[0].path == "reference/country_vat.csv"
+
+    with pytest.raises(DbtProjectError, match=r"seed \(reference\)"):
+        make_plan("add", [_seed()], dbt_project_dir, tmp_path, store=store)
+
+
+def test_kind_and_surface_must_agree_in_both_directions(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    store = FilesystemStore(tmp_path)
+    with pytest.raises(PlanError, match="seed paths"):
+        make_plan(
+            "bad",
+            [_seed(path="models/staging/country_vat.csv")],
+            dbt_project_dir,
+            tmp_path,
+            store=store,
+        )
+
+    model_in_seeds = PlanEdit(
+        path="seeds/x.sql", kind=EditKind.MODEL_SQL, new_content="select 1\n"
+    )
+    with pytest.raises(PlanError, match="seed path"):
+        make_plan("bad", [model_in_seeds], dbt_project_dir, tmp_path, store=store)
+
+
+def test_a_schema_yml_beside_a_seed_is_accepted(dbt_project_dir: Path, tmp_path: Path):
+    edit = PlanEdit(
+        path="seeds/schema.yml",
+        kind=EditKind.SCHEMA_YML,
+        new_content="version: 2\nseeds:\n  - name: country_vat\n",
+    )
+    stored, _diffs, _warnings = make_plan(
+        "declare the seed's column types",
+        [edit],
+        dbt_project_dir,
+        tmp_path,
+        store=FilesystemStore(tmp_path),
+    )
+    assert stored.edits[0].path == "seeds/schema.yml"
+
+
+def test_a_seed_is_loaded_and_counts_as_a_node(dbt_project_dir: Path):
+    seeds = dbt_project_dir / "seeds"
+    seeds.mkdir()
+    (seeds / "country_vat.csv").write_text(SEED, encoding="utf-8")
+    (seeds / "schema.yml").write_text("version: 2\n", encoding="utf-8")
+
+    view = load_project(dbt_project_dir)
+    # Load-bearing, not bookkeeping: a seed missing from `files` hashes as a
+    # create on every re-plan and the apply after it conflicts on a file nobody
+    # touched.
+    assert "seeds/country_vat.csv" in view.files
+    assert set(node_files(view)) == {
+        "models/staging/stg_customers.sql",
+        "seeds/country_vat.csv",
+    }
+
+
+def test_deleting_a_seed_a_model_still_refs_is_refused(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    # `.csv` never matched the old `.endswith(".sql")` test, so this delete used
+    # to be accepted and would break the build.
+    seeds = dbt_project_dir / "seeds"
+    seeds.mkdir()
+    (seeds / "country_vat.csv").write_text(SEED, encoding="utf-8")
+    (dbt_project_dir / "models" / "staging" / "uses_seed.sql").write_text(
+        "select * from {{ ref('country_vat') }}\n", encoding="utf-8"
+    )
+    delete = PlanEdit(path="seeds/country_vat.csv", kind=EditKind.SEED_CSV, op="delete")
+    with pytest.raises(PlanError, match="country_vat"):
+        make_plan(
+            "drop the lookup",
+            [delete],
+            dbt_project_dir,
+            tmp_path,
+            store=FilesystemStore(tmp_path),
+        )
+
+
+# --- the build ------------------------------------------------------------------
+
+
+def test_a_dev_build_materializes_an_applied_seed(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    # The acceptance criterion: `dbt build` runs seeds natively, so applying one
+    # and building is all it takes. No new command, and no `dbt seed` step for
+    # the caller to remember.
+    duckdb = pytest.importorskip("duckdb")
+
+    payload = _edits_file(
+        tmp_path,
+        {"path": "seeds/country_vat.csv", "kind": "seed_csv", "content": SEED},
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "add the VAT lookup",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+    rc, _envelope = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+    assert rc == 0
+
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+    statuses = {n["name"]: n["status"] for n in envelope["data"]["nodes"]}
+    assert statuses["country_vat"] == "success"
+
+    con = duckdb.connect(str(tmp_path / "dev.duckdb"), read_only=True)
+    try:
+        rows = con.execute(
+            "select country_code, currency from country_vat order by country_code"
+        ).fetchall()
+        assert rows == [("FR", "EUR"), ("IT", "EUR"), ("US", "USD")]
+    finally:
+        con.close()

--- a/packages/dex-core/tests/transform/test_snapshot_edit.py
+++ b/packages/dex-core/tests/transform/test_snapshot_edit.py
@@ -1,0 +1,429 @@
+"""`snapshot_sql` end to end: the block's structure, the config fields each
+strategy cannot work without, containment to the snapshot paths, and the two
+things a snapshot shares with a model that a macro does not (it builds a
+relation, and it is ``ref()``-able, so deleting one is guarded)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.cli import main
+from exmergo_dex_core.dbt_project import DbtProjectError, node_files
+from exmergo_dex_core.dbt_project import load as load_project
+from exmergo_dex_core.storage import FilesystemStore
+from exmergo_dex_core.transform.plans import EditKind, PlanEdit, PlanError
+from exmergo_dex_core.transform.plans import plan as make_plan
+from exmergo_dex_core.transform.validate import EditValidationError, validate_edit
+
+TIMESTAMP_SNAPSHOT = """{% snapshot snap_customers %}
+{{
+    config(
+        target_schema='snapshots',
+        unique_key='id',
+        strategy='timestamp',
+        updated_at='updated_at',
+    )
+}}
+
+select id, email, updated_at from {{ ref('stg_customers') }}
+
+{% endsnapshot %}
+"""
+
+CHECK_SNAPSHOT = """{% snapshot snap_orders %}
+{{ config(unique_key='id', strategy='check', check_cols=['status', 'total']) }}
+select id, status, total from {{ ref('stg_customers') }}
+{% endsnapshot %}
+"""
+
+
+def _run(argv: list[str], capsys) -> tuple[int, dict]:
+    rc = main(argv)
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1, "exactly one line on stdout"
+    return rc, json.loads(out)
+
+
+def _edits_file(tmp_path: Path, *entries: dict) -> Path:
+    payload = tmp_path / "edits.json"
+    payload.write_text(json.dumps({"edits": list(entries)}), encoding="utf-8")
+    return payload
+
+
+def _snapshot(content: str, path: str = "snapshots/snap_customers.sql") -> PlanEdit:
+    return PlanEdit(path=path, kind=EditKind.SNAPSHOT_SQL, new_content=content)
+
+
+# --- the structural check --------------------------------------------------------
+
+
+@pytest.mark.parametrize("content", [TIMESTAMP_SNAPSHOT, CHECK_SNAPSHOT])
+def test_a_well_formed_snapshot_validates(content: str):
+    assert validate_edit(_snapshot(content)) == []
+
+
+@pytest.mark.parametrize(
+    ("mutation", "fix_named"),
+    [
+        pytest.param(lambda s: "select 1\n", "{% snapshot", id="no_block"),
+        pytest.param(
+            lambda s: s.replace("{% endsnapshot %}", ""),
+            "endsnapshot",
+            id="unclosed",
+        ),
+        pytest.param(lambda s: s + s, "exactly one snapshot block", id="two_blocks"),
+        pytest.param(
+            lambda s: s + "\nselect 1\n", "loose content", id="content_outside"
+        ),
+        pytest.param(
+            lambda s: s.replace("        unique_key='id',\n", ""),
+            "unique_key",
+            id="no_unique_key",
+        ),
+        pytest.param(
+            lambda s: s.replace("strategy='timestamp'", "strategy='scd2'"),
+            "unknown snapshot strategy",
+            id="unknown_strategy",
+        ),
+        pytest.param(
+            lambda s: s.replace("        strategy='timestamp',\n", ""),
+            "needs a strategy",
+            id="no_strategy",
+        ),
+        pytest.param(
+            lambda s: s.replace("        updated_at='updated_at',\n", ""),
+            "needs updated_at",
+            id="timestamp_without_updated_at",
+        ),
+        pytest.param(
+            lambda s: s.replace(
+                "select id, email, updated_at from {{ ref('stg_customers') }}",
+                "delete from customers",
+            ),
+            "read-only SELECT",
+            id="not_a_select",
+        ),
+        pytest.param(
+            lambda s: s.replace(
+                "select id, email, updated_at from {{ ref('stg_customers') }}", ""
+            ),
+            "no query",
+            id="no_query",
+        ),
+    ],
+)
+def test_a_broken_snapshot_is_refused_with_the_fix(mutation, fix_named: str):
+    with pytest.raises(EditValidationError, match=fix_named):
+        validate_edit(_snapshot(mutation(TIMESTAMP_SNAPSHOT)))
+
+
+def test_a_check_snapshot_without_check_cols_is_refused():
+    broken = CHECK_SNAPSHOT.replace(", check_cols=['status', 'total']", "")
+    with pytest.raises(EditValidationError, match="needs check_cols"):
+        validate_edit(_snapshot(broken, "snapshots/snap_orders.sql"))
+
+
+# --- containment and kind agreement ----------------------------------------------
+
+
+def test_a_snapshot_plans_applies_and_lands_as_a_create_diff(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    payload = _edits_file(
+        tmp_path,
+        {
+            "path": "snapshots/snap_customers.sql",
+            "kind": "snapshot_sql",
+            "content": TIMESTAMP_SNAPSHOT,
+        },
+        {
+            "path": "snapshots/schema.yml",
+            "kind": "schema_yml",
+            "content": (
+                "version: 2\n"
+                "snapshots:\n"
+                "  - name: snap_customers\n"
+                "    description: customer history\n"
+            ),
+        },
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "capture customer history",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+    assert envelope["data"]["paths"] == [
+        "snapshots/snap_customers.sql",
+        "snapshots/schema.yml",
+    ]
+    diffs = {d["path"]: d for d in envelope["diffs"]}
+    # A create: nothing on the removed side, the whole file on the added one.
+    created = diffs["snapshots/snap_customers.sql"]
+    assert created["op"] == "create"
+    assert created["deletions"] == 0
+    assert "{% snapshot snap_customers %}" in created["unified"]
+
+    rc, envelope = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+    assert rc == 0, envelope["errors"]
+    written = dbt_project_dir / "snapshots" / "snap_customers.sql"
+    assert written.read_text(encoding="utf-8") == TIMESTAMP_SNAPSHOT
+
+
+def test_custom_snapshot_paths_are_honored(dbt_project_dir: Path, tmp_path: Path):
+    project_yml = dbt_project_dir / "dbt_project.yml"
+    project_yml.write_text(
+        project_yml.read_text(encoding="utf-8") + 'snapshot-paths: ["history"]\n',
+        encoding="utf-8",
+    )
+    store = FilesystemStore(tmp_path)
+    stored, _diffs, _warnings = make_plan(
+        "capture",
+        [_snapshot(TIMESTAMP_SNAPSHOT, "history/snap_customers.sql")],
+        dbt_project_dir,
+        tmp_path,
+        store=store,
+    )
+    assert stored.edits[0].path == "history/snap_customers.sql"
+
+    # And the default location is no longer part of the surface once moved:
+    # containment refuses it before the kind is ever consulted, and the refusal
+    # names where the snapshot family actually is now.
+    with pytest.raises(DbtProjectError, match=r"snapshot \(history\)"):
+        make_plan(
+            "capture",
+            [_snapshot(TIMESTAMP_SNAPSHOT)],
+            dbt_project_dir,
+            tmp_path,
+            store=store,
+        )
+
+
+def test_kind_and_surface_must_agree_in_both_directions(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    store = FilesystemStore(tmp_path)
+    with pytest.raises(PlanError, match="snapshot paths"):
+        make_plan(
+            "bad",
+            [_snapshot(TIMESTAMP_SNAPSHOT, "models/staging/snap_customers.sql")],
+            dbt_project_dir,
+            tmp_path,
+            store=store,
+        )
+
+    model_in_snapshots = PlanEdit(
+        path="snapshots/x.sql",
+        kind=EditKind.MODEL_SQL,
+        new_content="select 1\n",
+    )
+    with pytest.raises(PlanError, match="snapshot_sql"):
+        make_plan("bad", [model_in_snapshots], dbt_project_dir, tmp_path, store=store)
+
+
+def test_the_misfiled_refusal_comes_from_dex_not_from_dbt(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    # Through the command layer, where dbt's own parser also runs. dex refuses
+    # first, so the caller reads "must live under the project's snapshot paths"
+    # rather than dbt's "Encountered unknown tag 'snapshot'", which names no
+    # fix at all. Found by dogfooding: the direct-to-`plan` tests above cannot
+    # see what the command does before it.
+    payload = _edits_file(
+        tmp_path,
+        {
+            "path": "models/staging/snap_customers.sql",
+            "kind": "snapshot_sql",
+            "content": TIMESTAMP_SNAPSHOT,
+        },
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "misfiled",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc != 0
+    assert "snapshot paths" in envelope["errors"][0]
+    assert "unknown tag" not in envelope["errors"][0]
+
+
+def test_a_snapshot_missing_unique_key_is_refused_with_the_fix_not_dbt_s_message(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    payload = _edits_file(
+        tmp_path,
+        {
+            "path": "snapshots/snap_customers.sql",
+            "kind": "snapshot_sql",
+            "content": TIMESTAMP_SNAPSHOT.replace("        unique_key='id',\n", ""),
+        },
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "no key",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc != 0
+    # dbt says "Snapshots must be configured with a 'strategy' and
+    # 'unique_key'", which names neither which one is missing nor what it is
+    # for. dex names both.
+    assert (
+        "needs a unique_key, the column dbt tracks each row by"
+        in (envelope["errors"][0])
+    )
+
+
+def test_a_schema_yml_beside_a_snapshot_is_accepted(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    edit = PlanEdit(
+        path="snapshots/schema.yml",
+        kind=EditKind.SCHEMA_YML,
+        new_content="version: 2\nsnapshots:\n  - name: snap_customers\n",
+    )
+    stored, _diffs, _warnings = make_plan(
+        "document the snapshot",
+        [edit],
+        dbt_project_dir,
+        tmp_path,
+        store=FilesystemStore(tmp_path),
+    )
+    assert stored.edits[0].path == "snapshots/schema.yml"
+
+
+# --- the project view: a snapshot is a node, not just a file ---------------------
+
+
+def test_a_snapshot_is_loaded_and_counts_as_a_node(dbt_project_dir: Path):
+    snapshots = dbt_project_dir / "snapshots"
+    snapshots.mkdir()
+    (snapshots / "snap_customers.sql").write_text(TIMESTAMP_SNAPSHOT, encoding="utf-8")
+    (snapshots / "schema.yml").write_text("version: 2\n", encoding="utf-8")
+
+    view = load_project(dbt_project_dir)
+    assert "snapshots/snap_customers.sql" in view.files
+    assert "snapshots/schema.yml" in view.files
+    # The properties YAML is loaded (so editing it pins a real hash) but builds
+    # nothing, so it is not a node.
+    assert set(node_files(view)) == {
+        "models/staging/stg_customers.sql",
+        "snapshots/snap_customers.sql",
+    }
+
+
+def test_deleting_a_snapshot_a_model_still_refs_is_refused(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    snapshots = dbt_project_dir / "snapshots"
+    snapshots.mkdir()
+    (snapshots / "snap_customers.sql").write_text(TIMESTAMP_SNAPSHOT, encoding="utf-8")
+    (dbt_project_dir / "models" / "staging" / "uses_snapshot.sql").write_text(
+        "select * from {{ ref('snap_customers') }}\n", encoding="utf-8"
+    )
+    delete = PlanEdit(
+        path="snapshots/snap_customers.sql",
+        kind=EditKind.SNAPSHOT_SQL,
+        op="delete",
+    )
+    with pytest.raises(PlanError, match="snap_customers"):
+        make_plan(
+            "drop the snapshot",
+            [delete],
+            dbt_project_dir,
+            tmp_path,
+            store=FilesystemStore(tmp_path),
+        )
+
+
+# --- the build ------------------------------------------------------------------
+
+
+def test_a_snapshot_is_priced_and_a_seed_is_not():
+    from exmergo_dex_core.transform.build import _PRICED_RESOURCE_TYPES
+
+    # A snapshot writes a table, so it scans and is priced; a seed loads a local
+    # CSV and issues no billed build statement. Pinned from both sides so a
+    # future edit to the set cannot quietly flip either.
+    assert "snapshot" in _PRICED_RESOURCE_TYPES
+    assert "seed" not in _PRICED_RESOURCE_TYPES
+
+
+def test_a_dev_build_materializes_an_applied_snapshot(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    duckdb = pytest.importorskip("duckdb")
+
+    payload = _edits_file(
+        tmp_path,
+        {
+            "path": "snapshots/snap_customers.sql",
+            "kind": "snapshot_sql",
+            "content": TIMESTAMP_SNAPSHOT.replace(
+                "select id, email, updated_at from {{ ref('stg_customers') }}",
+                "select 1 as id, 'a' as email, "
+                "cast('2026-01-01' as timestamp) as updated_at",
+            ).replace("target_schema='snapshots',\n        ", ""),
+        },
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "capture customer history",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+    rc, _envelope = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+    assert rc == 0
+
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+    statuses = {n["name"]: n["status"] for n in envelope["data"]["nodes"]}
+    assert statuses["snap_customers"] == "success"
+
+    con = duckdb.connect(str(tmp_path / "dev.duckdb"), read_only=True)
+    try:
+        rows = con.execute("select id from snap_customers").fetchall()
+        assert rows == [(1,)]
+    finally:
+        con.close()

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -114,13 +114,16 @@ hands it over via `--edits-file <path>` (or `-` for stdin), a JSON payload:
 {"edits": [
   {"path": "models/staging/stg_orders.sql", "kind": "model_sql", "content": "..."},
   {"path": "models/staging/stg_orders.yml", "kind": "schema_yml", "content": "..."},
+  {"path": "snapshots/snap_orders.sql", "kind": "snapshot_sql", "content": "..."},
+  {"path": "seeds/country_vat.csv", "kind": "seed_csv", "content": "..."},
   {"path": "models/marts/dim_orders.sql", "kind": "model_sql", "op": "delete"}
 ]}
 ```
 
 `kind` is one of `model_sql`, `schema_yml`, `semantic_yml` (optional on
 `semantic define|update`, which imply `semantic_yml`), `packages_yml`,
-`macro_sql`, `project_yml`, or `profiles_yml`. Each edit also has an `op`:
+`macro_sql`, `snapshot_sql`, `seed_csv`, `project_yml`, or `profiles_yml`. Each
+edit also has an `op`:
 `upsert` (create or update, the default, carrying `content`) or `delete` (remove
 the file, no `content`). A delete is a reviewable diff pinned to the file's hash
 like any other edit, and it is guarded: the plan is refused if any surviving file
@@ -134,7 +137,14 @@ parse; semantic YAML must satisfy MetricFlow's schemas; a `packages_yml` edit
 must carry a `packages:` or `dependencies:` list and targets the project-root
 `packages.yml` or `dependencies.yml`; a `macro_sql` edit must hold only macro
 definitions and jinja comments and must target the project's macro paths, where
-no other kind may go; a `project_yml` edit targets the project-root
+no other kind may go; a `snapshot_sql` edit must hold exactly one
+`{% snapshot %}` block whose `config()` names a `unique_key` and a `strategy` of
+`timestamp` (with `updated_at`) or `check` (with `check_cols`), whose body is a
+single read-only SELECT, and must target the project's snapshot paths; a
+`seed_csv` edit must parse as CSV with a named, duplicate-free header and one
+field per column on every row, must stay under 5,000 data rows and 1 MiB, must
+not name columns that look like personal data, and must target the project's
+seed paths; a `project_yml` edit targets the project-root
 `dbt_project.yml` and must keep a `name`; a `profiles_yml` edit targets the
 project-root `profiles.yml` and must reference every secret via
 `{{ env_var('NAME') }}`, never a literal), pins it to the sha256 of the file it
@@ -144,7 +154,26 @@ would change, computes the diffs, and stores the plan under
 reviewable diff like any other edit, then `transform deps` (or the automatic
 deps step in `transform build`) installs them. `macro_sql` is how a macro is
 repaired or customized by hand; `transform macro <name>` is the scaffolding path
-for the macros dex ships. `project_yml` and `profiles_yml` bring the two
+for the macros dex ships. `snapshot_sql` and `seed_csv` bring slowly-changing
+dimension capture and small reference tables into the same flow, each confined to
+its own path family (`snapshot-paths` and `seed-paths` in `dbt_project.yml`, read
+with dbt's own defaults) and each gated by dbt's parser at plan time. A
+`schema_yml` edit is accepted beside either one, which is where dbt expects a
+seed's column types and a snapshot's tests and docs to be declared. `dbt build`
+runs seeds and snapshots natively, so nothing new has to be run after an apply;
+a snapshot writes a table and is priced in the cost handshake, while a seed
+loads a local CSV, scans nothing, and is deliberately unpriced.
+
+`seed_csv` is the first kind that puts **values**, not logic, into a reviewable
+diff, and a diff goes into git and stays there. So a seed's header is checked
+both against the PII detector `explore` profiles warehouse columns with and
+against the flags already in the `.dex/` cache. A column at or above the block
+threshold is refused, and the refusal names the `pii_overrides` entry that would
+clear it (never a value). The standing limit is worth knowing: dex detects PII
+from names and types and never from values, everywhere, so a seed column named
+`code` full of email addresses passes this gate.
+
+`project_yml` and `profiles_yml` bring the two
 project-root config files into the same plan/diff/apply flow; because they carry
 project-wide settings and connection targets, they are gated by dbt's own parser
 at plan time, and a `profiles_yml` edit is refused if it (or the file it would

--- a/references/dbt-project.md
+++ b/references/dbt-project.md
@@ -6,9 +6,17 @@ the project, reasons over it together with warehouse introspection and the
 
 ## What dex reads
 
-- `dbt_project.yml`: the project name, profile name, and `model-paths`.
-- Every `*.sql` / `*.yml` / `*.yaml` under the model paths: the editing surface
-  (model SQL, `schema.yml`, dbt semantic models).
+- `dbt_project.yml`: the project name, profile name, and the four authored path
+  families (`model-paths`, `macro-paths`, `snapshot-paths`, `seed-paths`), each
+  defaulted the way dbt defaults it when the key is absent.
+- The source files under those families, scanned for the suffixes each one can
+  hold: `*.sql` / `*.yml` / `*.yaml` under the model, macro and snapshot paths,
+  and `*.csv` / `*.yml` / `*.yaml` under the seed paths. Together they are the
+  editing surface (model SQL, `schema.yml`, dbt semantic models, macros,
+  snapshots, seeds). A file dex can author but does not load would hash as
+  absent, so a later edit to it would register as a create and the apply after
+  it would conflict on a file nobody touched; the scan covers every family for
+  that reason, not for completeness.
 - `target/manifest.json` when the project has been compiled; a fresh project
   loads fine without one.
 - `profiles.yml` (searched the way dbt searches: `$DBT_PROFILES_DIR`, the project
@@ -51,8 +59,23 @@ by dbt's own parser). A rename is expressed as one plan: delete the old model,
 create the new one, and update every referrer, validated together.
 
 Human edits to dbt are authoritative by construction; dex holds no competing copy
-to overwrite them from. Writes are confined to the project's model paths; path
-escapes are refused. dex never builds to a non-dev target, and a delete only ever
+to overwrite them from. Writes are confined to the four authored path families
+plus the project-root manifests dbt keeps there (`dbt_project.yml`,
+`profiles.yml`, `packages.yml`, `dependencies.yml`); path escapes are refused.
+Within the surface, an edit's kind and its location have to agree: a snapshot
+belongs under the snapshot paths and nowhere else, a seed under the seed paths, a
+macro under the macro paths, and model SQL and semantic YAML under the model
+paths. `schema.yml` is the one kind several families admit, because dbt expects a
+seed's column types and a snapshot's tests declared beside the thing they
+describe. Filing a kind in the wrong family is refused at plan time naming both
+fixes (move the file, or relabel the kind), since dbt would otherwise parse a
+snapshot as a model, or never load a seed at all.
+
+A model, a snapshot and a seed each build a relation dbt names after the file and
+each is `ref()`-able, so all three count as nodes: deleting one is guarded
+against surviving references exactly like deleting a model, and all three are
+what `maintain` fingerprints as the transformation layer. A macro is not a node
+and never was one. dex never builds to a non-dev target, and a delete only ever
 removes a file from the repo, never a relation from the warehouse.
 
 ## Running dbt (build, deps, parse)

--- a/references/project.md
+++ b/references/project.md
@@ -188,6 +188,13 @@ generates alongside the path, so placement alone cannot open that channel: a for
 that places a staging model elsewhere gets the proposal as advice rather than having
 dbt written into its tree. One `None` and one path is the shape this exists for.
 
+The kind list grows over time (`MACRO_SQL`, `SNAPSHOT_SQL` and `SEED_CSV` are all
+dbt-shaped artifacts a non-dbt format may have no equivalent of), and `None` stays
+the right answer for every one your format does not place. The shipped dbt format
+answers `None` for them too: reconcile proposes staging models and their
+`schema.yml` and nothing else, so a path for the rest would be invented rather
+than known.
+
 `editing_surface()` declares the region those paths must stay inside, and it is a
 different question with a different caller. `transform plan` validates edits an agent
 authored, where there is no `(kind, model)` pair to ask `edit_path` about and no

--- a/skills/transform/SKILL.md
+++ b/skills/transform/SKILL.md
@@ -32,21 +32,48 @@ and stores the proposal as a plan. Hand content over with `--edits-file <path>`
 {"edits": [
   {"path": "models/staging/stg_orders.sql", "kind": "model_sql", "content": "..."},
   {"path": "models/staging/stg_orders.yml", "kind": "schema_yml", "content": "..."},
+  {"path": "snapshots/snap_orders.sql", "kind": "snapshot_sql", "content": "..."},
+  {"path": "seeds/country_vat.csv", "kind": "seed_csv", "content": "..."},
   {"path": "models/marts/dim_orders.sql", "kind": "model_sql", "op": "delete"}
 ]}
 ```
 
 `kind` is `model_sql`, `schema_yml`, `semantic_yml` (optional on
 `semantic define|update|plan`, which imply it), `macro_sql` (a macro file under
-the project's macro paths), `packages_yml`, `project_yml` (the project-root
-`dbt_project.yml`), or `profiles_yml` (the project-root `profiles.yml`). Model
-SQL must be a single read-only SELECT once its jinja is stripped; semantic YAML
-is validated against MetricFlow's schemas, cross-reference-checked, and (when
-dbt is available) parsed by dbt itself before the plan is accepted; a macro file
-must hold only macro definitions and jinja comments. `project_yml` must keep a
-`name`; `profiles_yml` must reference every secret via `{{ env_var('NAME') }}`
-(a literal credential is refused so none reaches the diff), and both config
-kinds are parsed by dbt at plan time.
+the project's macro paths), `snapshot_sql` (a snapshot under the snapshot
+paths), `seed_csv` (a seed's CSV under the seed paths), `packages_yml`,
+`project_yml` (the project-root `dbt_project.yml`), or `profiles_yml` (the
+project-root `profiles.yml`). Model SQL must be a single read-only SELECT once
+its jinja is stripped; semantic YAML is validated against MetricFlow's schemas,
+cross-reference-checked, and (when dbt is available) parsed by dbt itself before
+the plan is accepted; a macro file must hold only macro definitions and jinja
+comments. A snapshot must hold exactly one `{% snapshot %}` block whose
+`config()` names a `unique_key` and a `strategy` of `timestamp` (with
+`updated_at`) or `check` (with `check_cols`), and whose body is a single
+read-only SELECT. A seed must parse as CSV with a named, duplicate-free header
+and one field per column on every row, and stays under 5,000 data rows and 1 MiB
+(past that it is data rather than a lookup: load it into the warehouse and
+`source()` it). `project_yml` must keep a `name`; `profiles_yml` must reference
+every secret via `{{ env_var('NAME') }}` (a literal credential is refused so
+none reaches the diff). Config kinds, snapshots and seeds are all parsed by dbt
+at plan time.
+
+Each kind is confined to its own family of paths, and filing one in the wrong
+family is refused naming both fixes. `schema_yml` is the exception, accepted
+beside a model, a snapshot or a seed, because that is where dbt expects a
+snapshot's tests and a seed's column types declared.
+
+**A seed puts values, not logic, into a diff, and a diff goes into git and stays
+there.** So a seed whose header names a column that looks like personal data is
+refused, and the refusal names the `pii_overrides` entry in `.dex/config.yml`
+that a human can add to clear it. Detection reads names and types and never
+values (everywhere in dex), so it cannot see personal data hiding under a
+neutral column name: do not build a seed out of warehouse rows you have not
+looked at.
+
+`dbt build` runs seeds and snapshots natively, so `transform build` after an
+apply is all it takes; there is no separate seed step. A snapshot writes a table
+and is priced in the cost handshake, a seed scans nothing and is not.
 
 `op` is `upsert` (the default: create or update, carrying `content`) or
 `delete` (remove the file, no `content`). A delete is a first-class reviewable


### PR DESCRIPTION
Closes #210. Closes #211.

`transform plan` refused a snapshot file:

```
edit path 'snapshots/snap_orders.sql' is outside the project's model paths
(models); dex edits only the dbt project surface
```

That message is self-contradicting from the caller's side. A snapshot **is** the
dbt project surface, and so is a seed. The engine read `model-paths` and
`macro-paths` and nothing else, so the two most common remaining dbt artifacts
had to be written by hand, outside the plan-then-apply path, which drops the
reviewable diff, the hash pinning and the conflict detection for exactly the kind
of change that most deserves them.

Two edit kinds now exist, `snapshot_sql` and `seed_csv`, each confined to its own
family of paths, each validated for the shape dbt will demand of it, and each
gated by dbt's own parser before a plan is stored. `dbt build` runs both
natively, so nothing new has to be run after an apply.

Both issues are one PR because they share every seam: the same four-family
project view, the same containment, the same placement table, the same delete
guard, the same drift-baseline consequence.

## The four path families

`DbtProjectView` now carries `snapshot_paths` and `seed_paths` alongside the two
it had, defaulted the way dbt defaults them, and `load()` scans per family rather
than through one global suffix filter: `.sql`/`.yml`/`.yaml` under model, macro
and snapshot paths, and `.csv` plus YAML under seed paths.

**That scan is load-bearing, not bookkeeping.** A file dex can author but does
not load hashes as absent, so a later edit to it registers as a create and the
apply after it conflicts on a file nobody touched. Every seed would have done
that on every re-plan.

`contained_path` now takes the view rather than two positional path lists. Four
families is where a positional list stops paying, all three callers already held
a view, and the refusal names every family with its configured directories:

```
edit path 'analyses/scratch.sql' is outside the project's authored paths
[macro (macros), snapshot (snapshots), seed (seeds), model (models)];
dex edits only the dbt project surface
```

`DbtProject.editing_surface()` widened in lockstep, because `plans.apply`
re-checks a stored plan against that declaration before handing it to the writer.
A surface narrower than what the writer accepts refuses at apply what it accepted
at plan.

## Kind and location have to agree

The rule that kept a macro out of `models/` was two symmetric `if`s. With four
exclusive families it becomes a table keyed by family and file suffix:

| family | `.sql` | `.csv` | `.yml` / `.yaml` |
|---|---|---|---|
| macro | `macro_sql` | refused | refused (unchanged) |
| snapshot | `snapshot_sql` | refused | `schema_yml` |
| seed | refused | `seed_csv` | `schema_yml` |
| model | `model_sql` | refused | `schema_yml` / `semantic_yml` |

`schema_yml` is admitted under the two new families because that is where dbt
expects a seed's column types and a snapshot's tests declared, and refusing it
would leave both kinds authorable but untestable. The dogfood confirmed the
concrete cost: without `seeds/schema.yml` the seed's `is_terminal` column loads
as a string rather than a boolean.

**Macro-path behavior is deliberately left exactly as it is.** Admitting
`schema_yml` there would be more consistent, and it is a live behavior change
with a test pinning both directions, so it belongs in its own change rather than
smuggled in beside two new kinds.

A misfiled edit is refused naming both fixes, because either one is complete and
only the caller knows which they meant:

```
a snapshot_sql edit must live under the project's snapshot paths (snapshots),
got 'models/staging/bad.sql', which is a model path; a .sql file there is model_sql
```

## Validation

**Snapshots**, structurally, mirroring the macro checks: exactly one
`{% snapshot %}` / `{% endsnapshot %}` block with nothing loose outside it, a
`config()` inside it naming a `unique_key` and a `strategy` of `timestamp` or
`check` along with the field that strategy cannot work without, and a body that
passes `strip_jinja` then `assert_select_only`, exactly as a model does. Each
refusal names the fix:

```
a 'timestamp' strategy snapshot needs updated_at in its config
(the column that changes when a row does)
```

**Seeds**, via `csv.reader`: it parses, the header is present and every column is
named, no two columns collide case-insensitively (warehouses fold identifier
case), and every row carries one field per column, with the row and the column at
fault named. `MAX_SEED_ROWS = 5_000` and `MAX_SEED_BYTES = 1 << 20` bound it,
because a multi-megabyte CSV in a plan diff is unreadable in review, which is the
one thing a reviewable diff is for. Module constants rather than config, the same
call `explore`'s own caps make.

Behind both, dbt's parser is the authoritative gate: `SNAPSHOT_SQL` and
`SEED_CSV` joined the `shadow_parse` set, which already degrades to a warning
where dbt is not installed.

## The PII gate, which is the part that is new in kind

Every other edit kind puts *logic* into a reviewable diff. A seed puts **values**
into one, and a diff goes into git and stays there. The issue asked for the
conservative rule and this is it.

A seed's header is read two ways: through the same name-and-type detector
`explore` profiles warehouse columns with, and against the PII flags already in
the `.dex/` cache, which is where a column a human reviewed and cleared has
already stopped being flagged. The two are unioned at the stronger flag. A hit at
or above `PII_BLOCK_CONFIDENCE` refuses:

```
seeds/contacts.csv: a seed's values land in git and stay there, and this one has
columns that look like personal data: 'email' looks like email (confidence 0.95),
cleared by `- {column: contacts.email}`; 'full_name' looks like name (confidence
0.75), cleared by `- {column: contacts.full_name}`. If the review says otherwise,
add that entry under pii_overrides in .dex/config.yml and re-plan. Only names and
types were read; no value was.
```

Four calls in there are worth explaining.

**Header detection, not cache matching alone.** The issue proposed matching
against PII-flagged *source* columns. That catches a seed built from warehouse
data and misses a seed typed out by hand with an `email` column in it, which is
just as much personal data entering git. The header detector is what covers the
second case, and on a fresh repo with no cache it is the only half that can run.

**The refusal fires before the diff exists.** `validate_edit` runs inside
`plans.plan` before `file_diff`, and the envelope sanitizer walks `data` and
never `diffs`, so that ordering is the only thing standing between a seed's
values and the transcript. The spine test asserts the ordering, not just the
refusal: no plan stored, no file written, and the addresses absent from the
message.

**The suggested override is one the engine actually consults.** A seed has no
warehouse identifier, so the override path is the dbt name of the thing being
authored, `<seed>.<column>`, matched through the same `PIIOverrideMatcher` every
other override goes through. Pasting the suggested line into `.dex/config.yml`
and re-planning was tried in the dogfood and works. A refusal naming an override
the engine ignores would be worse than no suggestion at all.

**The generic `*_name` match warns rather than blocks.** This is the one call
that is not maximally conservative, and the demo warehouse handed over the
argument for it. `_classify_pii` returns a marker saying the generic match is
*provisional*: on a warehouse column `explore` refines it against value shape,
up to 0.75 for person-shaped values or down to 0.3 for a reference vocabulary.
The demo's `warehouse_locations.site_name` is cached at exactly 0.3 for that
reason. dex never reads a seed's values, so the refinement cannot run, and
blocking on the unrefined 0.6 would claim a certainty the detector itself
disclaims. It warns loudly instead. Every explicit pattern still blocks, and so
does a `*_name` column the cache has already flagged for real.

`_classify_pii` became public as `classify_pii` to carry that marker across the
module boundary; `detect_pii` is unchanged and is still the front door for
callers that do not care.

**The standing limit is stated, not papered over.** dex detects PII from names
and types and never from values, everywhere. A seed column named `code` full of
email addresses passes this gate. That is the whole subsystem's limit rather than
a gap in this check, and value inspection is a separate axis. A test pins it as
documented behavior so nobody reads the guard as stronger than it is.

## The drift baseline, which widening the view moves

The part that would have broken quietly.

`maintain/snapshot.py`'s `transform_layer` and `dbt_project.backed_relation_names`
both derived "the things this project builds" by taking every `.sql` in the view
and using its filename. Loading snapshots would have made snapshots models there,
and seeds would have been missed entirely.

Both now go through `node_files`, scoped to the families that actually produce a
dbt node: `.sql` under model and snapshot paths, `.csv` under seed paths. Macro
`.sql` files were counted as models before and are not any more, which is a fix
(a macro builds no relation and is `ref()`-able by nobody) but is a behavior
change worth naming.

`TransformLayer.files` deliberately stays the whole editable surface. It is a
change fingerprint over what a human can edit, not a node list.

The question that mattered was what an existing `.dex/snapshot.json` does on the
first `maintain check` after this lands. Checked live and covered by a test with
a pre-change baseline injected: nothing phantom. Structurally, no detector diffs
`files` or `models` set-wise; those two feed `orphan_relation` and the semantic
dangling-reference check, both of which ask whether a *warehouse* table is still
backed by the project. The visible improvement is that a finding on a snapshot's
relation now names the models standing on it, where before a snapshot was not in
the layer at all.

## Deletes

`validate_deletions` derived "deleted models" from any `.sql` outside macro
paths. Both new kinds are `ref()`-able, so both belong in that set, and the seed
half was a real hole: `.csv` never matched `.endswith(".sql")`, so deleting a
seed a model still `ref()`s would have been accepted and broken the build. The
set is now read off `node_files`, so the guard and the drift derivation can never
disagree about what a node is.

## Found by dogfooding, not by the suite

**Adding the two kinds to the `shadow_parse` gate put dbt's parser ahead of dex's
own refusals, and handed a refused seed's values to a subprocess.**

That gate runs before `_make_plan`, and `shadow_parse` copies the project into a
temp directory *with the edits written into it*. So a seed refused for carrying
personal data had already reached disk and a dbt subprocess by the time the gate
fired, which is the exact failure the profiles secret-guard is ordered against
one line above in the same function. And dex's own messages were being written
and never shown:

```
before: dbt parse failed: Encountered an error: Encountered unknown tag 'snapshot'.
after:  a snapshot_sql edit must live under the project's snapshot paths ...

before: dbt parse failed: Snapshots must be configured with a 'strategy' and 'unique_key'.
after:  the snapshot's config needs a unique_key, the column dbt tracks each row by ...
```

The issue's acceptance says "refused **with the fix**", and dbt's message names
neither which field is missing nor what it is for.

The fix extracts `plans.admit_edit`, the refusing half of plan-time validation
(containment, placement, root-manifest pinning, per-kind content validation), so
`plans.plan` and `commands.plan` run the same checks and the command runs them
before the subprocess. Warnings from the early pass are dropped on purpose;
`plans.plan` produces them again and is what the caller sees.

Three tests pin it, including a spine test that monkeypatches `shadow_parse` to
raise if it is ever reached with a PII-flagged seed. Every existing unit test
called the validator directly, which is why none of them could see what the
command layer did first. Same shape as the previous PR's lesson: the gap was
never in the function under test.

## Verification

`uv run pytest -q` in `packages/dex-core` with every connector extra synced:
**2486 passed, 83 skipped**, up from 2434 on the branch point, no failures.
`uvx ruff@0.15.19 check .` and `format --check .` clean, `uvx pytest evals -q`
clean, and the em-dash gate clean across every tracked markdown file.

Dogfooded on four warehouses. The DuckDB demo end to end: both snapshot
strategies, a seed with its `schema.yml`, a dev-target build verified by querying
the warehouse rather than trusting dbt's exit code, every refusal read for
whether it names a fix, both delete guards, and the drift-baseline question. Then
a snapshot and a seed through plan, apply and a dev build on BigQuery and
Snowflake, confirming the cost handshake prices snapshots and not seeds on both
paradigms.

On Databricks, plan and apply are verified and the handshake behaves, but the
dev-target build could not be: dbt itself cannot open a connection to that
workspace. `dbt compile` and `dbt build` both time out, and a bare `dbt debug`
hangs identically at "Opening a new connection" with no models in the picture, so
it is the `auth_type: oauth` U2M flow stalling in a non-interactive subprocess
rather than anything about these two kinds. It blocks every dev-target build on
Databricks and is worth chasing separately. Details, including the log excerpt,
in the field-feedback note.

## Out of scope, deliberately

- A `snapshot_yml` kind for dbt 1.9's YAML-defined snapshots. Worth an issue.
- Value-level PII inspection for seeds: a separate axis for the whole subsystem.
- Admitting `schema_yml` under macro paths, which is inconsistent with the two
  new families but is a live behavior change with a test pinning it.
- A pre-existing scaffold defect the dogfood surfaced: `transform plan --scaffold`
  rewrites `_dex_sources.yml` from the tables named in that one call, silently
  dropping the sources a previous scaffold declared and breaking the earlier
  staging model. It predates this work and touches the scaffold path rather than
  the authoring surface. Written up in the field-feedback note and worth filing.
