### PR TITLE
`transform` authors singular tests and analyses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,11 +104,21 @@ declaring a dbt package is a reviewable diff too), `macro_sql`, `snapshot_sql`
 naming a `unique_key` and a strategy), `seed_csv` (a small reference CSV under
 the seed paths, capped at 5,000 rows and 1 MiB and refused when a column name
 looks like personal data, since a seed puts values into a diff and a diff goes
-into git), `project_yml` (the project-root `dbt_project.yml`), or `profiles_yml`
+into git), `test_sql` (a file under the test paths: a singular test, which is a
+SELECT that must return no rows, or a generic test definition, which is a
+`{% test %}` block checked like a macro), `analysis_sql` (SQL under the analysis
+paths that dbt compiles and never runs, held to the same read-only SELECT
+anyway), `project_yml` (the project-root `dbt_project.yml`), or `profiles_yml`
 (the project-root `profiles.yml`, secret-guarded so a credential never enters the
 diff: reference secrets via `{{ env_var('NAME') }}`). Each kind is confined to
-its own path family, and `schema_yml` is accepted beside a snapshot or a seed as
-well as beside a model. `op` is `upsert` (create or update, the
+its own path family, and `schema_yml` is accepted beside a snapshot, a seed, a
+test or an analysis as well as beside a model. A singular test and an analysis
+build no relation and nothing can `ref()` either, so neither is a node: neither
+enters the drift baseline and neither raises a dangling-reference guard on
+delete. Note that three separate things are called a test: generic tests
+declared inside a `schema.yml`, unit tests scaffolded by
+`transform test --scaffold` into a `unit_tests:` block, and the files under
+`test-paths` that `test_sql` authors. `op` is `upsert` (create or update, the
 default, carrying `content`) or `delete` (remove the file, no `content`); a
 delete is a reviewable diff too, guarded so the plan is refused if any surviving
 file still `ref()`s a deleted model, and a rename is one plan (delete old, create

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,52 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **`transform` authors singular tests and analyses** ([#212]). A `test_sql` edit
+  kind confined to `test-paths` and an `analysis_sql` kind confined to
+  `analysis-paths`, both read from `dbt_project.yml` with dbt's own defaults.
+  A singular test, an arbitrary SELECT that must return no rows, is where most
+  project-specific assertions actually live, and it was the one class of test
+  that could not be authored: generic tests were already reachable because they
+  are declared in `schema.yml`, but a singular test is a file, and the file was
+  refused as "outside the project's model paths". Analyses were in the same
+  position.
+
+  `test_sql` covers both shapes that share dbt's test paths, because only the
+  file's content says which one was written. A file holding
+  `{% test %}` / `{% endtest %}` blocks is a generic test definition and gets the
+  structural check a macro gets: balanced definitions, nothing loose between
+  them but jinja comments. Anything else is a singular test and gets a model's
+  check: a single read-only SELECT once its jinja is stripped. Reading the close
+  delimiter as well as the open one means an unclosed block is refused as the
+  broken definition it is, rather than as a query that fails to parse.
+
+  A singular test that names no `ref()` or `source()` warns rather than refuses:
+  it runs against nothing and passes unconditionally, which is worse than having
+  no test, but an assertion over literals is unusual rather than wrong. The
+  warning is suppressed when the file is entirely jinja, since a query assembled
+  inside a macro is content dex has just said it could not read, and guessing at
+  it would be a claim beyond the evidence.
+
+  An analysis is held to the same read-only SELECT as a model even though dbt
+  compiles it and never runs it. That is deliberate: read-only against data is a
+  guarantee dex makes about what it writes, not a restatement of what dbt
+  happens to execute, and compiled SQL sitting in `target/` is one copy-paste
+  from a warehouse. A spine assertion now pins that every SQL-carrying kind
+  passes through the guard, so a future kind cannot arrive without it.
+
+  Neither kind builds a relation and nothing can `ref()` either, so neither is a
+  node: they do not enter the drift baseline, and deleting one is not guarded
+  against dangling references because there are none to dangle. dbt does call a
+  singular test a node, which is exactly why this is said out loud rather than
+  left to the reader. `dbt build` runs a singular test natively and prices it
+  like any other test; an analysis is compiled by `dbt compile`, never built, and
+  contributes nothing to the cost handshake.
+
+  Three different things in this project are called a test, and they are not
+  interchangeable: generic tests declared inside a `schema.yml`, unit tests
+  scaffolded by `transform test --scaffold` into a `unit_tests:` block, and the
+  files under `test-paths` this kind authors. The docs now name all three.
+
 - **`transform` authors dbt snapshots** ([#210]). A `snapshot_sql` edit kind, and
   `snapshot-paths` read from `dbt_project.yml` with dbt's own default. Before
   this, `transform plan` refused a snapshot file as "outside the project's model
@@ -114,14 +160,18 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   it. Found by dogfooding the demo warehouse, and now asserted: every count in
   the payload reconciles with the objects it sits next to.
 
-- **The project view now loads all four of dbt's authored path families**
-  ([#210], [#211]). Loading snapshots and seeds is what makes them authorable: a
+- **The project view now loads all six of dbt's authored path families**
+  ([#210], [#211], [#212]). Loading a family is what makes it authorable: a
   file dex can write but does not load hashes as absent, so a later edit to it
   registers as a create and the apply after it conflicts on a file nobody
   touched. The scan is per-family now rather than one global suffix filter
-  (`.sql`/`.yml`/`.yaml` under model, macro and snapshot paths, `.csv` plus YAML
-  under seed paths), so a stray CSV elsewhere in the repo is still nobody's
-  fixture to hash.
+  (`.sql` plus YAML under model, macro, snapshot, test and analysis paths,
+  `.csv` plus YAML under seed paths), so a stray CSV elsewhere in the repo is
+  still nobody's fixture to hash.
+
+  One consequence is visible from outside: an `analyses/` directory used to be
+  refused as outside the project surface and is now part of it, so its files
+  are loaded and hashed.
 
   That widening moved what `maintain` fingerprints, which is the part that would
   otherwise have broken quietly. Two derivations read "the things this project
@@ -129,6 +179,10 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   loading snapshots would have made snapshots models there, and seeds would have
   been missed entirely. Both are now scoped to the families that actually produce
   a dbt node: `.sql` under model and snapshot paths, `.csv` under seed paths.
+  Singular tests and analyses stay out for the same reason macros do, which is
+  worth stating because dbt calls a singular test a node: it builds no relation
+  and nothing can `ref()` it, so counting it would put a name into the drift
+  baseline that no warehouse table will ever back.
   Macros counted as models before and no longer do, which is a fix rather than a
   regression (a macro builds no relation and is `ref()`-able by nobody) but is a
   behavior change worth naming. A baseline pinned before this lands reports no
@@ -141,13 +195,22 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   `ref()`s would have been accepted and broken the build.
 
 - **An edit's kind and its location must agree, across every family.** The rule
-  that kept a macro out of `models/` is now a table over the four families and
-  the file suffix, and it refuses in both directions naming both fixes (move the
-  file, or relabel the kind). `schema_yml` is admitted beside a snapshot and a
-  seed as well as beside a model, because that is where dbt expects a snapshot's
-  tests and a seed's column types declared. Macro-path behavior is unchanged.
+  that kept a macro out of `models/` is now a table over the families and the
+  file suffix, and it refuses in both directions naming both fixes (move the
+  file, or relabel the kind). `schema_yml` is admitted beside a snapshot, a
+  seed, a test and an analysis as well as beside a model, because that is where
+  dbt expects a snapshot's tests, a seed's column types, a singular test's
+  severity and an analysis's description declared. Macro-path behavior is
+  unchanged.
 
 ### Fixed
+
+- **A `project_yml` edit that drops any authored path key now warns** ([#212]).
+  The warning covered `model-paths` and `macro-paths` only, so a `dbt_project.yml`
+  that dropped `snapshot-paths` or `seed-paths` silently orphaned every file
+  under them, which was a gap left behind when those two families were added. It
+  now checks every key dex authors into, six of them, since which family a caller
+  restructures is not something the warning gets to have an opinion about.
 
 - **`transform plan` refuses on its own terms before it hands anything to dbt's
   parser** ([#210], [#211]). The parse gate runs before the plan is stored, and

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -57,17 +57,20 @@ _ALLOWED_ROOT_FILES = frozenset(
     {"packages.yml", "dependencies.yml", PROJECT_FILE, PROFILES_FILE}
 )
 
-# What each of dbt's authored path families can hold. Models and snapshots are
-# SQL plus their properties YAML; macros are jinja plus their properties YAML;
-# seeds are CSV data plus the YAML that declares their column types. The scan is
-# per-family rather than one global suffix filter because ".csv" is only a seed
-# anywhere else it is somebody's fixture, and a fixture is not dex's to hash.
+# What each of dbt's authored path families can hold. Models, snapshots, tests
+# and analyses are SQL plus their properties YAML; macros are jinja plus their
+# properties YAML; seeds are CSV data plus the YAML that declares their column
+# types. The scan is per-family rather than one global suffix filter because
+# ".csv" is only a seed under the seed paths: anywhere else it is somebody's
+# fixture, and a fixture is not dex's to hash.
 _YAML_SUFFIXES = frozenset({".yml", ".yaml"})
 _FAMILY_SUFFIXES: dict[str, frozenset[str]] = {
     "model": _YAML_SUFFIXES | {".sql"},
     "macro": _YAML_SUFFIXES | {".sql"},
     "snapshot": _YAML_SUFFIXES | {".sql"},
     "seed": _YAML_SUFFIXES | {".csv"},
+    "test": _YAML_SUFFIXES | {".sql"},
+    "analysis": _YAML_SUFFIXES | {".sql"},
 }
 
 
@@ -93,9 +96,9 @@ class DbtProjectView(BaseModel):
     """The in-memory view of a dbt project.
 
     ``files`` holds the editable surface: the source files under each of dbt's
-    four authored path families, each scanned for the suffixes that family can
-    hold (see :data:`_FAMILY_SUFFIXES`). ``manifest`` is the compiled artifact
-    when the project has been compiled; a fresh project loads fine without one.
+    authored path families, each scanned for the suffixes that family can hold
+    (see :data:`_FAMILY_SUFFIXES`). ``manifest`` is the compiled artifact when
+    the project has been compiled; a fresh project loads fine without one.
 
     A file that is *not* in ``files`` hashes as absent, so a later edit to it
     registers as a create and the apply that follows conflicts on a file nobody
@@ -110,6 +113,8 @@ class DbtProjectView(BaseModel):
     macro_paths: list[str] = Field(default_factory=lambda: ["macros"])
     snapshot_paths: list[str] = Field(default_factory=lambda: ["snapshots"])
     seed_paths: list[str] = Field(default_factory=lambda: ["seeds"])
+    test_paths: list[str] = Field(default_factory=lambda: ["tests"])
+    analysis_paths: list[str] = Field(default_factory=lambda: ["analyses"])
     files: dict[str, SourceFile] = Field(default_factory=dict)
     manifest: dict[str, Any] | None = None
 
@@ -120,13 +125,16 @@ class DbtProjectView(BaseModel):
         matched against when deciding which family it belongs to: the specific
         families first, models last as the catch-all. Two families configured to
         the same directory is a project mistake dex does not adjudicate; the
-        first listed wins and the containment message names all four.
+        first listed wins and the containment message names every family it
+        checked.
         """
 
         return [
             ("macro", list(self.macro_paths)),
             ("snapshot", list(self.snapshot_paths)),
             ("seed", list(self.seed_paths)),
+            ("test", list(self.test_paths)),
+            ("analysis", list(self.analysis_paths)),
             ("model", list(self.model_paths)),
         ]
 
@@ -264,6 +272,8 @@ def load(project_dir: Path | str = ".") -> DbtProjectView:
     macro_paths = list(raw.get("macro-paths", ["macros"]))
     snapshot_paths = list(raw.get("snapshot-paths", ["snapshots"]))
     seed_paths = list(raw.get("seed-paths", ["seeds"]))
+    test_paths = list(raw.get("test-paths", ["tests"]))
+    analysis_paths = list(raw.get("analysis-paths", ["analyses"]))
 
     # Suffixes unioned per directory rather than per family, so a project that
     # points two families at one directory gets both sets scanned instead of
@@ -274,6 +284,8 @@ def load(project_dir: Path | str = ".") -> DbtProjectView:
         ("macro", macro_paths),
         ("snapshot", snapshot_paths),
         ("seed", seed_paths),
+        ("test", test_paths),
+        ("analysis", analysis_paths),
     ):
         for configured in paths:
             scan.setdefault(configured, set()).update(_FAMILY_SUFFIXES[family])
@@ -334,6 +346,8 @@ def load(project_dir: Path | str = ".") -> DbtProjectView:
         macro_paths=macro_paths,
         snapshot_paths=snapshot_paths,
         seed_paths=seed_paths,
+        test_paths=test_paths,
+        analysis_paths=analysis_paths,
         files=files,
         manifest=manifest,
     )
@@ -603,13 +617,14 @@ def contained_path(root: Path, rel_path: str, view: DbtProjectView) -> Path:
     Writes are confined to the repo, and within the repo to the dbt editing
     surface: model SQL, schema.yml and semantic YAML under the model paths,
     macros under the macro paths, snapshots under the snapshot paths, seeds
-    under the seed paths, plus the root manifests dbt keeps at the project root.
-    Escapes (absolute paths, ``..``) are refused outright.
+    under the seed paths, singular and generic tests under the test paths,
+    analyses under the analysis paths, plus the root manifests dbt keeps at the
+    project root. Escapes (absolute paths, ``..``) are refused outright.
 
     The families are read off the view rather than passed positionally. Four of
-    them is where a positional list stops being readable, and every caller
-    already holds a view: the writer loads one, and both plan-time callers were
-    handed one.
+    them was where a positional list stopped being readable, and there are six
+    now; every caller already holds a view: the writer loads one, and both
+    plan-time callers were handed one.
     """
 
     candidate = Path(rel_path)
@@ -652,13 +667,19 @@ def path_family(root: Path, rel_path: str, view: DbtProjectView) -> str | None:
 
 
 def node_files(view: DbtProjectView) -> dict[str, SourceFile]:
-    """The files that become a dbt node named after the file, keyed by path.
+    """The files that build a relation dbt names after the file, keyed by path.
 
-    A model, a snapshot and a seed each build a relation dbt names after the
-    file and each is ``ref()``-able; a macro, a schema.yml and a semantic YAML
-    build nothing. Every derivation that reads "the things this project builds"
-    out of the file list goes through here, so widening the load to a new family
-    cannot quietly turn its files into models by filename.
+    A model, a snapshot and a seed each build such a relation and each is
+    ``ref()``-able; a macro, a schema.yml and a semantic YAML build nothing.
+    Every derivation that reads "the things this project builds" out of the file
+    list goes through here, so widening the load to a new family cannot quietly
+    turn its files into models by filename.
+
+    "Node" is the looser word and it is why this function is not called that: a
+    singular test *is* a dbt node, and it belongs here no more than a macro
+    does, because it builds no relation and nothing can ``ref()`` it. An
+    analysis is compiled and never built at all. Both are loaded so they can be
+    authored and hashed; neither is a thing this project builds.
     """
 
     nodes: dict[str, SourceFile] = {}

--- a/packages/dex-core/src/exmergo_dex_core/transform/plans.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/plans.py
@@ -75,6 +75,18 @@ class EditKind(str, Enum):
     # fails the build, and a seed filed anywhere else is never loaded at all.
     SNAPSHOT_SQL = "snapshot_sql"
     SEED_CSV = "seed_csv"
+    # A file under the project's test paths (a singular test, which is a SELECT
+    # that must return no rows, or a generic test definition) and one under its
+    # analysis paths (SQL dbt compiles and never runs). Neither builds a
+    # relation and nothing can ref() either, but each is still dbt's to parse
+    # from its own directory: a singular test filed under models/ is built as a
+    # model, and an analysis filed anywhere else is never compiled at all.
+    #
+    # `test_sql` is dbt's `test-paths`, not `transform test --scaffold` (which
+    # writes a unit_tests: block through schema_yml) and not the generic tests
+    # declared inside a schema.yml.
+    TEST_SQL = "test_sql"
+    ANALYSIS_SQL = "analysis_sql"
     # dbt project-root config: the project settings and the connection profiles.
     # Each governs the whole project (a wider blast radius than a single model),
     # so each is pinned by name to the one root file it may target, and
@@ -137,11 +149,12 @@ def contained_key(rel_path: str, surface: list[str]) -> str:
 # `.csv` under the seed paths, and the properties YAML that declares a seed's
 # column types or a snapshot's tests belongs beside the thing it describes.
 #
-# `schema_yml` is admitted under the snapshot and seed families for exactly that
-# reason, and deliberately *not* under macros: macro properties YAML is a
+# `schema_yml` is admitted under the snapshot, seed, test and analysis families
+# for exactly that reason (a singular test's config and severity, an analysis's
+# description), and deliberately *not* under macros: macro properties YAML is a
 # different document shape, dex has never authored one, and a test pins both
 # directions of today's macro rule. Widening that is a live behavior change and
-# belongs in its own change, not smuggled in beside two new kinds.
+# belongs in its own change, not smuggled in beside new kinds.
 _PLACEMENT: dict[str, dict[str, frozenset[EditKind]]] = {
     "macro": {".sql": frozenset({EditKind.MACRO_SQL})},
     "snapshot": {
@@ -151,6 +164,16 @@ _PLACEMENT: dict[str, dict[str, frozenset[EditKind]]] = {
     },
     "seed": {
         ".csv": frozenset({EditKind.SEED_CSV}),
+        ".yml": frozenset({EditKind.SCHEMA_YML}),
+        ".yaml": frozenset({EditKind.SCHEMA_YML}),
+    },
+    "test": {
+        ".sql": frozenset({EditKind.TEST_SQL}),
+        ".yml": frozenset({EditKind.SCHEMA_YML}),
+        ".yaml": frozenset({EditKind.SCHEMA_YML}),
+    },
+    "analysis": {
+        ".sql": frozenset({EditKind.ANALYSIS_SQL}),
         ".yml": frozenset({EditKind.SCHEMA_YML}),
         ".yaml": frozenset({EditKind.SCHEMA_YML}),
     },
@@ -190,6 +213,16 @@ _ROOT_KINDS = frozenset(
 )
 
 
+def _an(word: str) -> str:
+    """``word`` with the article that reads right in front of it.
+
+    Refusal text is assembled from kind and family names, and "a analysis_sql
+    edit" reads as a typo in the one message whose whole job is to be trusted.
+    """
+
+    return f"an {word}" if word[:1].lower() in "aeiou" else f"a {word}"
+
+
 def assert_kind_placement(
     edit: PlanEdit, family: str | None, view: DbtProjectView
 ) -> None:
@@ -221,9 +254,9 @@ def assert_kind_placement(
             else ""
         )
         raise PlanError(
-            f"a {edit.kind.value} edit must live under the project's {home} "
+            f"{_an(edit.kind.value)} edit must live under the project's {home} "
             f"paths ({', '.join(configured) or 'none configured'}), got "
-            f"'{edit.path}', which is a {family} path{instead}"
+            f"'{edit.path}', which is {_an(family)} path{instead}"
         )
     if edit.kind in admitted:
         return
@@ -234,11 +267,11 @@ def assert_kind_placement(
         )
         named = suffix or "suffixless"
         raise PlanError(
-            f"'{edit.path}' is under a {family} path, which holds {holds}; "
+            f"'{edit.path}' is under {_an(family)} path, which holds {holds}; "
             f"dex authors no '{named}' file there"
         )
     raise PlanError(
-        f"'{edit.path}' is under a {family} path but the edit kind is "
+        f"'{edit.path}' is under {_an(family)} path but the edit kind is "
         f"{edit.kind.value}; use "
         f"{' or '.join(sorted(k.value for k in admitted))} for a {suffix} file "
         "there"
@@ -442,9 +475,11 @@ def plan(
                     "{{ env_var('NAME') }} before editing so no credential "
                     "enters the plan diff"
                 )
-        # A dbt_project.yml that drops model or macro paths silently orphans the
-        # files under them; warn rather than refuse, since a deliberate
-        # restructure is a legitimate reason to change them.
+        # A dbt_project.yml that drops a path key silently orphans the files
+        # under it; warn rather than refuse, since a deliberate restructure is a
+        # legitimate reason to change them. Every key dex authors into is
+        # checked: covering only some of them makes the warning a coin flip on
+        # which family the caller happened to restructure.
         if (
             edit.kind is EditKind.PROJECT_YML
             and edit.op is EditOp.UPSERT
@@ -452,7 +487,14 @@ def plan(
         ):
             old = yaml.safe_load(current.content) or {}
             new = yaml.safe_load(edit.new_content) or {}
-            for key in ("model-paths", "macro-paths"):
+            for key in (
+                "model-paths",
+                "macro-paths",
+                "snapshot-paths",
+                "seed-paths",
+                "test-paths",
+                "analysis-paths",
+            ):
                 dropped = set(old.get(key) or []) - set(new.get(key) or [])
                 if dropped:
                     warnings.append(

--- a/packages/dex-core/src/exmergo_dex_core/transform/validate.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/validate.py
@@ -132,6 +132,19 @@ _MACRO_OPEN = re.compile(r"\{%-?\s*macro\s+\w+\s*\(")
 _MACRO_CLOSE = re.compile(r"\{%-?\s*endmacro\s*-?%\}")
 _MACRO_BLOCK = re.compile(r"\{%-?\s*macro\s.*?\{%-?\s*endmacro\s*-?%\}", re.DOTALL)
 
+# Generic test definitions, which are macros under another keyword and may live
+# under the test paths as well as the macro paths. Their presence is what tells
+# a `test_sql` edit apart from a singular test: same directory, two shapes, and
+# only the file's own content says which one the caller wrote.
+_TEST_OPEN = re.compile(r"\{%-?\s*test\s+\w+\s*\(")
+_TEST_CLOSE = re.compile(r"\{%-?\s*endtest\s*-?%\}")
+_TEST_BLOCK = re.compile(r"\{%-?\s*test\s.*?\{%-?\s*endtest\s*-?%\}", re.DOTALL)
+
+# A test that names no table always passes, which is worse than no test at all,
+# so a singular test with neither call is warned about rather than refused: a
+# fixture-free assertion against a literal is unusual but not wrong.
+_REF_OR_SOURCE = re.compile(r"\{\{-?\s*(?:ref|source)\s*\(")
+
 # Snapshot delimiters, on the same principle as the macro ones. A snapshot file
 # holds exactly one block: dbt names the snapshot after the block, not the file,
 # and a second block in one file is a build-time surprise nobody reading the
@@ -202,6 +215,71 @@ def strip_jinja(sql: str) -> str:
 # needs a bigger reference table wants a warehouse table, not a seed.
 MAX_SEED_ROWS = 5_000
 MAX_SEED_BYTES = 1 << 20
+
+
+def assert_definitions_only(
+    path: str,
+    content: str,
+    *,
+    keyword: str,
+    open_re: re.Pattern[str],
+    close_re: re.Pattern[str],
+    block_re: re.Pattern[str],
+) -> None:
+    """Refuse a jinja definition file that is not only definitions.
+
+    Macros and generic tests are the same document shape under two keywords: a
+    file of ``{% keyword name(...) %}`` blocks, balanced, with nothing loose
+    between them but jinja comments. It is a structural check rather than a SQL
+    one because the file is jinja, not SQL, and the body is a template that only
+    becomes a query once dbt renders it against a model.
+
+    Refusals name the delimiter at fault, so the caller reads what to write
+    rather than which rule they broke.
+    """
+
+    opens = len(open_re.findall(content))
+    closes = len(close_re.findall(content))
+    if opens == 0:
+        raise EditValidationError(
+            f"{path}: a {keyword}_sql edit needs at least one "
+            f"{{% {keyword} name(...) %}} definition"
+        )
+    if opens != closes:
+        raise EditValidationError(
+            f"{path}: unbalanced {keyword} definitions "
+            f"({opens} {keyword}, {closes} end{keyword})"
+        )
+    outside = _JINJA_COMMENT.sub("", block_re.sub("", content))
+    if outside.strip():
+        raise EditValidationError(
+            f"{path}: a {keyword} file holds only {keyword} definitions and "
+            "jinja comments; found loose content outside them"
+        )
+
+
+def _assert_query_only(path: str, content: str, noun: str) -> list[str]:
+    """Refuse SQL that is not a single read-only SELECT, once jinja is stripped.
+
+    The check every authored query gets, whatever dbt will do with it: a model
+    that materializes, a singular test dbt runs and counts the rows of, an
+    analysis dbt only compiles. Read-only against data is a guarantee dex makes
+    about its own writes, so it does not soften for the kinds dbt runs less
+    often.
+
+    ``noun`` names the kind in the one warning this raises: a file that is
+    entirely jinja has no SQL left to check, which is legitimate for a macro-
+    driven query and worth saying out loud rather than passing silently.
+    """
+
+    stripped = strip_jinja(content)
+    if not stripped:
+        return [f"{path}: {noun} is entirely jinja; SELECT-only check skipped"]
+    try:
+        assert_select_only(stripped)
+    except Exception as exc:
+        raise EditValidationError(f"{path}: {exc}") from exc
+    return []
 
 
 def validate_snapshot(path: str, content: str) -> None:
@@ -535,24 +613,48 @@ def validate_edit(
 
     warnings: list[str] = []
     if edit.kind is EditKind.MACRO_SQL:
-        opens = len(_MACRO_OPEN.findall(edit.new_content))
-        closes = len(_MACRO_CLOSE.findall(edit.new_content))
-        if opens == 0:
-            raise EditValidationError(
-                f"{edit.path}: a macro_sql edit needs at least one "
-                "{% macro name(...) %} definition"
+        assert_definitions_only(
+            edit.path,
+            edit.new_content,
+            keyword="macro",
+            open_re=_MACRO_OPEN,
+            close_re=_MACRO_CLOSE,
+            block_re=_MACRO_BLOCK,
+        )
+    elif edit.kind is EditKind.TEST_SQL:
+        # Two shapes share the test paths and only the content tells them apart.
+        # A generic test is a macro under another keyword, so it gets the
+        # structural check; anything else is a singular test, which is a query
+        # and gets a model's. Reading the close delimiter too means an unclosed
+        # or orphaned block is refused as the broken definition it is rather
+        # than as a query that fails to parse.
+        if _TEST_OPEN.search(edit.new_content) or _TEST_CLOSE.search(edit.new_content):
+            assert_definitions_only(
+                edit.path,
+                edit.new_content,
+                keyword="test",
+                open_re=_TEST_OPEN,
+                close_re=_TEST_CLOSE,
+                block_re=_TEST_BLOCK,
             )
-        if opens != closes:
-            raise EditValidationError(
-                f"{edit.path}: unbalanced macro definitions "
-                f"({opens} macro, {closes} endmacro)"
-            )
-        outside = _JINJA_COMMENT.sub("", _MACRO_BLOCK.sub("", edit.new_content))
-        if outside.strip():
-            raise EditValidationError(
-                f"{edit.path}: a macro file holds only macro definitions and "
-                "jinja comments; found loose content outside them"
-            )
+        else:
+            unreadable = _assert_query_only(edit.path, edit.new_content, "test")
+            warnings.extend(unreadable)
+            # Only when the query was readable. A test that is entirely jinja
+            # builds itself inside a macro dex does not follow, so "names no
+            # ref()" would be a guess about content the warning above has just
+            # said could not be read.
+            if not unreadable and not _REF_OR_SOURCE.search(edit.new_content):
+                warnings.append(
+                    f"{edit.path}: this test names no ref() or source(), so it "
+                    "runs against nothing and passes unconditionally"
+                )
+    elif edit.kind is EditKind.ANALYSIS_SQL:
+        # An analysis is compiled and never run, so dbt asks less of it than of
+        # a model. dex does not: the SELECT-only guard is a safety guarantee,
+        # not a dbt requirement, and a DELETE sitting in analyses/ is one
+        # copy-paste away from being run by hand.
+        warnings.extend(_assert_query_only(edit.path, edit.new_content, "analysis"))
     elif edit.kind is EditKind.SNAPSHOT_SQL:
         validate_snapshot(edit.path, edit.new_content)
     elif edit.kind is EditKind.SEED_CSV:
@@ -570,16 +672,7 @@ def validate_edit(
             )
         )
     elif edit.kind is EditKind.MODEL_SQL:
-        stripped = strip_jinja(edit.new_content)
-        if not stripped:
-            warnings.append(
-                f"{edit.path}: model is entirely jinja; SELECT-only check skipped"
-            )
-        else:
-            try:
-                assert_select_only(stripped)
-            except Exception as exc:
-                raise EditValidationError(f"{edit.path}: {exc}") from exc
+        warnings.extend(_assert_query_only(edit.path, edit.new_content, "model"))
     else:
         try:
             parsed = yaml.safe_load(edit.new_content)

--- a/packages/dex-core/tests/adapters/test_project_parity.py
+++ b/packages/dex-core/tests/adapters/test_project_parity.py
@@ -368,6 +368,10 @@ def test_the_dbt_editing_surface_admits_everything_its_writer_accepts(tmp_path: 
         "snapshots/snap_customers.sql",
         "seeds/country_vat.csv",
         "seeds/schema.yml",
+        "tests/assert_totals_reconcile.sql",
+        "tests/generic/not_negative.sql",
+        "analyses/email_skew.sql",
+        "analyses/schema.yml",
         *dbt_project._ALLOWED_ROOT_FILES,
     ):
         contained_key(path, surface)

--- a/packages/dex-core/tests/maintain/test_reconcile.py
+++ b/packages/dex-core/tests/maintain/test_reconcile.py
@@ -315,5 +315,11 @@ def test_the_no_format_fallback_answers_exactly_what_dbt_answers():
     # `None` is a complete answer, not a gap: reconcile proposes staging models
     # and their schema.yml, and a kind it does not propose gets no path this
     # class would be inventing.
-    for unplaced in (EditKind.MACRO_SQL, EditKind.SNAPSHOT_SQL, EditKind.SEED_CSV):
+    for unplaced in (
+        EditKind.MACRO_SQL,
+        EditKind.SNAPSHOT_SQL,
+        EditKind.SEED_CSV,
+        EditKind.TEST_SQL,
+        EditKind.ANALYSIS_SQL,
+    ):
         assert _placed(None, unplaced, "orders") is None

--- a/packages/dex-core/tests/maintain/test_transform_layer_scope.py
+++ b/packages/dex-core/tests/maintain/test_transform_layer_scope.py
@@ -27,6 +27,10 @@ MACRO = "{% macro cents_to_dollars(column) %}({{ column }} / 100){% endmacro %}\
 
 SEED = "status_code,label\nP,placed\nS,shipped\n"
 
+SINGULAR_TEST = "select order_id from {{ ref('stg_orders') }} where order_id is null\n"
+
+ANALYSIS = "select count(*) as n from {{ ref('stg_orders') }}\n"
+
 
 def _populate(root: Path) -> None:
     (root / "snapshots").mkdir(exist_ok=True)
@@ -35,9 +39,15 @@ def _populate(root: Path) -> None:
     (root / "macros" / "cents_to_dollars.sql").write_text(MACRO, encoding="utf-8")
     (root / "seeds").mkdir(exist_ok=True)
     (root / "seeds" / "status_labels.csv").write_text(SEED, encoding="utf-8")
+    (root / "tests").mkdir(exist_ok=True)
+    (root / "tests" / "assert_order_id_present.sql").write_text(
+        SINGULAR_TEST, encoding="utf-8"
+    )
+    (root / "analyses").mkdir(exist_ok=True)
+    (root / "analyses" / "order_volume.sql").write_text(ANALYSIS, encoding="utf-8")
 
 
-def test_a_node_is_a_model_a_snapshot_or_a_seed_and_never_a_macro(maintain_repo):
+def test_a_node_is_a_model_a_snapshot_or_a_seed_and_nothing_else(maintain_repo):
     _populate(maintain_repo.root)
     layer = transform_layer(load_project(maintain_repo.root))
 
@@ -47,10 +57,23 @@ def test_a_node_is_a_model_a_snapshot_or_a_seed_and_never_a_macro(maintain_repo)
     assert set(layer.models) == {"stg_orders", "snap_orders", "status_labels"}
     assert "cents_to_dollars" not in layer.models
 
+    # A singular test and an analysis are the case the scoping exists for. dbt
+    # calls a singular test a node, and it is still not one here: it builds no
+    # relation and nothing can ref() it, so counting it as a model would put a
+    # name into the drift baseline that no warehouse table will ever back.
+    assert "assert_order_id_present" not in layer.models
+    assert "order_volume" not in layer.models
+
     # The file fingerprint stays the whole editable surface: it is a change
     # fingerprint over what a human can edit, not a node list.
     assert "macros/cents_to_dollars.sql" in layer.files
     assert "seeds/status_labels.csv" in layer.files
+    assert "tests/assert_order_id_present.sql" in layer.files
+    assert "analyses/order_volume.sql" in layer.files
+
+    # And a test's ref() is not recorded as a model's dependency either, since
+    # there is no model there to depend on anything.
+    assert "assert_order_id_present" not in layer.model_refs
 
     # And a snapshot's ref() is recorded like a model's, which is what carries a
     # warehouse finding through to the snapshot standing on it.
@@ -62,11 +85,14 @@ def test_a_baseline_pinned_before_the_widening_reports_no_phantom_drift(
 ):
     """The risk this change carries, checked rather than assumed.
 
-    A baseline pinned before snapshots and seeds were loaded holds a smaller
-    file set and a models list that counted macros. Adding those files must read
-    as "nothing drifted", because no detector diffs the file set or the model
-    list: they feed `orphan_relation` and the semantic dangling-reference check,
-    both of which ask whether a *warehouse* table is still backed by the project.
+    A baseline pinned before the new families were loaded holds a smaller file
+    set and a models list that counted macros. Adding those files must read as
+    "nothing drifted", because no detector diffs the file set or the model list:
+    they feed `orphan_relation` and the semantic dangling-reference check, both
+    of which ask whether a *warehouse* table is still backed by the project.
+
+    Re-run against every family as they are added, since the widening is what
+    carries the risk and each new one widens it again.
     """
 
     maintain_repo.snapshot()

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -368,6 +368,52 @@ def test_select_only_guard_rejects_writes():
             assert_select_only(bad)
 
 
+def test_every_authored_sql_kind_runs_through_the_select_only_guard():
+    """No edit kind carrying SQL may reach the repo without the guard.
+
+    dex writes SQL a human reviews and dbt later runs, so the read-only
+    guarantee has to hold at the point of authorship, not only at the point of
+    execution. The failure mode this pins is a new kind added with its own
+    validation branch that forgets the guard: the file lands, the diff reads
+    fine, and a DELETE is sitting in the project waiting for someone to run it.
+
+    An analysis is the sharpest case. dbt never runs one, so nothing downstream
+    would object, and it is still refused: compiled SQL in ``target/`` is one
+    copy-paste from a warehouse, and the guarantee is about what dex writes, not
+    about who presses the button.
+    """
+
+    from exmergo_dex_core import transform
+    from exmergo_dex_core.transform.validate import EditValidationError, validate_edit
+
+    carriers = {
+        transform.EditKind.MODEL_SQL: "models/staging/stg_x.sql",
+        transform.EditKind.TEST_SQL: "tests/assert_x.sql",
+        transform.EditKind.ANALYSIS_SQL: "analyses/scratch.sql",
+    }
+    for kind, path in carriers.items():
+        for bad in ("delete from customers", "drop table customers"):
+            with pytest.raises(EditValidationError, match="read-only SELECT"):
+                validate_edit(transform.PlanEdit(path=path, kind=kind, new_content=bad))
+
+    # A snapshot carries its query inside the block, and the body gets the same
+    # guard as a standalone one.
+    with pytest.raises(EditValidationError, match="read-only SELECT"):
+        validate_edit(
+            transform.PlanEdit(
+                path="snapshots/snap_x.sql",
+                kind=transform.EditKind.SNAPSHOT_SQL,
+                new_content=(
+                    "{% snapshot snap_x %}\n"
+                    "{{ config(unique_key='id', strategy='timestamp', "
+                    "updated_at='updated_at') }}\n"
+                    "delete from customers\n"
+                    "{% endsnapshot %}\n"
+                ),
+            )
+        )
+
+
 def _firewall_cache():
     from exmergo_dex_core.cache import ColumnProfile, Dataset, DexCache
 
@@ -1830,11 +1876,11 @@ def test_an_authored_kind_cannot_land_outside_its_own_path_family(
     """Writes are confined to the repo, and within the repo to the part of the
     dbt surface the kind belongs to.
 
-    Containment alone is not enough once there are four families: a snapshot
-    written into ``models/`` is inside the surface and still wrong, because dbt
-    parses it as a model and the build fails. So the kind and its location have
-    to agree, in both directions, and neither confirmation nor a re-plan can
-    talk past it.
+    Containment alone is not enough once the surface has several families: a
+    snapshot written into ``models/`` is inside the surface and still wrong,
+    because dbt parses it as a model and the build fails. So the kind and its
+    location have to agree, in both directions, and neither confirmation nor a
+    re-plan can talk past it.
     """
 
     from exmergo_dex_core import transform
@@ -1849,6 +1895,22 @@ def test_an_authored_kind_cannot_land_outside_its_own_path_family(
         (transform.EditKind.SEED_CSV, "models/staging/lookup.csv", "seed paths"),
         (transform.EditKind.SEED_CSV, "macros/lookup.csv", "seed paths"),
         (transform.EditKind.SNAPSHOT_SQL, "seeds/snap.sql", "snapshot paths"),
+        # The two families that hold nothing but `.sql` and sit beside each
+        # other, which is where a misfiling is easiest to make and hardest to
+        # notice: dbt would build a misfiled test as a model, and would never
+        # look at a misfiled analysis at all.
+        (
+            transform.EditKind.TEST_SQL,
+            "models/staging/assert_ids.sql",
+            "test paths",
+        ),
+        (transform.EditKind.TEST_SQL, "analyses/assert_ids.sql", "test paths"),
+        (
+            transform.EditKind.ANALYSIS_SQL,
+            "models/staging/scratch.sql",
+            "analysis paths",
+        ),
+        (transform.EditKind.ANALYSIS_SQL, "tests/scratch.sql", "analysis paths"),
     ]
     for kind, path, named in misplaced:
         with pytest.raises(transform.PlanError, match=named):

--- a/packages/dex-core/tests/transform/test_analysis_edit.py
+++ b/packages/dex-core/tests/transform/test_analysis_edit.py
@@ -1,0 +1,329 @@
+"""`analysis_sql` end to end: containment to the analysis paths, and the two
+things an analysis is not.
+
+dbt compiles an analysis and never runs it, so it builds no relation, nothing can
+`ref()` it, and it contributes nothing to the cost of a build. That makes it the
+cheapest thing in the project and the one most likely to be mistaken for free
+rein: dex still holds it to the same read-only SELECT as a model, because that is
+a guarantee dex makes about its own writes rather than a rule dbt imposes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.cli import main
+from exmergo_dex_core.dbt_project import DbtProjectError, node_files
+from exmergo_dex_core.dbt_project import load as load_project
+from exmergo_dex_core.storage import FilesystemStore
+from exmergo_dex_core.transform.plans import EditKind, PlanEdit, PlanError
+from exmergo_dex_core.transform.plans import plan as make_plan
+from exmergo_dex_core.transform.validate import EditValidationError, validate_edit
+
+ANALYSIS = """-- Scratch: how lumpy is the customer distribution?
+select
+    email,
+    count(*) as rows_per_email
+from {{ ref('stg_customers') }}
+group by 1
+order by 2 desc
+"""
+
+
+def _run(argv: list[str], capsys) -> tuple[int, dict]:
+    rc = main(argv)
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1, "exactly one line on stdout"
+    return rc, json.loads(out)
+
+
+def _edits_file(tmp_path: Path, *entries: dict) -> Path:
+    payload = tmp_path / "edits.json"
+    payload.write_text(json.dumps({"edits": list(entries)}), encoding="utf-8")
+    return payload
+
+
+def _analysis(content: str, path: str = "analyses/email_skew.sql") -> PlanEdit:
+    return PlanEdit(path=path, kind=EditKind.ANALYSIS_SQL, new_content=content)
+
+
+# --- the query check --------------------------------------------------------------
+
+
+def test_an_analysis_validates():
+    assert validate_edit(_analysis(ANALYSIS)) == []
+
+
+def test_an_analysis_with_no_ref_is_not_warned_about():
+    # Unlike a singular test, an analysis that names no table is not suspicious:
+    # a scratch query over literals is a legitimate thing to keep in the repo.
+    assert validate_edit(_analysis("select 1 as answer\n")) == []
+
+
+@pytest.mark.parametrize(
+    ("content", "fix_named"),
+    [
+        pytest.param("delete from customers\n", "read-only SELECT", id="delete"),
+        pytest.param("create table t as select 1\n", "read-only SELECT", id="ddl"),
+        pytest.param(
+            "select 1;\nselect 2;\n", "exactly one statement", id="two_statements"
+        ),
+    ],
+)
+def test_a_writing_analysis_is_refused(content: str, fix_named: str):
+    # dbt would compile any of these happily, because it never runs an analysis.
+    # dex refuses them anyway: compiled SQL sitting in target/ is one copy-paste
+    # from being run by hand, and read-only against data is not conditional on
+    # who presses the button.
+    with pytest.raises(EditValidationError, match=fix_named):
+        validate_edit(_analysis(content))
+
+
+def test_an_analysis_that_is_entirely_jinja_warns():
+    assert validate_edit(_analysis("{{ some_macro() }}\n")) == [
+        "analyses/email_skew.sql: analysis is entirely jinja; SELECT-only check skipped"
+    ]
+
+
+# --- containment and kind agreement ----------------------------------------------
+
+
+def test_an_analysis_plans_applies_and_lands_as_a_create_diff(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    payload = _edits_file(
+        tmp_path,
+        {
+            "path": "analyses/email_skew.sql",
+            "kind": "analysis_sql",
+            "content": ANALYSIS,
+        },
+        {
+            "path": "analyses/schema.yml",
+            "kind": "schema_yml",
+            "content": (
+                "version: 2\n"
+                "analyses:\n"
+                "  - name: email_skew\n"
+                "    description: how lumpy the customer distribution is\n"
+            ),
+        },
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "look at email skew",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+    assert envelope["data"]["paths"] == [
+        "analyses/email_skew.sql",
+        "analyses/schema.yml",
+    ]
+    created = {d["path"]: d for d in envelope["diffs"]}["analyses/email_skew.sql"]
+    assert created["op"] == "create"
+    assert created["deletions"] == 0
+    assert "rows_per_email" in created["unified"]
+
+    rc, envelope = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+    assert rc == 0, envelope["errors"]
+    written = dbt_project_dir / "analyses" / "email_skew.sql"
+    assert written.read_text(encoding="utf-8") == ANALYSIS
+
+
+def test_custom_analysis_paths_are_honored(dbt_project_dir: Path, tmp_path: Path):
+    project_yml = dbt_project_dir / "dbt_project.yml"
+    project_yml.write_text(
+        project_yml.read_text(encoding="utf-8") + 'analysis-paths: ["scratch"]\n',
+        encoding="utf-8",
+    )
+    store = FilesystemStore(tmp_path)
+    stored, _diffs, _warnings = make_plan(
+        "look",
+        [_analysis(ANALYSIS, "scratch/email_skew.sql")],
+        dbt_project_dir,
+        tmp_path,
+        store=store,
+    )
+    assert stored.edits[0].path == "scratch/email_skew.sql"
+
+    with pytest.raises(DbtProjectError, match=r"analysis \(scratch\)"):
+        make_plan("look", [_analysis(ANALYSIS)], dbt_project_dir, tmp_path, store=store)
+
+
+def test_kind_and_surface_must_agree_in_both_directions(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    store = FilesystemStore(tmp_path)
+    with pytest.raises(PlanError, match="analysis paths"):
+        make_plan(
+            "bad",
+            [_analysis(ANALYSIS, "models/staging/email_skew.sql")],
+            dbt_project_dir,
+            tmp_path,
+            store=store,
+        )
+
+    model_in_analyses = PlanEdit(
+        path="analyses/x.sql", kind=EditKind.MODEL_SQL, new_content="select 1\n"
+    )
+    with pytest.raises(PlanError, match="analysis_sql"):
+        make_plan("bad", [model_in_analyses], dbt_project_dir, tmp_path, store=store)
+
+
+def test_the_refusal_reads_as_english_for_a_vowel_initial_name(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    # Found by dogfooding: "a analysis_sql edit ... which is a analysis path"
+    # reads as a typo in the one message whose whole job is to be trusted, and
+    # `analysis` is the first family name that starts with a vowel.
+    store = FilesystemStore(tmp_path)
+    with pytest.raises(PlanError) as misfiled_kind:
+        make_plan(
+            "bad",
+            [_analysis(ANALYSIS, "tests/scratch.sql")],
+            dbt_project_dir,
+            tmp_path,
+            store=store,
+        )
+    assert "an analysis_sql edit" in str(misfiled_kind.value)
+
+    with pytest.raises(PlanError) as misfiled_file:
+        make_plan(
+            "bad",
+            [
+                PlanEdit(
+                    path="analyses/x.sql",
+                    kind=EditKind.MODEL_SQL,
+                    new_content="select 1\n",
+                )
+            ],
+            dbt_project_dir,
+            tmp_path,
+            store=store,
+        )
+    assert "which is an analysis path" in str(misfiled_file.value)
+
+
+def test_a_schema_yml_beside_an_analysis_is_accepted(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    properties = PlanEdit(
+        path="analyses/schema.yml",
+        kind=EditKind.SCHEMA_YML,
+        new_content="version: 2\nanalyses:\n  - name: email_skew\n",
+    )
+    stored, _diffs, _warnings = make_plan(
+        "document the analysis",
+        [properties],
+        dbt_project_dir,
+        tmp_path,
+        store=FilesystemStore(tmp_path),
+    )
+    assert stored.edits[0].path == "analyses/schema.yml"
+
+
+# --- the project view: an analysis is loaded, and is not a node ------------------
+
+
+def test_an_analysis_is_loaded_but_is_not_a_node(dbt_project_dir: Path):
+    analyses = dbt_project_dir / "analyses"
+    analyses.mkdir()
+    (analyses / "email_skew.sql").write_text(ANALYSIS, encoding="utf-8")
+    (analyses / "schema.yml").write_text("version: 2\n", encoding="utf-8")
+
+    view = load_project(dbt_project_dir)
+    assert "analyses/email_skew.sql" in view.files
+    assert "analyses/schema.yml" in view.files
+    assert set(node_files(view)) == {"models/staging/stg_customers.sql"}
+
+
+# --- the build ------------------------------------------------------------------
+
+
+def test_an_analysis_is_not_priced():
+    from exmergo_dex_core.transform.build import _PRICED_RESOURCE_TYPES
+
+    # An analysis is compiled and never run, so it issues no billed statement.
+    # Pinned beside the kinds that do so a future edit to the set cannot quietly
+    # start charging for one.
+    assert "analysis" not in _PRICED_RESOURCE_TYPES
+    assert {"model", "snapshot", "test"} <= _PRICED_RESOURCE_TYPES
+
+
+def test_a_dev_build_compiles_an_applied_analysis_and_materializes_nothing(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    duckdb = pytest.importorskip("duckdb")
+
+    payload = _edits_file(
+        tmp_path,
+        {
+            "path": "analyses/email_skew.sql",
+            "kind": "analysis_sql",
+            "content": ANALYSIS,
+        },
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "look at email skew",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+    rc, _envelope = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+    assert rc == 0
+
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+
+    # dbt's semantics, checked rather than trusted. dbt parses the file from the
+    # analysis paths and registers it as an analysis node, which is what proves
+    # the apply put it where dbt looks. It is not in the build graph, so it is
+    # never built, never materialized, and `dbt build` does not even compile it
+    # (only `dbt compile` does, which is why this asserts on the manifest rather
+    # than on target/compiled).
+    names = {n["name"] for n in envelope["data"]["nodes"]}
+    assert "email_skew" not in names
+    manifest = json.loads(
+        (dbt_project_dir / "target" / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert "analysis.dex_test.email_skew" in manifest["nodes"]
+
+    con = duckdb.connect(str(tmp_path / "dev.duckdb"), read_only=True)
+    try:
+        relations = {
+            row[0]
+            for row in con.execute(
+                "select table_name from information_schema.tables"
+            ).fetchall()
+        }
+    finally:
+        con.close()
+    assert "email_skew" not in relations

--- a/packages/dex-core/tests/transform/test_build.py
+++ b/packages/dex-core/tests/transform/test_build.py
@@ -1287,7 +1287,7 @@ def _write_manifest(project: Path, nodes: dict) -> None:
     )
 
 
-def test_compile_estimate_sums_priced_nodes_and_skips_seeds_and_ephemeral(
+def test_compile_estimate_sums_priced_nodes_and_skips_the_unbilled_ones(
     dbt_project_dir: Path, monkeypatch
 ):
     build_mod = importlib.import_module("exmergo_dex_core.transform.build")
@@ -1323,6 +1323,15 @@ def test_compile_estimate_sums_priced_nodes_and_skips_seeds_and_ephemeral(
             "compiled_code": "",
             "config": {},
         },
+        # Compiled by `dbt compile` and never built, so it has compiled SQL and
+        # still issues no billed statement. Priced at zero on purpose, not by
+        # accident of having no code to price.
+        "analysis.p.scratch": {
+            "resource_type": "analysis",
+            "name": "scratch",
+            "compiled_code": "select 5",
+            "config": {},
+        },
     }
     _write_manifest(dbt_project_dir, nodes)
     _compile_runner(
@@ -1333,7 +1342,8 @@ def test_compile_estimate_sums_priced_nodes_and_skips_seeds_and_ephemeral(
     total, per_node, notes = build_mod.compile_estimate(
         dbt_project_dir, _EstimatingAdapter(), target="dev"
     )
-    # model(view) + snapshot + test priced at 10 each; ephemeral and seed skipped.
+    # model(view) + snapshot + test priced at 10 each; ephemeral, seed and
+    # analysis skipped.
     assert total == 30.0
     assert set(per_node) == {"stg_a", "snap", "not_null_stg_a"}
     assert notes == []

--- a/packages/dex-core/tests/transform/test_dbt_project.py
+++ b/packages/dex-core/tests/transform/test_dbt_project.py
@@ -34,6 +34,27 @@ def test_load_parses_project_and_files(dbt_project_dir: Path):
     assert sql.sha256 == content_hash(sql.content)
 
 
+def test_load_defaults_every_path_family_the_way_dbt_does(dbt_project_dir: Path):
+    # The fixture's dbt_project.yml declares only `model-paths`, which is the
+    # common case: a project that never wrote the other keys still gets dbt's
+    # own defaults, so a first authored test or analysis lands where dbt looks.
+    view = load(dbt_project_dir)
+    assert view.macro_paths == ["macros"]
+    assert view.snapshot_paths == ["snapshots"]
+    assert view.seed_paths == ["seeds"]
+    assert view.test_paths == ["tests"]
+    assert view.analysis_paths == ["analyses"]
+    # And the order they are matched in, with models last as the catch-all.
+    assert [name for name, _paths in view.path_families()] == [
+        "macro",
+        "snapshot",
+        "seed",
+        "test",
+        "analysis",
+        "model",
+    ]
+
+
 def test_load_without_manifest_is_graceful(dbt_project_dir: Path):
     assert load(dbt_project_dir).manifest is None
 
@@ -260,8 +281,10 @@ def test_write_edits_all_or_nothing_across_a_delete_and_an_upsert(
         "../outside.sql",
         "models/../../escape.sql",
         # Inside the project, outside every authored family: the surface is the
-        # four path families plus the root manifests, not the whole repo.
-        "analyses/scratch.sql",
+        # path families plus the root manifests, not the whole repo. `analyses/`
+        # used to sit here and no longer does, which is the one behavior change
+        # a project with a stray analyses directory sees.
+        "docs/scratch.sql",
         "target/compiled.sql",
     ],
 )

--- a/packages/dex-core/tests/transform/test_plan.py
+++ b/packages/dex-core/tests/transform/test_plan.py
@@ -400,6 +400,49 @@ def test_project_yml_dropping_a_model_path_warns(dbt_project_dir: Path):
     assert any("model-paths drops" in w and "models" in w for w in warnings)
 
 
+def test_project_yml_dropping_any_authored_path_family_warns(dbt_project_dir: Path):
+    """Every path key dex authors into, not the two that happened to be first.
+
+    Dropping a family orphans every file under it, and which family a caller
+    restructures is not something the warning gets to have an opinion about.
+    Only `model-paths` and `macro-paths` were covered before, so a
+    dbt_project.yml that dropped `seed-paths` silently orphaned every seed.
+    """
+
+    original = (
+        "name: dex_test\nprofile: dex_test\n"
+        'model-paths: ["models"]\n'
+        'macro-paths: ["macros"]\n'
+        'snapshot-paths: ["snapshots"]\n'
+        'seed-paths: ["seeds"]\n'
+        'test-paths: ["tests"]\n'
+        'analysis-paths: ["analyses"]\n'
+    )
+    (dbt_project_dir / "dbt_project.yml").write_text(original, encoding="utf-8")
+
+    edit = _cfg_edit(
+        "dbt_project.yml",
+        "name: dex_test\nprofile: dex_test\n",
+        transform.EditKind.PROJECT_YML,
+    )
+    _plan, _diffs, warnings = transform.plan(
+        "flatten the project",
+        [edit],
+        dbt_project_dir,
+        repo_root=dbt_project_dir.parent,
+        store=FilesystemStore(dbt_project_dir.parent),
+    )
+    for key, directory in (
+        ("model-paths", "models"),
+        ("macro-paths", "macros"),
+        ("snapshot-paths", "snapshots"),
+        ("seed-paths", "seeds"),
+        ("test-paths", "tests"),
+        ("analysis-paths", "analyses"),
+    ):
+        assert any(f"{key} drops" in w and directory in w for w in warnings), key
+
+
 # --- column contract: authored SELECT list vs. declared schema.yml (#214) -----
 
 

--- a/packages/dex-core/tests/transform/test_singular_test_edit.py
+++ b/packages/dex-core/tests/transform/test_singular_test_edit.py
@@ -1,0 +1,366 @@
+"""`test_sql` end to end: the two shapes that share the test paths, containment
+to those paths, and the two things a test is not.
+
+A singular test is a query dbt runs and counts the rows of; a generic test is a
+macro under another keyword. Both live under `test-paths` and only the file's
+content says which one was written, so the shape check has to read it. Neither
+builds a relation and nothing can `ref()` either, which is why a test is not a
+node here even though dbt calls it one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.cli import main
+from exmergo_dex_core.dbt_project import DbtProjectError, node_files
+from exmergo_dex_core.dbt_project import load as load_project
+from exmergo_dex_core.storage import FilesystemStore
+from exmergo_dex_core.transform.plans import EditKind, PlanEdit, PlanError
+from exmergo_dex_core.transform.plans import plan as make_plan
+from exmergo_dex_core.transform.validate import EditValidationError, validate_edit
+
+SINGULAR = """-- Every order must reconcile against its items.
+select
+    o.id,
+    o.total
+from {{ ref('stg_customers') }} as o
+where o.total < 0
+"""
+
+GENERIC = """{% test not_negative(model, column_name) %}
+select *
+from {{ model }}
+where {{ column_name }} < 0
+{% endtest %}
+"""
+
+
+def _run(argv: list[str], capsys) -> tuple[int, dict]:
+    rc = main(argv)
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1, "exactly one line on stdout"
+    return rc, json.loads(out)
+
+
+def _edits_file(tmp_path: Path, *entries: dict) -> Path:
+    payload = tmp_path / "edits.json"
+    payload.write_text(json.dumps({"edits": list(entries)}), encoding="utf-8")
+    return payload
+
+
+def _test(content: str, path: str = "tests/assert_totals_reconcile.sql") -> PlanEdit:
+    return PlanEdit(path=path, kind=EditKind.TEST_SQL, new_content=content)
+
+
+# --- the two shapes ---------------------------------------------------------------
+
+
+def test_a_singular_test_validates():
+    assert validate_edit(_test(SINGULAR)) == []
+
+
+def test_a_generic_test_definition_validates():
+    # dbt admits a generic test definition under the test paths as well as the
+    # macro paths, so refusing it here would refuse a legitimate dbt file inside
+    # the family this kind exists to open.
+    assert validate_edit(_test(GENERIC, "tests/generic/not_negative.sql")) == []
+
+
+def test_a_singular_test_against_nothing_warns_rather_than_refuses():
+    # A test that names no table always passes, which is worse than no test. It
+    # is a warning and not a refusal because an assertion over a literal is
+    # unusual rather than wrong.
+    warnings = validate_edit(_test("select 1 as id where 1 = 0\n"))
+    assert warnings == [
+        "tests/assert_totals_reconcile.sql: this test names no ref() or "
+        "source(), so it runs against nothing and passes unconditionally"
+    ]
+
+
+def test_a_generic_test_never_draws_the_no_ref_warning():
+    # A generic test's body reads `{{ model }}`, never `ref()`. Applying the
+    # singular test's warning to both shapes would warn on every well-formed
+    # generic test in the project.
+    assert validate_edit(_test(GENERIC, "tests/generic/not_negative.sql")) == []
+
+
+@pytest.mark.parametrize(
+    ("content", "fix_named"),
+    [
+        pytest.param("drop table customers\n", "read-only SELECT", id="not_a_select"),
+        pytest.param(
+            "select 1;\nselect 2;\n", "exactly one statement", id="two_statements"
+        ),
+        pytest.param(
+            "{% test x(model) %}\nselect 1\n", "unbalanced test", id="unclosed"
+        ),
+        pytest.param(
+            "select 1\n{% endtest %}\n",
+            r"needs at least one \{% test name",
+            id="orphan_endtest",
+        ),
+        pytest.param(
+            "{% test x(model) %}select 1{% endtest %}\nselect 2\n",
+            "loose content",
+            id="content_outside",
+        ),
+    ],
+)
+def test_a_broken_test_is_refused_with_the_fix(content: str, fix_named: str):
+    with pytest.raises(EditValidationError, match=fix_named):
+        validate_edit(_test(content, "tests/generic/x.sql"))
+
+
+def test_a_test_that_is_entirely_jinja_says_so_and_claims_nothing_further():
+    # One warning, not two. The no-ref() warning is suppressed here on purpose:
+    # a query built inside a macro dex does not follow is content it has just
+    # said it cannot read, so asserting the test names no table would be a guess.
+    warnings = validate_edit(_test("{{ some_macro_that_builds_the_query() }}\n"))
+    assert warnings == [
+        "tests/assert_totals_reconcile.sql: test is entirely jinja; "
+        "SELECT-only check skipped"
+    ]
+
+
+# --- containment and kind agreement ----------------------------------------------
+
+
+def test_a_test_plans_applies_and_lands_as_a_create_diff(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    payload = _edits_file(
+        tmp_path,
+        {
+            "path": "tests/assert_totals_reconcile.sql",
+            "kind": "test_sql",
+            "content": SINGULAR,
+        },
+        {
+            "path": "tests/schema.yml",
+            "kind": "schema_yml",
+            "content": (
+                "version: 2\n"
+                "data_tests:\n"
+                "  - name: assert_totals_reconcile\n"
+                "    config:\n"
+                "      severity: warn\n"
+            ),
+        },
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "assert order totals reconcile",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+    assert envelope["data"]["paths"] == [
+        "tests/assert_totals_reconcile.sql",
+        "tests/schema.yml",
+    ]
+    diffs = {d["path"]: d for d in envelope["diffs"]}
+    created = diffs["tests/assert_totals_reconcile.sql"]
+    assert created["op"] == "create"
+    assert created["deletions"] == 0
+    assert "where o.total < 0" in created["unified"]
+
+    rc, envelope = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+    assert rc == 0, envelope["errors"]
+    written = dbt_project_dir / "tests" / "assert_totals_reconcile.sql"
+    assert written.read_text(encoding="utf-8") == SINGULAR
+
+
+def test_custom_test_paths_are_honored(dbt_project_dir: Path, tmp_path: Path):
+    project_yml = dbt_project_dir / "dbt_project.yml"
+    project_yml.write_text(
+        project_yml.read_text(encoding="utf-8") + 'test-paths: ["assertions"]\n',
+        encoding="utf-8",
+    )
+    store = FilesystemStore(tmp_path)
+    stored, _diffs, _warnings = make_plan(
+        "assert",
+        [_test(SINGULAR, "assertions/assert_totals_reconcile.sql")],
+        dbt_project_dir,
+        tmp_path,
+        store=store,
+    )
+    assert stored.edits[0].path == "assertions/assert_totals_reconcile.sql"
+
+    # The default location is no longer part of the surface once moved:
+    # containment refuses it before the kind is ever consulted, and the refusal
+    # names where the test family actually is now.
+    with pytest.raises(DbtProjectError, match=r"test \(assertions\)"):
+        make_plan("assert", [_test(SINGULAR)], dbt_project_dir, tmp_path, store=store)
+
+
+def test_kind_and_surface_must_agree_in_both_directions(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    store = FilesystemStore(tmp_path)
+    with pytest.raises(PlanError, match="test paths"):
+        make_plan(
+            "bad",
+            [_test(SINGULAR, "models/staging/assert_totals_reconcile.sql")],
+            dbt_project_dir,
+            tmp_path,
+            store=store,
+        )
+
+    model_in_tests = PlanEdit(
+        path="tests/x.sql", kind=EditKind.MODEL_SQL, new_content="select 1\n"
+    )
+    with pytest.raises(PlanError, match="test_sql"):
+        make_plan("bad", [model_in_tests], dbt_project_dir, tmp_path, store=store)
+
+
+def test_a_test_is_refused_under_the_analysis_paths(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    # The two new families are adjacent and both hold `.sql`, so the one
+    # misfiling a caller is most likely to make is between them.
+    with pytest.raises(PlanError, match="test paths"):
+        make_plan(
+            "bad",
+            [_test(SINGULAR, "analyses/assert_totals_reconcile.sql")],
+            dbt_project_dir,
+            tmp_path,
+            store=FilesystemStore(tmp_path),
+        )
+
+
+def test_a_schema_yml_beside_a_test_is_accepted(dbt_project_dir: Path, tmp_path: Path):
+    properties = PlanEdit(
+        path="tests/schema.yml",
+        kind=EditKind.SCHEMA_YML,
+        new_content="version: 2\ndata_tests:\n  - name: assert_totals_reconcile\n",
+    )
+    stored, _diffs, _warnings = make_plan(
+        "document the test",
+        [properties],
+        dbt_project_dir,
+        tmp_path,
+        store=FilesystemStore(tmp_path),
+    )
+    assert stored.edits[0].path == "tests/schema.yml"
+
+
+# --- the project view: a test is loaded, and is not a node -----------------------
+
+
+def test_a_test_is_loaded_but_is_not_a_node(dbt_project_dir: Path):
+    tests = dbt_project_dir / "tests"
+    (tests / "generic").mkdir(parents=True)
+    (tests / "assert_totals_reconcile.sql").write_text(SINGULAR, encoding="utf-8")
+    (tests / "generic" / "not_negative.sql").write_text(GENERIC, encoding="utf-8")
+    (tests / "schema.yml").write_text("version: 2\n", encoding="utf-8")
+
+    view = load_project(dbt_project_dir)
+    # Loaded, because a file dex can author and does not load hashes as absent:
+    # a later edit registers as a create and the apply after it conflicts on a
+    # file nobody touched.
+    assert "tests/assert_totals_reconcile.sql" in view.files
+    assert "tests/generic/not_negative.sql" in view.files
+    assert "tests/schema.yml" in view.files
+
+    # dbt calls a singular test a node. It is not one here, because `node_files`
+    # answers "what does this project build", and a test builds no relation and
+    # nothing can ref() it.
+    assert set(node_files(view)) == {"models/staging/stg_customers.sql"}
+
+
+def test_deleting_a_test_is_not_guarded_against_references(
+    dbt_project_dir: Path, tmp_path: Path
+):
+    tests = dbt_project_dir / "tests"
+    tests.mkdir()
+    (tests / "assert_totals_reconcile.sql").write_text(SINGULAR, encoding="utf-8")
+
+    delete = PlanEdit(
+        path="tests/assert_totals_reconcile.sql",
+        kind=EditKind.TEST_SQL,
+        op="delete",
+    )
+    # Nothing can ref() a test, so there is no dangling reference to guard
+    # against and the plan stands. The file-level guards still apply: the delete
+    # is a diff pinned to the file's hash like any other edit.
+    stored, diffs, _warnings = make_plan(
+        "drop the assertion",
+        [delete],
+        dbt_project_dir,
+        tmp_path,
+        store=FilesystemStore(tmp_path),
+    )
+    assert stored.edits[0].op == "delete"
+    assert diffs[0]["op"] == "delete"
+
+
+# --- the build ------------------------------------------------------------------
+
+
+def test_a_singular_test_is_priced():
+    from exmergo_dex_core.transform.build import _PRICED_RESOURCE_TYPES
+
+    # A test runs a scanning SELECT against the warehouse, so it costs money and
+    # is priced. Already true for the generic tests in schema.yml; authoring
+    # singular ones does not change it, and pinning it says so on purpose.
+    assert "test" in _PRICED_RESOURCE_TYPES
+
+
+def test_a_dev_build_runs_an_applied_singular_test(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    pytest.importorskip("duckdb")
+
+    payload = _edits_file(
+        tmp_path,
+        {
+            "path": "tests/assert_no_negative_ids.sql",
+            "kind": "test_sql",
+            "content": "select id from {{ ref('stg_customers') }} where id < 0\n",
+        },
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "plan",
+            "assert no negative ids",
+            "--edits-file",
+            str(payload),
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+    rc, _envelope = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+    assert rc == 0
+
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope["errors"]
+    # The acceptance criterion: `dbt build` picks the test up natively, so an
+    # apply and a build is all it takes. No separate `dbt test` for the caller
+    # to remember.
+    statuses = {n["name"]: n["status"] for n in envelope["data"]["nodes"]}
+    # dbt reports a passing test as "pass", not the "success" a model gets.
+    assert statuses["assert_no_negative_ids"] == "pass"

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -116,14 +116,16 @@ hands it over via `--edits-file <path>` (or `-` for stdin), a JSON payload:
   {"path": "models/staging/stg_orders.yml", "kind": "schema_yml", "content": "..."},
   {"path": "snapshots/snap_orders.sql", "kind": "snapshot_sql", "content": "..."},
   {"path": "seeds/country_vat.csv", "kind": "seed_csv", "content": "..."},
+  {"path": "tests/assert_totals_reconcile.sql", "kind": "test_sql", "content": "..."},
+  {"path": "analyses/email_skew.sql", "kind": "analysis_sql", "content": "..."},
   {"path": "models/marts/dim_orders.sql", "kind": "model_sql", "op": "delete"}
 ]}
 ```
 
 `kind` is one of `model_sql`, `schema_yml`, `semantic_yml` (optional on
 `semantic define|update`, which imply `semantic_yml`), `packages_yml`,
-`macro_sql`, `snapshot_sql`, `seed_csv`, `project_yml`, or `profiles_yml`. Each
-edit also has an `op`:
+`macro_sql`, `snapshot_sql`, `seed_csv`, `test_sql`, `analysis_sql`,
+`project_yml`, or `profiles_yml`. Each edit also has an `op`:
 `upsert` (create or update, the default, carrying `content`) or `delete` (remove
 the file, no `content`). A delete is a reviewable diff pinned to the file's hash
 like any other edit, and it is guarded: the plan is refused if any surviving file
@@ -144,7 +146,12 @@ single read-only SELECT, and must target the project's snapshot paths; a
 `seed_csv` edit must parse as CSV with a named, duplicate-free header and one
 field per column on every row, must stay under 5,000 data rows and 1 MiB, must
 not name columns that look like personal data, and must target the project's
-seed paths; a `project_yml` edit targets the project-root
+seed paths; a `test_sql` edit must target the project's test paths and must be
+either a generic test definition (only `{% test %}` blocks and jinja comments,
+balanced) or a singular test that is a single read-only SELECT once its jinja is
+stripped; an `analysis_sql` edit must target the project's analysis paths and be
+a single read-only SELECT on the same terms; a `project_yml` edit targets the
+project-root
 `dbt_project.yml` and must keep a `name`; a `profiles_yml` edit targets the
 project-root `profiles.yml` and must reference every secret via
 `{{ env_var('NAME') }}`, never a literal), pins it to the sha256 of the file it
@@ -163,6 +170,28 @@ seed's column types and a snapshot's tests and docs to be declared. `dbt build`
 runs seeds and snapshots natively, so nothing new has to be run after an apply;
 a snapshot writes a table and is priced in the cost handshake, while a seed
 loads a local CSV, scans nothing, and is deliberately unpriced.
+
+`test_sql` and `analysis_sql` do the same for the two remaining families
+(`test-paths` and `analysis-paths`, again with dbt's defaults). A singular test
+is an arbitrary SELECT that must return no rows, which is where most
+project-specific assertions live, and generic test definitions share the same
+directory, so `test_sql` reads the file to tell them apart: a `{% test %}` block
+is checked structurally like a macro, anything else is checked like a model. A
+singular test naming no `ref()` or `source()` warns rather than refuses, since it
+runs against nothing and passes unconditionally. An analysis is held to the same
+read-only SELECT even though dbt only ever compiles it, because read-only against
+data describes what dex writes rather than what dbt runs. `schema_yml` is
+accepted beside each. Neither kind builds a relation and nothing can `ref()`
+either, so neither is a node: neither enters the drift baseline, and deleting one
+raises no dangling-reference guard. `dbt build` runs a singular test natively and
+prices it like any other test; an analysis is compiled by `dbt compile`, never
+built, and costs nothing.
+
+**Three different things here are called a test.** Generic tests are declared
+inside a `schema.yml` (`data_tests:` on a model or a column). Unit tests are
+scaffolded by `transform test --scaffold <model>` into a `unit_tests:` block,
+also `schema_yml`. Singular tests and generic test *definitions* are files under
+`test-paths`, and those are what `test_sql` authors.
 
 `seed_csv` is the first kind that puts **values**, not logic, into a reviewable
 diff, and a diff goes into git and stays there. So a seed's header is checked

--- a/references/dbt-project.md
+++ b/references/dbt-project.md
@@ -6,17 +6,18 @@ the project, reasons over it together with warehouse introspection and the
 
 ## What dex reads
 
-- `dbt_project.yml`: the project name, profile name, and the four authored path
-  families (`model-paths`, `macro-paths`, `snapshot-paths`, `seed-paths`), each
-  defaulted the way dbt defaults it when the key is absent.
+- `dbt_project.yml`: the project name, profile name, and the six authored path
+  families (`model-paths`, `macro-paths`, `snapshot-paths`, `seed-paths`,
+  `test-paths`, `analysis-paths`), each defaulted the way dbt defaults it when
+  the key is absent.
 - The source files under those families, scanned for the suffixes each one can
-  hold: `*.sql` / `*.yml` / `*.yaml` under the model, macro and snapshot paths,
-  and `*.csv` / `*.yml` / `*.yaml` under the seed paths. Together they are the
-  editing surface (model SQL, `schema.yml`, dbt semantic models, macros,
-  snapshots, seeds). A file dex can author but does not load would hash as
-  absent, so a later edit to it would register as a create and the apply after
-  it would conflict on a file nobody touched; the scan covers every family for
-  that reason, not for completeness.
+  hold: `*.sql` / `*.yml` / `*.yaml` under the model, macro, snapshot, test and
+  analysis paths, and `*.csv` / `*.yml` / `*.yaml` under the seed paths. Together
+  they are the editing surface (model SQL, `schema.yml`, dbt semantic models,
+  macros, snapshots, seeds, singular and generic tests, analyses). A file dex can
+  author but does not load would hash as absent, so a later edit to it would
+  register as a create and the apply after it would conflict on a file nobody
+  touched; the scan covers every family for that reason, not for completeness.
 - `target/manifest.json` when the project has been compiled; a fresh project
   loads fine without one.
 - `profiles.yml` (searched the way dbt searches: `$DBT_PROFILES_DIR`, the project
@@ -59,24 +60,39 @@ by dbt's own parser). A rename is expressed as one plan: delete the old model,
 create the new one, and update every referrer, validated together.
 
 Human edits to dbt are authoritative by construction; dex holds no competing copy
-to overwrite them from. Writes are confined to the four authored path families
+to overwrite them from. Writes are confined to the six authored path families
 plus the project-root manifests dbt keeps there (`dbt_project.yml`,
 `profiles.yml`, `packages.yml`, `dependencies.yml`); path escapes are refused.
 Within the surface, an edit's kind and its location have to agree: a snapshot
 belongs under the snapshot paths and nowhere else, a seed under the seed paths, a
-macro under the macro paths, and model SQL and semantic YAML under the model
-paths. `schema.yml` is the one kind several families admit, because dbt expects a
-seed's column types and a snapshot's tests declared beside the thing they
-describe. Filing a kind in the wrong family is refused at plan time naming both
-fixes (move the file, or relabel the kind), since dbt would otherwise parse a
-snapshot as a model, or never load a seed at all.
+macro under the macro paths, a singular or generic test under the test paths, an
+analysis under the analysis paths, and model SQL and semantic YAML under the
+model paths. `schema.yml` is the one kind several families admit, because dbt
+expects a seed's column types, a snapshot's tests, a singular test's severity and
+an analysis's description declared beside the thing they describe. Filing a kind
+in the wrong family is refused at plan time naming both fixes (move the file, or
+relabel the kind), since dbt would otherwise parse a snapshot or a test as a
+model, or never load a seed or an analysis at all.
 
 A model, a snapshot and a seed each build a relation dbt names after the file and
 each is `ref()`-able, so all three count as nodes: deleting one is guarded
 against surviving references exactly like deleting a model, and all three are
 what `maintain` fingerprints as the transformation layer. A macro is not a node
-and never was one. dex never builds to a non-dev target, and a delete only ever
-removes a file from the repo, never a relation from the warehouse.
+and never was one.
+
+**Neither a singular test nor an analysis is a node here, and the word is worth
+being careful with.** dbt calls a singular test a node (`test.<project>.<name>`)
+and it is one in dbt's graph, but it builds no relation and nothing can `ref()`
+it, so it is not one of "the things this project builds": counting it would put a
+name into the drift baseline that no warehouse table will ever back. An analysis
+is further out still, compiled by `dbt compile` into `target/compiled/`, never
+built, and absent from a `dbt build` entirely. Both are loaded so they can be
+authored and hashed like anything else; neither enters the transform-layer model
+list, and deleting either raises no dangling-reference guard because there is
+nothing that could dangle.
+
+dex never builds to a non-dev target, and a delete only ever removes a file from
+the repo, never a relation from the warehouse.
 
 ## Running dbt (build, deps, parse)
 

--- a/references/project.md
+++ b/references/project.md
@@ -188,9 +188,10 @@ generates alongside the path, so placement alone cannot open that channel: a for
 that places a staging model elsewhere gets the proposal as advice rather than having
 dbt written into its tree. One `None` and one path is the shape this exists for.
 
-The kind list grows over time (`MACRO_SQL`, `SNAPSHOT_SQL` and `SEED_CSV` are all
-dbt-shaped artifacts a non-dbt format may have no equivalent of), and `None` stays
-the right answer for every one your format does not place. The shipped dbt format
+The kind list grows over time (`MACRO_SQL`, `SNAPSHOT_SQL`, `SEED_CSV`, `TEST_SQL`
+and `ANALYSIS_SQL` are all dbt-shaped artifacts a non-dbt format may have no
+equivalent of), and `None` stays the right answer for every one your format does
+not place. The shipped dbt format
 answers `None` for them too: reconcile proposes staging models and their
 `schema.yml` and nothing else, so a path for the rest would be invented rather
 than known.
@@ -218,8 +219,9 @@ the format itself declared. Your own writer still has to check, because `write_e
 is a public method of your format and dex is not its only caller, and the conformance
 suite asserts the case a prefix comparison gets wrong.
 
-**Declare what your writer accepts, not less.** The shipped dbt format lists its
-model and macro paths *and* the four root manifests it authors by name, because a
+**Declare what your writer accepts, not less.** The shipped dbt format lists every
+one of its authored path families *and* the four root manifests it authors by
+name, because a
 declaration narrower than the writer is not a modest one: it refuses the project
 config, the profiles and the package manifests at apply, every one of which is a path
 dex authors through a plan.

--- a/skills/transform/SKILL.md
+++ b/skills/transform/SKILL.md
@@ -34,6 +34,8 @@ and stores the proposal as a plan. Hand content over with `--edits-file <path>`
   {"path": "models/staging/stg_orders.yml", "kind": "schema_yml", "content": "..."},
   {"path": "snapshots/snap_orders.sql", "kind": "snapshot_sql", "content": "..."},
   {"path": "seeds/country_vat.csv", "kind": "seed_csv", "content": "..."},
+  {"path": "tests/assert_totals_reconcile.sql", "kind": "test_sql", "content": "..."},
+  {"path": "analyses/email_skew.sql", "kind": "analysis_sql", "content": "..."},
   {"path": "models/marts/dim_orders.sql", "kind": "model_sql", "op": "delete"}
 ]}
 ```
@@ -41,7 +43,9 @@ and stores the proposal as a plan. Hand content over with `--edits-file <path>`
 `kind` is `model_sql`, `schema_yml`, `semantic_yml` (optional on
 `semantic define|update|plan`, which imply it), `macro_sql` (a macro file under
 the project's macro paths), `snapshot_sql` (a snapshot under the snapshot
-paths), `seed_csv` (a seed's CSV under the seed paths), `packages_yml`,
+paths), `seed_csv` (a seed's CSV under the seed paths), `test_sql` (a singular
+test or a generic test definition under the test paths), `analysis_sql` (SQL dbt
+compiles but never runs, under the analysis paths), `packages_yml`,
 `project_yml` (the project-root `dbt_project.yml`), or `profiles_yml` (the
 project-root `profiles.yml`). Model SQL must be a single read-only SELECT once
 its jinja is stripped; semantic YAML is validated against MetricFlow's schemas,
@@ -53,15 +57,29 @@ comments. A snapshot must hold exactly one `{% snapshot %}` block whose
 read-only SELECT. A seed must parse as CSV with a named, duplicate-free header
 and one field per column on every row, and stays under 5,000 data rows and 1 MiB
 (past that it is data rather than a lookup: load it into the warehouse and
-`source()` it). `project_yml` must keep a `name`; `profiles_yml` must reference
+`source()` it). A `test_sql` file is read to decide which of the two shapes
+sharing the test paths it is: one holding `{% test %}` blocks is a generic test
+definition and must hold only those and jinja comments, balanced; anything else
+is a singular test and must be a single read-only SELECT. A singular test that
+names no `ref()` or `source()` is warned about, not refused, because it runs
+against nothing and passes unconditionally. An analysis must be a single
+read-only SELECT too, even though dbt only compiles it. `project_yml` must keep
+a `name`; `profiles_yml` must reference
 every secret via `{{ env_var('NAME') }}` (a literal credential is refused so
 none reaches the diff). Config kinds, snapshots and seeds are all parsed by dbt
 at plan time.
 
 Each kind is confined to its own family of paths, and filing one in the wrong
 family is refused naming both fixes. `schema_yml` is the exception, accepted
-beside a model, a snapshot or a seed, because that is where dbt expects a
-snapshot's tests and a seed's column types declared.
+beside a model, a snapshot, a seed, a test or an analysis, because that is where
+dbt expects a snapshot's tests, a seed's column types, a singular test's severity
+and an analysis's description declared.
+
+**Three things here are called a test, and they are not interchangeable.**
+Generic tests are declared inside a `schema.yml` (`data_tests:` on a model or a
+column). Unit tests come from `transform test --scaffold <model>`, which writes a
+`unit_tests:` block, also `schema_yml`. Singular tests and generic test
+*definitions* are files under `test-paths`, and `test_sql` is the kind for those.
 
 **A seed puts values, not logic, into a diff, and a diff goes into git and stays
 there.** So a seed whose header names a column that looks like personal data is
@@ -71,9 +89,13 @@ values (everywhere in dex), so it cannot see personal data hiding under a
 neutral column name: do not build a seed out of warehouse rows you have not
 looked at.
 
-`dbt build` runs seeds and snapshots natively, so `transform build` after an
-apply is all it takes; there is no separate seed step. A snapshot writes a table
-and is priced in the cost handshake, a seed scans nothing and is not.
+`dbt build` runs seeds, snapshots and singular tests natively, so `transform
+build` after an apply is all it takes; there is no separate seed or test step. A
+snapshot writes a table and a test runs a scanning SELECT, so both are priced in
+the cost handshake; a seed scans nothing and an analysis is never built at all,
+so neither is. A singular test and an analysis build no relation and nothing can
+`ref()` either, so neither is a node: neither enters `maintain`'s drift baseline,
+and deleting one raises no dangling-reference guard.
 
 `op` is `upsert` (the default: create or update, carrying `content`) or
 `delete` (remove the file, no `content`). A delete is a first-class reviewable
@@ -285,8 +307,10 @@ database, which is fine for model-only builds.
 
 ## Guardrails (enforced in the engine, not here)
 
-- Writes confined to the repo, and within it to the dbt project's model paths.
-  dex never writes to source warehouse data.
+- Writes confined to the repo, and within it to the dbt project's authored path
+  families (models, macros, snapshots, seeds, tests, analyses) plus the
+  project-root manifests dbt keeps there. dex never writes to source warehouse
+  data.
 - Dev-target only. Prod-target execution is never initiated by dex.
 - Cost surfaced before any spend. A build that would spend requires explicit
   confirmation and a session budget.


### PR DESCRIPTION
Closes #212.

`transform plan` refused a singular test:

```
edit path 'tests/assert_totals_reconcile.sql' is outside the project's model
paths (models); dex edits only the dbt project surface
```

Generic tests were already authorable, because they are declared inside a
`schema.yml` and a `schema.yml` is a model-path file. A singular test is not: it
is an arbitrary SELECT that must return no rows, living in its own file under
`test-paths`, and that is where most project-specific assertions actually are. So
the one class of test dex could not write was the one carrying the project's real
business rules. Analyses were in the same position.

This is the last pair of dbt's six authored path families, and it is mostly table
extension rather than new machinery, because #210 and #211 left the right seams:
`path_families()` is the single registration point, `editing_surface()` is derived
from it, `_HOME_FAMILY` is derived from `_PLACEMENT`, and `node_files()` is an
explicit allowlist instead of a filename guess. Adding two families touched five
lines of registration and two validation branches.

## Two shapes share the test paths

dbt admits a generic test *definition* (`{% test name(...) %}` / `{% endtest %}`)
under `test-paths` as well as under `macro-paths`. Only the file's own content says
which shape was written, so `test_sql` reads it:

- a file holding `{% test %}` blocks is checked structurally, exactly as
  `macro_sql` is: balanced definitions, nothing loose between them but jinja
  comments
- anything else is a singular test and is checked as a model is: a single
  read-only SELECT once its jinja is stripped

The alternative was to validate only the singular shape and refuse the other. That
would have reproduced the exact complaint this issue opens with, a legitimate dbt
file refused inside the family the change just opened, with a message naming a
mistake the caller had not made. The dogfood confirmed the choice was load-bearing:
the generic test dex authored was registered by dbt as macro
`test_not_in_the_future` and ran as `not_in_the_future_stg_orders_placed_at`.

The open and the close delimiter are both read when deciding the shape. A file with
an orphaned `{% endtest %}` is then refused as the broken definition it is, rather
than falling through to the singular path and failing to parse as SQL.

## The placement table, at six families

| family | `.sql` | `.csv` | `.yml` / `.yaml` |
|---|---|---|---|
| macro | `macro_sql` | refused | refused (unchanged) |
| snapshot | `snapshot_sql` | refused | `schema_yml` |
| seed | refused | `seed_csv` | `schema_yml` |
| test | `test_sql` | refused | `schema_yml` |
| analysis | `analysis_sql` | refused | `schema_yml` |
| model | `model_sql` | refused | `schema_yml` / `semantic_yml` |

`schema_yml` is admitted under both new families for the reason it was admitted
under snapshots and seeds: dbt reads a properties file under `test-paths`
(`data_tests:`, which is how a singular test gets a config, a description or a
severity) and under `analysis-paths` (`analyses:`). Refusing it would make a
singular test authorable but not configurable. Macro-path behavior is still
deliberately untouched.

## An analysis is held to read-only SELECT, and that is a choice

dbt compiles an analysis and never runs it, so nothing downstream would object to a
`DELETE` sitting in `analyses/`. dex refuses it anyway. Read-only against data
describes what dex writes, not what dbt happens to execute, and compiled SQL in
`target/` is one copy-paste from a warehouse.

That reasoning is now pinned rather than left in a comment: a spine assertion walks
every SQL-carrying kind, `model_sql`, `test_sql`, `analysis_sql` and a snapshot's
body, and fails if any of them reaches the repo without the guard. The failure mode
it exists for is a future kind arriving with its own validation branch that forgets
it.

## Neither kind is a node, and the word needed sharpening

`node_files()` was documented as "the files that become a dbt node named after the
file". That definition breaks here: dbt calls a singular test a node
(`test.<project>.<name>`), and it must not be one for dex, because `node_files` is
what answers "the things this project builds" for the drift baseline, the
`ref()`-delete guard and `backed_relation_names`. Counting a test would put a name
into `maintain`'s baseline that no warehouse table will ever back.

The function is unchanged, which is the point: #210/#211 made it an explicit
allowlist, so two new families cannot leak into it. What changed is that it now
says what it means, in the docstring and in `references/dbt-project.md`: it holds
the files that build a relation dbt names after the file and that something can
`ref()`. An analysis is further out still, compiled by `dbt compile`, never built,
and absent from a `dbt build` entirely.

Consequences, all of them the right ones: neither kind enters the transform-layer
model list, and deleting either raises no dangling-reference guard, because there
is nothing that could dangle.

## Neither kind joins the dbt-parser gate

`shadow_parse` runs for deletes and for the kinds whose shape dbt fully owns
(`project_yml`, `profiles_yml`, `snapshot_sql`, `seed_csv`), at the cost of a dbt
subprocess per plan. Both new kinds are bare SELECTs, and `model_sql`, the closest
analogue, is deliberately not gated, so neither was added.

A *delete* still reaches the parser, because `has_delete` triggers it regardless of
kind, and the dogfood showed that is where it earns its place: deleting a test and
an analysis left their `schema.yml` entries orphaned and dbt warned about both. The
backstop arrives free on the one operation that can cause the problem.

## One behavior change a downstream user sees

`analyses/` moves from refused to authored. A project with a stray `analyses/`
directory now has those files loaded into the project view and hashed, which is
what makes them editable without a spurious conflict. A test that pinned
`analyses/scratch.sql` as outside the surface was updated on purpose rather than
deleted, and it still pins a path that is genuinely outside every family.

The same widening grows `TransformLayer.files`, as #210/#211's did. No detector
diffs the file set, so a baseline pinned before this change reads as "nothing
drifted"; the existing test for that now covers all six families, and the dogfood
checked it against a real stripped baseline.

## An adjacent gap, fixed here

`plans.py` warns when a `project_yml` edit drops a path key, but the loop covered
`model-paths` and `macro-paths` only. `snapshot-paths` and `seed-paths` were never
added when those families arrived, so a `dbt_project.yml` that dropped either
silently orphaned every file under it. It now checks all six.

This is #210/#211's miss, not #212's, and it rides along because the PR that
creates the last two of the six keys is the right place to stop the list being a
coin flip on which family the caller happened to restructure.

## Found by dogfooding, not by the suite

The refusal text did not agree with itself in English. `analysis` is the first
family name in dex beginning with a vowel, and both halves of the message are
assembled from kind and family names, so it broke four refusal strings at once:

```
before: a analysis_sql edit must live under the project's analysis paths ...
        got 'tests/scratch.sql', which is a test path
before: a model_sql edit must live under the project's model paths ...
        got 'analyses/stg_x.sql', which is a analysis path

after:  an analysis_sql edit must live under the project's analysis paths ...
after:  ... got 'analyses/stg_x.sql', which is an analysis path
```

Fixed with an article helper, and pinned by a test that uses `analysis`
specifically, since it is the only name in the current set that catches it.

Three dbt facts also came back from the dogfood and corrected assumptions written
into tests: `dbt build` does not compile an analysis (only `dbt compile` does, so
the manifest node is the right assertion and a stronger one), dbt reports a passing
test as `pass` rather than the `success` a model gets, and a singular test's
properties entry is `data_tests:` in current dbt.

## Verification

`uv run pytest -q` in `packages/dex-core` with every connector extra synced:
**2524 passed, 83 skipped**, up from 2486 at the branch point, no failures.
`uv run pytest -q tests/test_safety_spine.py` clean. `uvx ruff@0.15.19 check .` and
`format --check .` clean, `uvx pytest evals -q` clean, and the em-dash gate clean
across every tracked file.

Dogfooded on DuckDB in full and on BigQuery for the cost claim, written up in
`dex-212-field-feedback-2026-08-26.md`. On BigQuery a singular test prices at the
10 MB floor and appears by name in `per_table_bytes`; an analysis appears in
neither the priced set nor the could-not-be-priced set, because it is not in the
build graph at all.

## Out of scope, deliberately

- Admitting `schema_yml` under macro paths. Still inconsistent with every other
  family, still a live behavior change with a test pinning both directions, still
  its own issue.
- Scaffolding `tests/` or `analyses/` in `transform init`, which creates neither
  `seeds/` nor `snapshots/` either. The writer makes the parent directory on apply
  and dbt reads its own defaults, so nothing needs it.
- A scaffold command for either kind. `transform macro <name>` exists because dex
  ships macros; it ships no test or analysis templates.
- Pricing a singular test whose upstream model does not exist in the dev target
  yet. dex already names the node it could not price and calls the total a partial
  floor; making it priceable would mean speculating about a table that is not
  there.
