### PR TITLE
SCRUM-991-Add opt-in SQLite cache backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **An opt-in SQLite cache backend** ([#139]). `FilesystemStore` writes loose
+  JSON under `.dex/`, which is right for the CLI (persistence is git, a reviewer
+  reads the state in a pull request) and wrong for a host that wants durable
+  local state without a directory of files to gitignore and clean up. Select
+  `cache.backend: sqlite` (or `--cache-backend sqlite` for one run) and
+  everything lands in a single `.dex/dex.db` file instead; `filesystem` stays
+  the default.
+
+  It implements the full storage `Protocol` from [#137]: the cache, the
+  snapshot, the drift report, the transform plans, and both ledgers, backed by
+  real tables rather than a directory of loose files, and it passes the same
+  conformance suite the two shipped backends already run against. The spend
+  ledger's `spend_since`, the query the cumulative session budget reads on every
+  billed command, answers from an indexed lookup on `at` and `connector` rather
+  than reading and parsing every line ever appended, which is the gap the
+  filesystem backend's JSONL scan does not close as a ledger grows. The
+  cross-process spend lock is a `BEGIN IMMEDIATE` transaction on the database
+  file itself, so the cumulative ceiling still binds across two CLI processes
+  sharing a repo, the same guarantee the filesystem backend's advisory file lock
+  provides.
+
+  `.dex/dex.db` is a binary file, not a JSON document a reviewer can diff, so it
+  belongs in `.gitignore` the way any local database file does.
+
 - **`transform rename` and `transform remove` generate the whole propagation
   plan** ([#221]). `transform references` could tell you where a name was used
   and then left you to retype the change file by file. These two make the change:

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -479,7 +479,9 @@ class CacheConfig(BaseModel):
 
     ``backend`` is an open registry rather than a closed set. It accepts a name
     dex ships (``filesystem``, the default, which writes the loose JSON under
-    `.dex/` that a reviewer reads in a pull request), a dotted
+    `.dex/` that a reviewer reads in a pull request; or ``sqlite``, which writes
+    one `.dex/dex.db` file instead and is not git-reviewable, for a host that
+    wants durable state without scattering JSON files), a dotted
     ``mypkg.stores:my_store`` path, or a name an installed distribution registered
     under the ``exmergo_dex_core.stores`` entry-point group. A backend published
     as its own package is therefore selectable without a change to dex.

--- a/packages/dex-core/src/exmergo_dex_core/storage/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/__init__.py
@@ -35,6 +35,7 @@ from .base import (
 from .filesystem import DEX_DIR, FilesystemStore
 from .memory import MemoryStore
 from .resolver import build_store, resolve_store_factory
+from .sqlite import SqliteStore
 
 __all__ = [
     "DEX_DIR",
@@ -45,6 +46,7 @@ __all__ = [
     "MaintainStore",
     "MemoryStore",
     "SpendLock",
+    "SqliteStore",
     "Store",
     "StoreContext",
     "StoreFactory",

--- a/packages/dex-core/src/exmergo_dex_core/storage/resolver.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/resolver.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from ..errors import ConfigurationError
 from .base import ExploreStore, StoreContext, StoreFactory
 from .filesystem import FilesystemStore
+from .sqlite import SqliteStore
 
 ENTRY_POINT_GROUP = "exmergo_dex_core.stores"
 
@@ -38,6 +39,7 @@ ENTRY_POINT_GROUP = "exmergo_dex_core.stores"
 #: installed, so no third-party registration can take over a shipped name.
 SHIPPED: dict[str, StoreFactory] = {
     "filesystem": FilesystemStore.from_context,
+    "sqlite": SqliteStore.from_context,
 }
 
 #: Shipped backends that are deliberately *not* selectable, and why. Refusing by

--- a/packages/dex-core/src/exmergo_dex_core/storage/sqlite.py
+++ b/packages/dex-core/src/exmergo_dex_core/storage/sqlite.py
@@ -1,0 +1,433 @@
+"""A single `.dex/dex.db` file: the opt-in durable backend.
+
+:class:`~.filesystem.FilesystemStore` is right for the CLI because persistence is
+git: a loose JSON file diffs cleanly in a pull request. Some hosts do not want
+that trade. A long-running local session, or a library caller that wants state to
+survive a process restart without writing anything the user has to `git add` or
+`.gitignore`, wants one file it can point a backup or a `.gitignore` line at and
+forget.
+
+This backend trades the reviewable-diff property for that: everything lands in
+one SQLite file, `.dex/dex.db`, with real tables and an index on the spend
+ledger's `at`/`connector` columns, so :meth:`spend_since` is a bounded query
+rather than a scan of every line ever appended. Nothing here is committed to the
+user's repo the way `.dex/cache.json` is; `.dex/dex.db` (and the `-journal` file
+that appears mid-write) belong in `.gitignore`, the way any local database file
+does.
+
+Selected the way :class:`~.filesystem.FilesystemStore` is, by naming it in
+`.dex/config.yml` (`cache.backend: sqlite`) or on the command line
+(`--cache-backend sqlite`); `filesystem` stays the default. See
+``references/storage.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..cache import DexCache
+from ..errors import ConfigurationError
+from .base import Document, StoreContext, spend_total
+
+if TYPE_CHECKING:
+    from ..maintain.drift import DriftReport
+    from ..maintain.snapshot import Snapshot
+    from ..transform.plans import EditKind, TransformPlan
+
+DEX_DIR = ".dex"
+DB_FILE = "dex.db"
+
+# This backend's own table-schema version, tracked via SQLite's `user_version`
+# pragma. Deliberately unrelated to `cache.py`'s `CACHE_SCHEMA_VERSION`: that one
+# versions the `DexCache` document the engine reads out of any backend, and
+# `base.py` is explicit that a store never polices it. This one versions the
+# *tables* below, and it is this module's alone to read and migrate. There is no
+# migration to write yet because 1 is the only version that has ever shipped; the
+# branch below is where the next one lands.
+_SCHEMA_VERSION = 1
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS documents (
+    kind TEXT PRIMARY KEY,
+    body TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS query_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entry TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS spend_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    at TEXT,
+    connector TEXT,
+    entry TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_spend_log_at ON spend_log(at);
+CREATE INDEX IF NOT EXISTS idx_spend_log_connector_at ON spend_log(connector, at);
+CREATE TABLE IF NOT EXISTS plans (
+    plan_id TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL,
+    applied_at TEXT,
+    body TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_plans_applied_created ON plans(applied_at, created_at);
+"""
+
+# One re-entrant lock per resolved database path, mirroring FilesystemStore's
+# `_PROCESS_LOCKS`: it is what serializes threads in this process wanting the
+# spend lock, kept separate from the cross-process mechanism below because a
+# `BEGIN IMMEDIATE` on one connection says nothing about a second connection on
+# the same thread trying the same thing.
+_PROCESS_LOCKS: dict[str, threading.RLock] = {}
+_PROCESS_LOCKS_GUARD = threading.Lock()
+
+# Re-entrancy for one holder is tracked here rather than left to the RLock alone,
+# for the same reason FilesystemStore tracks it: the *cross-process* half of the
+# lock is a held SQLite transaction, and a second `BEGIN IMMEDIATE` from the same
+# connection on the same thread would not be a nested acquisition, it would be an
+# error. A nested call takes the fast path below and never touches the connection
+# at all.
+_HELD = threading.local()
+
+
+def _process_lock(key: str) -> threading.RLock:
+    with _PROCESS_LOCKS_GUARD:
+        lock = _PROCESS_LOCKS.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _PROCESS_LOCKS[key] = lock
+        return lock
+
+
+def _held_depths() -> dict[str, int]:
+    depths = getattr(_HELD, "depths", None)
+    if depths is None:
+        depths = {}
+        _HELD.depths = depths
+    return depths
+
+
+class SqliteStore:
+    """Reads and writes `.dex/dex.db` for a given repo root."""
+
+    def __init__(self, repo_root: Path | str = "."):
+        self.root = Path(repo_root)
+        self.dex_dir = self.root / DEX_DIR
+        self.path = self.dex_dir / DB_FILE
+        self._conn: sqlite3.Connection | None = None
+        # Guards every use of `_conn`: the sqlite3 module documents a connection
+        # as safe to share across threads only if the caller serializes access to
+        # it, which this backend is (a host can call any store method from any
+        # thread, the same as the other two backends allow).
+        self._conn_lock = threading.Lock()
+        # A second, dedicated connection to the same file, opened only inside
+        # `spend_lock`. Kept apart from `_conn` so holding the lock's write
+        # transaction open across the caller's block never blocks an unrelated
+        # `load_cache`/`save_cache` on `_conn` from another thread; the lock's
+        # scope is the ledger, not the whole store, the same rule
+        # FilesystemStore's separate `spend.lock` file follows.
+        self._lock_conn: sqlite3.Connection | None = None
+
+    @classmethod
+    def from_context(cls, context: StoreContext) -> SqliteStore:
+        """Build from a :class:`~.base.StoreContext`.
+
+        Same two refusals as :meth:`~.filesystem.FilesystemStore.from_context`,
+        for the same reason: accepted-and-ignored is worse than rejected.
+        """
+
+        if context.repo_root is None:
+            raise ConfigurationError(
+                "the sqlite store keeps state in a single `.dex/dex.db` file and "
+                "so needs a repo root, and this context carries none. Point dex "
+                "at a project (DexEngine.from_repo(repo_root), or the CLI's "
+                "--repo-root), or select a backend that does not need one"
+            )
+        if context.options:
+            raise ConfigurationError(
+                "the sqlite store takes no options and this context carries "
+                f"{', '.join(sorted(context.options))}. Its only input is the "
+                "repo root; an option it silently ignored would look like a "
+                "setting that took effect"
+            )
+        return cls(context.repo_root)
+
+    # --- connection -----------------------------------------------------------
+
+    def _connection(self) -> sqlite3.Connection:
+        """The shared connection, opening and migrating the file on first use.
+
+        Nothing touches disk until the first document, ledger, or plan
+        operation: `locator()` answers from `self.path` alone, and a store built
+        but never used leaves no `.dex/` directory, the same promise
+        FilesystemStore makes.
+        """
+
+        if self._conn is None:
+            self.dex_dir.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(str(self.path), check_same_thread=False)
+            version = conn.execute("PRAGMA user_version").fetchone()[0]
+            if version == 0:
+                conn.executescript(_SCHEMA)
+                conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+                conn.commit()
+            elif version > _SCHEMA_VERSION:
+                conn.close()
+                raise ConfigurationError(
+                    f"{self.path} was written by a newer dex (schema version "
+                    f"{version}) than this one knows how to read (version "
+                    f"{_SCHEMA_VERSION}). Upgrade dex to open it, or point "
+                    "cache.backend at a fresh sqlite file"
+                )
+            # version == _SCHEMA_VERSION: already current. A version between 1
+            # and _SCHEMA_VERSION - 1 would migrate here; none exist yet, because
+            # 1 is the only version that has ever shipped.
+            self._conn = conn
+        return self._conn
+
+    def _lock_connection(self) -> sqlite3.Connection:
+        if self._lock_conn is None:
+            self.dex_dir.mkdir(parents=True, exist_ok=True)
+            self._lock_conn = sqlite3.connect(
+                str(self.path), check_same_thread=False, isolation_level=None
+            )
+        return self._lock_conn
+
+    # --- documents ------------------------------------------------------------
+
+    def load_cache(self) -> DexCache | None:
+        body = self._load_document(Document.CACHE)
+        return None if body is None else DexCache.model_validate_json(body)
+
+    def save_cache(self, cache: DexCache, *, now: datetime | None = None) -> str:
+        if now is not None:
+            cache.provenance.updated_at = now.isoformat()
+        return self._save_document(Document.CACHE, cache.model_dump_json())
+
+    def load_snapshot(self) -> Snapshot | None:
+        from ..maintain.snapshot import Snapshot
+
+        body = self._load_document(Document.SNAPSHOT)
+        return None if body is None else Snapshot.model_validate_json(body)
+
+    def save_snapshot(self, snapshot: Snapshot) -> str:
+        return self._save_document(Document.SNAPSHOT, snapshot.model_dump_json())
+
+    def load_drift(self) -> DriftReport | None:
+        from ..maintain.drift import DriftReport
+
+        body = self._load_document(Document.DRIFT)
+        return None if body is None else DriftReport.model_validate_json(body)
+
+    def save_drift(self, report: DriftReport) -> str:
+        return self._save_document(Document.DRIFT, report.model_dump_json())
+
+    def _load_document(self, document: Document) -> str | None:
+        with self._conn_lock:
+            row = (
+                self._connection()
+                .execute("SELECT body FROM documents WHERE kind = ?", (document.value,))
+                .fetchone()
+            )
+        return None if row is None else row[0]
+
+    def _save_document(self, document: Document, body: str) -> str:
+        with self._conn_lock:
+            conn = self._connection()
+            conn.execute(
+                "INSERT INTO documents(kind, body) VALUES (?, ?) "
+                "ON CONFLICT(kind) DO UPDATE SET body = excluded.body",
+                (document.value, body),
+            )
+            conn.commit()
+        return self.locator(document)
+
+    # --- ledgers --------------------------------------------------------------
+
+    def append_query_log(self, entry: dict) -> None:
+        with self._conn_lock:
+            conn = self._connection()
+            conn.execute(
+                "INSERT INTO query_log(entry) VALUES (?)", (json.dumps(entry),)
+            )
+            conn.commit()
+
+    def append_spend_log(self, entry: dict) -> None:
+        at = entry.get("at")
+        connector = entry.get("connector")
+        with self._conn_lock:
+            conn = self._connection()
+            conn.execute(
+                "INSERT INTO spend_log(at, connector, entry) VALUES (?, ?, ?)",
+                (
+                    at if isinstance(at, str) else None,
+                    connector if isinstance(connector, str) else None,
+                    json.dumps(entry),
+                ),
+            )
+            conn.commit()
+
+    def spend_since(
+        self,
+        cutoff_iso: str,
+        *,
+        field: str = "billed_bytes",
+        connector: str | None = None,
+    ) -> float:
+        # The index on (connector, at) and on (at) alone lets SQLite narrow to the
+        # qualifying rows directly rather than reading every entry ever appended,
+        # which is the whole point: FilesystemStore's equivalent reads and
+        # json.loads()s the entire ledger file on every call. The final
+        # filter-and-sum still goes through spend_total, in Python, so a
+        # malformed field value or a stamp SQL cannot interpret is skipped the
+        # same way every backend skips it, rather than one bad row failing the
+        # whole query.
+        query = (
+            "SELECT entry FROM spend_log WHERE at >= ? AND (? IS NULL OR connector = ?)"
+        )
+        with self._conn_lock:
+            rows = (
+                self._connection()
+                .execute(query, (cutoff_iso, connector, connector))
+                .fetchall()
+            )
+        entries = []
+        for (raw,) in rows:
+            try:
+                entries.append(json.loads(raw))
+            except json.JSONDecodeError:
+                continue
+        return spend_total(entries, cutoff_iso, field=field, connector=connector)
+
+    @contextmanager
+    def spend_lock(self, *, timeout: float = 30.0) -> Iterator[None]:
+        """Serialize the spend admission across every process holding this file.
+
+        The cross-process half is a `BEGIN IMMEDIATE` transaction on a dedicated
+        connection, held open for the duration of the caller's block: SQLite
+        grants that at most one connection to a file at a time, so a second
+        process's `BEGIN IMMEDIATE` on the same file blocks (up to
+        `busy_timeout`) until this one commits. The in-process half is the same
+        `_process_lock`/depth-tracking pattern FilesystemStore uses, needed for
+        the same reason: the OS-level primitive underneath is not itself
+        re-entrant, so a nested acquisition on one thread has to take a fast path
+        that never touches the connection at all.
+        """
+
+        key = str(self.path)
+        depths = _held_depths()
+        if depths.get(key, 0):
+            depths[key] += 1
+            try:
+                yield
+            finally:
+                depths[key] -= 1
+            return
+
+        deadline = time.monotonic() + timeout
+        if not _process_lock(key).acquire(timeout=max(timeout, 0.0)):
+            raise TimeoutError(
+                f"waited {timeout}s for the spend lock on {self.path} and "
+                "another thread still holds it"
+            )
+        try:
+            conn = self._lock_connection()
+            remaining = max(deadline - time.monotonic(), 0.0)
+            conn.execute(f"PRAGMA busy_timeout = {int(remaining * 1000)}")
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+            except sqlite3.OperationalError as exc:
+                raise TimeoutError(
+                    f"waited {timeout}s for the spend lock on {self.path} and "
+                    "another process still holds it"
+                ) from exc
+            depths[key] = 1
+            try:
+                yield
+            finally:
+                depths[key] = 0
+                conn.execute("COMMIT")
+        finally:
+            _process_lock(key).release()
+
+    # --- plans ----------------------------------------------------------------
+
+    def save_plan(self, plan: TransformPlan) -> str:
+        with self._conn_lock:
+            conn = self._connection()
+            conn.execute(
+                "INSERT INTO plans(plan_id, created_at, applied_at, body) "
+                "VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(plan_id) DO UPDATE SET "
+                "created_at = excluded.created_at, "
+                "applied_at = excluded.applied_at, "
+                "body = excluded.body",
+                (
+                    plan.plan_id,
+                    plan.created_at,
+                    plan.applied_at,
+                    plan.model_dump_json(),
+                ),
+            )
+            conn.commit()
+        return self.plan_locator(plan.plan_id)
+
+    def load_plan(self, plan_id: str) -> TransformPlan:
+        from ..transform.plans import PlanNotFoundError, TransformPlan
+
+        with self._conn_lock:
+            row = (
+                self._connection()
+                .execute("SELECT body FROM plans WHERE plan_id = ?", (plan_id,))
+                .fetchone()
+            )
+        if row is None:
+            raise PlanNotFoundError(
+                f"no plan '{plan_id}' in {self.path}; run `transform plan` first "
+                "or check the id"
+            )
+        return TransformPlan.model_validate_json(row[0])
+
+    def list_plans(self) -> list[TransformPlan]:
+        from ..transform.plans import TransformPlan
+
+        with self._conn_lock:
+            rows = (
+                self._connection()
+                .execute("SELECT body FROM plans ORDER BY created_at DESC")
+                .fetchall()
+            )
+        return [TransformPlan.model_validate_json(row[0]) for row in rows]
+
+    def latest_plan(self, kind: EditKind | None = None) -> TransformPlan | None:
+        from ..transform.plans import TransformPlan
+
+        with self._conn_lock:
+            rows = (
+                self._connection()
+                .execute(
+                    "SELECT body FROM plans WHERE applied_at IS NULL "
+                    "ORDER BY created_at DESC"
+                )
+                .fetchall()
+            )
+        for (raw,) in rows:
+            plan = TransformPlan.model_validate_json(raw)
+            if kind is None or all(edit.kind is kind for edit in plan.edits):
+                return plan
+        return None
+
+    # --- locators -------------------------------------------------------------
+
+    def locator(self, document: Document) -> str:
+        return f"{self.path}#{document.value}"
+
+    def plan_locator(self, plan_id: str) -> str:
+        return f"{self.path}#plans/{plan_id}"

--- a/packages/dex-core/tests/storage/test_parity.py
+++ b/packages/dex-core/tests/storage/test_parity.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from exmergo_dex_core.storage import FilesystemStore, MemoryStore
+from exmergo_dex_core.storage import FilesystemStore, MemoryStore, SqliteStore
 from exmergo_dex_core.storage.conformance import SpendLockContract, StoreContract
 
 
@@ -36,3 +36,14 @@ class TestMemoryStore(SpendLockContract, StoreContract):
         # Nothing to key on: a MemoryStore's state is the instance, so a distinct
         # instance is a distinct key by construction.
         return MemoryStore()
+
+
+class TestSqliteStore(SpendLockContract, StoreContract):
+    @pytest.fixture(autouse=True)
+    def _root(self, tmp_path: Path):
+        # Same convention as TestFilesystemStore: one root per test, the key as a
+        # subdirectory, so each gets its own dex.db.
+        self.root = tmp_path
+
+    def make_store(self, key: str) -> SqliteStore:
+        return SqliteStore(self.root / key)

--- a/packages/dex-core/tests/storage/test_resolver.py
+++ b/packages/dex-core/tests/storage/test_resolver.py
@@ -16,6 +16,7 @@ from exmergo_dex_core import ConfigurationError
 from exmergo_dex_core.storage import (
     ExploreStore,
     FilesystemStore,
+    SqliteStore,
     StoreContext,
     build_store,
     resolve_store_factory,
@@ -40,6 +41,12 @@ def _clean_registry():
 def test_the_default_name_builds_the_filesystem_backend(tmp_path: Path):
     store = build_store("filesystem", StoreContext(repo_root=str(tmp_path)))
     assert isinstance(store, FilesystemStore)
+    assert store.root == tmp_path
+
+
+def test_sqlite_is_a_shipped_name_too(tmp_path: Path):
+    store = build_store("sqlite", StoreContext(repo_root=str(tmp_path)))
+    assert isinstance(store, SqliteStore)
     assert store.root == tmp_path
 
 

--- a/packages/dex-core/tests/storage/test_sqlite.py
+++ b/packages/dex-core/tests/storage/test_sqlite.py
@@ -1,0 +1,248 @@
+"""What is true only of the `.dex/dex.db` layout.
+
+The backend-agnostic contract lives in test_parity.py. This file pins the things
+specific to this backend: that everything lands in one file, that the schema
+version is tracked and a newer one is refused, that spend_since answers from an
+indexed query rather than a scan, and the cross-process half of the spend lock
+(a `BEGIN IMMEDIATE` transaction), which the shared conformance suite cannot
+portably assert.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core import ConfigurationError
+from exmergo_dex_core.cache import Dataset, DexCache
+from exmergo_dex_core.storage import Document, StoreContext
+from exmergo_dex_core.storage.sqlite import DB_FILE, DEX_DIR, SqliteStore
+from exmergo_dex_core.transform.plans import EditKind, PlanEdit, TransformPlan
+
+
+def test_nothing_is_created_until_something_is_saved(tmp_path: Path):
+    store = SqliteStore(tmp_path)
+    assert store.load_cache() is None
+    # load_cache is itself a use of the connection (it has to open the file to
+    # find nothing there), so the directory exists after it; what must not exist
+    # is anything left over from a call that never happened.
+    assert (tmp_path / DEX_DIR / DB_FILE).is_file()
+    conn = sqlite3.connect(str(tmp_path / DEX_DIR / DB_FILE))
+    assert conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM plans").fetchone()[0] == 0
+    conn.close()
+
+
+def test_a_fresh_store_created_but_never_touched_leaves_no_file(tmp_path: Path):
+    SqliteStore(tmp_path)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_everything_lands_in_one_file(tmp_path: Path):
+    store = SqliteStore(tmp_path)
+    store.save_cache(DexCache(datasets=[Dataset(identifier="db.main.orders")]))
+    store.append_spend_log({"at": "2026-07-03T10:00:00+00:00", "billed_bytes": 1})
+    store.save_plan(
+        TransformPlan(
+            plan_id="pabc",
+            created_at="2026-07-03T10:00:00+00:00",
+            intent="add a model",
+            project_dir="analytics",
+            edits=[
+                PlanEdit(
+                    path="models/staging/stg_orders.sql",
+                    kind=EditKind.MODEL_SQL,
+                    new_content="select 1 as id\n",
+                )
+            ],
+        )
+    )
+    dex_dir = tmp_path / DEX_DIR
+    assert [p.name for p in dex_dir.iterdir()] == [DB_FILE]
+
+
+def test_the_dex_directory_is_created_on_demand(tmp_path: Path):
+    nested = tmp_path / "deep" / "project"
+    store = SqliteStore(nested)
+    store.append_spend_log({"at": "2026-07-03T10:00:00+00:00", "billed_bytes": 1})
+    assert (nested / DEX_DIR / DB_FILE).is_file()
+
+
+def test_a_fresh_file_is_stamped_with_the_current_schema_version(tmp_path: Path):
+    store = SqliteStore(tmp_path)
+    store.append_query_log({"at": "2026-07-03T10:00:00+00:00", "sql": "select 1"})
+    conn = sqlite3.connect(str(tmp_path / DEX_DIR / DB_FILE))
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+    conn.close()
+
+
+def test_a_file_from_a_newer_dex_is_refused_rather_than_silently_reread(
+    tmp_path: Path,
+):
+    dex_dir = tmp_path / DEX_DIR
+    dex_dir.mkdir()
+    conn = sqlite3.connect(str(dex_dir / DB_FILE))
+    conn.execute("PRAGMA user_version = 999")
+    conn.commit()
+    conn.close()
+
+    store = SqliteStore(tmp_path)
+    with pytest.raises(ConfigurationError) as refusal:
+        store.load_cache()
+    message = str(refusal.value)
+    assert "newer dex" in message
+    assert "999" in message
+
+
+def test_spend_since_answers_from_an_indexed_query_not_a_full_scan(tmp_path: Path):
+    # Not a performance assertion (that would be flaky); a behavioral one that
+    # only an indexed query, not a Python-side filter after loading everything,
+    # can satisfy: the WHERE clause itself has to exclude the other connector's
+    # rows and the pre-cutoff rows, which is exactly what the EXPLAIN plan below
+    # confirms is happening via the index rather than a table scan.
+    store = SqliteStore(tmp_path)
+    for i in range(50):
+        store.append_spend_log(
+            {
+                "at": f"2026-07-{(i % 28) + 1:02d}T10:00:00+00:00",
+                "connector": "bigquery" if i % 2 else "snowflake",
+                "billed_bytes": 10,
+            }
+        )
+    assert store.spend_since("2026-07-15T00:00:00+00:00", connector="bigquery") > 0
+
+    conn = sqlite3.connect(str(tmp_path / DEX_DIR / DB_FILE))
+    plan = conn.execute(
+        "EXPLAIN QUERY PLAN SELECT entry FROM spend_log "
+        "WHERE at >= ? AND (? IS NULL OR connector = ?)",
+        ("2026-07-15T00:00:00+00:00", "bigquery", "bigquery"),
+    ).fetchall()
+    conn.close()
+    plan_text = " ".join(str(row) for row in plan)
+    assert "USING INDEX" in plan_text, (
+        f"spend_since's query plan does not use an index: {plan_text}"
+    )
+
+
+def test_spend_since_skips_a_hand_corrupted_row(tmp_path: Path):
+    # The ledger is a binary file now, not a hand-editable JSONL one, but a row
+    # can still end up holding text that will not parse (a partial write, a
+    # manual UPDATE). The policy is the same as the filesystem backend's: skip
+    # it, do not poison every subsequent budget check.
+    store = SqliteStore(tmp_path)
+    store.append_spend_log({"at": "2026-07-03T10:00:00+00:00", "billed_bytes": 100})
+    conn = sqlite3.connect(str(tmp_path / DEX_DIR / DB_FILE))
+    conn.execute(
+        "INSERT INTO spend_log(at, connector, entry) VALUES (?, ?, ?)",
+        ("2026-07-03T11:00:00+00:00", None, "not json"),
+    )
+    conn.commit()
+    conn.close()
+    assert store.spend_since("2026-07-03T00:00:00+00:00") == 100
+
+
+def test_from_context_keys_the_store_to_the_repo_root(tmp_path: Path):
+    store = SqliteStore.from_context(StoreContext(repo_root=str(tmp_path)))
+    store.save_cache(DexCache(datasets=[Dataset(identifier="db.main.orders")]))
+    assert (tmp_path / DEX_DIR / DB_FILE).is_file()
+
+
+def test_from_context_refuses_a_context_with_no_repo_root():
+    with pytest.raises(ConfigurationError) as refusal:
+        SqliteStore.from_context(StoreContext())
+    assert "repo root" in str(refusal.value)
+
+
+def test_from_context_refuses_options_it_would_have_ignored(tmp_path: Path):
+    with pytest.raises(ConfigurationError) as refusal:
+        SqliteStore.from_context(
+            StoreContext(repo_root=str(tmp_path), options={"tenant": "acme"})
+        )
+    assert "tenant" in str(refusal.value)
+
+
+def test_locators_name_the_file_and_the_document(tmp_path: Path):
+    store = SqliteStore(tmp_path)
+    cache_locator = store.locator(Document.CACHE)
+    assert str(tmp_path / DEX_DIR / DB_FILE) in cache_locator
+    assert "cache" in cache_locator
+    assert store.plan_locator("pabc") != cache_locator
+
+
+# --- the spend lock, in the shape only this backend has -------------------------
+
+_LOCK_CHILD = """
+import sys, time
+from exmergo_dex_core.storage.sqlite import SqliteStore
+
+store = SqliteStore(sys.argv[1])
+with store.spend_lock():
+    print("held", flush=True)
+    time.sleep(float(sys.argv[2]))
+"""
+
+
+def test_the_spend_lock_excludes_another_process(tmp_path: Path):
+    """The property the conformance contract cannot portably assert.
+
+    A `threading.Lock` satisfies every assertion the shipped contract makes and
+    would leave the CLI exactly as broken as it was, because the CLI is one
+    command per process and the file on disk is all two commands share.
+    """
+
+    import subprocess
+    import sys as _sys
+
+    store = SqliteStore(tmp_path)
+    child = subprocess.Popen(  # noqa: S603
+        [_sys.executable, "-c", _LOCK_CHILD, str(tmp_path), "0.5"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout.readline().strip() == "held"
+        started = time.monotonic()
+        with store.spend_lock():
+            waited = time.monotonic() - started
+    finally:
+        child.wait(timeout=30)
+    assert waited > 0.2, (
+        f"took the lock after {waited:.3f}s while another process held it, so "
+        "two CLI commands can be admitted against the same headroom"
+    )
+
+
+def test_a_contended_lock_gives_up_rather_than_waiting_forever(tmp_path: Path):
+    import subprocess
+    import sys as _sys
+
+    store = SqliteStore(tmp_path)
+    child = subprocess.Popen(  # noqa: S603
+        [_sys.executable, "-c", _LOCK_CHILD, str(tmp_path), "2"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout.readline().strip() == "held"
+        with (
+            pytest.raises(TimeoutError) as refusal,
+            store.spend_lock(timeout=0.2),
+        ):
+            pass
+    finally:
+        child.wait(timeout=30)
+    assert "spend lock" in str(refusal.value)
+
+
+def test_the_lock_does_not_block_an_unrelated_document_read(tmp_path: Path):
+    # The lock is scoped to the ledger, not the whole store: a document read on
+    # the main connection must not wait behind a held spend lock.
+    store = SqliteStore(tmp_path)
+    store.save_cache(DexCache(datasets=[Dataset(identifier="db.main.orders")]))
+    with store.spend_lock():
+        loaded = store.load_cache()
+    assert loaded is not None
+    assert [d.identifier for d in loaded.datasets] == ["db.main.orders"]

--- a/references/storage.md
+++ b/references/storage.md
@@ -12,10 +12,16 @@ cache, the reconcile baseline, the last drift report, the append-only query and
 spend ledgers, and the stored transform plans. Delete all of it and nothing
 canonical is lost. That is what a `Store` holds.
 
-Two backends ship. `FilesystemStore` writes plain files under `.dex/` and is what
-the CLI uses, so persistence is git and a reviewer can read the state in a pull
-request. `MemoryStore` writes nothing and is the library default, which is why
-`import exmergo_dex_core` cannot leave a `.dex/` directory in a consumer's repo.
+Three backends ship. `FilesystemStore` writes plain files under `.dex/` and is
+what the CLI uses by default, so persistence is git and a reviewer can read the
+state in a pull request. `MemoryStore` writes nothing and is the library
+default, which is why `import exmergo_dex_core` cannot leave a `.dex/` directory
+in a consumer's repo. `SqliteStore` is opt-in: one `.dex/dex.db` file with real
+tables in place of loose JSON, for a host that wants durable local state without
+a directory of files to review, gitignore, or clean up. Select it with
+`cache.backend: sqlite` or `--cache-backend sqlite`; `filesystem` stays the
+default, and `.dex/dex.db` is not reviewable the way `.dex/cache.json` is, so add
+it to `.gitignore` the way you would any local database file.
 
 Secrets never live in any backend.
 
@@ -468,7 +474,7 @@ order:
 
 | Name | Example | For |
 |---|---|---|
-| shipped | `filesystem` | dex's own backends, and never shadowable by anything installed |
+| shipped | `filesystem`, `sqlite` | dex's own backends, and never shadowable by anything installed |
 | dotted path | `mypkg.stores:my_store` | a factory reachable by import, with no packaging work |
 | entry point | `acme` | a name an installed distribution registered under `exmergo_dex_core.stores` |
 
@@ -502,10 +508,10 @@ exists.
 
 Recorded so they are not re-argued.
 
-**Always pass `repo_root`.** It builds both shipped backends and would build an
-opt-in SQLite file, and it cannot build a tenant-keyed backend at all. That is the
-class of backend this seam was made public for, and widening a released config
-schema afterwards costs a deprecation.
+**Always pass `repo_root`.** It builds all three shipped backends, but it cannot
+build a tenant-keyed backend at all. That is the class of backend this seam was
+made public for, and widening a released config schema afterwards costs a
+deprecation.
 
 **Require a `from_config` classmethod on the store.** It puts an obligation on the
 structural protocol, which is what makes "no base class to inherit and no


### PR DESCRIPTION
Closes: https://github.com/exmergo/dex/issues/139
- Adds `SqliteStore`, an opt-in cache backend that writes a single
  `.dex/dex.db` file instead of the loose JSON `FilesystemStore`
  writes under `.dex/`. Select it with `cache.backend: sqlite` in
  `.dex/config.yml` or `--cache-backend sqlite` for one run;
  `filesystem` stays the default.
- Implements the full storage Protocol from #137: the cache,
  snapshot, drift report, transform plans, and both ledgers.
  `spend_since` (what the cumulative session budget reads on every
  billed command) answers from an indexed query on the ledger's
  `at`/`connector` columns instead of scanning every line ever
  appended.
- The cross-process spend lock is a `BEGIN IMMEDIATE` transaction on
  the database file itself, so the cumulative ceiling still binds
  across two CLI processes sharing a repo, the same guarantee
  `FilesystemStore`'s advisory file lock provides.
- No new dependency (stdlib `sqlite3`); no changes needed to
  `config.py`'s `cache.backend` field, `cli.py`'s `--cache-backend`
  flag, or `engine.py`, since all three were already fully wired to
  the resolver before this change. The only wiring was adding
  `SqliteStore.from_context` to `resolver.py`'s `SHIPPED` registry.
- `.dex/dex.db` is a binary file, not a JSON document a reviewer can
  diff, so it belongs in `.gitignore` (documented in
  `references/storage.md`).
Before:
<img width="1563" height="112" alt="Screenshot 2026-08-26 141345" src="https://github.com/user-attachments/assets/9b6bf394-2db2-41af-831b-6aac2ce023e0" />
After: 
<img width="1563" height="697" alt="Screenshot 2026-08-26 141402" src="https://github.com/user-attachments/assets/4485c2a1-16ef-4e3c-ba74-7f9b1ae043db" />
<img width="1581" height="376" alt="Screenshot 2026-08-26 141904" src="https://github.com/user-attachments/assets/93ff05e2-f3d3-4601-87bf-15f9f3ae610c" />
