### PR TITLE
`maintain grain` re-verifies the grains your project declares

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ credentials and no network.
 | `maintain check` | sweep every drift axis vs the snapshot; ranked drift report (read-only); two-phase on billed connectors (free axes now, one estimate for the scanning axes) |
 | `maintain schema [<objects>]` | structural drift: columns/tables added, dropped, retyped, renamed; nullability; dangling sources (free) |
 | `maintain volume [<objects>]` | freshness drift: row counts that collapsed, emptied, or spiked (free metadata) |
-| `maintain grain [<objects>]` | cardinality/identity drift: lost key uniqueness, changed grain, join fanout (scans; gated on billed connectors) |
+| `maintain grain [<objects>]` | cardinality/identity drift: lost key uniqueness, changed grain, join fanout, plus the grains the project itself declares (model-level `unique_combination_of_columns`) re-verified against the data (scans; gated on billed connectors). Two codes come out of the uniqueness checks and the difference is the baseline: `key_lost_uniqueness` is a key measurement proved unique and no longer is, `declared_grain_not_unique` is a declared combination that never held, which is a declaration to fix rather than drift to absorb |
 | `maintain semantic [<objects>]` | definition drift and dangling refs (free) plus categorical dimension cardinality change (scans; gated on billed connectors) |
 | `maintain reconcile [<class>]` | propose the dbt edits that reconcile detected drift, as a stored plan of diffs tagged mechanical or advisory (never applied; apply with `transform apply <plan-id>`) |
 | `viz preview` | emit the dbt semantic model to the Viz preview (not yet implemented) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-25
+
 ### Added
 
 - **An opt-in SQLite cache backend** ([#139]). `FilesystemStore` writes loose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,48 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   lost. Capped at 200 occurrences across 50 files with every elision counted in
   `notes`; `--full` lifts both.
 
+- **`maintain grain` re-verifies the grains your project declares** ([#337]). The
+  axis checked what explore had *measured* and nothing else, which left a blind
+  spot on exactly the tables where grain matters most. Explore lets a
+  measurement-proven single column win the reported grain over a declared
+  composite, and its candidate keys stay measurement-only because an unmeasured
+  declared key is a claim rather than a baseline. Both are the right calls for a
+  cache, and together they meant a fact table declaring a four-column grain never
+  had that grain checked, while a member column that happened to be unique in the
+  early data was checked every run.
+
+  A model-level `unique_combination_of_columns` now enters the plan alongside the
+  measured combinations, resolved to a warehouse object the same way explore
+  resolves a declaration for a diagram. It reports under its own code,
+  `declared_grain_not_unique`, because a failure there is not drift:
+  `key_lost_uniqueness` has a measured before and after, so something changed,
+  while a declared combination has neither and the honest reading is that the
+  project asserts a grain the data never had. Reconcile treats them differently
+  for the same reason, and proposes no edit for either, since widening or
+  narrowing a declared grain is choosing one.
+
+  **Declared grains are surveyed against the current warehouse, not against the
+  baseline**, which is the one way they differ structurally from every other check
+  on this axis. A measured check needs a before to compare with, so it can only
+  speak about an object the baseline captured. A declaration needs nothing of the
+  kind: the project's claim is the standard, and the question is whether today's
+  data meets it. So a model built since the last snapshot has its declared grain
+  checked, which is exactly when a freshly declared grain is most likely to be
+  wrong. For the same reason, a declared grain that does not hold is not absorbed
+  by re-running `maintain snapshot`: pinning current state as known-good settles
+  drift, and this was never drift.
+
+  **This costs more on a metered connector, and the cost is surfaced before it is
+  spent.** The declared combinations are surveyed and priced from the same plan
+  the run executes, so the dry-run figure in the handshake covers them and an
+  operator can decline. That parity was promised by construction and asserted by
+  nothing, and is now pinned by a spine test that fails if a scan ever reaches
+  execution without appearing in the estimate. Three ways a declaration can go
+  unverified are each reported as a note rather than dropped, because an
+  unverified grain and a holding one look identical from the envelope: one that
+  resolves to no warehouse object or to several, one naming columns the table does
+  not have, and a connector with no combination probe at all.
+
 ### Changed
 
 - **The delete guard reads the reference index rather than the file text**
@@ -451,6 +493,32 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   warehouse is most of them. The suite never saw it because every fake fed a
   plain Python list. Now an explicit `is None` check, with a test that feeds the
   ndarray the driver actually returns.
+
+- **`maintain reconcile` no longer proposes a column-level `unique` against a
+  declared composite grain** ([#337], reported by @catincloudlabs). The proposal
+  applied cleanly, reported `conflicts=0`, and changed nothing the project
+  declared. The edit asserted something the project explicitly does not claim: on
+  the shipped dbt format both tests run independently, so the new one failed every
+  build from then on and could only go green by changing the declared grain, while
+  a format that resolves the two as dbt's semantics imply discarded it and the
+  plan applied having changed nothing. Across a real declarations directory there
+  was no model for which the proposal did anything.
+
+  Reconcile now asks the project what it declares, through the tier-1
+  `definitions()` channel rather than by re-reading YAML, and declines when a
+  declared composite grain covers the drifted column. The warning names the
+  combination, because that is the fact that decides what happens next: either the
+  composite is still the grain and the baseline needs re-taking, or something
+  downstream relied on that column alone and the assumption is now false.
+
+  Two smaller things went with it. The advisory action for `key_lost_uniqueness`
+  promised "the unique test keeps the break visible in builds" unconditionally,
+  while the test edit could be declined on five separate paths, so the payload
+  routinely claimed an edit that was not in the plan; the clause is now appended
+  only where an edit was produced. And reconcile was the one project-reading
+  command that dropped `_layer_notes`, on a channel (`ProjectDefinitions.notes`)
+  that no command read at all, so a format explaining what it could not supply was
+  explaining it to nobody at the moment an edit was at stake.
 
 ## [1.7.0] - 2026-08-25
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
@@ -275,6 +275,14 @@ class DeclaringProjectContract:
         differently shaped. Override it if you can express one, because
         ``declared_composite_keys`` is a separate field from ``declared_keys``
         and nothing else in this suite reaches it.
+
+        **What getting this wrong costs, now that the field is read.** It is no
+        longer decoration on a diagram. The grain axis re-verifies the
+        combinations that arrive here, and reconcile checks them before proposing
+        a column-level ``unique``, so a format that leaves this empty loses grain
+        verification on exactly the tables whose grain is composite, and gets
+        offered ``unique`` tests on their member columns: assertions its own
+        parser is entitled to discard and dbt is entitled to fail every build on.
         """
 
         return None
@@ -366,6 +374,26 @@ class DeclaringProjectContract:
         assert tuple(matching[0].columns) == tuple(columns), (
             f"expected columns {tuple(columns)} in order, got "
             f"{tuple(matching[0].columns)}"
+        )
+        assert len(matching) == 1, (
+            f"expected one composite key on {model}, got {len(matching)}: "
+            f"{matching}. One declaration is one grain, and splitting it across "
+            "entries makes the grain axis verify combinations the project never "
+            "declared"
+        )
+        leaked = sorted(
+            key.column
+            for key in project.definitions().declared_keys
+            if key.model == model
+            and key.unique
+            and key.column.lower() in {c.lower() for c in columns}
+        )
+        assert not leaked, (
+            f"{model} reports {leaked} as unique on their own while also declaring "
+            f"the composite grain {tuple(columns)}. The fixture's grain needs every "
+            "one of those columns, so no single one of them is unique, and the "
+            "stronger claim is the one that gets acted on: reconcile reads it as a "
+            "grain the project already asserts and proposes edits against it"
         )
 
     def test_a_join_keeps_its_two_sides_apart_when_they_are_named_differently(

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -462,8 +462,15 @@ def grain_drift(engine: DexEngine, objects: list[str] | None = None) -> DriftRes
         if scope_names
         else None
     )
-    plan = drift_mod.grain_plan(adapter, snap, scope)
-    if plan.key_checks or plan.fanout_pairs or plan.composite_checks:
+    plan = drift_mod.grain_plan(
+        adapter, snap, scope, engine.project_format().definitions()
+    )
+    if (
+        plan.key_checks
+        or plan.fanout_pairs
+        or plan.composite_checks
+        or plan.declared_composite_checks
+    ):
         estimate, per_table = drift_mod.grain_estimate(adapter, plan)
         command_args.billed_handshake(
             "maintain grain", adapter, estimate, per_table=per_table
@@ -472,7 +479,9 @@ def grain_drift(engine: DexEngine, objects: list[str] | None = None) -> DriftRes
         adapter, plan, timeout_seconds=engine.config.query.timeout_seconds
     )
     noted = {dataset.identifier for dataset, _keys, _rows in plan.key_checks} | {
-        dataset.identifier for dataset, _combos, _rows in plan.composite_checks
+        dataset.identifier
+        for dataset, _combos, _rows in plan.composite_checks
+        + plan.declared_composite_checks
     }
     notes = _adapter_notes(adapter, sorted(noted))
 
@@ -486,6 +495,7 @@ def grain_drift(engine: DexEngine, objects: list[str] | None = None) -> DriftRes
         warnings=_grain_baseline_warnings(snap)
         + _column_detail_warnings(snap)
         + _baseline_warnings(store, snap, engine.config.profile_freshness_hours)
+        + plan.notes
         + notes,
     )
     return command_args.stamp_spend(result, adapter)
@@ -637,10 +647,19 @@ def check(engine: DexEngine, objects: list[str] | None = None) -> DriftResult:
         else []
     )
 
-    plan = drift_mod.grain_plan(adapter, snap, scope)
+    plan = drift_mod.grain_plan(
+        adapter, snap, scope, engine.project_format().definitions()
+    )
+    # Added before both returns, so a declared grain the survey could not reach
+    # is reported whether the scans run or stop at the handshake.
+    warnings.extend(plan.notes)
     checks = drift_mod.cardinality_plan(current_semantic, snap, names)
     scans_needed = bool(
-        plan.key_checks or plan.fanout_pairs or plan.composite_checks or checks
+        plan.key_checks
+        or plan.fanout_pairs
+        or plan.composite_checks
+        or plan.declared_composite_checks
+        or checks
     )
     pending: ConfirmationRequest | None = None
     if scans_needed and command_args.cost_gate(adapter) is not None:
@@ -801,6 +820,11 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
     # refusal raised from inside an argument list reads as though `build` did it.
     cache = readable_cache(store)
 
+    # What the project declares, which is a different question from what its
+    # files contain. `view` carries the bytes an edit is pinned against; this
+    # carries the grain, and an edit that contradicts a declared grain is one no
+    # format is obliged to keep. Tier 1, so it cannot raise.
+    definitions = engine.project_format().definitions()
     proposals, edits, build_warnings = reconcile_mod.build(
         findings,
         snap,
@@ -808,8 +832,15 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
         view,
         pii_overrides=pii_override_paths(engine.config.pii_overrides),
         placement=editable if isinstance(editable, PlacingProject) else None,
+        definitions=definitions,
     )
     warnings.extend(build_warnings)
+    # Reconcile was the one project-reading command that dropped these, and the
+    # declarations channel is one no command read at all: a format that says it
+    # could not supply something says it here too, where an edit is at stake.
+    warnings.extend(
+        _layer_notes(definitions, snap.transform_layer, snap.semantic_layer)
+    )
 
     result = ReconcileResult(proposals=proposals, warnings=warnings)
     # A plan is pinned to the directory its edits were planned against, so there is
@@ -1047,6 +1078,12 @@ def _layer_notes(*layers: object) -> list[str]:
     project. Surfacing one side would leave the other axis's limits unexplained.
     In practice both come from the same format and say the same thing, so the
     common case deduplicates to one line.
+
+    Anything carrying ``notes`` is accepted, not only the two snapshot layers.
+    ``ProjectDefinitions`` carries them on the declarations channel, which is
+    where a format explains an ambiguous or unreadable project, and reconcile
+    reads that one because a declaration it could not see is the difference
+    between declining an edit and proposing a wrong one.
     """
 
     seen: list[str] = []

--- a/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel, Field
 
 from ..adapters.base import Adapter, distinct_combination_sql
 from ..cache import Dataset, Relationship, match_identifier
+from ..dbt_project import ProjectDefinitions
 from ..explore import relationships as rel_mod
 from .snapshot import SemanticLayer, Snapshot, TransformLayer
 
@@ -410,11 +411,36 @@ class GrainPlan(NamedTuple):
     # Proven multi-column keys re-verified as combinations: their members are
     # not individually unique, so they never enter key_checks.
     composite_checks: list[tuple[Dataset, list[list[str]], int]]
+    # Grains the *project* declares (model-level unique_combination_of_columns)
+    # that measurement never proved. Kept apart from `composite_checks` because
+    # a failure here is a different fact with a different finding code: nothing
+    # lapsed, the declaration was never true. Priced identically.
+    declared_composite_checks: list[tuple[Dataset, list[list[str]], int]]
+    # What the plan could not survey, so an unchecked declaration never reads as
+    # a clean bill.
+    notes: list[str]
 
 
 def grain_plan(
-    adapter: Adapter, snap: Snapshot, scope: set[str] | None = None
+    adapter: Adapter,
+    snap: Snapshot,
+    scope: set[str] | None = None,
+    definitions: ProjectDefinitions | None = None,
 ) -> GrainPlan:
+    """Survey the grain scans from free metadata, measured and declared.
+
+    ``definitions`` is the project speaking for itself. Measurement and
+    declaration disagree more often than they look like they should: explore
+    lets a measurement-proven single column win the grain verdict over a
+    declared composite, and ``candidate_keys`` stays measurement-only because an
+    unmeasured declared key is a claim rather than a baseline. Both are the right
+    calls for a cache, and together they mean the grain a project actually
+    declares was never re-verified on exactly the tables where it matters most.
+    Reading the declaration here, at plan time, closes that without putting a
+    claim into the measurement store: the declared combinations are surveyed and
+    priced with the measured ones, and the cache is untouched.
+    """
+
     described: dict[str, tuple[set[str], int | None]] = {}
     current = {meta.identifier for meta in adapter.list_objects()}
 
@@ -424,8 +450,12 @@ def grain_plan(
             described[identifier] = ({c.name for c in columns}, meta.row_count)
         return described[identifier]
 
+    declared_by_identifier, notes = _declared_composites(
+        definitions, sorted(current), scope
+    )
     key_checks: list[tuple[Dataset, list[str], int]] = []
     composite_checks: list[tuple[Dataset, list[list[str]], int]] = []
+    declared_checks: list[tuple[Dataset, list[list[str]], int]] = []
     for dataset in snap.warehouse.datasets:
         if scope is not None and dataset.identifier not in scope:
             continue
@@ -460,6 +490,59 @@ def grain_plan(
         if live_composites and row_count:
             composite_checks.append((dataset, live_composites, row_count))
 
+    # Declared grains are surveyed against the *current* warehouse rather than
+    # against the baseline, which is the one way they differ structurally from
+    # everything above. A measured check needs a before to compare with, so it can
+    # only speak about an object the baseline captured. A declaration needs
+    # nothing of the kind: the project's claim is the standard, and the question
+    # is whether the data meets it today. Driving these off the baseline too would
+    # go quiet on a model built since the last snapshot, which is exactly when a
+    # freshly declared grain is most likely to be wrong.
+    measured_composites = {
+        dataset.identifier: combos for dataset, combos, _rows in composite_checks
+    }
+    baselined = {dataset.identifier: dataset for dataset in snap.warehouse.datasets}
+    for identifier, declared in sorted(declared_by_identifier.items()):
+        columns, row_count = describe(identifier)
+        # A declared combination measurement also proved is checked once, as a
+        # measured one: it has a baseline, so `key_lost_uniqueness` is the true
+        # statement about it and the weaker declared code would be a downgrade.
+        known = measured_composites.get(identifier, [])
+        live_declared = [
+            combo
+            for combo in declared
+            if set(combo) <= columns
+            and not any(_same_combo(combo, seen) for seen in known)
+        ]
+        missing = [combo for combo in declared if not set(combo) <= columns]
+        if missing:
+            notes.append(
+                f"the declared grain on {identifier} names columns it does not "
+                "have ("
+                + "; ".join(
+                    ", ".join(sorted(set(combo) - columns)) for combo in missing
+                )
+                + "), so it was not verified"
+            )
+        if not live_declared:
+            continue
+        if not row_count:
+            notes.append(
+                f"{identifier} has no row count to compare against, so its "
+                "declared grain was not verified"
+            )
+            continue
+        # A `Dataset` carrying only the identifier where the baseline has none:
+        # the declared pass reads nothing else off it, and inventing measurements
+        # for an object nobody profiled would put a claim where a baseline goes.
+        declared_checks.append(
+            (
+                baselined.get(identifier) or Dataset(identifier=identifier),
+                live_declared,
+                row_count,
+            )
+        )
+
     fanout_pairs: list[tuple[Relationship, Relationship]] = []
     for rel in snap.warehouse.relationships:
         if not rel.verified or rel.orphan_fraction is None:
@@ -472,11 +555,82 @@ def grain_plan(
         to_columns, _ = describe(rel.to_dataset)
         if rel.from_columns[0] in from_columns and rel.to_columns[0] in to_columns:
             fanout_pairs.append((rel, rel.model_copy(deep=True)))
-    return GrainPlan(key_checks, fanout_pairs, composite_checks)
+    unsurveyed = [
+        dataset.identifier
+        for dataset, _combos, _rows in declared_checks
+        if getattr(adapter, "distinct_combination_counts", None) is None
+    ]
+    if unsurveyed:
+        # Named rather than dropped: an adapter with no combination probe cannot
+        # verify a declared grain, and a plan that quietly omitted the scan would
+        # report the same empty result a holding grain does.
+        notes = [
+            *notes,
+            "this connector cannot probe column combinations, so the declared "
+            "grains on " + ", ".join(sorted(set(unsurveyed))) + " were not verified",
+        ]
+        declared_checks = []
+    return GrainPlan(key_checks, fanout_pairs, composite_checks, declared_checks, notes)
+
+
+def _same_combo(left: list[str], right: list[str]) -> bool:
+    """Two column combinations naming the same grain: order and case are the
+    project's spelling choices, not part of what the combination asserts."""
+
+    return {c.lower() for c in left} == {c.lower() for c in right}
+
+
+def _declared_composites(
+    definitions: ProjectDefinitions | None,
+    known: list[str],
+    scope: set[str] | None,
+) -> tuple[dict[str, list[list[str]]], list[str]]:
+    """Declared composite grains keyed by warehouse identifier, and what could
+    not be resolved.
+
+    A declaration names a *model*; the plan scans an *identifier*. Resolution
+    goes through the same ``resolve_declared`` explore uses, so a declaration
+    that maps cleanly for the diagram maps cleanly here. Both failure modes are
+    noted rather than skipped, because "no finding" is what a holding grain also
+    looks like.
+    """
+
+    if definitions is None or not definitions.declared_composite_keys:
+        return {}, []
+
+    by_identifier: dict[str, list[list[str]]] = {}
+    notes: list[str] = []
+    for composite in definitions.declared_composite_keys:
+        identifier, ambiguous = rel_mod.resolve_declared(
+            composite.relation, composite.model, known
+        )
+        if identifier is None:
+            notes.append(
+                f"the declared grain on '{composite.model}' "
+                f"({', '.join(composite.columns)}) "
+                + (
+                    "matches several warehouse objects"
+                    if ambiguous
+                    else "matches no warehouse object"
+                )
+                + ", so it was not verified"
+            )
+            continue
+        if scope is not None and identifier not in scope:
+            continue
+        bucket = by_identifier.setdefault(identifier, [])
+        if not any(_same_combo(composite.columns, seen) for seen in bucket):
+            bucket.append(list(composite.columns))
+    return by_identifier, notes
 
 
 def grain_estimate(adapter: Adapter, plan: GrainPlan) -> tuple[float, dict[str, float]]:
-    """Free dry-run pricing of the plan's scans; zero on free adapters."""
+    """Free dry-run pricing of the plan's scans; zero on free adapters.
+
+    Every list on the plan is priced, declared combinations included: the plan is
+    the single survey both this and ``grain_drift`` read, so a scan that reaches
+    execution without appearing here would be spend the operator never saw.
+    """
 
     query_estimate = getattr(adapter, "query_estimate", None)
     if query_estimate is None:
@@ -486,7 +640,9 @@ def grain_estimate(adapter: Adapter, plan: GrainPlan) -> tuple[float, dict[str, 
         per_table[dataset.identifier] = query_estimate(
             _distinct_count_sql(dataset.identifier, keys, adapter.dialect)
         )
-    for dataset, combos, _row_count in plan.composite_checks:
+    for dataset, combos, _row_count in (
+        plan.composite_checks + plan.declared_composite_checks
+    ):
         per_table[dataset.identifier] = per_table.get(
             dataset.identifier, 0.0
         ) + query_estimate(
@@ -504,9 +660,17 @@ def grain_drift(
     adapter: Adapter, plan: GrainPlan, *, timeout_seconds: float = 30.0
 ) -> list[DriftFinding]:
     """Cardinality and identity drift, from aggregates only: exact distinct
-    counts against the baseline's proven keys, and the overlap probes re-run
-    against their baseline orphan fractions. Billed on metered connectors; the
-    command layer holds the handshake."""
+    counts against the baseline's proven keys, the grains the project declares
+    re-verified, and the overlap probes re-run against their baseline orphan
+    fractions. Billed on metered connectors; the command layer holds the
+    handshake.
+
+    Two codes come out of the uniqueness checks and the difference is the
+    baseline, not the SQL. ``key_lost_uniqueness`` needs a measured before: a key
+    explore proved unique and no longer is. ``declared_grain_not_unique`` has no
+    before at all, because the combination comes from the project rather than
+    from a measurement, so the honest reading of a failure is that the
+    declaration is false rather than that anything changed."""
 
     findings: list[DriftFinding] = []
     for dataset, keys, row_count in plan.key_checks:
@@ -578,6 +742,47 @@ def grain_drift(
                         "was_grain": bool(
                             dataset.grain and list(combo) == list(dataset.grain)
                         ),
+                    },
+                )
+            )
+
+    # The declared grains, reported under their own code. Nothing lapsed here:
+    # measurement never proved these unique, so there is no before-and-after and
+    # "no longer unique" would be a false account of the same numbers. What the
+    # numbers say is that the project asserts a grain the data does not have.
+    for dataset, combos, row_count in plan.declared_composite_checks:
+        if combo_counts is None:
+            break
+        counts = combo_counts(dataset.identifier, combos)
+        live_meta, _ = adapter.table_metadata(dataset.identifier)
+        if live_meta.row_count is not None:
+            row_count = live_meta.row_count
+        for combo in combos:
+            count = counts.get(tuple(combo))
+            if count is None or count >= row_count:
+                continue
+            duplicates = row_count - count
+            members = ", ".join(combo)
+            findings.append(
+                DriftFinding(
+                    axis="grain",
+                    code="declared_grain_not_unique",
+                    identifier=dataset.identifier,
+                    column=members,
+                    severity="high",
+                    detail=(
+                        f"the project declares ({members}) as the grain of "
+                        f"{dataset.identifier}, and the combination is not "
+                        f"unique: {count} distinct combinations over "
+                        f"{row_count} rows (~{duplicates} duplicate rows). "
+                        "Builds asserting this grain will fail and joins on it "
+                        "will fan out"
+                    ),
+                    data={
+                        "columns": list(combo),
+                        "distinct_count": count,
+                        "row_count": row_count,
+                        "declared": True,
                     },
                 )
             )

--- a/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel, Field
 from ..adapters.project import PlacingProject
 from ..cache import ColumnProfile, Dataset, DexCache
 from ..config import PIIOverrideMatcher
-from ..dbt_project import DbtProjectView
+from ..dbt_project import DbtProjectView, ProjectDefinitions
 from ..explore.profile import detect_pii
 from ..transform.plans import EditKind, PlanEdit
 from ..transform.scaffold import model_edits
@@ -83,6 +83,7 @@ def build(
     *,
     pii_overrides: PIIOverrideMatcher | None = None,
     placement: PlacingProject | None = None,
+    definitions: ProjectDefinitions | None = None,
 ) -> tuple[list[Proposal], list[PlanEdit], list[str]]:
     """Map findings to proposals and plan edits. Pure: writes nothing.
 
@@ -98,7 +99,15 @@ def build(
 
     ``placement`` is the format answering where each edit lands. ``None`` keeps
     the dbt scaffold convention this module hard-coded before the seam existed,
-    so a caller that does not pass one is unaffected."""
+    so a caller that does not pass one is unaffected.
+
+    ``definitions`` is the format answering what the project *declares*, which is
+    the question a file's bytes cannot answer. A model may declare a composite
+    grain, and a column-level ``unique`` on one of its members then asserts
+    something the project explicitly does not claim: dbt runs both tests and the
+    new one fails every build forever, while a format that resolves the two the
+    way dbt's semantics imply discards it. Neither is an edit worth proposing, so
+    without this the module could only propose it and hope."""
 
     proposals: list[Proposal] = []
     edits: list[PlanEdit] = []
@@ -195,7 +204,9 @@ def build(
             )
         )
 
-    grain_edits, grain_warnings = _grain_test_edits(proposals, view, placement)
+    grain_edits, grain_warnings = _grain_test_edits(
+        proposals, view, placement, definitions
+    )
     edits.extend(grain_edits)
     warnings.extend(grain_warnings)
 
@@ -249,9 +260,20 @@ def _advisory(finding: DriftFinding) -> Proposal:
             "check the load or pipeline; if the new volume is expected, re-run "
             "`explore map` and `maintain snapshot` to accept it"
         ),
+        # No promise of a test here. `_grain_test_edits` runs after this and
+        # declines on five separate paths, so a clause asserting an edit would be
+        # false on most of them; it appends the clause itself where it does emit
+        # one.
         "key_lost_uniqueness": (
             "decide: dedup upstream, change the declared grain, or accept the "
-            "duplicates; the unique test keeps the break visible in builds"
+            "duplicates"
+        ),
+        "declared_grain_not_unique": (
+            "the project asserts a grain the data does not have, so this is a "
+            "declaration to fix rather than drift to absorb: widen the "
+            "combination to the real grain, dedup upstream, or drop the claim. "
+            "dex proposes no edit, because narrowing or widening a declared "
+            "grain is choosing one"
         ),
         "join_orphans_increased": (
             "investigate the upstream load; a dbt `relationships` test would "
@@ -335,19 +357,29 @@ def _patched_dataset(
     return patched
 
 
+#: Appended to a key_lost_uniqueness action only where a test edit is actually
+#: in the plan. Kept here rather than in `_advisory`'s table because the two run
+#: in that order and only this side knows the answer.
+_TEST_EDIT_CLAUSE = "; the unique test keeps the break visible in builds"
+
+
 def _grain_test_edits(
     proposals: list[Proposal],
     view: DbtProjectView | None,
     placement: PlacingProject | None = None,
+    definitions: ProjectDefinitions | None = None,
 ) -> tuple[list[PlanEdit], list[str]]:
     """Back key_lost_uniqueness proposals with a `unique` test edit when the
-    scaffolded YAML exists and does not already alert. The duplicates
-    themselves stay a human decision; the edit only makes the break visible.
+    scaffolded YAML exists, does not already alert, and the project does not
+    declare a composite grain over that column. The duplicates themselves stay a
+    human decision; the edit only makes the break visible.
 
-    Every path out of this that produces no edit says so in ``warnings``. The
-    proposal itself survives either way, so a silent skip here would leave a
-    reader looking at a `key_lost_uniqueness` proposal with no test edit and no
-    way to tell whether dex declined or failed."""
+    Every path out of this that produces no edit says so in ``warnings``, and the
+    action string gains its "the unique test keeps the break visible" clause only
+    where an edit was produced. The proposal itself survives either way, so a
+    silent skip would leave a reader looking at a `key_lost_uniqueness` proposal
+    with no test edit and no way to tell whether dex declined or failed, and an
+    unconditional promise would tell them an edit landed when none did."""
 
     if view is None:
         return [], []
@@ -419,6 +451,37 @@ def _grain_test_edits(
             continue
         if "unique" in (entry.get("tests") or []):
             continue  # already alerting
+        composite, unresolved = _declared_grain(definitions, declared, proposal.column)
+        if unresolved:
+            # Not a decline: nothing established that a composite covers this
+            # column, so the edit stands. What is missing is the confidence, and
+            # a reader deciding whether to apply the diff should know the check
+            # could not run rather than read silence as a clean answer.
+            warnings.append(
+                f"the project's declarations for '{declared}' could not be read "
+                f"({unresolved}), so the `unique` test proposed on "
+                f"{proposal.identifier}.{proposal.column} was not checked against "
+                "a declared composite grain; confirm the model's grain before "
+                "applying"
+            )
+        elif composite is not None:
+            # The edit would assert a grain the project does not claim. dbt runs
+            # a column-level `unique` and a `unique_combination_of_columns`
+            # independently, so it would fail every build from here on and could
+            # only go green by changing the declared grain; a format resolving the
+            # two as dbt's semantics imply discards it instead. Proposing it and
+            # letting the format sort it out is how a plan comes back
+            # `conflicts=0` having changed nothing.
+            warnings.append(
+                f"'{declared}' declares a composite grain "
+                f"({', '.join(composite)}), so no column-level `unique` is "
+                f"proposed on {proposal.column}: the project never claimed that "
+                "column is unique on its own. Either the composite is still the "
+                "grain, in which case re-run `explore map` and `maintain "
+                f"snapshot` to re-baseline, or something downstream relied on "
+                f"{proposal.column} alone and that assumption is now false"
+            )
+            continue
         entry.setdefault("tests", []).append("unique")
         edits.append(
             PlanEdit(
@@ -428,4 +491,39 @@ def _grain_test_edits(
             )
         )
         proposal.paths.append(path)
+        proposal.action += _TEST_EDIT_CLAUSE
     return edits, warnings
+
+
+def _declared_grain(
+    definitions: ProjectDefinitions | None, model: str, column: str
+) -> tuple[list[str] | None, str | None]:
+    """The declared composite grain of ``model`` covering ``column``, or why the
+    question could not be answered.
+
+    Matching is by model name against the name the placed file gave, the same
+    answer the caller already took the file's own word for, so the two halves of
+    the check cannot disagree about which model this is. Returning the columns
+    rather than a boolean is deliberate: the warning has to name the combination,
+    because that is the fact that tells an operator whether to re-baseline or to
+    go looking for what relied on the column alone.
+    """
+
+    # `None` is a caller that did not ask for the check, and is silent for the
+    # same reason `placement=None` is: an optional argument left out must not
+    # change what an existing caller sees. An *absent* project is different. The
+    # caller only reaches here holding a loaded view, so a format that answers
+    # "nothing readable" on the declarations channel while handing over that view
+    # is contradicting itself, and the operator is about to apply an edit decided
+    # on the half that came back empty.
+    if definitions is None:
+        return None, None
+    if not definitions.present:
+        return None, "the project format reported no readable project"
+    target = column.lower()
+    for composite in definitions.declared_composite_keys:
+        if composite.model != model:
+            continue
+        if target in {c.lower() for c in composite.columns}:
+            return list(composite.columns), None
+    return None, None

--- a/packages/dex-core/tests/maintain/test_grain.py
+++ b/packages/dex-core/tests/maintain/test_grain.py
@@ -228,7 +228,11 @@ def test_estimated_row_counts_cannot_fabricate_duplicates():
 
     dataset = Dataset(identifier="db.s.t", candidate_keys=[["id"]], grain=["id"])
     plan = GrainPlan(
-        key_checks=[(dataset, ["id"], 1200)], fanout_pairs=[], composite_checks=[]
+        key_checks=[(dataset, ["id"], 1200)],
+        fanout_pairs=[],
+        composite_checks=[],
+        declared_composite_checks=[],
+        notes=[],
     )
     findings = grain_drift(EstimatingAdapter(), plan)
     assert findings == []
@@ -319,6 +323,8 @@ def test_composite_key_lost_uniqueness_is_detected():
         key_checks=[],
         fanout_pairs=[],
         composite_checks=[(dataset, [["order_key", "line_number"]], 1000)],
+        declared_composite_checks=[],
+        notes=[],
     )
     adapter = _ComboAdapter(rows=1000, combo_count=950)
     findings = grain_drift(adapter, plan)
@@ -343,6 +349,8 @@ def test_composite_check_is_quiet_when_the_key_still_holds():
         key_checks=[],
         fanout_pairs=[],
         composite_checks=[(dataset, [["order_key", "line_number"]], 1000)],
+        declared_composite_checks=[],
+        notes=[],
     )
     findings = grain_drift(_ComboAdapter(rows=1000, combo_count=1000), plan)
     assert findings == []
@@ -356,6 +364,8 @@ def test_adapter_without_combination_counts_skips_composite_checks():
         key_checks=[],
         fanout_pairs=[],
         composite_checks=[(dataset, [["order_key", "line_number"]], 1000)],
+        declared_composite_checks=[],
+        notes=[],
     )
     adapter = _ComboAdapter(rows=1000, combo_count=950)
     adapter.distinct_combination_counts = None  # shadow: adapter can't probe
@@ -545,6 +555,8 @@ def test_grain_estimate_prices_composite_checks():
         key_checks=[],
         fanout_pairs=[],
         composite_checks=[(dataset, [["order_key", "line_number"]], 1000)],
+        declared_composite_checks=[],
+        notes=[],
     )
     priced: list[str] = []
 
@@ -555,3 +567,223 @@ def test_grain_estimate_prices_composite_checks():
     assert per_table == {"db.s.line_items": 7.0}
     assert len(priced) == 1
     assert "SELECT DISTINCT" in priced[0]
+
+
+# --- declared grains: the combination the project claims ------------------------
+#
+# Measurement and declaration disagree by design. Explore lets a proven single
+# column win the grain verdict over a declared composite, and `candidate_keys`
+# stays measurement-only because an unmeasured declared key is a claim, not a
+# baseline. Both are right for a cache, and together they left the grain a project
+# actually declares unverified on exactly the fact tables where it matters. These
+# cover reading it at plan time instead, which is what keeps the cache clean.
+
+
+def _declaring(*composites: tuple[str, list[str]]):
+    from exmergo_dex_core.dbt_project import DeclaredCompositeKey, ProjectDefinitions
+
+    return ProjectDefinitions(
+        present=True,
+        declared_composite_keys=[
+            DeclaredCompositeKey(model=model, columns=columns, source="yaml")
+            for model, columns in composites
+        ],
+    )
+
+
+def _single_key_snapshot():
+    """A dataset whose *measured* grain is one column, as explore records it when
+    a proven single key beats a declared composite."""
+
+    from exmergo_dex_core.cache import Dataset
+    from exmergo_dex_core.maintain.snapshot import Snapshot, WarehouseBaseline
+
+    dataset = Dataset(
+        identifier="db.s.line_items",
+        candidate_keys=[["order_key"]],
+        grain=["order_key"],
+    )
+    return dataset, Snapshot.model_construct(
+        warehouse=WarehouseBaseline.model_construct(
+            datasets=[dataset], relationships=[]
+        )
+    )
+
+
+class _SingleAndComboAdapter(_ComboAdapter):
+    """`_ComboAdapter` with the single-column check allowed: the declared cases
+    need a dataset that has both a measured single key and a declared
+    combination."""
+
+    def __init__(self, rows: int, combo_count: int | None, key_count: int):
+        super().__init__(rows, combo_count)
+        self.key_count = key_count
+
+    def exact_distinct_counts(self, identifier, columns):
+        return dict.fromkeys(columns, self.key_count)
+
+
+def test_a_declared_grain_measurement_never_proved_is_planned_and_verified():
+    from exmergo_dex_core.maintain.drift import grain_drift, grain_plan
+
+    dataset, snap = _single_key_snapshot()
+    adapter = _SingleAndComboAdapter(rows=1000, combo_count=900, key_count=1000)
+    plan = grain_plan(
+        adapter, snap, None, _declaring(("line_items", ["order_key", "line_number"]))
+    )
+
+    # The measured single key still goes through key_checks; the declaration is a
+    # separate list because a failure on it is a separate fact.
+    assert plan.key_checks == [(dataset, ["order_key"], 1000)]
+    assert plan.composite_checks == []
+    assert plan.declared_composite_checks == [
+        (dataset, [["order_key", "line_number"]], 1000)
+    ]
+    assert plan.notes == []
+
+    findings = grain_drift(adapter, plan)
+    assert [f.code for f in findings] == ["declared_grain_not_unique"]
+    finding = findings[0]
+    assert finding.column == "order_key, line_number"
+    assert finding.data["columns"] == ["order_key", "line_number"]
+    assert finding.data["declared"] is True
+    # Nothing lapsed here: there was never a measurement saying this held, so
+    # "no longer" would be a false account of the same two numbers.
+    assert "no longer" not in finding.detail
+    assert "declares" in finding.detail
+
+
+def test_a_declared_grain_that_holds_reports_nothing():
+    from exmergo_dex_core.maintain.drift import grain_drift, grain_plan
+
+    _dataset, snap = _single_key_snapshot()
+    adapter = _SingleAndComboAdapter(rows=1000, combo_count=1000, key_count=1000)
+    plan = grain_plan(
+        adapter, snap, None, _declaring(("line_items", ["order_key", "line_number"]))
+    )
+    assert grain_drift(adapter, plan) == []
+
+
+def test_a_declared_grain_measurement_also_proved_is_checked_once():
+    """A declaration duplicating a measured composite is checked as the measured
+    one: it has a baseline, so `key_lost_uniqueness` is the true statement about
+    it and the declared code would be a downgrade. Order and case are the
+    project's spelling, not part of the claim."""
+
+    from exmergo_dex_core.maintain.drift import grain_drift, grain_plan
+
+    dataset, snap = _composite_snapshot()
+    adapter = _ComboAdapter(rows=1000, combo_count=950)
+    plan = grain_plan(
+        adapter, snap, None, _declaring(("line_items", ["LINE_NUMBER", "order_key"]))
+    )
+    assert plan.composite_checks == [(dataset, [["order_key", "line_number"]], 1000)]
+    assert plan.declared_composite_checks == []
+
+    findings = grain_drift(adapter, plan)
+    assert [f.code for f in findings] == ["key_lost_uniqueness"]
+    assert adapter.combo_calls == [[["order_key", "line_number"]]]
+
+
+def test_an_unresolvable_declared_grain_is_noted_rather_than_dropped():
+    """A declaration naming no warehouse object, or several, is not verified, and
+    an unverified grain must not read like a holding one: "no finding" is what
+    both look like from the envelope."""
+
+    from exmergo_dex_core.maintain.drift import grain_plan
+
+    _dataset, snap = _single_key_snapshot()
+    adapter = _SingleAndComboAdapter(rows=1000, combo_count=900, key_count=1000)
+    plan = grain_plan(
+        adapter, snap, None, _declaring(("nowhere", ["order_key", "line_number"]))
+    )
+
+    assert plan.declared_composite_checks == []
+    assert len(plan.notes) == 1
+    assert "nowhere" in plan.notes[0] and "not verified" in plan.notes[0]
+
+
+def test_a_connector_that_cannot_probe_combinations_says_so():
+    from exmergo_dex_core.maintain.drift import grain_plan
+
+    _dataset, snap = _single_key_snapshot()
+    adapter = _SingleAndComboAdapter(rows=1000, combo_count=900, key_count=1000)
+    adapter.distinct_combination_counts = None  # shadow: adapter can't probe
+
+    plan = grain_plan(
+        adapter, snap, None, _declaring(("line_items", ["order_key", "line_number"]))
+    )
+    assert plan.declared_composite_checks == []
+    assert len(plan.notes) == 1
+    assert "cannot probe column combinations" in plan.notes[0]
+
+
+def test_grain_estimate_prices_the_declared_checks_too():
+    """The plan is the one survey both the estimate and the run read, so a scan
+    that reaches execution without appearing here is spend nobody saw."""
+
+    from exmergo_dex_core.maintain.drift import grain_estimate, grain_plan
+
+    _dataset, snap = _single_key_snapshot()
+    adapter = _SingleAndComboAdapter(rows=1000, combo_count=900, key_count=1000)
+    plan = grain_plan(
+        adapter, snap, None, _declaring(("line_items", ["order_key", "line_number"]))
+    )
+    priced: list[str] = []
+    adapter.query_estimate = lambda sql: priced.append(sql) or 3.0
+
+    total, per_table = grain_estimate(adapter, plan)
+    assert total == 6.0  # the single key, plus the declared combination
+    assert per_table == {"db.s.line_items": 6.0}
+    assert len(priced) == 2
+
+
+def test_a_declared_grain_is_verified_on_a_table_the_baseline_never_captured():
+    """The one way declared checks differ structurally from measured ones.
+
+    A measured check needs a before to compare against, so it can only speak
+    about an object the baseline captured. A declaration needs no before: the
+    project's claim is the standard and the question is whether the data meets it
+    today. Driving these off the baseline as well went quiet on a model built
+    since the last snapshot, which is exactly when a newly declared grain is most
+    likely to be wrong, and it went quiet *because* the declaration resolved: the
+    unresolvable note disappeared as the situation got worse.
+    """
+
+    from exmergo_dex_core.maintain.drift import grain_drift, grain_plan
+    from exmergo_dex_core.maintain.snapshot import Snapshot, WarehouseBaseline
+
+    empty = Snapshot.model_construct(
+        warehouse=WarehouseBaseline.model_construct(datasets=[], relationships=[])
+    )
+    adapter = _ComboAdapter(rows=1000, combo_count=900)
+    plan = grain_plan(
+        adapter, empty, None, _declaring(("line_items", ["order_key", "line_number"]))
+    )
+
+    assert plan.key_checks == [] and plan.composite_checks == []
+    assert len(plan.declared_composite_checks) == 1
+    dataset, combos, rows = plan.declared_composite_checks[0]
+    assert dataset.identifier == "db.s.line_items"
+    # Nothing measured was invented for it: the identifier is all the declared
+    # pass reads, and a profile it never had would be a claim in a baseline's
+    # place.
+    assert dataset.candidate_keys == [] and dataset.grain is None
+    assert combos == [["order_key", "line_number"]] and rows == 1000
+
+    findings = grain_drift(adapter, plan)
+    assert [f.code for f in findings] == ["declared_grain_not_unique"]
+
+
+def test_a_declared_grain_naming_absent_columns_is_noted():
+    from exmergo_dex_core.maintain.drift import grain_plan
+
+    _dataset, snap = _single_key_snapshot()
+    adapter = _SingleAndComboAdapter(rows=1000, combo_count=900, key_count=1000)
+    plan = grain_plan(
+        adapter, snap, None, _declaring(("line_items", ["order_key", "invoice_no"]))
+    )
+
+    assert plan.declared_composite_checks == []
+    assert len(plan.notes) == 1
+    assert "invoice_no" in plan.notes[0] and "not verified" in plan.notes[0]

--- a/packages/dex-core/tests/maintain/test_reconcile.py
+++ b/packages/dex-core/tests/maintain/test_reconcile.py
@@ -192,6 +192,193 @@ def test_grain_drift_adds_no_test_when_one_already_alerts(maintain_repo):
     assert payload["diffs"] == []
 
 
+# --- a declared composite grain outranks a column-level unique -----------------
+#
+# The reported case (#337). A model declares its grain as a combination, one
+# member of that combination was unique in the data at profile time and no longer
+# is, and reconcile used to propose a column-level `unique` on it. dbt runs that
+# test alongside the composite one, so it fails every build from then on and can
+# only go green by changing the declared grain; a project format that resolves the
+# two the way dbt's semantics imply discards it and the plan applies having
+# changed nothing.
+#
+# Drift is induced on `orders` rather than on `stg_orders`, because the test edit
+# lands in the *staging model's* declaration: a finding on `stg_orders` resolves to
+# `stg_stg_orders.yml` and never reaches the check under test.
+
+_COMPOSITE_GRAIN = (
+    "    tests:\n"
+    "      - dbt_utils.unique_combination_of_columns:\n"
+    "          combination_of_columns: [order_id, customer_id, ordered_at]\n"
+)
+
+_STG_ORDERS_YML = (
+    "version: 2\n"
+    "models:\n"
+    "  - name: stg_orders\n"
+    "{grain}"
+    "    columns:\n"
+    "      - name: order_id\n"
+    "        tests: [not_null]\n"
+    "      - name: customer_id\n"
+    "        tests: [not_null]\n"
+    "      - name: ordered_at\n"
+)
+
+
+def _drift_a_member_of_the_grain(repo, *, grain: str) -> dict:
+    """Reconcile a lost single-column key against ``grain`` on stg_orders.
+
+    The UPDATE breaks `order_id` alone while leaving every declared combination
+    intact, which is the situation the report describes: the grain the project
+    declares still holds, and only a column measurement once proved unique does
+    not.
+    """
+
+    repo.edit("models/staging/stg_orders.yml", _STG_ORDERS_YML.format(grain=grain))
+    repo.dex("explore", "map", "--verify")
+    repo.snapshot()
+    repo.sql("UPDATE orders SET order_id = 1 WHERE order_id BETWEEN 2 AND 5")
+    rc, grain_payload = repo.dex("maintain", "grain")
+    assert rc == 0 and any(
+        f["code"] == "key_lost_uniqueness" and f["column"] == "order_id"
+        for f in grain_payload["data"]["findings"]
+    ), grain_payload
+
+    rc, payload = repo.dex("maintain", "reconcile", "grain")
+    assert rc == 0 and payload["status"] == "ok", payload
+    return payload
+
+
+def test_a_declared_composite_grain_gets_no_column_level_unique(maintain_repo):
+    payload = _drift_a_member_of_the_grain(maintain_repo, grain=_COMPOSITE_GRAIN)
+
+    assert payload["diffs"] == []
+    assert payload["data"].get("plan_id") is None
+    # The warning names the combination, because that is the fact that decides
+    # what the operator does next: re-baseline if this is still the grain, or go
+    # find what relied on the column alone.
+    declined = next(w for w in payload["warnings"] if "declares a composite grain" in w)
+    assert "order_id, customer_id, ordered_at" in declined
+
+    proposal = next(
+        p
+        for p in payload["data"]["proposals"]
+        if p["finding_code"] == "key_lost_uniqueness"
+    )
+    assert proposal["paths"] == []
+    # The advisory used to promise a test unconditionally, so the payload said an
+    # edit was in the plan while the plan was empty.
+    assert "unique test" not in proposal["action"]
+
+
+def test_without_the_composite_the_same_drift_still_gets_the_unique_edit(
+    maintain_repo,
+):
+    """The positive control, and it is not optional.
+
+    A run that reports "no edit" proves nothing unless the same harness reports
+    an edit when one is due. Identical project, identical SQL, identical
+    findings; the composite declaration is the only difference, so anything that
+    differs below is attributable to it.
+    """
+
+    payload = _drift_a_member_of_the_grain(maintain_repo, grain="")
+
+    yml_diff = next(
+        d for d in payload["diffs"] if d["path"] == "models/staging/stg_orders.yml"
+    )
+    assert "unique" in yml_diff["unified"]
+    assert not [w for w in payload["warnings"] if "composite grain" in w]
+
+    proposal = next(
+        p
+        for p in payload["data"]["proposals"]
+        if p["finding_code"] == "key_lost_uniqueness"
+    )
+    assert proposal["paths"] == ["models/staging/stg_orders.yml"]
+    assert "the unique test keeps the break visible in builds" in proposal["action"]
+
+
+def test_a_composite_grain_not_covering_the_drifted_column_still_gets_the_edit(
+    maintain_repo,
+):
+    # The decline is about *this* column being a member, not about the model
+    # carrying a composite test at all: a grain over other columns says nothing
+    # either way about whether order_id is unique.
+    payload = _drift_a_member_of_the_grain(
+        maintain_repo,
+        grain=(
+            "    tests:\n"
+            "      - dbt_utils.unique_combination_of_columns:\n"
+            "          combination_of_columns: [customer_id, ordered_at, status]\n"
+        ),
+    )
+
+    assert [d["path"] for d in payload["diffs"]] == ["models/staging/stg_orders.yml"]
+    assert not [w for w in payload["warnings"] if "composite grain" in w]
+
+
+def test_a_declared_grain_that_never_held_is_advisory_and_proposes_no_edit(
+    maintain_repo,
+):
+    # `declared_grain_not_unique` is a different fact from a lost key: nothing
+    # lapsed, the project asserts a grain the data does not have. Reconcile has no
+    # edit for it either, because widening or narrowing a declared grain is
+    # choosing one.
+    maintain_repo.edit(
+        "models/staging/stg_orders.yml",
+        _STG_ORDERS_YML.format(grain=_COMPOSITE_GRAIN),
+    )
+    maintain_repo.dex("explore", "map", "--verify")
+    maintain_repo.snapshot()
+    maintain_repo.sql(
+        "INSERT INTO stg_orders SELECT * FROM stg_orders WHERE order_id <= 10"
+    )
+    maintain_repo.dex("maintain", "grain")
+
+    rc, payload = maintain_repo.dex("maintain", "reconcile", "grain")
+    assert rc == 0 and payload["status"] == "ok", payload
+    proposal = next(
+        p
+        for p in payload["data"]["proposals"]
+        if p["finding_code"] == "declared_grain_not_unique"
+    )
+    assert proposal["kind"] == "advisory"
+    assert "declaration to fix" in proposal["action"]
+    assert proposal["paths"] == []
+    # Not the fallback text a code with no entry in the action table would get.
+    assert "no automatic fix applies" not in proposal["action"]
+
+
+def test_reconcile_surfaces_what_the_format_could_not_supply(maintain_repo):
+    """`ProjectDefinitions.notes` reaches the envelope.
+
+    Reconcile was the one project-reading command that dropped layer notes, and
+    the declarations channel was one no command read at all. A stale manifest is
+    the shipped format saying its declarations may lag the files, which is
+    exactly the caveat that matters when the declarations are what decided
+    whether to propose an edit.
+    """
+
+    from conftest import write_manifest
+
+    write_manifest(
+        maintain_repo.project_dir,
+        models={"stg_orders": '"warehouse"."main"."stg_orders"'},
+        generated_at="2020-01-01T00:00:00+00:00",
+    )
+    maintain_repo.snapshot()
+    maintain_repo.sql("INSERT INTO orders SELECT * FROM orders WHERE order_id <= 10")
+    maintain_repo.dex("maintain", "grain")
+
+    rc, payload = maintain_repo.dex("maintain", "reconcile", "grain")
+    assert rc == 0 and payload["status"] == "ok", payload
+    assert any("older than the model sources" in w for w in payload["warnings"]), (
+        payload["warnings"]
+    )
+
+
 def test_semantic_and_volume_drift_are_advisory_only(maintain_repo):
     maintain_repo.snapshot()
     maintain_repo.sql(

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -777,6 +777,91 @@ def test_a_scope_flag_cannot_widen_the_committed_allowlist():
             narrow_target(target, connector, ["somewhere_else"])
 
 
+def test_the_grain_estimate_prices_every_scan_the_grain_run_executes():
+    """Family 2: cost is surfaced before any spend, and on this axis that rests
+    entirely on one structural claim.
+
+    ``GrainPlan`` promises the estimate and the confirmed run "price and execute
+    exactly the same statements", and the only thing making that true is that both
+    read the same plan. Nothing asserted it. Every list on the plan is a scan, so
+    a list the run iterates and the estimator does not is a table scanned outside
+    the number the operator confirmed, and nothing about it would look wrong: the
+    handshake still appears, the findings still arrive, the bill is just larger
+    than the quote. The plan below carries all three kinds at once so a fourth
+    added to one side and not the other fails here rather than on someone's
+    invoice.
+    """
+
+    from exmergo_dex_core.adapters.base import ColumnMeta, ObjectMeta
+    from exmergo_dex_core.cache import Dataset
+    from exmergo_dex_core.maintain.drift import GrainPlan, grain_drift, grain_estimate
+
+    columns = ["order_key", "line_number", "shipped_on"]
+
+    class RecordingAdapter:
+        name = "stub"
+        dialect = "duckdb"
+
+        def __init__(self):
+            self.priced: list[str] = []
+            self.scanned: list[tuple[str, tuple[str, ...]]] = []
+
+        def query_estimate(self, sql: str) -> float:
+            self.priced.append(sql)
+            return 1.0
+
+        def table_metadata(self, identifier):
+            meta = ObjectMeta(
+                identifier=identifier,
+                object_type="table",
+                schema="s",
+                name="line_items",
+                row_count=1000,
+                byte_size=None,
+                column_count=len(columns),
+            )
+            return meta, [
+                ColumnMeta(name=n, data_type="INTEGER", nullable=False, ordinal=i)
+                for i, n in enumerate(columns)
+            ]
+
+        def exact_distinct_counts(self, identifier, cols):
+            self.scanned.append((identifier, tuple(cols)))
+            return dict.fromkeys(cols, 1000)
+
+        def distinct_combination_counts(self, identifier, combinations):
+            for combo in combinations:
+                self.scanned.append((identifier, tuple(combo)))
+            return {tuple(c): 1000 for c in combinations}
+
+    dataset = Dataset(identifier="db.s.line_items")
+    plan = GrainPlan(
+        key_checks=[(dataset, ["order_key"], 1000)],
+        fanout_pairs=[],
+        composite_checks=[(dataset, [["order_key", "line_number"]], 1000)],
+        declared_composite_checks=[(dataset, [["line_number", "shipped_on"]], 1000)],
+        notes=[],
+    )
+
+    priced_adapter, run_adapter = RecordingAdapter(), RecordingAdapter()
+    total, per_table = grain_estimate(priced_adapter, plan)
+    grain_drift(run_adapter, plan)
+
+    assert total > 0 and per_table == {"db.s.line_items": total}
+    assert run_adapter.scanned, "the plan executed nothing, so this proves nothing"
+    priced_text = "\n".join(priced_adapter.priced)
+    for identifier, scanned_columns in run_adapter.scanned:
+        assert identifier in per_table, (
+            f"{identifier} was scanned and never priced: the operator confirmed a "
+            "figure that did not include it"
+        )
+        for column in scanned_columns:
+            assert column in priced_text, (
+                f"{identifier}.{column} was scanned and no priced statement names "
+                "it, so the quote covered fewer columns than the run read"
+            )
+
+
 # --- Family 3: PII flagged, never surfaced -----------------------------------
 
 

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -141,7 +141,8 @@ dex maintain schema [<objects>]   -> structural drift: columns/tables added, dro
                                      nullability; dangling sources (metadata, free everywhere)
 dex maintain volume [<objects>]   -> freshness drift: row counts that collapsed, emptied, or spiked (free)
 dex maintain grain [<objects>]    -> cardinality/identity drift: lost key uniqueness, changed grain, join
-                                     fanout (aggregates; gated by --confirm --budget on billed connectors)
+                                     fanout, and the grains the project declares re-verified
+                                     (aggregates; gated by --confirm --budget on billed connectors)
 dex maintain semantic [<objects>] -> definition drift and dangling refs (free) + categorical dimension
                                      cardinality change (a scan; gated on billed connectors)
 dex maintain reconcile [<class>]  -> propose the dbt edits that reconcile detected drift, as a stored plan

--- a/references/methodology.md
+++ b/references/methodology.md
@@ -122,6 +122,18 @@ unique on its own. Declared joins come
 from the dbt project when one is present; absent a dbt project, declared joins are
 simply empty, which is expected because explore is designed to work without one.
 
+A project's declarations refine those verdicts without entering them. A declared
+grain fills in where measurement found none, and is noted where it disagrees, but
+a measurement-proven single column still wins the reported grain and the candidate
+keys stay measurement-only: an unmeasured declared key is a claim, and the cache is
+a drift baseline rather than a record of what the project asserts. The consequence
+is that a declared grain needs verifying somewhere else, which is what `maintain
+grain` does with it, and why that axis reports two different things about
+uniqueness. A key measurement proved unique that no longer is has a before and an
+after, so it lapsed. A declared combination that does not hold has neither: nothing
+changed, the project is asserting a grain the data never had, and the fix is to the
+declaration rather than to the data.
+
 ## The draft map: composing and persisting
 
 `explore map` composes the above into the `.dex/` cache (never the source of

--- a/references/project.md
+++ b/references/project.md
@@ -232,6 +232,25 @@ model named `orders`). If you pack several models into one file, no entry matche
 you get a warning instead of an edit, which is a refusal to guess rather than a wrong
 write.
 
+**That edit is checked against your declarations before it is proposed.** If
+`definitions()` reports a composite grain covering the column, no column-level
+`unique` is proposed on it and the warning names the combination, because the edit
+would assert something your project explicitly does not claim: dbt runs a
+column-level `unique` and a `unique_combination_of_columns` independently, so the
+new test fails every build from then on and can only go green by changing the
+declared grain, while a format that resolves the two as dbt's semantics imply
+discards it and the plan applies having changed nothing.
+
+This is the practical reason `declared_composite_keys` is worth populating properly,
+and why it is a separate field from `declared_keys` rather than several entries in
+it. It is not decoration on a diagram. `maintain grain` re-verifies the combinations
+that arrive there, so a format that leaves the field empty loses grain verification
+on exactly the tables whose grain is composite, and gets offered `unique` tests on
+their member columns. Splitting one grain across several entries is worse than
+leaving it out, because each entry then claims a column is unique on its own, which
+is a stronger claim than the one you made and the one that gets acted on. The
+conformance suite checks both shapes.
+
 ## The one rule that is not visible in the signatures
 
 **`definitions()` must not raise.** Not on a project that is absent, not on an

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -51,7 +51,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.7.0"
+DEX_CORE_VERSION = "1.8.0"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/SKILL.md
+++ b/skills/maintain/SKILL.md
@@ -63,9 +63,18 @@ comparison live in the engine, so any other path is guesswork.
 - `maintain volume [<objects>]` detects **freshness drift**: row counts that
   collapsed, spiked, or went to zero. This is the "is the data still flowing
   correctly?" axis, distinct from "did the shape change?".
-- `maintain grain [<objects>]` detects **grain drift**: a declared primary or
-  unique key that now has duplicates, a changed row-per-entity cardinality, or an
-  increased join fanout. Uses aggregates, never raw rows.
+- `maintain grain [<objects>]` detects **grain drift**: a key that now has
+  duplicates, a changed row-per-entity cardinality, or an increased join fanout.
+  It also re-verifies the grains your project *declares* (a model-level
+  `unique_combination_of_columns`), which measurement on its own can miss. Uses
+  aggregates, never raw rows.
+
+  Two findings come out of the uniqueness checks and the difference is the
+  baseline. `key_lost_uniqueness` is a key that was proven unique and is not any
+  more: something changed in the data. `declared_grain_not_unique` is a declared
+  combination that does not hold, and nothing changed at all: the project asserts
+  a grain the data never had, so the fix is to the declaration (widen it, dedup
+  upstream, or drop the claim) rather than to the data.
 - `maintain semantic [<objects>]` detects **definition drift**: metric, measure,
   dimension, or entity definitions that changed against the baseline; semantic
   references that no longer resolve to a model or column; and categorical
@@ -111,7 +120,11 @@ Reconcile tags every proposal by `kind`, because the fix differs sharply by axis
 - **`advisory`**: grain, volume, and semantic drift are decisions, not auto-fixes
   (dex cannot dedup your warehouse or decide whether a new `'refunded'` status
   belongs in a metric). The proposal is the decision surfaced, at most backed by a
-  test edit that makes the break visible in builds.
+  test edit that makes the break visible in builds. It declines that test where
+  the test would be wrong: if your model declares a composite grain covering the
+  column, no column-level `unique` is proposed on it, and the warning names the
+  combination so you can tell "re-baseline, this is still the grain" from
+  "something relied on that column alone".
 
 When reconcile produces edits it stores them as a plan and prints a `plan_id`.
 Apply them with `transform apply <plan-id>` (the one apply door): a human edit made

--- a/skills/maintain/evals/evals.json
+++ b/skills/maintain/evals/evals.json
@@ -44,8 +44,10 @@
       "assertions": [
         "Grain drift is established from SQL aggregates (uniqueness, cardinality), never raw rows",
         "The finding names the key that lost uniqueness or the changed row-per-entity cardinality",
+        "A key that was proven unique and lapsed is reported differently from a declared grain that never held",
         "On a billed connector, surfaces the dry-run cost estimate and re-issues with --confirm and a user-agreed budget rather than inventing one; on DuckDB it runs directly",
-        "Any proposed fix is a reviewable diff; nothing is applied silently"
+        "Any proposed fix is a reviewable diff; nothing is applied silently",
+        "No column-level unique test is proposed against a column covered by a declared composite grain"
       ]
     },
     {

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -51,7 +51,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.7.0"
+DEX_CORE_VERSION = "1.8.0"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -51,7 +51,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.7.0"
+DEX_CORE_VERSION = "1.8.0"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
## What this changes

A downstream report (#337, from @catincloudlabs, running a second tier-3 format at
`dagster-dex` 0.4.0) that turned out to be two defects and a blind spot behind them.

**Reconcile no longer proposes a column-level `unique` against a declared composite
grain.** The proposal applied cleanly, reported `conflicts=0`, and changed nothing
the project declared. `_grain_test_edits` authored the test from the drifted column
and the placed file's stem and never asked whether the model carried a
`unique_combination_of_columns`, so the edit asserted something the project
explicitly does not claim.

The reporter framed this as a silent discard, which is his format's semantics, and
that framing understates it. dbt runs a column-level `unique` and a
`unique_combination_of_columns` independently: on the shipped format the edit lands
and becomes a test that fails every build from then on and can only go green by
changing the declared grain. The discard is the safe outcome; dbt gets the unsafe
one. So the defect fixed here is dex proposing a false test, not a format failing to
relay it.

Reconcile now reads `definitions().declared_composite_keys`, the tier-1 channel the
format already populates, rather than re-parsing the YAML it happens to be holding.
Re-parsing would have hard-coded dbt's spelling of the test name into reconcile,
which is the exact mistake the comment above the model-name lookup exists to stop
repeating. It declines the edit and names the combination in `warnings`, because the
combination is the fact that decides what happens next: either the composite is
still the grain and the baseline wants re-taking, or something downstream relied on
that column alone and the assumption is now false. It does not author a composite
test instead, since the project already declares one and picking a different
combination is dex choosing a grain.

**The grain axis now verifies the grains the project declares.** This is the blind
spot underneath, and it is what made the report reachable through dex's own
pipeline rather than only through a hand-built finding. Explore lets a
measurement-proven single column beat a declared composite for the reported grain,
and `candidate_keys` stays measurement-only because an unmeasured declared key is a
claim rather than a baseline. Both are right for a cache. Together they meant a fact
table declaring a four-column grain never had that grain checked, while a member
column that happened to be unique in the early data was checked on every run: the
column drifts, `key_lost_uniqueness` fires on it, and the grain the project actually
declares was never in the plan.

Declarations now enter `grain_plan` as an argument, resolved through the same
`resolve_declared` explore uses. Nothing is written into the cache, so the
measurement store stays a measurement store. A failure reports as
`declared_grain_not_unique` rather than `key_lost_uniqueness`, because the
difference is the baseline and not the SQL: a measured key that lapsed has a before
and an after, a declared combination has neither, and "no longer unique" would be a
false account of the same two numbers. Reconcile has no edit for it either.

**Declared grains are surveyed against the current warehouse, not the baseline.**
This is the one way they differ structurally from every other check on the axis, and
I got it wrong first: I drove them off the baseline loop like the measured checks,
which is a constraint that does not apply. A measured check needs a before, so it
can only speak about an object the baseline captured. A declaration needs no before.
Dogfooding caught it in the worst possible shape (below).

## Two smaller things that came with it

`_advisory` built `"...the unique test keeps the break visible in builds"` for every
`key_lost_uniqueness` finding, while `_grain_test_edits` runs afterwards and can
decline on five separate paths. The payload routinely claimed an edit that was not
in the plan. The clause is now appended by the path that actually produces one.

Reconcile was the one project-reading command that dropped `_layer_notes`, and
`ProjectDefinitions.notes` was a channel no command read at all. A format explaining
what it could not supply was explaining it to nobody, at the moment an edit was at
stake. Both are surfaced now, deduplicated through the existing collector.

## Cost

`maintain grain` and `maintain check` scan more than they did on a metered
connector, and the increase is in the quote before it is spent. `grain_estimate`
prices off the same `GrainPlan` the run executes, so this holds by construction.
That parity was promised in the `GrainPlan` docstring and asserted nowhere, which is
the kind of claim that stays true until someone adds a check list to one side. It is
now a Family 2 spine test, verified to fail when the estimator drops a list.

Measured on BigQuery: `df_orders` prices at two 10 MB floors (its single key plus
its declared combination) where every other table prices at one, and the confirmed
run billed 41.9 MB against a 52.4 MB quote.

## Conformance

`declared_composite_keys` stops being decoration on a diagram and becomes
load-bearing for two things, so `test_a_composite_grain_keeps_every_column_and_their_order`
now also asserts one declaration produces one entry, and that no member arrives in
`declared_keys` as `unique` on its own. The suite already warned about that shape in
an assertion message and never checked it. A format that splits a grain across
entries is worse off than one that omits it, because each entry then makes a
stronger claim than the author did and the stronger claim is the one acted on.

## Dogfood

Two sessions, both against real warehouses.

**DuckDB** (`dex demo`, plus a project declaring three composite grains): the
reported bug reproduced and is fixed, no plan and no diff, the warning naming the
combination. The positive control passed, which is the part that makes the null
result mean anything: identical project, identical SQL, identical findings, the
composite declaration removed as the only difference, and the `unique` edit comes
back with the clause appended. `declared_grain_not_unique` fired on a declaration
that never held with numbers I checked against ground truth. A declared combination
that measurement had also proved was checked once, as the measured one. Scope
filtering held. A false declaration survived `maintain snapshot`, which is right:
re-baselining settles drift and this was never drift.

**It also found a real bug in the new code, and found it in the shape that matters.**
I built a model after taking the baseline, declared a grain on it that was
demonstrably false (5020 rows, 5000 distinct combinations), and dex said nothing at
all. Worse, the "matches no warehouse object" note *disappeared* as the situation got
worse, because the declaration now resolved and then fell out of a loop driven by the
baseline. The signal got quieter as the problem got real. Fixed by surveying declared
grains against the current warehouse, with two regression tests, one of which pins
that no measurement is invented for an object nobody profiled.

**BigQuery** (`exmergo-viz.dex_ci`): the cost path, which DuckDB cannot exercise.
Priced handshake correct per table, actual spend under the quote, two false
declarations reported with real numbers, an unresolvable declaration noted, and the
note surfacing on `maintain check`'s pending path as well as its completed one. The
reconcile decline and its positive control both reproduce there. Total spend across
the session: 62.9 MB, under a cent.

## Two things I found and did not fix

Neither is a regression and neither is in scope, but both are worth a decision.

The `unique` test edit is still `yaml.safe_dump(parsed, sort_keys=False)`, so
applying it reserialises the whole document. In the dogfood diff a 10-line file came
back as a 12-line whole-file diff with the list style restyled and a blank line
dropped; on a commented file the comments go, including (in the reporter's case) the
one explaining why the composite is the grain. He recorded this as a property of the
mechanism rather than the defect, and it is. But `transform/rewrite.py` now exists
and its module docstring argues at length that regenerating is wrong for exactly
this reason, so this is the one edit still doing what the rest of the codebase
documents as the wrong thing. Appending to a YAML sequence by splice is a different
operation from the renames that module does today, so it is real work, not a
rewiring.

`explore map` and `explore profile` reuse a profile that is fresh and schema-
unchanged, so a re-baseline can carry a stale uniqueness verdict and a
`key_lost_uniqueness` finding that no longer reflects the data. This is documented
behavior with an escape hatch (`--refresh`), and I only mistook it for a bug because
I did not use it. Noting it because the interaction with `maintain snapshot` is not
obvious: re-baselining to absorb a finding will not absorb it if the profile behind
it is reused.

## Test plan

`2642 passed, 83 skipped`, up 14. Lint and format clean, em-dash check clean.

- `tests/maintain/test_reconcile.py`: the decline, the positive control, a composite
  not covering the drifted column, the new code's advisory, and definitions notes
  reaching the envelope.
- `tests/maintain/test_grain.py`: declared verification, a holding grain, the
  dedup against a measured composite, an unresolvable model, a connector with no
  combination probe, absent columns, and the non-baselined table regression.
- `tests/test_safety_spine.py`: estimate/execute parity on the grain axis.
