### PR TITLE
SCRUM-1017-Add governed drop_orphan_relations macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **A governed macro for dropping orphan relations** ([#151]), the execution
+  half PR #146 deferred when it shipped `orphan_relation` detection
+  ([#113]). `maintain reconcile` used to hand back a bare `DROP TABLE ...;`
+  string for a human to type by hand; it now proposes scaffolding
+  `transform macro drop_orphan_relations` and running it through `dbt
+  run-operation`, with the exact invocation (the finding's identifier
+  already filled into `--args`) spelled out in the proposal. Reconciling
+  more than one orphan in a run adds one more warning naming a single
+  batched invocation for all of them.
+
+  The macro itself takes an explicit list of relations (nothing inferred),
+  is dry-run by default, resolves and drops through `adapter.get_relation`/
+  `adapter.drop_relation` rather than a hand-written DDL string, and refuses
+  to run at all if any named relation is still a live model, seed, or
+  snapshot in the current manifest, so a typo in the list cannot delete
+  something real. A relation that no longer exists in the warehouse is
+  skipped rather than raised on, so the same list is safe to re-run per
+  target. dex still never executes it: authoring the macro and printing the
+  invocation is as far as dex's role goes, the same boundary `transform
+  macro` already draws for every other shipped macro, and the human runs it
+  under the project's own deploy identity.
+
+  Two pieces of the original issue are explicitly deferred rather than
+  bundled in here, matching the scope PR #146 itself drew: a three-state
+  classification (provable dbt orphan / foreign object / unknown) needs dex
+  to retain more than the single most-recent `maintain snapshot`, which
+  today's storage protocol does not keep; and running the macro directly on
+  a dev target through the existing build preflight is a separate, bounded
+  addition to `transform build`'s dbt-invocation surface.
+
 - **`transform rename` and `transform remove` generate the whole propagation
   plan** ([#221]). `transform references` could tell you where a name was used
   and then left you to retype the change file by file. These two make the change:

--- a/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/reconcile.py
@@ -106,12 +106,15 @@ def build(
 
     schema_patches: dict[str, list[DriftFinding]] = {}
     definition_churn = False
+    orphan_identifiers: list[str] = []
     for finding in findings:
         if finding.axis == "schema" and finding.code in _PATCHABLE:
             schema_patches.setdefault(finding.identifier, []).append(finding)
         elif finding.code.startswith("definition_"):
             definition_churn = True
         else:
+            if finding.code == "orphan_relation":
+                orphan_identifiers.append(finding.identifier)
             proposals.append(_advisory(finding))
 
     for identifier, table_findings in sorted(schema_patches.items()):
@@ -205,17 +208,28 @@ def build(
             "reconciled: if the current definitions are intended, re-run "
             "`maintain snapshot` to accept them as the new baseline"
         )
+    if len(orphan_identifiers) > 1:
+        warnings.append(
+            f"{len(orphan_identifiers)} orphan relations found this run; once "
+            "you've confirmed none are read, drop them together in one "
+            "governed pass: dbt run-operation drop_orphan_relations --args "
+            f"'{_run_operation_args(orphan_identifiers)}'"
+        )
     return proposals, edits, warnings
 
 
 # --- helpers -------------------------------------------------------------------
 
 
+def _run_operation_args(identifiers: list[str]) -> str:
+    """The ``--args`` payload for ``dbt run-operation drop_orphan_relations``."""
+
+    relations = ", ".join(f'"{identifier}"' for identifier in identifiers)
+    return f"{{relations: [{relations}], dry_run: false}}"
+
+
 def _advisory(finding: DriftFinding) -> Proposal:
     if finding.code == "orphan_relation":
-        drop_statement = finding.data.get(
-            "drop_statement", f"DROP TABLE {finding.identifier};"
-        )
         return Proposal(
             axis=finding.axis,
             kind="advisory",
@@ -224,8 +238,12 @@ def _advisory(finding: DriftFinding) -> Proposal:
             column=finding.column,
             action=(
                 "no dbt model or source declares this relation anymore; once "
-                "you've confirmed nothing reads it, drop it by hand (dex "
-                f"never executes this): {drop_statement}"
+                "you've confirmed nothing reads it, drop it through the "
+                "governed macro (dex never executes this itself): scaffold "
+                "it with `transform macro drop_orphan_relations` if the "
+                "project does not have it yet, then run dbt run-operation "
+                "drop_orphan_relations --args "
+                f"'{_run_operation_args([finding.identifier])}'"
             ),
         )
     actions = {

--- a/packages/dex-core/src/exmergo_dex_core/transform/assets/macros/drop_orphan_relations.sql
+++ b/packages/dex-core/src/exmergo_dex_core/transform/assets/macros/drop_orphan_relations.sql
@@ -1,0 +1,94 @@
+{#- drop_orphan_relations v1, scaffolded by dex.
+
+    Drop warehouse relations that no longer have a backing dbt model or
+    source: the residue a rename or removal leaves behind, since dbt only
+    ever creates and never drops the object a renamed or removed model used
+    to build. `maintain check` names these as orphan_relation findings and
+    `maintain reconcile` proposes running this macro with the specific
+    identifiers it found; nothing here is inferred, the caller always names
+    exactly what to drop.
+
+    Dry-run by default. Nothing is dropped until you pass dry_run=false:
+
+        dbt run-operation drop_orphan_relations \
+            --args '{relations: ["analytics.marts.old_fct_orders"], dry_run: false}'
+
+    Each entry in `relations` is a dot-separated `schema.identifier` or
+    `database.schema.identifier` (a bare `schema.identifier` resolves against
+    the current target's database). Any entry that still names a live model,
+    seed, or snapshot in the current manifest refuses the whole run before
+    anything is dropped: a typo in the list must never delete something real.
+    A named relation that does not exist in the warehouse is skipped, not an
+    error, so the same list is safe to re-run per target.
+
+    Edit freely: this file is yours. Re-running
+    `dex transform macro drop_orphan_relations` proposes a diff back to the
+    shipped version.
+-#}
+
+{% macro drop_orphan_relations(relations=[], dry_run=true) %}
+    {%- if relations | length == 0 -%}
+        {{ log("drop_orphan_relations: no relations given; nothing to do. Pass --args '{relations: [...]}'", info=True) }}
+        {% do return(none) %}
+    {%- endif -%}
+
+    {%- set built = [] -%}
+    {%- for node in graph.nodes.values() if node.resource_type in ('model', 'seed', 'snapshot') -%}
+        {%- do built.append((node.database, node.schema, node.alias) | map('lower') | join('.')) -%}
+    {%- endfor -%}
+
+    {%- set live = [] -%}
+    {%- for entry in relations -%}
+        {%- set parts = entry.split('.') -%}
+        {%- if parts | length == 3 -%}
+            {%- set key = parts | map('lower') | join('.') -%}
+        {%- elif parts | length == 2 -%}
+            {%- set key = ([target.database] + parts) | map('lower') | join('.') -%}
+        {%- else -%}
+            {{ exceptions.raise_compiler_error(
+                "drop_orphan_relations: '" ~ entry ~
+                "' is not schema.identifier or database.schema.identifier"
+            ) }}
+        {%- endif -%}
+        {%- if key in built -%}
+            {%- do live.append(entry) -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {%- if live | length > 0 -%}
+        {{ exceptions.raise_compiler_error(
+            "drop_orphan_relations refuses to run: " ~ (live | join(', ')) ~
+            " still names a live model, seed, or snapshot in this manifest. "
+            ~ "Nothing was dropped; fix the list and re-run"
+        ) }}
+    {%- endif -%}
+
+    {%- set dropped = [] -%}
+    {%- set would_drop = [] -%}
+    {%- set skipped = [] -%}
+    {%- for entry in relations -%}
+        {%- set parts = entry.split('.') -%}
+        {%- if parts | length == 3 -%}
+            {%- set relation = adapter.get_relation(database=parts[0], schema=parts[1], identifier=parts[2]) -%}
+        {%- else -%}
+            {%- set relation = adapter.get_relation(database=target.database, schema=parts[0], identifier=parts[1]) -%}
+        {%- endif -%}
+        {%- if relation is none -%}
+            {%- do skipped.append(entry) -%}
+            {{ log("skip (not found): " ~ entry, info=True) }}
+        {%- elif dry_run -%}
+            {%- do would_drop.append(entry) -%}
+            {{ log("would drop: " ~ relation, info=True) }}
+        {%- else -%}
+            {%- do adapter.drop_relation(relation) -%}
+            {%- do dropped.append(entry) -%}
+            {{ log("dropped: " ~ relation, info=True) }}
+        {%- endif -%}
+    {%- endfor -%}
+
+    {{ log(
+        "drop_orphan_relations: " ~ (dropped | length) ~ " dropped, "
+        ~ (would_drop | length) ~ " would drop (dry_run), "
+        ~ (skipped | length) ~ " skipped (not found)",
+        info=True
+    ) }}
+{% endmacro %}

--- a/packages/dex-core/src/exmergo_dex_core/transform/scaffold.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/scaffold.py
@@ -40,6 +40,11 @@ MACRO_ASSETS: dict[str, str] = {
         "rows, top-level keys only; native semi-structured value type on "
         "every connector"
     ),
+    "drop_orphan_relations": (
+        "drop named warehouse relations that no longer have a backing model "
+        "or source; dry-run by default, refuses to run at all if any named "
+        "relation is still a live model, seed, or snapshot"
+    ),
 }
 
 

--- a/packages/dex-core/tests/maintain/test_reconcile.py
+++ b/packages/dex-core/tests/maintain/test_reconcile.py
@@ -75,6 +75,68 @@ def test_drift_added_column_honors_pattern_pii_override():
     assert added.pii_overridden is not None
 
 
+def test_orphan_relation_action_names_the_macro_and_the_one_relation():
+    from exmergo_dex_core.maintain.drift import DriftFinding
+    from exmergo_dex_core.maintain.reconcile import build
+    from exmergo_dex_core.maintain.snapshot import Snapshot, WarehouseBaseline
+
+    finding = DriftFinding(
+        axis="schema",
+        code="orphan_relation",
+        identifier="db.marts.old_fct_orders",
+        detail="relation exists with no backing model or source",
+        data={"drop_statement": "DROP TABLE db.marts.old_fct_orders;"},
+    )
+    snap = Snapshot(
+        created_at="2026-07-03T10:00:00+00:00",
+        connector="duckdb",
+        warehouse=WarehouseBaseline(datasets=[]),
+        warehouse_from="metadata",
+    )
+
+    proposals, edits, warnings = build([finding], snap, None, None)
+
+    assert edits == []
+    orphan = next(p for p in proposals if p.finding_code == "orphan_relation")
+    assert orphan.kind == "advisory"
+    assert "transform macro drop_orphan_relations" in orphan.action
+    assert "dbt run-operation drop_orphan_relations" in orphan.action
+    assert '"db.marts.old_fct_orders"' in orphan.action
+    # A single orphan does not earn the batched-invocation warning.
+    assert not any("orphan relations found" in w for w in warnings)
+
+
+def test_multiple_orphans_also_get_one_batched_invocation_warning():
+    from exmergo_dex_core.maintain.drift import DriftFinding
+    from exmergo_dex_core.maintain.reconcile import build
+    from exmergo_dex_core.maintain.snapshot import Snapshot, WarehouseBaseline
+
+    findings = [
+        DriftFinding(
+            axis="schema",
+            code="orphan_relation",
+            identifier=identifier,
+            detail="relation exists with no backing model or source",
+            data={"drop_statement": f"DROP TABLE {identifier};"},
+        )
+        for identifier in ("db.marts.old_dim_orders", "db.marts.old_fct_orders")
+    ]
+    snap = Snapshot(
+        created_at="2026-07-03T10:00:00+00:00",
+        connector="duckdb",
+        warehouse=WarehouseBaseline(datasets=[]),
+        warehouse_from="metadata",
+    )
+
+    proposals, _edits, warnings = build(findings, snap, None, None)
+
+    assert sum(p.finding_code == "orphan_relation" for p in proposals) == 2
+    batched = next(w for w in warnings if "orphan relations found" in w)
+    assert "dbt run-operation drop_orphan_relations" in batched
+    assert '"db.marts.old_dim_orders"' in batched
+    assert '"db.marts.old_fct_orders"' in batched
+
+
 def test_reconcile_needs_a_drift_report(maintain_repo):
     maintain_repo.snapshot()
     rc, payload = maintain_repo.dex("maintain", "reconcile")
@@ -272,7 +334,7 @@ def test_dropped_source_reconcile_is_advisory_when_no_scaffold(maintain_repo):
     assert "dangling_source" in codes or "table_dropped" in codes
 
 
-def test_orphan_relation_reconcile_is_advisory_with_drop_statement(maintain_repo):
+def test_orphan_relation_reconcile_proposes_the_governed_macro(maintain_repo):
     maintain_repo.snapshot()
     (maintain_repo.project_dir / "models" / "staging" / "stg_orders.sql").unlink()
     maintain_repo.dex("maintain", "schema")
@@ -284,8 +346,10 @@ def test_orphan_relation_reconcile_is_advisory_with_drop_statement(maintain_repo
         p for p in by_axis["schema"] if p["finding_code"] == "orphan_relation"
     ]
     assert orphan_proposals and all(p["kind"] == "advisory" for p in orphan_proposals)
-    assert "DROP TABLE" in orphan_proposals[0]["action"]
-    assert "warehouse.main.stg_orders" in orphan_proposals[0]["action"]
+    action = orphan_proposals[0]["action"]
+    assert "transform macro drop_orphan_relations" in action
+    assert "dbt run-operation drop_orphan_relations" in action
+    assert "warehouse.main.stg_orders" in action
 
 
 def test_the_no_format_fallback_answers_exactly_what_dbt_answers():

--- a/packages/dex-core/tests/transform/test_macro.py
+++ b/packages/dex-core/tests/transform/test_macro.py
@@ -125,6 +125,43 @@ def test_generate_schema_name_scaffolds_into_an_existing_project(
     assert (dbt_project_dir / "macros" / "generate_schema_name.sql").is_file()
 
 
+def test_drop_orphan_relations_asset_ships_and_is_balanced():
+    # importlib.resources is how the engine loads it at runtime, so this is the
+    # packaging regression guard: a wheel that drops the asset fails here.
+    asset = (
+        resources.files("exmergo_dex_core.transform")
+        / "assets"
+        / "macros"
+        / "drop_orphan_relations.sql"
+    )
+    content = asset.read_text(encoding="utf-8")
+    assert content.count("{% macro ") == content.count("{% endmacro %}")
+    assert "adapter.get_relation" in content
+    assert "adapter.drop_relation" in content
+
+
+def test_drop_orphan_relations_scaffolds_and_parses_into_an_existing_project(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    # dbt's own parser sees the macro in a shadow copy of the project before
+    # the plan is even proposed (transform/commands.py::macro), so a green
+    # run here also proves the Jinja is syntactically valid, not just that the
+    # file scaffolds.
+    rc, envelope = _run(
+        ["--repo-root", str(tmp_path), "transform", "macro", "drop_orphan_relations"],
+        capsys,
+    )
+    assert rc == 0, envelope
+    assert envelope["data"]["paths"] == ["macros/drop_orphan_relations.sql"]
+    unified = envelope["diffs"][0]["unified"]
+    assert "dry_run" in unified
+    assert "graph.nodes" in unified
+
+    rc, envelope = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+    assert rc == 0, envelope
+    assert (dbt_project_dir / "macros" / "drop_orphan_relations.sql").is_file()
+
+
 def test_macro_refuses_an_unknown_name_naming_the_available(
     dbt_project_dir: Path, tmp_path: Path, capsys
 ):


### PR DESCRIPTION
Closes : https://github.com/exmergo/dex/issues/151
- Follow-up to #113 / PR #146, which shipped `orphan_relation` detection and an advisory-only `DROP TABLE ...;` proposal, with
  execution explicitly deferred: "execution (macro + dbt run-operation) deferred to a follow-up issue."
- Adds `transform/assets/macros/drop_orphan_relations.sql`, a shipped macro (reachable via `transform macro drop_orphan_relations`, through the same plan/apply flow every other shipped macro uses).
 - It takes an explicit list of relations (nothing inferred), is dry-run by default, resolves/drops through `adapter.get_relation`/
  `adapter.drop_relation` rather than a hand-written DDL string, and refuses to run at all if any named relation is still a live model, seed, or snapshot in the current manifest, so a typo in the list cannot delete something real. A relation that no longer exists in the warehouse is skipped rather than raised on.
- `maintain reconcile`'s `orphan_relation` advisory now proposes that macro plus the exact `dbt run-operation drop_orphan_relations --args '{relations: [...], dry_run: false}'` invocation, with the finding's identifier already filled in, instead of a bare `DROP TABLE` string. Reconciling more than one orphan in a run adds one more warning with a single batched invocation covering all of them.
- dex still never executes DDL: authoring the macro and printing the invocation is as far as dex's role goes, the same boundary
  `transform macro` already draws for every other shipped macro. The human runs it under the project's own deploy identity.

## Explicitly out of scope (deferred, matching how PR #146 itself scoped down)

- **Three-state classification** (provable dbt orphan / foreign object / unknown): needs dex to retain more than the single
  most-recent `maintain snapshot`, which today's storage protocol does not keep. A separate, larger piece of work.
- **Dev-target direct execution**: letting dex run the macro itself on dev targets through the existing `transform build` preflight/
  cost-gate. Bounded, but a new dbt-invocation surface, and the original issue floats it as a "could," not a requirement.

<img width="1597" height="292" alt="image" src="https://github.com/user-attachments/assets/1394ae57-2ff1-419b-8108-6961e59f0230" />
maintain reconcile's orphan_relation proposal before/after: the action field now names the governed drop_orphan_relations macro and gives the exact dbt run-operation invocation with the relation already filled into --args, instead of the old bare DROP TABLE ...; string for a human to type by hand.
