### PR TITLE
Issue-307: `explore map` and `explore profile` failed on the seeded schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Redshift: `explore map` and `explore profile` died on any table with a
+  `TIMESTAMPTZ` column, and on any slash-date string column.** Two spellings in
+  the generated profiling statement are refused by the Redshift server, and
+  because both ride the single batched aggregate pass, either one failed the
+  whole profile rather than degrading one statistic.
+
+  `DATEDIFF` resolves to `pg_catalog.date_diff`, declared over
+  `DATE`/`TIME`/`TIMETZ`/`TIMESTAMP` with no `TIMESTAMPTZ` overload, while
+  `DATE_TRUNC` over a `TIMESTAMPTZ` column returns `TIMESTAMPTZ`. So the periods
+  the temporal-continuity probe diffs were exactly the shape it rejects, with
+  `function pg_catalog.date_diff("unknown", timestamp with time zone, timestamp
+  with time zone) does not exist`. Both operands are now cast to `TIMESTAMP`:
+  total for every type that reaches the probe, and shifting nothing, because it
+  applies to both sides by the same rule.
+
+  `SUBSTR`, the spelling the shared type-contradiction expressions use for the
+  slash-date component extraction, is refused by name (`SUBSTR() function is not
+  supported (Hint: use SUBSTRING instead)`) at execution over a real table, not
+  only in a leader-node-only query. The idiom is now a per-connector callable
+  with the shared `SUBSTR` as the default, because the swap is not universal in
+  the other direction either: BigQuery has `SUBSTR` and no `SUBSTRING`.
+
+  Both are pinned offline against the Redshift fake, with a `TIMESTAMPTZ` column
+  added to the fixture: the previous one profiled a bare `TIMESTAMP`, which is
+  why an offline test asserting the generated statement passed while the live
+  one could not run.
+
+- **A progress line could fail a profiling run that had already billed.**
+  `ProgressReporter`'s `stream` was a `TextIO = sys.stderr` default argument, so
+  it captured whatever `sys.stderr` was when the module was first imported and
+  wrote there for the life of the process. Under pytest that object is the
+  capture buffer live at collection, closed long before any run is slow enough
+  to cross the five-second progress gate, so a live `explore map` profiled the
+  whole schema, spent its compute seconds, and then returned
+  `errors: ['I/O operation on closed file.']` instead of the map. The same
+  binding sent progress to the wrong place for any embedder that reassigns
+  `sys.stderr` or wraps a call in `contextlib.redirect_stderr`.
+
+  The stream is now resolved when a line is written, and the write is
+  best-effort. A diagnostic that narrates work already done, and on a metered
+  connector already paid for, is never worth failing that work over.
+
 ## [1.9.0] - 2026-08-27
 
 ### Changed

--- a/packages/dex-core/src/exmergo_dex_core/adapters/base.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/base.py
@@ -495,6 +495,17 @@ _HEX_LENGTH_NAMES = {32: "md5", 40: "sha1", 64: "sha256"}
 _CAST_SENTINEL = "'0'"
 
 
+def default_substring_expr(qcol: str, start: int, length: int) -> str:
+    """The positional substring idiom every dialect here accepts *except*
+    Redshift, whose server refuses the name outright ("SUBSTR() function is
+    not supported (Hint: use SUBSTRING instead)") even over a real table, so
+    a connector whose spelling differs supplies its own (see
+    `type_contradiction_expressions`). The reverse swap is not free either:
+    BigQuery has SUBSTR and no SUBSTRING, so neither spelling is universal."""
+
+    return f"SUBSTR({qcol}, {start}, {length})"
+
+
 def type_contradiction_expressions(
     qcol: str,
     i: int,
@@ -503,6 +514,7 @@ def type_contradiction_expressions(
     is_integer: bool,
     regexp_predicate: Callable[[str, str], str],
     bigint_type: str,
+    substring_expr: Callable[[str, int, int], str] = default_substring_expr,
 ) -> list[str]:
     """Declared-type-vs-content aggregate expressions for one column.
 
@@ -579,8 +591,8 @@ def type_contradiction_expressions(
         ]
         slash_either = f"({slash_date_pred} OR {slash_datetime_pred})"
         slash_shaped = shaped(slash_either)
-        first_val = total_cast(slash_either, f"SUBSTR({qcol}, 1, 2)")
-        second_val = total_cast(slash_either, f"SUBSTR({qcol}, 4, 2)")
+        first_val = total_cast(slash_either, substring_expr(qcol, 1, 2))
+        second_val = total_cast(slash_either, substring_expr(qcol, 4, 2))
         exprs += [
             fraction(slash_shaped, f"{first_val} > 12", f"ts_sl1_{i}"),
             fraction(slash_shaped, f"{second_val} > 12", f"ts_sl2_{i}"),

--- a/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
@@ -165,8 +165,28 @@ def _date_trunc_expr(qcol: str, unit: str) -> str:
     return f"DATE_TRUNC('{unit}', {qcol})"
 
 
+def _substring_expr(qcol: str, start: int, length: int) -> str:
+    # Redshift refuses SUBSTR by name -- "SUBSTR() function is not supported
+    # (Hint: use SUBSTRING instead)" -- and does so at execution, over a real
+    # table, not only in a leader-node-only query. SUBSTRING takes the same
+    # positional arguments and is what the hint asks for.
+    return f"SUBSTRING({qcol}, {start}, {length})"
+
+
 def _date_diff_expr(unit: str, later: str, earlier: str) -> str:
-    return f"DATEDIFF({unit}, {earlier}, {later})"
+    # Both operands are cast, and the cast is not decorative: Redshift's
+    # DATEDIFF resolves to pg_catalog.date_diff, which is declared over
+    # DATE/TIME/TIMETZ/TIMESTAMP and has no TIMESTAMPTZ overload, while
+    # DATE_TRUNC over a TIMESTAMPTZ column returns TIMESTAMPTZ. The periods
+    # this diffs are therefore exactly the shape it refuses ("function
+    # pg_catalog.date_diff(\"unknown\", timestamp with time zone, timestamp
+    # with time zone) does not exist"), and a plain DATEDIFF failed the whole
+    # profiling statement for any table carrying a TIMESTAMPTZ column. The cast
+    # is total for every type that reaches here (DATE and TIMESTAMP widen
+    # unchanged; TIME is never temporal-profiled, see `is_temporal_type`), and
+    # it shifts nothing: both operands convert to the session timezone by the
+    # same rule, so their difference is what it was.
+    return f"DATEDIFF({unit}, {earlier}::TIMESTAMP, {later}::TIMESTAMP)"
 
 
 class RedshiftConnectionError(ConnectorError):
@@ -847,6 +867,7 @@ class RedshiftAdapter:
                         is_integer=is_integer_type(col.data_type),
                         regexp_predicate=_regexp_predicate,
                         bigint_type=_BIGINT_TYPE,
+                        substring_expr=_substring_expr,
                     )
                 )
             wants_key_shape = (col.name in key_shape_req) and not degraded

--- a/packages/dex-core/src/exmergo_dex_core/progress.py
+++ b/packages/dex-core/src/exmergo_dex_core/progress.py
@@ -42,8 +42,12 @@ class ProgressReporter:
     stream, and clock decisions live here so the loop stays ignorant of them.
 
     ``stream`` must never default to stdout: writing there would corrupt the JSON
-    envelope. The ``clock`` seam mirrors the adapters' injected ``time.monotonic``
-    so tests can drive timing deterministically.
+    envelope. It defaults to ``None``, meaning "whatever ``sys.stderr`` is when a
+    line is actually written", which is not the same thing as a ``sys.stderr``
+    default argument: that captures the stream this module saw at import and
+    holds it for the life of the process (see :meth:`_emit`). The ``clock`` seam
+    mirrors the adapters' injected ``time.monotonic`` so tests can drive timing
+    deterministically.
     """
 
     def __init__(
@@ -52,7 +56,7 @@ class ProgressReporter:
         label: str,
         noun: str,
         *,
-        stream: TextIO = sys.stderr,
+        stream: TextIO | None = None,
         clock: Callable[[], float] = time.monotonic,
         first_after: float = PROGRESS_FIRST_AFTER,
         interval: float = PROGRESS_INTERVAL,
@@ -107,5 +111,26 @@ class ProgressReporter:
         self._emit(self.total)
 
     def _emit(self, done: int) -> None:
-        self._stream.write(f"dex: {self.label} {done}/{self.total} {self.noun}\n")
-        self._stream.flush()
+        """Write one line to the *current* stderr, and never fail the caller.
+
+        Resolving the stream here rather than binding it as a default argument
+        is the whole point. A ``stream: TextIO = sys.stderr`` default is
+        evaluated once, when this module is first imported, so the reporter
+        writes to that object forever after: under pytest, the capture buffer
+        live at collection time, which is closed by the time any run is slow
+        enough to cross ``first_after`` (`ValueError: I/O operation on closed
+        file`), and for an embedder that reassigns ``sys.stderr`` or wraps a
+        call in ``contextlib.redirect_stderr``, the wrong destination entirely.
+
+        The write is also best-effort. This line narrates work that has already
+        happened and, on a metered connector, already billed; a diagnostic the
+        caller may not even be reading must not be what turns a finished
+        profiling run into an error envelope.
+        """
+
+        stream = sys.stderr if self._stream is None else self._stream
+        try:
+            stream.write(f"dex: {self.label} {done}/{self.total} {self.noun}\n")
+            stream.flush()
+        except (OSError, ValueError):
+            return

--- a/packages/dex-core/src/exmergo_dex_core/progress.py
+++ b/packages/dex-core/src/exmergo_dex_core/progress.py
@@ -132,5 +132,5 @@ class ProgressReporter:
         try:
             stream.write(f"dex: {self.label} {done}/{self.total} {self.noun}\n")
             stream.flush()
-        except (OSError, ValueError):
+        except (OSError, ValueError, AttributeError):
             return

--- a/packages/dex-core/tests/test_progress.py
+++ b/packages/dex-core/tests/test_progress.py
@@ -8,6 +8,7 @@ touch real stderr.
 from __future__ import annotations
 
 import io
+import sys
 
 from exmergo_dex_core.progress import (
     PROGRESS_FIRST_AFTER,
@@ -112,10 +113,32 @@ def test_total_zero_and_one_stay_silent() -> None:
         assert stream.getvalue() == ""
 
 
-def test_stream_defaults_to_stderr_never_stdout() -> None:
+def test_stream_defaults_to_the_current_stderr_never_stdout(monkeypatch) -> None:
     # The default stream must be stderr: writing progress to stdout would corrupt
-    # the single-JSON-envelope contract.
-    import sys
+    # the single-JSON-envelope contract. It must also be *the stderr in force
+    # when the line is written*, not the one this module saw at import: a
+    # `stream: TextIO = sys.stderr` default argument is evaluated once per
+    # process, and under pytest that object is a capture buffer which is closed
+    # long before any run is slow enough to emit, so a live profiling run died
+    # on `ValueError: I/O operation on closed file` after it had already billed.
+    clock, stream = _Clock(), io.StringIO()
+    reporter = ProgressReporter(90, "profiled", "objects", clock=clock)
 
-    reporter = ProgressReporter(1, "profiled", "objects")
-    assert reporter._stream is sys.stderr
+    monkeypatch.setattr(sys, "stderr", stream)
+    clock.tick(PROGRESS_FIRST_AFTER + 0.1)
+    reporter.advance()
+
+    assert stream.getvalue() == "dex: profiled 1/90 objects\n"
+
+
+def test_a_dead_stream_never_fails_the_run() -> None:
+    # Progress narrates work that already happened and, on a metered connector,
+    # already billed. A stream that has gone away must not be what turns a
+    # finished run into an error.
+    clock, stream = _Clock(), io.StringIO()
+    reporter = ProgressReporter(90, "profiled", "objects", stream=stream, clock=clock)
+    stream.close()
+
+    clock.tick(PROGRESS_FIRST_AFTER + 0.1)
+    reporter.advance()  # must not raise
+    reporter.done()

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -4181,7 +4181,14 @@ def test_redshift_generated_sql_is_select_only(fake_redshift_connection):
 
     adapter = _redshift_adapter(fake_redshift_connection)
     _meta, columns = adapter.table_metadata("dexdb.shop.customers")
-    columns = [*columns, ColumnMeta("signup_ts", "TIMESTAMP", True, len(columns))]
+    columns = [
+        *columns,
+        ColumnMeta("signup_ts", "TIMESTAMP", True, len(columns)),
+        # The seeded timestamps are TIMESTAMPTZ, and that is not decoration:
+        # Redshift's DATEDIFF has no TIMESTAMPTZ overload, so a
+        # TIMESTAMP-only fixture asserts a statement the server would refuse.
+        ColumnMeta("created_at", "timestamp with time zone", True, len(columns) + 1),
+    ]
     shape = {
         c.name
         for c in columns
@@ -4195,7 +4202,7 @@ def test_redshift_generated_sql_is_select_only(fake_redshift_connection):
         if is_string_type(c.data_type) or is_integer_type(c.data_type)
     }
     key_shape_req = {c.name for c in columns if is_string_type(c.data_type)}
-    temporal_req = {"signup_ts"}
+    temporal_req = {"signup_ts", "created_at"}
     sql, _plan = adapter._build_aggregate_sql(
         "dexdb.shop.customers",
         columns,
@@ -4215,6 +4222,18 @@ def test_redshift_generated_sql_is_select_only(fake_redshift_connection):
     # Temporal-continuity statistics (#206) ride the same statement too.
     assert "tc_da_" in sql and "tp_d_" in sql and "tg_h_" in sql
     assert "DATE_TRUNC" in sql and "DATEDIFF" in sql
+    # ...with both DATEDIFF operands cast to TIMESTAMP, because Redshift
+    # resolves DATEDIFF to a pg_catalog.date_diff that is declared over
+    # DATE/TIME/TIMETZ/TIMESTAMP only: DATE_TRUNC over the TIMESTAMPTZ column
+    # yields TIMESTAMPTZ, and an uncast diff of two of those failed the whole
+    # profiling statement server-side.
+    assert "DATEDIFF(day, prev_period::TIMESTAMP, period::TIMESTAMP)" in sql
+    assert "DATEDIFF(month, prev_period::TIMESTAMP, period::TIMESTAMP)" in sql
+    assert "DATEDIFF(hour, prev_period::TIMESTAMP, period::TIMESTAMP)" in sql
+    # SUBSTR is the shared spelling, and Redshift refuses it by name ("SUBSTR()
+    # function is not supported (Hint: use SUBSTRING instead)") at execution
+    # over a real table, so this adapter must emit SUBSTRING and nothing else.
+    assert "SUBSTRING(" in sql and "SUBSTR(" not in sql.replace("SUBSTRING(", "")
     assert assert_select_only(sql, dialect="redshift") == sql
 
 

--- a/references/redshift.md
+++ b/references/redshift.md
@@ -171,6 +171,24 @@ rejects. It is enforced offline for all six adapters (see
 `assert_every_cast_is_total`), because no unit test can catch a dialect that
 disagrees with the standard about evaluation order.
 
+**Two more spellings the server refuses outright, both verified live.**
+`DATEDIFF` resolves to `pg_catalog.date_diff`, which is declared over
+`DATE`/`TIME`/`TIMETZ`/`TIMESTAMP` and has no `TIMESTAMPTZ` overload, while
+`DATE_TRUNC` over a `TIMESTAMPTZ` column returns `TIMESTAMPTZ`: the periods
+the temporal-continuity probe diffs are exactly the shape it rejects
+(`function pg_catalog.date_diff("unknown", timestamp with time zone,
+timestamp with time zone) does not exist`), which failed the whole profiling
+statement for any table carrying a `TIMESTAMPTZ` column. Both operands are
+therefore cast to `TIMESTAMP`, a conversion that is total for every type
+reaching that path and shifts nothing, since it applies to both sides by the
+same rule. And `SUBSTR`, the spelling the shared expressions use, is refused
+by name (`SUBSTR() function is not supported (Hint: use SUBSTRING instead)`)
+at execution over a real table, not only in a leader-node-only query, so this
+adapter emits `SUBSTRING` for the slash-date component extraction. Neither
+spelling is universal in the other direction: BigQuery has `SUBSTR` and no
+`SUBSTRING`, which is why the idiom is per-connector rather than swapped in
+the shared builder.
+
 ## dbt builds
 
 `transform init` renders a `type: redshift` dev profile from whichever


### PR DESCRIPTION
## Redshift: `explore map` and `explore profile` failed on the seeded schema

Three bugs on one code path, each hidden behind the one before it. All three are
fixed and verified live against the seeded Serverless workgroup.

### 1. `DATEDIFF` has no `TIMESTAMPTZ` overload

Redshift resolves `DATEDIFF` to `pg_catalog.date_diff`, declared over
`DATE`/`TIME`/`TIMETZ`/`TIMESTAMP`, while `DATE_TRUNC` over a `TIMESTAMPTZ`
column returns `TIMESTAMPTZ`. The periods the temporal-continuity probe diffs
were exactly the shape it rejects, so any table with a `TIMESTAMPTZ` column
failed the whole profiling statement. Both operands are now cast to `TIMESTAMP`.

### 2. `SUBSTR` is refused by name

`SUBSTR() function is not supported (Hint: use SUBSTRING instead)`, raised at
execution over a real table. The shared slash-date extraction now goes through a
per-connector callable defaulting to `SUBSTR`, with Redshift supplying
`SUBSTRING`. The swap is not universal in reverse: BigQuery has `SUBSTR` and no
`SUBSTRING`.

### 3. A progress line could fail a run that had already billed

`ProgressReporter`'s `stream` was a `TextIO = sys.stderr` default argument,
evaluated once at import. Under pytest that buffer is closed by the time a run
crosses the five-second progress gate, so `explore map` profiled the schema,
spent its compute seconds, and returned `errors: ['I/O operation on closed
file.']` instead of the map. The stream now resolves per line and the write is
best-effort. The same binding also broke `contextlib.redirect_stderr` for any
embedder.

### Tests

- Offline: both SQL spellings pinned against the Redshift fake, with a
  `TIMESTAMPTZ` column added to the fixture. The old one profiled a bare
  `TIMESTAMP`, which is why an offline test asserting this statement passed while
  the live one could not run. Two more tests cover the progress stream.
- Live: `tests/integration -m redshift`, 8 passed, 3 skipped.
- Full offline suite: 2870 passed.

Also documents both dialect refusals in `references/redshift.md`.
