### PR TITLE
BigQuery DATETIME hour-grain continuity now has live coverage

### DIFF
--- a/packages/dex-core/tests/adapters/test_temporal_type_predicates.py
+++ b/packages/dex-core/tests/adapters/test_temporal_type_predicates.py
@@ -1,0 +1,141 @@
+"""Every temporal spelling the connectors actually report, held against the
+shared type predicates in one table.
+
+``is_date_only_type`` is a substring rule, and a substring rule is what
+produced the defect it now guards (#188): ``DATETIME`` contains ``DATE`` and
+not ``TIMESTAMP``, so BigQuery ``DATETIME`` and ClickHouse ``DateTime`` were
+read as bare calendar dates and their hour-grain continuity was never
+computed. Nothing about that was loud -- the column kept reporting day and
+month gaps and simply never reported an hour one, which reads as a clean
+result rather than a skipped one.
+
+So the rule is pinned against spellings, not against intent, and each row
+names the metadata source it comes from: that is what has to be re-read when a
+connector changes how it reports a type, and a connector added later owes this
+file its own rows. The live proof that the hour grain is really computed lives
+per connector (tests/integration/test_bigquery_explore.py and
+test_clickhouse_explore.py both profile a column with a known hole); what is
+here is the offline classification every one of them depends on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from exmergo_dex_core.adapters.base import (
+    TEMPORAL_UNITS_DATE_ONLY,
+    TEMPORAL_UNITS_WITH_TIME,
+    is_date_only_type,
+    is_temporal_type,
+    temporal_units_for,
+)
+
+# (metadata source, spelling, temporal, date-only)
+#
+# "temporal" is eligibility for span/gap analysis at all (explore.profile picks
+# its temporal columns with `is_temporal_type`); "date-only" is whether the
+# hour grain is skipped for it. A non-temporal spelling never reaches the
+# date-only question, and is listed with False/False.
+SPELLINGS = [
+    # BigQuery: SchemaField.field_type, which reports the legacy type names.
+    # DATETIME is the one that carried the bug.
+    ("bigquery", "DATE", True, True),
+    ("bigquery", "DATETIME", True, False),
+    ("bigquery", "TIMESTAMP", True, False),
+    ("bigquery", "TIME", False, False),
+    # Snowflake: the `type` field of SHOW COLUMNS' data_type JSON. DATETIME is
+    # an alias Snowflake resolves to TIMESTAMP_NTZ, so that spelling never
+    # arrives from this source -- and is classified correctly if it ever does.
+    ("snowflake", "DATE", True, True),
+    ("snowflake", "TIMESTAMP_NTZ", True, False),
+    ("snowflake", "TIMESTAMP_LTZ", True, False),
+    ("snowflake", "TIMESTAMP_TZ", True, False),
+    ("snowflake", "TIME", False, False),
+    # Databricks: ColumnInfo.type_text (SQL text, lower case) falling back to
+    # type_name (the SDK enum, upper case), so both cases reach the predicate.
+    ("databricks", "date", True, True),
+    ("databricks", "DATE", True, True),
+    ("databricks", "timestamp", True, False),
+    ("databricks", "TIMESTAMP", True, False),
+    ("databricks", "timestamp_ntz", True, False),
+    ("databricks", "TIMESTAMP_NTZ", True, False),
+    ("databricks", "interval day to second", False, False),
+    # Postgres: pg_catalog.format_type, which spells out the qualifiers and
+    # carries the precision inside the name.
+    ("postgres", "date", True, True),
+    ("postgres", "timestamp without time zone", True, False),
+    ("postgres", "timestamp with time zone", True, False),
+    ("postgres", "timestamp(3) without time zone", True, False),
+    ("postgres", "time without time zone", False, False),
+    ("postgres", "time with time zone", False, False),
+    ("postgres", "interval", False, False),
+    # Redshift: SVV_COLUMNS.data_type, which follows the same Postgres
+    # spellings (timestamptz is reported in its expanded form).
+    ("redshift", "date", True, True),
+    ("redshift", "timestamp without time zone", True, False),
+    ("redshift", "timestamp with time zone", True, False),
+    ("redshift", "time without time zone", False, False),
+    # DuckDB: duckdb_columns().data_type, including the sub-second variants.
+    ("duckdb", "DATE", True, True),
+    ("duckdb", "TIMESTAMP", True, False),
+    ("duckdb", "TIMESTAMP WITH TIME ZONE", True, False),
+    ("duckdb", "TIMESTAMP_NS", True, False),
+    ("duckdb", "TIMESTAMP_MS", True, False),
+    ("duckdb", "TIMESTAMP_S", True, False),
+    ("duckdb", "TIME", False, False),
+    ("duckdb", "INTERVAL", False, False),
+    # ClickHouse: system.columns.type, mixed case and wrapped. The adapter
+    # unwraps before asking, but the wrapped spelling reaches `is_temporal_type`
+    # through explore.profile's eligibility pass, so both forms are pinned.
+    ("clickhouse", "Date", True, True),
+    ("clickhouse", "Date32", True, True),
+    ("clickhouse", "DateTime", True, False),
+    ("clickhouse", "DateTime64(3)", True, False),
+    ("clickhouse", "Nullable(Date)", True, True),
+    ("clickhouse", "Nullable(DateTime)", True, False),
+    ("clickhouse", "LowCardinality(Nullable(DateTime64(3)))", True, False),
+]
+
+
+@pytest.mark.parametrize(
+    ("source", "spelling", "temporal", "date_only"),
+    [pytest.param(*row, id=f"{row[0]}-{row[1]}") for row in SPELLINGS],
+)
+def test_every_reported_spelling_is_classified(
+    source: str, spelling: str, temporal: bool, date_only: bool
+):
+    assert is_temporal_type(spelling) is temporal, source
+    if not temporal:
+        return
+    assert is_date_only_type(spelling) is date_only, source
+    expected = TEMPORAL_UNITS_DATE_ONLY if date_only else TEMPORAL_UNITS_WITH_TIME
+    assert temporal_units_for(spelling) == expected
+
+
+def test_no_timestamp_spelling_is_ever_read_as_a_bare_date():
+    """The rule, stated once over the whole table: a spelling that carries a
+    time component must never be date-only, whatever the dialect calls it.
+
+    A connector added later that reports, say, ``SMALLDATETIME`` gets the
+    correct answer from the ``DATETIME`` exclusion; one that invents a spelling
+    with a time component and neither substring in it does not, and is what
+    this assertion exists to make someone think about.
+    """
+
+    for _source, spelling, temporal, _date_only in SPELLINGS:
+        upper = spelling.upper()
+        if temporal and ("TIMESTAMP" in upper or "DATETIME" in upper):
+            assert not is_date_only_type(spelling), spelling
+            assert "hour" in temporal_units_for(spelling)
+
+
+def test_the_hour_grain_is_skipped_only_for_a_bare_date():
+    """The other direction, which is not a silent failure but an error: BigQuery
+    ``DATE_TRUNC`` is the one truncation function with no HOUR unit, so over-
+    correcting the predicate would make a DATE column's profile fail outright.
+    """
+
+    for _source, spelling, temporal, date_only in SPELLINGS:
+        if temporal and date_only:
+            assert temporal_units_for(spelling) == TEMPORAL_UNITS_DATE_ONLY
+            assert "hour" not in temporal_units_for(spelling)

--- a/packages/dex-core/tests/integration/test_bigquery_explore.py
+++ b/packages/dex-core/tests/integration/test_bigquery_explore.py
@@ -1,7 +1,9 @@
 """Live explore against public BigQuery data: free inventory, the confirm
-handshake with a real dry-run estimate, the over-ceiling refusal (free), and a
-firewalled query. Reads only bigquery-public-data; bills to the test project;
-every scan is capped by the suite's byte ceiling."""
+handshake with a real dry-run estimate, the over-ceiling refusal (free), a
+firewalled query, and temporal continuity over a DATETIME column. Reads
+bigquery-public-data plus one tiny table this suite writes into the scratch
+dataset; bills to the test project; every scan is capped by the suite's byte
+ceiling."""
 
 from __future__ import annotations
 
@@ -22,6 +24,7 @@ SHAKESPEARE = "bigquery-public-data.samples.shakespeare"
 # A deliberately large table (tens of GB): its dry-run estimate must blow any
 # sane test budget, proving the refusal live at zero cost.
 WIKIPEDIA = "bigquery-public-data.samples.wikipedia"
+CONTINUITY_TABLE = "dex_temporal_continuity"
 
 
 def test_inventory_is_free_and_ranked(tmp_path: Path, capsys, bq_project: str):
@@ -200,6 +203,111 @@ def test_unnest_of_a_function_derived_array_runs_live(
     )
     assert rc == 1
     assert "query refused" in envelope["errors"][0]
+
+
+# --- temporal continuity over a written fixture (the one shape public data lacks) -----
+
+
+@pytest.fixture
+def bq_continuity_table(bq_project: str, bq_scratch_dataset: str):
+    """One tiny table in the scratch dataset carrying a known hole at both
+    grains, because no public dataset offers a DATETIME column with a hole
+    whose size this suite can state.
+
+    Forty-eight rows are generated and three are dropped, leaving 45.
+    ``occurred_at`` advances one day per row from 2024-03-01, ``recorded_at``
+    one hour per row from 2024-03-01 00:30 (never midnight, so the column is
+    not day-aligned and hour is the grain the engine reports). The three
+    dropped rows are a 3-day hole in one column and a 3-hour hole in the
+    other; four later rows keep their date but carry a NULL ``recorded_at``,
+    so the hour grain has a second, wider hole of 4 that the day grain does
+    not. The two grains therefore report different numbers, and hour
+    statistics that were really the day column's would not pass.
+
+    Written and dropped by this fixture: the CI principal holds dataEditor on
+    the scratch dataset and nowhere else, and its table TTL is the backstop for
+    a crashed run.
+    """
+
+    from google.cloud import bigquery
+
+    identifier = f"{bq_project}.{bq_scratch_dataset}.{CONTINUITY_TABLE}"
+    client = bigquery.Client(project=bq_project)
+    try:
+        # DDL over generated literals: no table is read, so this scans nothing.
+        client.query(
+            f"CREATE OR REPLACE TABLE `{identifier}` AS SELECT "  # noqa: S608
+            "DATE_ADD(DATE '2024-03-01', INTERVAL i DAY) AS occurred_at, "
+            "IF(i BETWEEN 20 AND 23, NULL, DATETIME_ADD("
+            "DATETIME '2024-03-01 00:30:00', INTERVAL i HOUR)) AS recorded_at "
+            "FROM UNNEST(GENERATE_ARRAY(0, 47)) AS i "
+            "WHERE i NOT IN (10, 11, 12)"
+        ).result()
+        yield identifier
+    finally:
+        client.delete_table(identifier, not_found_ok=True)
+        client.close()
+
+
+def test_temporal_continuity_reports_the_seeded_hour_grain_hole(
+    tmp_path: Path,
+    capsys,
+    bq_project: str,
+    bq_scratch_dataset: str,
+    bq_continuity_table: str,
+):
+    """The hazard that reads as a clean result rather than a missing one.
+
+    ``DATETIME`` contains the substring DATE and not TIMESTAMP, so the shared
+    date-only check claimed it and every DATETIME column on BigQuery reported
+    day and month continuity while silently never reporting an hour gap. This
+    is BigQuery's own end-to-end proof that the hour grain is computed and
+    correct, the assertion the ClickHouse suite already carries for
+    ``DateTime`` and the connector that held the bug longest lacked.
+
+    It also pins the other direction: a bare ``DATE`` column must still skip
+    the hour grain, because ``DATE_TRUNC`` is the one truncation function
+    BigQuery gives no HOUR unit, and asking for one is an error, not a wrong
+    number.
+    """
+
+    seed_repo(tmp_path, bq_project, datasets=[f"{bq_project}.{bq_scratch_dataset}"])
+    rc, envelope = run_cli(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "explore",
+            "profile",
+            CONTINUITY_TABLE,
+            "--confirm",
+            "--budget",
+            str(MAX_BYTES),
+        ],
+        capsys,
+    )
+    assert_ok(rc, envelope)
+    dataset = envelope["data"]["datasets"][0]
+    assert dataset["identifier"] == bq_continuity_table
+    columns = {c["name"]: c for c in dataset["columns"]}
+
+    recorded = columns["recorded_at"]
+    assert recorded["data_type"] == "DATETIME"
+    assert recorded["temporal_granularity"] == "hour", (
+        "a granularity of day here means the date-only check claimed DATETIME "
+        "again: the hour grain was never computed and its absence reads clean"
+    )
+    assert recorded["temporal_span"] == 48
+    assert recorded["temporal_distinct_periods"] == 41
+    assert recorded["temporal_missing_periods"] == 7
+    assert recorded["temporal_largest_gap"] == 4
+
+    occurred = columns["occurred_at"]
+    assert occurred["data_type"] == "DATE"
+    assert occurred["temporal_granularity"] == "day"
+    assert occurred["temporal_span"] == 48
+    assert occurred["temporal_distinct_periods"] == 45
+    assert occurred["temporal_missing_periods"] == 3
+    assert occurred["temporal_largest_gap"] == 3
 
 
 # --- scope resolution against the live project (free: metadata GET, no query) ---------


### PR DESCRIPTION
## Problem

`is_date_only_type` used to claim any type containing `DATE` and not `TIMESTAMP`, which is true of BigQuery `DATETIME` as well as ClickHouse `DateTime`. Those columns were read as bare calendar dates, so the hour-grain half of temporal continuity was skipped: the column reported day and month gaps and never an hour gap, which reads as a clean result rather than a missing one. The predicate is fixed and unit-tested, and ClickHouse proves it live, but BigQuery, the connector that carried the bug longest, had no end-to-end assertion that it is gone.

## Fix

Add BigQuery's own live proof, plus an offline audit of the substring rule across every connector.

- A `bq_continuity_table` fixture writes one 45-row table into the TTL'd scratch dataset and drops it afterward (public data offers no `DATETIME` column with a hole whose size the suite can state). `occurred_at DATE` advances a day per row; `recorded_at DATETIME` advances an hour per row from 00:30, so it is never day-aligned. Three dropped rows give a 3-day hole in one column and a 3-hour hole in the other; four later rows keep their date but carry a NULL `recorded_at`, giving the hour grain a second, wider hole of 4. The two grains therefore report different numbers, so hour statistics that were really the day column's would not pass.
- The test asserts the hour grain end to end (`DATETIME`, hour, span 48, distinct 41, missing 7, largest gap 4) in the shape the ClickHouse suite already asserts, and pins the other direction on the same table (`DATE`, day, 48/45/3/3), since `DATE_TRUNC` is the one BigQuery truncation function with no HOUR unit.
- A new table test holds 44 spellings, every temporal type the seven connectors actually report, against `is_temporal_type`, `is_date_only_type`, and `temporal_units_for`, each row labeled with the metadata source it comes from so a connector that changes how it reports a type has to face the table.
- 
## Related issues

Closes #315 

## Files changed:

- `packages/dex-core/tests/integration/test_bigquery_explore.py:` the fixture, the continuity test, and an updated module docstring (the suite now writes one tiny table).
- `packages/dex-core/tests/adapters/test_temporal_type_predicates.py`: new, the per-connector spelling audit.
