### PR TITLE
Exhaustion refusal now inside CostGate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Changed
+
+- **An exhausted budget is now refused by the cost gate itself, rather than by
+  a check each adapter had to remember to write** ([#316]). The server-side cap
+  is an integer because every connector's cap setting takes one, and on the
+  time-paradigm connectors a cap of 0 does not mean "spend nothing" but *no
+  limit* (Postgres `statement_timeout`, ClickHouse `max_execution_time`,
+  Databricks `STATEMENT_TIMEOUT`). Exhaustion and "no cap applies" were already
+  distinguishable at the boundary, 0 against `None`, but telling them apart was
+  still left to the caller, and all six billed adapters did it the same way in
+  their own billed-statement path. That is a convention, not a contract: one
+  forgotten `if` in a new connector hands the server a 0, which removes the
+  backstop at exactly the moment the budget is nearly spent, and fails in the
+  most expensive possible direction while looking like an ordinary run.
+
+  `CostGate.remaining_for_statement` is now the private
+  `_remaining_for_statement`, reached only through `CostGate.statement_cap`,
+  which raises `OverCeilingError` on the shortfall. Its public result is
+  therefore either `None` or a strictly positive cap the server will honour,
+  with nothing in between for a caller to misread. `statement_cap` takes the
+  `unit` the refusal should name in the connector's own vocabulary (a
+  "database-second", a "warehouse-second", a "byte") and an optional `minimum`
+  for the smallest cap that server can usefully be given, which is how
+  BigQuery's 10 MB per-query billing minimum is expressed rather than as a
+  seventh hand-written check. The six per-adapter refusals are deleted, and the
+  property they enforced between them is now tested once, centrally: no code
+  path can hand a server a cap value that the server reads as unlimited.
+
+  The refusal also carries its `Cost` now, which the BigQuery one did not, so a
+  shortfall reports the paradigm and ceiling it was measured against instead of
+  an empty cost block on a spend refusal. The BigQuery shortfall message names
+  the per-query minimum the cap fell under rather than the connector.
+
 ## [1.9.1] - 2026-08-31
 
 ### Changed

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -1157,13 +1157,7 @@ class BigQueryAdapter:
         rather than charging the full requirement a second time on top of it.
         """
 
-        cap = self.cost_gate.remaining_for_statement()
-        if cap is not None and cap < _MIN_BILLED_BYTES:
-            raise OverCeilingError(
-                f"the remaining budget ({cap} bytes) is below BigQuery's "
-                f"{_MIN_BILLED_BYTES}-byte minimum billed per query; raise "
-                "--budget or narrow the work"
-            )
+        cap = self.cost_gate.statement_cap(unit="byte", minimum=_MIN_BILLED_BYTES)
         job_config = self._bq.QueryJobConfig(
             maximum_bytes_billed=cap,
             use_query_cache=True,

--- a/packages/dex-core/src/exmergo_dex_core/adapters/clickhouse.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/clickhouse.py
@@ -1365,19 +1365,15 @@ class ClickHouseAdapter:
         refusal.
         """
 
-        remaining = self.cost_gate.remaining_for_statement()
-        if remaining is not None and remaining < 1:
-            raise OverCeilingError(
-                "the remaining budget is under one database-second; raise "
-                "--budget or narrow the work"
-            )
+        remaining = self.cost_gate.statement_cap(unit="database-second")
         settings: dict[str, Any] = dict(_SESSION_SETTINGS)
         seconds: int | None = None
         budget_bound = False
         if remaining is not None:
-            # int() truncates, and max_execution_time = 0 means *no limit* in
-            # ClickHouse, so a sub-second remainder must never reach the server
-            # as a cap; the guard above is what makes that unreachable.
+            # max_execution_time = 0 means *no limit* in ClickHouse, so a
+            # sub-second remainder must never reach the server as a cap.
+            # `statement_cap` is what makes that unreachable: it refuses rather
+            # than returning anything below one second.
             seconds = int(remaining)
             budget_bound = True
             settings["max_bytes_to_read"] = int(remaining * _SCAN_BYTES_PER_SECOND)

--- a/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/databricks.py
@@ -1269,12 +1269,7 @@ class DatabricksAdapter:
         cannot overrun the ceiling."""
 
         self._warehouse()  # refuses when config pins no warehouse
-        remaining = self.cost_gate.remaining_for_statement()
-        if remaining is not None and remaining < 1:
-            raise OverCeilingError(
-                "the remaining budget is under one warehouse-second; raise "
-                "--budget or narrow the work"
-            )
+        remaining = self.cost_gate.statement_cap(unit="warehouse-second")
         bounds = [b for b in (remaining, cap_seconds) if b is not None]
         # Remember which bound won so a timeout kill is reported as the wall
         # limit or the budget, whichever actually fired.
@@ -1286,7 +1281,9 @@ class DatabricksAdapter:
         cursor = self._conn.cursor()
         if bounds:
             # An engine-built session statement, not agent SQL. STATEMENT_TIMEOUT
-            # treats 0 as "no timeout", so the cap never rounds below 1.
+            # treats 0 as "no timeout", so the cap never rounds below 1: the
+            # budget bound cannot (`statement_cap` refuses first) and the wall
+            # bound is floored here.
             cursor.execute(f"SET STATEMENT_TIMEOUT = {max(int(min(bounds)), 1)}")
         return cursor
 

--- a/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/postgres.py
@@ -1081,12 +1081,7 @@ class PostgresAdapter:
         the cursor and whether the budget (not the wall clock) is the binding
         bound."""
 
-        remaining = self.cost_gate.remaining_for_statement()
-        if remaining is not None and remaining < 1:
-            raise OverCeilingError(
-                "the remaining budget is under one database-second; raise "
-                "--budget or narrow the work"
-            )
+        remaining = self.cost_gate.statement_cap(unit="database-second")
         self._ensure_session()
         cursor = self._conn.cursor()
         timeout_ms: int | None = None

--- a/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/redshift.py
@@ -1182,12 +1182,7 @@ class RedshiftAdapter:
         the cursor and whether the budget (not the wall clock) is the binding
         bound."""
 
-        remaining = self.cost_gate.remaining_for_statement()
-        if remaining is not None and remaining < 1:
-            raise OverCeilingError(
-                "the remaining budget is under one compute-second; raise "
-                "--budget or narrow the work"
-            )
+        remaining = self.cost_gate.statement_cap(unit="compute-second")
         self._ensure_session()
         cursor = self._conn.cursor()
         timeout_ms: int | None = None

--- a/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/snowflake.py
@@ -1149,12 +1149,7 @@ class SnowflakeAdapter:
         of the budget, so even a wrong heuristic cannot overrun the ceiling."""
 
         info = self._warehouse()  # refuses when config pins no warehouse
-        remaining = self.cost_gate.remaining_for_statement()
-        if remaining is not None and remaining < 1:
-            raise OverCeilingError(
-                "the remaining budget is under one warehouse-second; raise "
-                "--budget or narrow the work"
-            )
+        remaining = self.cost_gate.statement_cap(unit="warehouse-second")
         cursor = self._conn.cursor()
         if not self._session_prepared:
             # dex-built session statements, not agent SQL: the warehouse

--- a/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
+++ b/packages/dex-core/src/exmergo_dex_core/guards/cost_guard.py
@@ -269,6 +269,26 @@ def preflight(
     return cost
 
 
+def _cap_shortfall(remaining: int, floor: int, unit: str) -> str:
+    """The refusal :meth:`CostGate.statement_cap` raises when what is left of
+    the budget cannot be expressed as a cap the server will honour.
+
+    Two sentences rather than one per connector: the shortfall is the same
+    event whether the floor is one second of statement timeout or BigQuery's
+    per-query billing minimum, and the caller's move is the same either way.
+    """
+
+    shortfall = (
+        f"the remaining budget is under one {unit}"
+        if floor == 1
+        else (
+            f"the remaining budget ({remaining:,} {unit}s) is below the "
+            f"{floor:,}-{unit} minimum this connector can cap a statement at"
+        )
+    )
+    return f"{shortfall}; raise --budget or narrow the work"
+
+
 def skipped_handshake_warning(paradigm: Paradigm, confirmed: bool) -> list[str]:
     """The warning a command carries when the confirm handshake would have
     fired but the paradigm cannot bill, so nothing needed confirming
@@ -639,10 +659,55 @@ class CostGate:
             return False
         return True
 
-    def remaining_for_statement(self) -> int | None:
-        """The server-side cap for the next statement, in the paradigm's unit
-        (bytes for ``maximum_bytes_billed``, seconds for a statement timeout):
-        what remains of the effective ceiling after everything already charged.
+    def statement_cap(self, *, unit: str, minimum: int = 1) -> int | None:
+        """The server-side cap to hand the warehouse for the next statement, in
+        the paradigm's unit (bytes for ``maximum_bytes_billed``, seconds for a
+        statement timeout), or ``None`` when no ceiling applies at all.
+
+        **The refusal is part of this call, which is why it is the only way to
+        price a statement.** A cap of 0 does not mean "spend nothing" to a
+        server: Postgres ``statement_timeout``, ClickHouse ``max_execution_time``
+        and Databricks ``STATEMENT_TIMEOUT`` all read it as *no limit*, so a
+        budget with less than one unit left would remove the backstop at exactly
+        the moment it is the only thing between a wrong estimate and an
+        unbounded scan. Each adapter used to test the returned magnitude for
+        itself and refuse, which worked and was a convention rather than a
+        contract: one forgotten ``if`` in a new connector, failing in the most
+        expensive direction while looking like an ordinary run (issue #316). So
+        the shortfall raises :class:`OverCeilingError` from here, and what this
+        returns is only ever a cap the server will honour.
+
+        ``minimum`` is the smallest cap that connector's server can usefully be
+        given: one unit for a statement timeout, and BigQuery's 10 MB per-query
+        billing minimum for ``maximum_bytes_billed``, under which every query is
+        refused by the server rather than bounded by it. ``unit`` names that unit
+        in the refusal in the connector's own vocabulary (a "database-second", a
+        "byte"), because it is what the caller has to raise ``--budget`` in.
+        """
+
+        floor = max(minimum, 1)
+        remaining = self._remaining_for_statement()
+        if remaining is not None and remaining < floor:
+            raise OverCeilingError(
+                _cap_shortfall(remaining, floor, unit),
+                cost=Cost(
+                    paradigm=self.paradigm,
+                    estimate=self._estimated,
+                    ceiling=self.effective_ceiling(),
+                ),
+            )
+        return remaining
+
+    def _remaining_for_statement(self) -> int | None:
+        """What remains of the effective ceiling after everything already
+        charged, as the integer every connector's cap setting takes: ``None``
+        when nothing bounds the statement, 0 when the budget is exhausted, and
+        otherwise at least 1.
+
+        Private, and reached only through :meth:`statement_cap`. Those two
+        answers are one careless comparison apart at a call site and mean
+        opposite things to a server, so the boundary that faces an adapter
+        refuses on the 0 rather than handing it over to be recognised.
 
         Bounded by the booking as well as by the ceiling, when there is one. The
         two differ exactly when another command is holding headroom, and handing
@@ -651,24 +716,17 @@ class CostGate:
         together. :meth:`charge` widens the booking when the estimate genuinely
         drifts, so this tightens the cap without capping honest work.
 
-        **A 0 here is a refusal, so only the ceiling may produce one.** The
-        result is an integer because every connector's cap setting takes one,
-        and on the time-paradigm connectors a cap of 0 does not mean "spend
-        nothing" but *no limit* (Postgres ``statement_timeout``, ClickHouse
-        ``max_execution_time``), so the adapters refuse when this returns under
-        one unit rather than handing the server a 0.
-
-        That makes which term produced a sub-unit value load-bearing, and
-        conflating the two was a real defect. ``effective_ceiling`` minus what
-        has actually been *billed* running low means the budget is genuinely
-        nearly gone, and refusing is right. The booking is a different thing: it
-        is headroom this command reserved for work that has not happened, and a
-        cheap statement legitimately books a fraction of a unit. Letting that
-        truncate to 0 refused perfectly affordable work, and it fired on every
-        small query the moment ``session_ceiling`` was set, since that is what
-        creates a reservation at all. So the exhaustion test reads the ceiling,
-        and the booking is only ever allowed to *tighten* the cap, never to turn
-        it into a refusal.
+        **Only the ceiling may produce the 0.** Which term produced a sub-unit
+        value is load-bearing, and conflating the two was a real defect.
+        ``effective_ceiling`` minus what has actually been *billed* running low
+        means the budget is genuinely nearly gone, and refusing is right. The
+        booking is a different thing: it is headroom this command reserved for
+        work that has not happened, and a cheap statement legitimately books a
+        fraction of a unit. Letting that truncate to 0 refused perfectly
+        affordable work, and it fired on every small query the moment
+        ``session_ceiling`` was set, since that is what creates a reservation at
+        all. So the exhaustion test reads the ceiling, and the booking is only
+        ever allowed to *tighten* the cap, never to turn it into a refusal.
         """
 
         ceiling = self.effective_ceiling()

--- a/packages/dex-core/tests/adapters/test_connect_bigquery.py
+++ b/packages/dex-core/tests/adapters/test_connect_bigquery.py
@@ -456,7 +456,7 @@ def test_server_side_cap_translates_when_the_estimate_drifts(fake_bq_client):
 # --- issue #320: the server-side cap must not be pinned below the confirmed
 # budget by BigQuery's own execution-time billing rounding, which no dry run
 # predicts. The bug's actual trigger is a `session_ceiling`: without one,
-# `remaining_for_statement()` already equals the confirmed ceiling directly
+# `statement_cap()` already equals the confirmed ceiling directly
 # (see `test_every_executed_job_carries_maximum_bytes_billed` above); with
 # one, the per-statement cap is additionally bounded by this command's own
 # reservation (booked at confirm time, sized to the dry-run estimate), which

--- a/packages/dex-core/tests/adapters/test_connect_clickhouse.py
+++ b/packages/dex-core/tests/adapters/test_connect_clickhouse.py
@@ -354,7 +354,7 @@ def test_a_sub_second_remainder_is_refused_rather_than_sent_as_zero(
     at exactly the moment the budget is nearly spent."""
 
     adapter = make_adapter(fake_clickhouse_connection, ceiling=600.0)
-    # Settled spend, not a booking: remaining_for_statement measures the ceiling
+    # Settled spend, not a booking: the statement cap measures the ceiling
     # against what has actually been billed, which is what the server cap is
     # derived from.
     adapter.cost_gate.record_billed(599.5, job_id=None, statement="prior")

--- a/packages/dex-core/tests/explore/test_billed_handshake.py
+++ b/packages/dex-core/tests/explore/test_billed_handshake.py
@@ -709,7 +709,9 @@ def test_a_mid_batch_shortfall_states_the_exact_extra_budget_needed(
     assert statuses.count("ok") >= 1
     assert "failed" in statuses
     failed = next(r for r in results if r["status"] == "failed")
-    assert "is below BigQuery's" in failed["error"]
+    # The shortfall is the cost gate's own refusal (issue #316), so it names
+    # the per-query minimum the cap fell under rather than the connector.
+    assert "is below the 10,485,760-byte minimum" in failed["error"]
     assert "needs at least" in failed["error"]
     assert "bytes_scanned" in failed["error"]
     assert "does not re-pay for them" in failed["error"]

--- a/packages/dex-core/tests/guards/test_cost_guard.py
+++ b/packages/dex-core/tests/guards/test_cost_guard.py
@@ -206,9 +206,9 @@ def test_gate_phase_zero_estimate_and_no_ceiling_never_raise():
 
 def test_gate_max_bytes_tracks_actual_billing():
     gate = _gate(ceiling=1_000.0)
-    assert gate.remaining_for_statement() == 1_000
+    assert gate.statement_cap(unit="byte") == 1_000
     gate.record_billed(400.0, statement="SELECT 1")
-    assert gate.remaining_for_statement() == 600
+    assert gate.statement_cap(unit="byte") == 600
 
 
 def test_gate_ledger_entries_carry_hashes_never_sql():
@@ -482,9 +482,9 @@ def test_the_server_side_cap_never_exceeds_what_was_booked():
     ledger = _Ledger()
     gate = _ledger_gate(ledger)
     gate.preflight_command(300.0)
-    assert gate.remaining_for_statement() == 300
+    assert gate.statement_cap(unit="byte") == 300
     gate.record_billed(100.0)
-    assert gate.remaining_for_statement() == 200
+    assert gate.statement_cap(unit="byte") == 200
 
 
 def test_settling_is_idempotent():
@@ -588,10 +588,10 @@ def test_the_ledger_and_envelope_spellings_stay_distinct():
 def test_a_sub_unit_remainder_caps_at_one_rather_than_reading_as_unlimited():
     """A cheap command under a cumulative ceiling must still be runnable.
 
-    `remaining_for_statement` is an integer because every connector's cap
-    setting takes one, and on the time-paradigm connectors a cap of 0 means *no
-    limit* rather than "spend nothing", so the adapters refuse rather than send
-    a 0. Truncating a fractional remainder therefore turned into a refusal of
+    A statement cap is an integer because every connector's cap setting takes
+    one, and on the time-paradigm connectors a cap of 0 means *no limit* rather
+    than "spend nothing", so the gate refuses rather than hand one over.
+    Truncating a fractional remainder therefore turned into a refusal of
     affordable work: setting `session_ceiling` creates a reservation, a cheap
     command books less than a second, and `int(0.5)` is 0, so every small query
     was refused with "the remaining budget is under one database-second" against
@@ -599,8 +599,8 @@ def test_a_sub_unit_remainder_caps_at_one_rather_than_reading_as_unlimited():
 
     The discriminator is which term produced the sub-unit value, so all three
     cases are asserted together: a booking under one unit still yields a usable
-    cap, a genuinely exhausted ceiling still reads as exhausted, and the booking
-    still tightens the cap when it is the smaller of the two. Dropping any one of
+    cap, a genuinely exhausted ceiling still refuses, and the booking still
+    tightens the cap when it is the smaller of the two. Dropping any one of
     them would trade a false refusal for a missing one, or the reverse.
     """
 
@@ -618,7 +618,7 @@ def test_a_sub_unit_remainder_caps_at_one_rather_than_reading_as_unlimited():
     )
     gate.preflight_command(0.5)
     gate.charge(0.5)
-    assert gate.remaining_for_statement() == 1
+    assert gate.statement_cap(unit="database-second") == 1
 
     spent = CostGate(
         paradigm=Paradigm.DB_LOAD,
@@ -630,10 +630,8 @@ def test_a_sub_unit_remainder_caps_at_one_rather_than_reading_as_unlimited():
         session_spent=0.0,
     )
     spent.record_billed(59.5, job_id=None, statement="prior")
-    assert spent.remaining_for_statement() == 0, (
-        "a ceiling with under a unit left is genuinely exhausted and must still "
-        "refuse, which is the half the booking fix must not break"
-    )
+    with pytest.raises(OverCeilingError, match="under one database-second"):
+        spent.statement_cap(unit="database-second")
 
     # And the booking still tightens: 5 booked against a 60-second ceiling caps
     # the statement at 5, not 60.
@@ -647,7 +645,78 @@ def test_a_sub_unit_remainder_caps_at_one_rather_than_reading_as_unlimited():
         session_spent=0.0,
     )
     tight.preflight_command(5.0)
-    assert tight.remaining_for_statement() == 5
+    assert tight.statement_cap(unit="database-second") == 5
+
+
+def test_an_exhausted_budget_refuses_at_the_gate_rather_than_at_each_adapter():
+    """Issue #316: the two states a cap of 0 could mean are told apart here.
+
+    An exhausted budget and "no cap applies" used to be a 0 and a `None` handed
+    back for the caller to tell apart, and every adapter told them apart the
+    same way in its own billed path. That is a convention, not a contract: the
+    connector that forgets the check sends the server a 0, which Postgres,
+    ClickHouse and Databricks all read as *no limit*, so the backstop
+    disappears exactly when the budget is nearly gone and the run looks
+    entirely ordinary while it happens.
+
+    So the shortfall is the call's own refusal. `statement_cap` returns a cap
+    the server will honour or raises, with nothing in between for a caller to
+    misread, and the refusal carries the cost the envelope reports.
+    """
+
+    from exmergo_dex_core.envelope import Paradigm
+    from exmergo_dex_core.guards.cost_guard import CostGate
+
+    def gate(paradigm: Paradigm, ceiling: float) -> CostGate:
+        return CostGate(
+            paradigm=paradigm,
+            connector="postgres",
+            command="explore query",
+            ceiling=ceiling,
+            confirmed=True,
+            session_ceiling=None,
+            session_spent=0.0,
+        )
+
+    exhausted = gate(Paradigm.DB_LOAD, 60.0)
+    exhausted.record_billed(59.7, job_id=None, statement="prior")
+    with pytest.raises(OverCeilingError) as refusal:
+        exhausted.statement_cap(unit="database-second")
+    # The refusal is priced: an empty cost block on a spend refusal reads as a
+    # claim that nothing was going to be spent.
+    assert refusal.value.cost is not None
+    assert refusal.value.cost.paradigm is Paradigm.DB_LOAD
+    assert refusal.value.cost.ceiling == 60.0
+
+    # A floor above one unit is the same event: BigQuery bills a 10 MB minimum
+    # per query, so a cap under that is refused by the server rather than
+    # honoured by it, and the shortfall names the number to raise --budget past.
+    bytes_gate = gate(Paradigm.BYTES_SCANNED, 12 * 1024 * 1024)
+    bytes_gate.record_billed(4 * 1024 * 1024, job_id=None, statement="prior")
+    with pytest.raises(OverCeilingError, match="10,485,760-byte minimum"):
+        bytes_gate.statement_cap(unit="byte", minimum=10 * 1024 * 1024)
+    # ...and it is a floor, not a rounding: 12 MB of the 12 MB budget is above
+    # it and still prices normally.
+    assert (
+        gate(Paradigm.BYTES_SCANNED, 12 * 1024 * 1024).statement_cap(
+            unit="byte", minimum=10 * 1024 * 1024
+        )
+        == 12 * 1024 * 1024
+    )
+
+    # `None` is the only other answer, and it means no ceiling bounds the
+    # statement at all rather than "spend nothing": distinct from every integer,
+    # so no adapter has to recognise a magnitude to tell them apart.
+    unbounded = CostGate(
+        paradigm=Paradigm.FREE_LOCAL,
+        connector="duckdb",
+        command="explore query",
+        ceiling=None,
+        confirmed=True,
+        session_ceiling=None,
+        session_spent=0.0,
+    )
+    assert unbounded.statement_cap(unit="database-second") is None
 
 
 # --- the ledger is a dependency of billing, not of every command -----------------

--- a/packages/dex-core/tests/test_engine.py
+++ b/packages/dex-core/tests/test_engine.py
@@ -586,7 +586,7 @@ def test_each_call_gets_its_own_cost_gate(monkeypatch: pytest.MonkeyPatch, tmp_p
     # labelled with its own command, and has its full budget available.
     assert second.cost_gate is not None
     assert second.cost_gate.command == "explore query"
-    assert second.cost_gate.remaining_for_statement() == 1_000
+    assert second.cost_gate.statement_cap(unit="byte") == 1_000
     second.cost_gate.charge(600.0)  # would raise if the first charge carried over
 
 


### PR DESCRIPTION
## What this changes
`CostGate.remaining_for_statement` becomes the private `_remaining_for_statement`, reachable only through a new `CostGate.statement_cap(*, unit, minimum=1) `that raises `OverCeilingError` on exhaustion. Its public result is now either None or a strictly positive, server-safe integer. The six per-adapter exhaustion checks are deleted, and the property they enforced between them is tested once, centrally.

## Problem
The server-side cap is an integer because every connector's cap setting takes one, and on the time-paradigm connectors a cap of 0 does not mean "spend nothing" but no limit: Postgres `statement_timeout`, ClickHouse `max_execution_time`, Databricks `STATEMENT_TIMEOUT`.

Exhaustion and "no cap applies" were already distinguishable at the boundary, 0 against None, but telling them apart was still the caller's job, and all six billed adapters did it the same way in their own billed-statement path. That is a convention, not a contract. One forgotten if in a new connector hands the server a 0, which removes the backstop at exactly the moment the budget is nearly spent, and it fails in the most expensive possible direction while looking like an ordinary run.

## Fix
`statement_cap` owns the refusal, so there is no intermediate value left for a caller to misread. Two parameters carry what the adapters used to hardcode: `unit` names the unit in the refusal in the connector's own vocabulary (a "database-second", a "byte"), since that is what the caller has to raise `--budget` in, and `minimum` is the smallest cap that server can usefully be given. `minimum` is how BigQuery's 10 MB per-query billing minimum is now expressed, rather than as a seventh hand-written check.

The distinction the earlier defect turned on is preserved. Only the ceiling minus actual billing may produce the 0; a per-command booking under one unit still tightens the cap without ever becoming a refusal.

Two behavior changes worth review: the BigQuery refusal now carries its `Cost` (it previously reported an empty cost block on a spend refusal), and its message names the per-query minimum rather than the connector.

Checked repo-wide, not just in the adapters: `transform/build.py` and `transform/init.py` build caps on a separate path that never touches a CostGate, and both already floor at 1, so no change was needed there.

Tests: 807 passing in the adapter and guard suites, 3052 across the full non-integration suite. Three test_packaging.py failures are pre-existing (they reproduce on a clean stash) and stem from a dbt-core-experimental-parser prerelease resolution issue.

## Related issue
Closes #316 