### PR TITLE
Fix data.bytes_billed present on transform build, absent on maintain check 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,11 @@ still binds exactly via a server-side statement timeout, except on ClickHouse,
 where it binds via `max_execution_time` **and** `max_bytes_to_read`, because
 time alone is checked only at block boundaries there. Actual spend comes
 back under `data.spend` (`bytes_billed` or `seconds_billed`) and accumulates
-in the `.dex/spend.jsonl` ledger per connector. That ledger gates billing and
+in the `.dex/spend.jsonl` ledger per connector. That is the only place spend is
+reported: every command that can bill carries the unit key whatever it settled
+at, zero included, and no command puts a billed magnitude anywhere else in
+`data`, because a key present on one command and absent on another reads as a
+spend of zero rather than as a key to look for elsewhere. That ledger gates billing and
 nothing else: it is read where work is admitted, not where a connection is
 assembled, so a command that cannot spend does not depend on it, and a ledger
 that cannot be read refuses billed work by name while reporting the day's total

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,56 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   as independent, and the row-count floor alone satisfies every acceptance
   criterion.
 
+- **`data.spend` is now the only place any command reports what it billed**
+  ([#276]). `transform build` stamped its billed magnitude twice, once under
+  `data.spend` like every other billed command and once as a top-level
+  `data.bytes_billed` that no other command carried:
+
+  | Command | `data.bytes_billed` | `data.spend.bytes_billed` |
+  |---|---|---|
+  | `transform build` | 4750049280 | 4750049280 |
+  | `maintain check` | absent | 891289600 |
+
+  A caller that reads the top-level key and defaults a miss to zero therefore
+  reports that `maintain check` was free. It was not; it had just scanned
+  0.89 GB. That happened in a real session, the wrong figure was reported to a
+  human, and it survived into the first draft of a written cost report before
+  being caught by reconciling the envelopes against `.dex/spend.jsonl`.
+
+  Silently under-reporting spend is the one class of envelope defect that
+  undermines the cost-governance guarantee rather than merely annoying the
+  caller, and this one is invisible from the caller's side: an agent reading one
+  key and getting nothing cannot distinguish "this cost nothing" from "look in
+  the other key", and both readings are plausible. So the duplicate is removed
+  rather than propagated. A key that exists on one command and not another is
+  worse than a key that never exists, because at the top of `data`, where a
+  command's own findings live, an absent key reads as a value.
+
+  The same rule has a second half, which was also broken on builds. A billed
+  command now reports the unit key whatever it settled at, zero included: a
+  build that billed nothing used to omit `data.spend` entirely, which is the
+  identical ambiguity one level down. And where a figure is genuinely
+  unavailable it is reported as `null` with a note saying why, never as zero.
+  That case is real: if dbt executed statements and reported no billing figure
+  for any of them, what the build cost is unknown, nothing is appended to the
+  ledger, and rounding it down to zero would be the same under-report by
+  another route. A build that died before executing anything did bill nothing
+  and still settles at zero.
+
+  Two smaller consequences of making the rule uniform. On ClickHouse Cloud a
+  build's translated figures (compute-unit-hours, USD) are reported at zero
+  seconds too, rather than being the same present-sometimes key one level
+  further down. And a build now tolerates a ledger read failure at settlement
+  the way gate settlement already does, reporting
+  `data.spend.session_spent_today: null`: what the build billed came from dbt
+  and is exact either way, so a store that goes away must not turn a build that
+  already spent into a failure that reports nothing.
+
+  Key parity across `transform build`, `maintain check`, `explore query`,
+  `explore map` and `explore profile` is now a contract test, asserted as an
+  equality between commands rather than against a list of expected keys. What a
+  connector reports is the connector's business; which command asked cannot be.
+
 ### Changed
 
 - **`explore query` now carries compact cache-backed column and query notes

--- a/packages/dex-core/src/exmergo_dex_core/transform/build.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/build.py
@@ -787,6 +787,11 @@ def _summarize(
         "counts": counts,
         "messages": messages,
     }
+    # Internal hand-off, not envelope shape: `_shape_build_result` pops this to
+    # ledger the build and report it under `data.spend`, the one key every billed
+    # command reports spend under (issue #276). Present only when dbt actually
+    # reported a figure, so the shaper can tell "billed nothing" from "billed an
+    # amount dbt never told us".
     if saw_billing:
         summary["bytes_billed"] = bytes_billed
     return summary

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -19,6 +19,7 @@ command here needs a repo root and refuses without one, naming what needed it.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import sys
 from typing import TYPE_CHECKING
@@ -1099,15 +1100,21 @@ def _plan_hint(result: PlanResult) -> dict[str, str]:
 def _record_build_spend(
     store: Store,
     connector: str,
-    billed: float,
+    billed: float | None,
     paradigm,
     estimate: float | None = None,
-) -> dict[str, float]:
+) -> dict[str, float | None]:
     """Account a billed dbt build in the spend ledger and report what it cost.
 
     The paradigm names both units, so a build draws against the same session
     budget as an explore scan and reports spend under the key every other
     command reports it under.
+
+    ``billed`` is ``None`` only where dbt executed statements and reported no
+    billing figure for any of them, which is unknown spend rather than none.
+    Nothing is ledgered then, because there is no figure to ledger, and the unit
+    key still reports ``None`` so the caller reads "unavailable" instead of the
+    zero that would under-report it.
 
     Returns the summary in :meth:`CostGate.spend_summary`'s shape, because a
     build settles outside any gate: dbt executes the statements, so
@@ -1130,27 +1137,36 @@ def _record_build_spend(
     from ..guards.cost_guard import ledger_field, spend_field, utc_day_start
 
     field = ledger_field(paradigm)
-    store.append_spend_log(
-        {
-            "at": datetime.now(UTC).isoformat(),
-            "connector": connector,
-            "command": "transform build",
-            # The kind every gate-written settlement carries. A build settles
-            # outside any gate and used to write an entry with no kind at all,
-            # which sums identically (the totals branch on no kind) but reads as
-            # a different sort of record to anything walking the ledger back.
-            "entry": "settlement",
-            field: float(billed),
-            "estimate": estimate,
-            "job_id": None,
-            "statement_sha256": None,
-        }
-    )
-    return {
-        spend_field(paradigm): float(billed),
-        "session_spent_today": store.spend_since(
+    if billed is not None:
+        store.append_spend_log(
+            {
+                "at": datetime.now(UTC).isoformat(),
+                "connector": connector,
+                "command": "transform build",
+                # The kind every gate-written settlement carries. A build settles
+                # outside any gate and used to write an entry with no kind at all,
+                # which sums identically (the totals branch on no kind) but reads
+                # as a different sort of record to anything walking the ledger
+                # back.
+                "entry": "settlement",
+                field: float(billed),
+                "estimate": estimate,
+                "job_id": None,
+                "statement_sha256": None,
+            }
+        )
+    # Read back best-effort, exactly as gate settlement reports the day's total:
+    # what this build billed came from dbt and is exact either way, so a ledger
+    # that cannot be read must not turn a build that already spent into a failure
+    # reporting nothing. `None` is the documented "day's total unavailable".
+    session_spent: float | None = None
+    with contextlib.suppress(Exception):
+        session_spent = store.spend_since(
             utc_day_start(), field=field, connector=connector
-        ),
+        )
+    return {
+        spend_field(paradigm): None if billed is None else float(billed),
+        "session_spent_today": session_spent,
     }
 
 
@@ -1249,6 +1265,13 @@ def _shape_build_result(
     *and* reported on the result, so a host summing settled spend from envelopes
     sees builds rather than silently counting them as free.
 
+    It is reported in exactly one place, ``data.spend``, which every billed
+    command reports under. Anything a caller has to look for in a second key on
+    some commands and not others is a key whose absence reads as a value, and the
+    value it read as here was zero (issue #276). For the same reason a billed
+    paradigm always reports the key, whatever it settled at: a spend of zero and
+    "this command does not report spend" have to be distinguishable.
+
     A failed run reports its spend too: dbt bills for the statements it ran
     before it stopped, and a caller sizing the re-run needs that number more
     than a successful one does.
@@ -1270,7 +1293,7 @@ def _shape_build_result(
         gate.settle()
     messages = summary.pop("messages", [])
     notes = [*extra_notes, *summary.pop("notes", [])]
-    spend: dict[str, float] | None = None
+    spend: dict[str, float | None] | None = None
     # What the handshake priced this build at, ledgered beside what it billed so
     # a later over-ceiling refusal on this connector can say how far the two
     # have run apart. `None` on the degraded-pricing path, where there was no
@@ -1282,25 +1305,49 @@ def _shape_build_result(
             "maximum_bytes_billed (a per-statement cap, not per run)",
             *notes,
         ]
-        billed = summary.get("bytes_billed")
-        if billed:
-            spend = _record_build_spend(store, connector, billed, paradigm, estimate)
+        # Popped, not read: `data.spend` is the one place any command reports
+        # what it billed, and a second copy at the top of `data` that only this
+        # command carried was worse than no copy at all (issue #276). A caller
+        # reading `data.bytes_billed` saw a build's spend and nothing for a
+        # `maintain check` that had just scanned 0.89 GB, and an absent key
+        # defaulted to zero reads as free.
+        billed = summary.pop("bytes_billed", None)
+        if billed is None and summary.get("nodes"):
+            # Statements ran and not one of them reported a billing figure, so
+            # what this build cost is unknown rather than nothing. Reporting the
+            # key as null says exactly that; zero would under-report spend, which
+            # is the one direction a cost guard must never round. A build that
+            # died before executing anything has an empty `nodes` and really did
+            # bill nothing, so it settles at zero like any other free run.
+            notes = [
+                *notes,
+                "dbt reported no billing figure for any statement in this run, "
+                "so spend is unknown rather than zero and nothing was appended "
+                "to the spend ledger",
+            ]
+        else:
+            billed = float(billed or 0.0)
+        spend = _record_build_spend(store, connector, billed, paradigm, estimate)
     elif paradigm is Paradigm.COMPUTE_TIME:
         cap_note = _COMPUTE_TIME_CAP_NOTES.get(
             connector, _DEFAULT_COMPUTE_TIME_CAP_NOTE
         )
         notes = [cap_note, *notes]
         # dbt-snowflake, dbt-databricks, and dbt-redshift report no billing figure;
-        # per-node execution time is the honest compute-seconds actual.
+        # per-node execution time is the honest compute-seconds actual. It is
+        # always known (a run with no nodes burned no seconds), so unlike the
+        # bytes path there is no unknown case to distinguish from zero.
         seconds = sum(
             float(node.get("execution_time") or 0) for node in summary.get("nodes", [])
         )
-        if seconds:
-            summary["seconds_billed"] = seconds
-            spend = _record_build_spend(store, connector, seconds, paradigm, estimate)
-            translate = getattr(adapter, "compute_spend_translation", None)
-            if translate is not None:
-                spend.update(translate(seconds))
+        spend = _record_build_spend(store, connector, seconds, paradigm, estimate)
+        translate = getattr(adapter, "compute_spend_translation", None)
+        if translate is not None:
+            # Unconditional, including at zero seconds: the translated keys
+            # (compute-unit-hours, USD) are part of this connector's spend shape,
+            # and a run that omitted them would be the same present-sometimes key
+            # this issue is about, one level down.
+            spend.update(translate(seconds))
     elif paradigm is Paradigm.DB_LOAD:
         notes = [_DB_LOAD_CAP_NOTES.get(connector, _UNCAPPED_BUILD_NOTE), *notes]
         # The db-load dbt adapters report no billing figure; per-node execution
@@ -1308,9 +1355,7 @@ def _shape_build_result(
         seconds = sum(
             float(node.get("execution_time") or 0) for node in summary.get("nodes", [])
         )
-        if seconds:
-            summary["seconds_billed"] = seconds
-            spend = _record_build_spend(store, connector, seconds, paradigm, estimate)
+        spend = _record_build_spend(store, connector, seconds, paradigm, estimate)
     notes = [
         *notes,
         *no_session_ceiling_warning(

--- a/packages/dex-core/tests/integration/test_databricks_transform.py
+++ b/packages/dex-core/tests/integration/test_databricks_transform.py
@@ -138,7 +138,7 @@ def test_init_plan_apply_build_into_the_scratch_catalog(
     statuses = {n["name"]: n["status"] for n in built["data"]["nodes"]}
     assert statuses.get(MODEL_NAME) == "success"
     # Warehouse time is accounted: the compute-time build records seconds.
-    assert built["data"].get("seconds_billed", 0) >= 0
+    assert built["data"]["spend"]["seconds_billed"] >= 0
 
     # The relation exists exactly where the dev target points, then
     # best-effort cleanup through the same discovered connection.

--- a/packages/dex-core/tests/integration/test_postgres_transform.py
+++ b/packages/dex-core/tests/integration/test_postgres_transform.py
@@ -92,7 +92,7 @@ def test_init_and_build_write_only_the_dev_schema(
     # EXPLAIN planner preflight is surfaced before the run.
     assert envelope["cost"]["estimate"] is not None
     assert envelope["cost"]["estimate"] > 0
-    assert data["seconds_billed"] > 0
+    assert data["spend"]["seconds_billed"] > 0
     assert any("statement_timeout" in w for w in envelope["warnings"])
 
     ledger = (tmp_path / ".dex" / "spend.jsonl").read_text(encoding="utf-8")

--- a/packages/dex-core/tests/integration/test_redshift_transform.py
+++ b/packages/dex-core/tests/integration/test_redshift_transform.py
@@ -116,7 +116,7 @@ def test_init_and_build_write_only_the_dev_schema(tmp_path: Path, capsys, dev_en
     # surfaced before the run (the 5x budget covers it comfortably).
     assert envelope["cost"]["estimate"] is not None
     assert envelope["cost"]["estimate"] > 0
-    assert data["seconds_billed"] > 0
+    assert data["spend"]["seconds_billed"] > 0
     assert any("statement_timeout" in w for w in envelope["warnings"])
 
     ledger = (tmp_path / ".dex" / "spend.jsonl").read_text(encoding="utf-8")

--- a/packages/dex-core/tests/integration/test_snowflake_transform.py
+++ b/packages/dex-core/tests/integration/test_snowflake_transform.py
@@ -126,7 +126,7 @@ def test_init_plan_apply_build_into_the_scratch_database(
     statuses = {n["name"]: n["status"] for n in built["data"]["nodes"]}
     assert statuses.get(MODEL_NAME) == "success"
     # Warehouse time is accounted: the compute-time build records seconds.
-    assert built["data"].get("seconds_billed", 0) >= 0
+    assert built["data"]["spend"]["seconds_billed"] >= 0
 
     # The relation exists exactly where the dev target points, then
     # best-effort cleanup; the transient database is the backstop.

--- a/packages/dex-core/tests/test_spend_parity.py
+++ b/packages/dex-core/tests/test_spend_parity.py
@@ -1,0 +1,463 @@
+"""Envelope-shape parity for spend: every billed command reports what it cost in
+one place, under the same keys (issue #276).
+
+`transform build` used to stamp its billed magnitude at the top of `data` *and*
+under `data.spend`, while every other billed command reported only the latter. A
+caller that read `data.bytes_billed` and defaulted a miss to zero therefore
+reported a `maintain check` that had just scanned 0.89 GB as free, which is the
+one direction a cost guarantee must never round.
+
+The fix is a contract rather than a per-command patch, so the test is too: it
+drives the five billed commands through the real CLI against one fake BigQuery
+warehouse and compares the *shape* of what came back, not the figures. A sixth
+command growing its own spelling of spend fails here.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("google.cloud.bigquery")
+
+from exmergo_dex_core.cache import ColumnProfile, Dataset, DexCache, PIIFlag
+from exmergo_dex_core.cli import main
+from exmergo_dex_core.config import BigQueryTarget
+from exmergo_dex_core.engine import DexEngine
+from exmergo_dex_core.envelope import Paradigm
+from exmergo_dex_core.guards.cost_guard import CostGate, ledger_field, utc_day_start
+from exmergo_dex_core.maintain.snapshot import Snapshot, WarehouseBaseline
+from exmergo_dex_core.storage import FilesystemStore
+
+MB = 1024 * 1024
+BUDGET = str(float(500 * MB))
+
+# Every spelling of "what this cost" that has ever appeared in an envelope or in
+# the ledger. None of them may appear at the top of `data`: that is the level
+# where a missing key reads as zero, because `data` is where a command's own
+# findings live and a caller cannot tell an omitted figure from an absent one.
+SPEND_SPELLINGS = frozenset(
+    {
+        "bytes_billed",
+        "seconds_billed",
+        "billed_bytes",
+        "billed_seconds",
+        "compute_unit_hours_billed",
+        "usd_billed",
+        "session_spent_today",
+        "spent_today",
+    }
+)
+
+# The one query the fake resolves for `explore query`. Cheap, single-table, and
+# already adjudicated in the seeded cache, so the run prices the query alone.
+QUERY_SQL = "SELECT COUNT(*) AS n FROM `test-proj`.`shop`.`customers`"
+
+
+def _scan_resolver(sql: str):
+    """Answer every scanning statement the profile, map and grain paths issue.
+
+    One superset row rather than a resolver per command: these tests assert on
+    envelope shape, so what each aggregate alias comes back as matters only
+    insofar as the scan completes and bills.
+    """
+
+    values = {"n_total": 100}
+    for i in range(10):
+        values[f"nn_{i}"] = 100
+        values[f"nd_{i}"] = 100 if i == 0 else 40
+        values[f"mn_{i}"] = 1
+        values[f"mx_{i}"] = 100
+        values[f"d_{i}"] = 100 if i == 0 else 40
+    values["nonnull_fk"] = 100
+    values["orphans"] = 0
+    return [values]
+
+
+def _run(argv: list[str], capsys) -> dict:
+    """One command through the real CLI, as an agent wrapper sees it."""
+
+    rc = main(argv)
+    out = capsys.readouterr().out
+    assert out.count("\n") == 1, "exactly one line on stdout"
+    envelope = json.loads(out)
+    assert rc == 0, envelope
+    assert envelope["status"] == "ok", envelope
+    return envelope
+
+
+def _billed_gate(store: FilesystemStore, command: str) -> CostGate:
+    """A confirmed, budgeted bytes-scanned gate wired to the store the command's
+    own engine will read back, so `session_spent_today` is the real day total."""
+
+    return CostGate(
+        paradigm=Paradigm.BYTES_SCANNED,
+        ceiling=float(500 * MB),
+        session_ceiling=None,
+        session_spent=lambda: store.spend_since(
+            utc_day_start(),
+            field=ledger_field(Paradigm.BYTES_SCANNED),
+            connector="bigquery",
+        ),
+        confirmed=True,
+        connector="bigquery",
+        command=command,
+        record=store.append_spend_log,
+        lock=store.spend_lock,
+    )
+
+
+def _route_warehouse(monkeypatch, fake_bq_client, root: Path, command: str) -> None:
+    """Point the engine's one adapter funnel at the fake warehouse.
+
+    `DexEngine._adapter` rather than `connect.open_adapter`: it is the seam every
+    command opens a connection through, so a command that grew a second way in
+    would fail here rather than quietly reaching a real warehouse.
+    """
+
+    from exmergo_dex_core.adapters.bigquery import BigQueryAdapter
+
+    store = FilesystemStore(root)
+
+    def opener(self, cmd=None, *, budget=None, confirmed=None):
+        return BigQueryAdapter(
+            project="test-proj",
+            cost_gate=_billed_gate(store, command),
+            target=BigQueryTarget(),
+            client=fake_bq_client,
+            principal_type="user",
+        )
+
+    monkeypatch.setattr(DexEngine, "_adapter", opener)
+
+
+def _route_build(monkeypatch, root: Path, project: Path) -> None:
+    """Make a billed `transform build` run without a warehouse or a real dbt.
+
+    The adapter is a stub carrying a real gate (a build settles outside it, so
+    only its paradigm and ceiling are load-bearing), `compile_estimate` is stubbed
+    so the free preflight issues no dry-runs, the dev-target check is neutralized
+    so it opens no second connection, and the dbt runner writes the per-node
+    billing artifact a real dbt-bigquery run writes.
+    """
+
+    from exmergo_dex_core.transform import dev_target
+
+    build_module = importlib.import_module("exmergo_dex_core.transform.build")
+    store = FilesystemStore(root)
+
+    class StubAdapter:
+        paradigm = Paradigm.BYTES_SCANNED
+        name = "bigquery"
+
+        def __init__(self):
+            self.cost_gate = _billed_gate(store, "transform build")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        DexEngine, "_adapter", lambda self, cmd=None, **kw: StubAdapter()
+    )
+    monkeypatch.setattr(
+        build_module,
+        "compile_estimate",
+        lambda proj, adapter, *, target, select=None, **kw: (
+            float(5 * MB),
+            {"stg_customers": float(5 * MB)},
+            [],
+        ),
+    )
+    monkeypatch.setattr(dev_target, "check", lambda *a, **k: [])
+
+    run_results = json.dumps(
+        {
+            "results": [
+                {
+                    "unique_id": "model.dex_test.stg_customers",
+                    "status": "success",
+                    "execution_time": 1.0,
+                    "adapter_response": {"bytes_billed": 3000},
+                }
+            ]
+        }
+    )
+
+    def fake(timeout: float, cwd, env=None):
+        def run(argv: list[str]):
+            artifact = project / "target" / "run_results.json"
+            artifact.parent.mkdir(parents=True, exist_ok=True)
+            artifact.write_text(run_results, encoding="utf-8")
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout="", stderr=""
+            )
+
+        return run
+
+    monkeypatch.setattr(build_module, "_default_runner", fake)
+
+
+def _seed_query_cache(root: Path) -> None:
+    """A cache that already adjudicates `shop.customers`, so `explore query`
+    prices the query itself instead of auto-profiling first. The column signature
+    matches the fake's live schema, or the engine re-profiles before trusting it."""
+
+    FilesystemStore(root).save_cache(
+        DexCache(
+            datasets=[
+                Dataset(
+                    identifier="test-proj.shop.customers",
+                    columns=[
+                        ColumnProfile(name="id", data_type="INTEGER", nullable=False),
+                        ColumnProfile(
+                            name="email",
+                            data_type="STRING",
+                            pii=PIIFlag(category="email", confidence=0.9),
+                        ),
+                    ],
+                )
+            ]
+        )
+    )
+
+
+def _seed_snapshot(root: Path) -> None:
+    """A baseline `maintain check` can drift against: customers with a proven
+    single-column key, which is what sends the grain axis to the warehouse."""
+
+    now = datetime.now(UTC).isoformat()
+    FilesystemStore(root).save_snapshot(
+        Snapshot(
+            created_at=now,
+            connector="bigquery",
+            warehouse=WarehouseBaseline(
+                datasets=[
+                    Dataset(
+                        identifier="test-proj.shop.customers",
+                        row_count=100,
+                        byte_size=5_000,
+                        columns=[
+                            ColumnProfile(
+                                name="id",
+                                data_type="INTEGER",
+                                nullable=False,
+                                null_fraction=0.0,
+                                distinct_count=100,
+                                distinct_count_exact=True,
+                                is_unique=True,
+                            ),
+                            ColumnProfile(name="email", data_type="STRING"),
+                        ],
+                        candidate_keys=[["id"]],
+                        grain=["id"],
+                        profiled_at=now,
+                    )
+                ]
+            ),
+            warehouse_from="cache",
+        )
+    )
+
+
+@pytest.fixture
+def bigquery_project(dbt_project_dir: Path) -> Path:
+    """The shared dbt project retyped to BigQuery: the dev-target preflight
+    (correctly) refuses a build whose profile names a different adapter than the
+    connector governing it, so the profile has to say what the test claims."""
+
+    (dbt_project_dir / "profiles.yml").write_text(
+        "dex_test:\n"
+        "  target: dev\n"
+        "  outputs:\n"
+        "    dev:\n"
+        "      type: bigquery\n"
+        "      method: oauth\n"
+        "      project: dex-test\n"
+        "      dataset: dbt_dev\n",
+        encoding="utf-8",
+    )
+    return dbt_project_dir
+
+
+@pytest.fixture
+def billed_data(
+    fake_bq_client, bigquery_project: Path, tmp_path: Path, capsys, monkeypatch
+) -> dict[str, dict]:
+    """The `data` payload of each billed command, run against one fake warehouse.
+
+    Each command gets its own repo root: they disagree about what the `.dex/`
+    cache should hold going in (a seeded query cache, a drift baseline, a cold
+    cache for `map`), and a shared root would make one command's prerequisite
+    another's cache hit, which is the fastest way to a billed command that
+    quietly bills nothing.
+    """
+
+    payloads: dict[str, dict] = {}
+
+    def root(name: str) -> Path:
+        path = tmp_path / name
+        path.mkdir()
+        return path
+
+    # `transform build` alone runs at the repo root the dbt project lives under,
+    # because that is how the project is discovered.
+    with monkeypatch.context() as patch:
+        _route_build(patch, tmp_path, bigquery_project)
+        payloads["transform build"] = _run(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--connector",
+                "bigquery",
+                "transform",
+                "build",
+                "--target",
+                "dev",
+                "--confirm",
+                "--budget",
+                BUDGET,
+            ],
+            capsys,
+        )["data"]
+
+    fake_bq_client.row_resolver = _scan_resolver
+
+    check_root = root("maintain-check")
+    _seed_snapshot(check_root)
+    with monkeypatch.context() as patch:
+        _route_warehouse(patch, fake_bq_client, check_root, "maintain")
+        payloads["maintain check"] = _run(
+            [
+                "--repo-root",
+                str(check_root),
+                "--connector",
+                "bigquery",
+                "maintain",
+                "check",
+                "--confirm",
+                "--budget",
+                BUDGET,
+            ],
+            capsys,
+        )["data"]
+
+    query_root = root("explore-query")
+    _seed_query_cache(query_root)
+    with monkeypatch.context() as patch:
+        _route_warehouse(patch, fake_bq_client, query_root, "explore")
+        fake_bq_client.row_resolver = lambda sql: [{"n": 100}]
+        payloads["explore query"] = _run(
+            [
+                "--repo-root",
+                str(query_root),
+                "--connector",
+                "bigquery",
+                "explore",
+                "query",
+                QUERY_SQL,
+                "--confirm",
+                "--budget",
+                BUDGET,
+            ],
+            capsys,
+        )["data"]
+
+    fake_bq_client.row_resolver = _scan_resolver
+
+    map_root = root("explore-map")
+    with monkeypatch.context() as patch:
+        _route_warehouse(patch, fake_bq_client, map_root, "explore")
+        payloads["explore map"] = _run(
+            [
+                "--repo-root",
+                str(map_root),
+                "--connector",
+                "bigquery",
+                "explore",
+                "map",
+                "--confirm",
+                "--budget",
+                BUDGET,
+            ],
+            capsys,
+        )["data"]
+
+    profile_root = root("explore-profile")
+    with monkeypatch.context() as patch:
+        _route_warehouse(patch, fake_bq_client, profile_root, "explore")
+        payloads["explore profile"] = _run(
+            [
+                "--repo-root",
+                str(profile_root),
+                "--connector",
+                "bigquery",
+                "explore",
+                "profile",
+                "customers",
+                "--confirm",
+                "--budget",
+                BUDGET,
+            ],
+            capsys,
+        )["data"]
+
+    return payloads
+
+
+def test_every_billed_command_reports_what_it_billed(billed_data: dict[str, dict]):
+    """The acceptance criterion, stated directly: one key, on all of them.
+
+    The figure is asserted nonzero to keep the test honest about its own premise.
+    A command that stopped scanning (a cache hit where the fixture meant a scan)
+    would satisfy every shape assertion here while proving nothing about a billed
+    run, and it is precisely a spend of zero that this issue is about misreading.
+    """
+
+    for command, data in billed_data.items():
+        assert "spend" in data, f"{command} reported no spend at all"
+        assert "bytes_billed" in data["spend"], (
+            f"{command} reported spend without the connector's unit: {data['spend']}"
+        )
+        assert data["spend"]["bytes_billed"] > 0, (
+            f"{command} was meant to bill and did not, so it proves nothing here"
+        )
+
+
+def test_no_billed_command_spells_spend_at_the_top_of_data(
+    billed_data: dict[str, dict],
+):
+    """`data.spend` is the only place spend is reported.
+
+    A duplicate one level up is not a harmless convenience: `transform build`
+    carried `data.bytes_billed` and nothing else did, so the same read that
+    worked on a build reported the next command as free.
+    """
+
+    for command, data in billed_data.items():
+        stray = SPEND_SPELLINGS & set(data)
+        assert not stray, f"{command} reports spend outside data.spend: {sorted(stray)}"
+
+
+def test_the_spend_payload_has_the_same_keys_on_every_billed_command(
+    billed_data: dict[str, dict],
+):
+    """Parity, which is the property that makes one read work everywhere.
+
+    Asserted as an equality across commands rather than against a literal list of
+    keys: what a connector reports (a translated USD figure, compute-unit-hours)
+    is the connector's business, but it cannot be the business of which command
+    asked.
+    """
+
+    shapes = {
+        command: frozenset(data["spend"]) for command, data in billed_data.items()
+    }
+    assert len(set(shapes.values())) == 1, (
+        "billed commands disagree about the spend payload's keys: "
+        f"{ {command: sorted(keys) for command, keys in shapes.items()} }"
+    )

--- a/packages/dex-core/tests/transform/test_build.py
+++ b/packages/dex-core/tests/transform/test_build.py
@@ -1131,7 +1131,11 @@ def test_billed_build_sums_bytes_billed_into_the_ledger(
     assert rc == 0, envelope
     # The confirmed run's envelope carries the preflight estimate and the actual.
     assert envelope["cost"]["estimate"] == 5_000_000.0
-    assert envelope["data"]["bytes_billed"] == 3000
+    # Issue #276: spend lives at `data.spend` and nowhere else. `transform build`
+    # used to also stamp a top-level `data.bytes_billed` that no other billed
+    # command carried, so a caller reading that key saw a build's spend and read
+    # `maintain check`'s missing key as zero.
+    assert "bytes_billed" not in envelope["data"]
     assert any("maximum_bytes_billed" in w for w in envelope["warnings"])
     ledger = (tmp_path / ".dex" / "spend.jsonl").read_text().splitlines()
     entry = json_mod.loads(ledger[-1])
@@ -1151,6 +1155,135 @@ def test_billed_build_sums_bytes_billed_into_the_ledger(
     # that refusal.
     assert entry["entry"] == "settlement"
     assert entry["estimate"] == envelope["cost"]["estimate"] == 5_000_000.0
+
+
+def test_a_billed_build_that_billed_nothing_still_reports_a_spend_of_zero(
+    bigquery_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """Issue #276, the other half: a key present only sometimes is worse than one
+    that never exists, so a billed connector reports `data.spend` whatever the
+    build settled at. A build that billed zero and one that does not report spend
+    have to be distinguishable, and `if billed:` made them identical."""
+
+    from exmergo_dex_core.envelope import Paradigm
+
+    _install_fake_pricing(
+        monkeypatch,
+        connector="bigquery",
+        paradigm=Paradigm.BYTES_SCANNED,
+        estimate=5_000_000.0,
+        per_node={"stg_customers": 5_000_000.0},
+        confirmed=True,
+        ceiling=100_000_000,
+    )
+    # dbt ran the node and BigQuery billed nothing for it: a cache hit, or a
+    # no-op incremental. The figure is reported, so it is zero.
+    run_results = json.dumps(
+        {
+            "results": [
+                {
+                    "unique_id": "model.dex_test.stg_customers",
+                    "status": "success",
+                    "execution_time": 1.0,
+                    "adapter_response": {"bytes_billed": 0},
+                }
+            ]
+        }
+    )
+    _fake_runner_factory(
+        monkeypatch,
+        returncode=0,
+        run_results_json=(
+            bigquery_project_dir / "target" / "run_results.json",
+            run_results,
+        ),
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--connector",
+            "bigquery",
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+            "--budget",
+            "100000000",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+    assert envelope["data"]["spend"]["bytes_billed"] == 0
+    assert envelope["data"]["spend"]["session_spent_today"] == 0
+    entry = json.loads((tmp_path / ".dex" / "spend.jsonl").read_text().splitlines()[-1])
+    assert entry["command"] == "transform build"
+    assert entry["billed_bytes"] == 0
+
+
+def test_a_build_whose_statements_reported_no_billing_figure_says_so(
+    bigquery_project_dir: Path, tmp_path: Path, capsys, monkeypatch
+):
+    """Statements ran and none of them reported what they billed, so the spend is
+    unknown rather than zero. The key is still there (parity), its value is null
+    (honesty), a note explains it, and nothing reaches the ledger: rounding an
+    unknown spend down to zero is the under-report issue #276 is about."""
+
+    from exmergo_dex_core.envelope import Paradigm
+
+    _install_fake_pricing(
+        monkeypatch,
+        connector="bigquery",
+        paradigm=Paradigm.BYTES_SCANNED,
+        estimate=5_000_000.0,
+        per_node={"stg_customers": 5_000_000.0},
+        confirmed=True,
+        ceiling=100_000_000,
+    )
+    run_results = json.dumps(
+        {
+            "results": [
+                {
+                    "unique_id": "model.dex_test.stg_customers",
+                    "status": "success",
+                    "execution_time": 1.0,
+                    # No adapter_response at all: whatever this scanned, dbt is
+                    # not saying.
+                    "adapter_response": {},
+                }
+            ]
+        }
+    )
+    _fake_runner_factory(
+        monkeypatch,
+        returncode=0,
+        run_results_json=(
+            bigquery_project_dir / "target" / "run_results.json",
+            run_results,
+        ),
+    )
+    rc, envelope = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--connector",
+            "bigquery",
+            "transform",
+            "build",
+            "--target",
+            "dev",
+            "--confirm",
+            "--budget",
+            "100000000",
+        ],
+        capsys,
+    )
+    assert rc == 0, envelope
+    assert envelope["data"]["spend"]["bytes_billed"] is None
+    # A build's per-paradigm notes ride in `warnings`, where its cap note does.
+    assert any("no billing figure" in w for w in envelope["warnings"])
+    assert not (tmp_path / ".dex" / "spend.jsonl").exists()
 
 
 def test_billed_build_failure_names_the_real_error_in_errors(

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -833,6 +833,19 @@ Rules the envelope enforces, all of them Tier-2 eval targets:
   plus `session_spent_today`, which is what the next command's cumulative
   ceiling will start from. A failed build reports it too: dbt bills for the
   statements it ran before it stopped.
+- **And it is the only place spend is reported.** No command puts a billed
+  magnitude anywhere else in `data`, and every command that can bill carries the
+  unit key whatever it settled at, zero included. Both halves are the same rule:
+  a key that exists on one command and not another is worse than one that never
+  exists, because at the top of `data` a missing key reads as a value, and the
+  value it reads as is zero. `transform build` used to stamp `data.bytes_billed`
+  as well, so a caller reading that key saw a build's spend and read a `maintain
+  check` that had just scanned 0.89 GB as free. Under-reporting spend is the one
+  envelope defect that breaks the cost-governance guarantee rather than annoying
+  the caller, so where a figure is genuinely unavailable the key reports `null`
+  and a note says why, rather than rounding an unknown down to zero. Key parity
+  across `transform build`, `maintain check`, `explore query`, `explore map` and
+  `explore profile` is a contract test.
 - **ClickHouse's paradigm depends on its declared deployment.** Config-free
   callers retain the backward-compatible `db_load` default; an effective
   `clickhouse.deployment: cloud` uses `compute_time`. Cloud keeps seconds as the


### PR DESCRIPTION
## What changes
`data.spend` becomes the single canonical location for settled spend on every billed command. A contract test enforces key parity across transform `build, maintain check, explore query, explore map, and explore profile`.

## Problem
`transform` build reported its billed magnitude twice, once under data.spend like every other billed command and once as a top-level `data.bytes_billed` that no other command carried. A caller reading the top-level key saw a build's spend and read maintain check's missing key as zero, so a command that had just scanned 0.89 GB was reported as free. That happened in a real session and survived into the first draft of a written cost report.

A build that settled at zero also omitted `data.spend` entirely, which is the same ambiguity one level down.

## Fix

- `_shape_build_result` pops dbt's per-node billing figure instead of leaving it in the payload, so `data.spend` is the only place spend appears.
- A billed paradigm always reports the unit key, whatever it settled at. Zero is reported as zero.
- Where dbt executed statements and reported no billing figure for any of them, the key reports `null` with a note and nothing reaches the ledger. Rounding an unknown down to zero would be the same under-report by another route.
- ClickHouse Cloud's translated keys (compute-unit-hours, USD) are emitted at zero seconds too, matching what explore always reports.
- The build's ledger read-back at settlement is best-effort, reporting `session_spent_today`: null as gate settlement already does, rather than turning a build that already spent into a failure that reports nothing.
- Also updated: the four integration tests that read the removed key, the `data.spend` bullet in `references/command-contract.md`, the spend paragraph in `AGENTS.md`, and a `Fixed changelog entry`.

Full unit suite green (3106 passed). The new parity test was verified to fail against the pre-fix code with transform build reports spend outside data.spend: ['bytes_billed'].

## What still stands

- The removal is a breaking envelope change for any caller reading `data.bytes_billed` or `data.seconds_billed` on transform build. That read is the defect, so it is not preserved.
- `connect` test still reports `session_spent_today` nested under `data.budget`. That command bills nothing and the contract documents the placement, so it is out of scope here.
- `explore`'s preflight estimate keys (for example ClickHouse's `estimated_compute_unit_hours`) are unchanged. They are estimates on the confirmation ask, not settled spend.

## Related issue
Closes #276 

## Note
Close #395 first