### PR TITLE
Fix BigQuery integration test for #288's column elision

### DIFF
--- a/packages/dex-core/src/exmergo_dex_core/engine.py
+++ b/packages/dex-core/src/exmergo_dex_core/engine.py
@@ -847,6 +847,7 @@ class DexEngine:
         refresh: bool = False,
         use_project: bool = False,
         check_cumulative: bool = False,
+        show_all_columns: bool = False,
     ) -> ProfileResult:
         from .explore import commands as explore
 
@@ -854,6 +855,7 @@ class DexEngine:
             self,
             list(objects),
             refresh=refresh,
+            show_all_columns=show_all_columns,
             use_project=use_project,
             check_cumulative=check_cumulative,
         )

--- a/packages/dex-core/tests/integration/test_bigquery_explore.py
+++ b/packages/dex-core/tests/integration/test_bigquery_explore.py
@@ -62,6 +62,13 @@ def test_profile_handshake_then_confirmed_run(tmp_path: Path, capsys, bq_project
             "--confirm",
             "--budget",
             str(MAX_BYTES),
+            # This test wants the real schema profiling found, not the
+            # finding-only default summary (#288): none of Shakespeare's four
+            # columns carries a PII flag, a null fraction, key membership, or
+            # a data-quality note, so the default summary would elide all of
+            # them rather than the one this assertion used to catch missing.
+            "--columns",
+            "all",
         ],
         capsys,
     )

--- a/packages/dex-core/tests/test_cli_contract.py
+++ b/packages/dex-core/tests/test_cli_contract.py
@@ -502,6 +502,9 @@ _SUBCOMMAND_PARITY: dict[tuple[str, str | None], dict] = {
             "refresh": "refresh",
             "use_project": "use_project",
             "check_cumulative": "check_cumulative",
+            # --columns takes the literal "all" (argparse `choices=["all"]"),
+            # translated to the engine's boolean `show_all_columns`.
+            "columns": _TRANSLATED,
         },
     },
     ("explore", "relationships"): {
@@ -685,6 +688,10 @@ _CONNECTION_DESTS = {
     "confirm",
     "budget",
     "help",
+    # The one-time cumulative-ceiling ask's two answers (#283), on every
+    # subparser via `_sub_connection_options()` same as --budget.
+    "session_ceiling",
+    "no_session_ceiling",
 }
 
 


### PR DESCRIPTION
`explore profile`'s column summarization (#288) elides columns with no
finding by default. The Shakespeare integration test asserted the full
schema without `--columns all`, so `word_count` (no PII/null/key/data-quality
finding) dropped out and the live BigQuery suite started failing.

## Fix
Added `--columns all` to the confirmed-run call in
`test_bigquery_explore.py`, restoring the full schema this test actually
checks.