### PR TITLE
Fix DexEngine/CLI parity gap for --columns and session-ceiling flags

### DIFF
--- a/packages/dex-core/src/exmergo_dex_core/engine.py
+++ b/packages/dex-core/src/exmergo_dex_core/engine.py
@@ -847,6 +847,7 @@ class DexEngine:
         refresh: bool = False,
         use_project: bool = False,
         check_cumulative: bool = False,
+        show_all_columns: bool = False,
     ) -> ProfileResult:
         from .explore import commands as explore
 
@@ -854,6 +855,7 @@ class DexEngine:
             self,
             list(objects),
             refresh=refresh,
+            show_all_columns=show_all_columns,
             use_project=use_project,
             check_cumulative=check_cumulative,
         )

--- a/packages/dex-core/tests/test_cli_contract.py
+++ b/packages/dex-core/tests/test_cli_contract.py
@@ -502,6 +502,9 @@ _SUBCOMMAND_PARITY: dict[tuple[str, str | None], dict] = {
             "refresh": "refresh",
             "use_project": "use_project",
             "check_cumulative": "check_cumulative",
+            # --columns takes the literal "all" (argparse `choices=["all"]"),
+            # translated to the engine's boolean `show_all_columns`.
+            "columns": _TRANSLATED,
         },
     },
     ("explore", "relationships"): {
@@ -685,6 +688,10 @@ _CONNECTION_DESTS = {
     "confirm",
     "budget",
     "help",
+    # The one-time cumulative-ceiling ask's two answers (#283), on every
+    # subparser via `_sub_connection_options()` same as --budget.
+    "session_ceiling",
+    "no_session_ceiling",
 }
 
 


### PR DESCRIPTION
## Summary
Two gaps the #344 parity test (`test_cli_contract.py`) itself caught once
this branch met current `main`:
- `explore profile --columns all` reached the CLI (#288) but not
  `DexEngine.profile()`, which was missing `show_all_columns`.
- `--session-ceiling`/`--no-session-ceiling` (#283) are connection-level
  flags on every subcommand, and the parity test's own exclusion list
  predated them, so 30 subcommands failed the check.

## Fix
Added `show_all_columns` to `DexEngine.profile()`; added both flags to
`_CONNECTION_DESTS`.