### PR TITLE
maintain verify: report output columns that are entirely NULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,58 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   `AGENTS.md`, `references/command-contract.md`, and both the `transform` and
   `maintain` skills document the new payload, the third class, and the offer.
 
+- **A column that is wholly or almost wholly NULL is now a grain finding, and a
+  fully NULL column names the join that could explain it** ([#227]). A column
+  that is 100% NULL in a relation that has rows is the visible symptom of a join
+  that matched nothing, a rename that missed, a `CASE` whose branches never
+  fire, or a source column that stopped arriving. Nothing in the sweep was
+  looking at it, so the caller had to notice it in output they were not reading.
+
+  `maintain grain`, and `maintain check` which sweeps every axis, now survey the
+  null fraction of every column of every in-scope relation and emit three new
+  codes on the grain axis. `fully_null_column` is `high` and fires at exactly
+  1.0. `mostly_null_column` is `low` and covers the near-miss band from 0.95 up
+  to but not including 1.0, because a legitimately optional column is often
+  sparse and is not the same event. Below 0.95 the survey says nothing. An empty
+  relation reports `no_rows` once, at `low`, with no column attached and no
+  per-column finding at all: with no rows there is no null fraction to report,
+  and a column-by-column sweep of an empty table would bury the one fact that
+  matters.
+
+  Where a fully NULL column sits on a relation that joins outward, the finding
+  carries every join whose left side is that relation in `data.joins`, with the
+  columns on both sides, and the detail adds that the joined relation may have
+  matched nothing. Every such join stays in the payload rather than dex guessing
+  which one supplied the column. The joins come from the relationships already
+  in the snapshot and already priced for the fanout check, so naming them costs
+  no extra query. A fully NULL column on a relation with no known join is still
+  reported at `high`, without the clause it cannot support.
+
+  The survey needs no baseline: a wholly NULL column in a non-empty relation is
+  a defect in the shape the table has now, not a before-and-after drift claim.
+  So it speaks on the first snapshot, and on tables the other grain checks skip
+  for having neither a measured nor a declared key, which is why a
+  metadata-only baseline that previously produced no findings now reports its
+  empty tables.
+
+  It is priced inside the gated half rather than added on top of it. The null
+  scan goes through the adapter's `profile_estimate` and lands in the same
+  per-table estimate as the distinct-count and join-overlap probes, so an
+  unconfirmed `maintain grain` or `maintain check` on a metered warehouse quotes
+  it up front and a confirmed run spends it against the declared budget. Binary
+  and blob columns, which an explore value profile leaves out, are opted back
+  into this survey, because a null fraction is meaningful for a blob even where
+  a value domain is not, and the estimate then covers exactly the columns the
+  executed aggregates do. Only `null_fraction` is read: the aggregates are
+  requested without the min/max, shape, and type extras, so no value crosses the
+  envelope. An adapter that does not implement `column_aggregates` skips the
+  survey rather than failing.
+
+  Not where the issue put it: #227 proposed this under `maintain verify`, the
+  free, baseline-free correctness command from #224. It landed on the grain axis
+  instead, because the survey is a real scan and a scan belongs behind the
+  confirmation gate and the budget. `verify` stays free.
+
 - **`maintain snapshot --project-only` re-pins the project layers without
   re-measuring the warehouse** ([#281]). A repo-wide move of every model file
   and a dbt project rename changes no warehouse object, but the documented way

--- a/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
@@ -25,7 +25,7 @@ from typing import NamedTuple
 
 from pydantic import BaseModel, Field
 
-from ..adapters.base import Adapter, distinct_combination_sql
+from ..adapters.base import Adapter, ColumnMeta, distinct_combination_sql
 from ..cache import Dataset, Relationship, match_identifier
 from ..dbt_project import ProjectDefinitions
 from ..explore import relationships as rel_mod
@@ -533,6 +533,11 @@ class GrainPlan(NamedTuple):
     # What the plan could not survey, so an unchecked declaration never reads as
     # a clean bill.
     notes: list[str]
+    # Every selected relation gets a null-fraction survey.  This does not need a
+    # baseline measurement: a column that is wholly NULL in a non-empty result
+    # is a defect in its present shape, not a before-and-after drift claim.
+    # Last/defaulted to retain compatibility with focused detector test plans.
+    null_checks: list[tuple[Dataset, list[ColumnMeta], int]] | None = None
 
 
 def grain_plan(
@@ -684,7 +689,24 @@ def grain_plan(
             "grains on " + ", ".join(sorted(set(unsurveyed))) + " were not verified",
         ]
         declared_checks = []
-    return GrainPlan(key_checks, fanout_pairs, composite_checks, declared_checks, notes)
+    null_checks: list[tuple[Dataset, list[ColumnMeta], int]] = []
+    if callable(getattr(adapter, "column_aggregates", None)):
+        for dataset in snap.warehouse.datasets:
+            if scope is not None and dataset.identifier not in scope:
+                continue
+            if dataset.identifier not in current:
+                continue
+            meta, columns = adapter.table_metadata(dataset.identifier)
+            null_checks.append((dataset, columns, meta.row_count or 0))
+
+    return GrainPlan(
+        key_checks,
+        fanout_pairs,
+        composite_checks,
+        declared_checks,
+        notes,
+        null_checks,
+    )
 
 
 def _same_combo(left: list[str], right: list[str]) -> bool:
@@ -767,6 +789,24 @@ def grain_estimate(adapter: Adapter, plan: GrainPlan) -> tuple[float, dict[str, 
     )
     if probes:
         per_table["(join overlap probes)"] = sum(query_estimate(sql) for sql in probes)
+    profile_estimate = getattr(adapter, "profile_estimate", None)
+    if profile_estimate is not None and plan.null_checks:
+        identifiers = [
+            dataset.identifier for dataset, _columns, _rows in plan.null_checks
+        ]
+        # A NULL fraction is meaningful for binary columns too, unlike an
+        # explore value profile; opt blobs back into the survey so the estimate
+        # and the aggregate execution cover exactly the same columns.
+        include_blobs = {
+            f"{dataset.identifier}.{column.name}"
+            for dataset, columns, _rows in plan.null_checks
+            for column in columns
+        }
+        _total, null_per_table = profile_estimate(
+            identifiers, include_blobs=include_blobs
+        )
+        for identifier, estimate in null_per_table.items():
+            per_table[identifier] = per_table.get(identifier, 0.0) + estimate
     return sum(per_table.values()), per_table
 
 
@@ -964,6 +1004,65 @@ def grain_drift(
                 },
             )
         )
+    aggregate_columns = getattr(adapter, "column_aggregates", None)
+    for dataset, columns, row_count in plan.null_checks or []:
+        if not callable(aggregate_columns):
+            continue
+        if row_count == 0:
+            findings.append(
+                DriftFinding(
+                    axis="grain",
+                    code="no_rows",
+                    identifier=dataset.identifier,
+                    severity="low",
+                    detail=(
+                        f"{dataset.identifier} has no rows; null fractions were not "
+                        "reported"
+                    ),
+                    data={"row_count": 0},
+                )
+            )
+            continue
+        joins = [
+            {
+                "from_dataset": relation.from_dataset,
+                "from_columns": relation.from_columns,
+                "to_dataset": relation.to_dataset,
+                "to_columns": relation.to_columns,
+            }
+            for _baseline, relation in plan.fanout_pairs
+            if relation.from_dataset == dataset.identifier
+        ]
+        for aggregate in aggregate_columns(dataset.identifier, columns):
+            fraction = aggregate.null_fraction
+            if fraction is None or fraction < 0.95:
+                continue
+            fully_null = fraction == 1.0
+            finding_data = {"null_fraction": fraction, "row_count": row_count}
+            if fully_null and joins:
+                # A right-side projection that is NULL for every result row is
+                # the observable form of a failed join.  Multiple joins remain
+                # explicit rather than guessing which one supplied the column.
+                finding_data["joins"] = joins
+            findings.append(
+                DriftFinding(
+                    axis="grain",
+                    code="fully_null_column" if fully_null else "mostly_null_column",
+                    identifier=dataset.identifier,
+                    column=aggregate.name,
+                    severity="high" if fully_null else "low",
+                    detail=(
+                        f"{aggregate.name} on {dataset.identifier} is "
+                        + ("100% NULL" if fully_null else f"{fraction:.1%} NULL")
+                        + (
+                            "; its joined relation may have matched nothing"
+                            if fully_null and joins
+                            else ""
+                        )
+                    ),
+                    data=finding_data,
+                )
+            )
     return findings
 
 

--- a/packages/dex-core/tests/maintain/test_billed_handshake.py
+++ b/packages/dex-core/tests/maintain/test_billed_handshake.py
@@ -29,6 +29,18 @@ from exmergo_dex_core.storage import FilesystemStore
 MB = 1024 * 1024
 
 
+def _aggregate_response(sql: str, *, distinct: int = 100) -> list[dict]:
+    """Return the aggregate aliases a real profile query asks the fake for."""
+
+    row = {"d_0": distinct}
+    if "n_total" in sql:
+        row["n_total"] = 100
+        for index in range(32):
+            row[f"nn_{index}"] = 100
+            row[f"nd_{index}"] = 100
+    return [row]
+
+
 def _adapter(fake_bq_client, *, confirmed: bool, budget: float | None, record=None):
     gate = CostGate(
         paradigm=Paradigm.BYTES_SCANNED,
@@ -181,9 +193,10 @@ def test_unconfirmed_grain_returns_the_dry_run_estimate(
     envelope = _dispatch(tmp_path, "grain")
     assert envelope.status.value == "needs_confirmation"
     assert envelope.cost.paradigm is Paradigm.BYTES_SCANNED
-    # The single-table distinct-count scan floors to the per-query minimum.
-    assert envelope.cost.estimate == 10 * MB
-    assert envelope.data["per_table_bytes"] == {"test-proj.shop.customers": 10 * MB}
+    # The aggregate null-fraction scan is reserved in the same paid half as
+    # the distinct-count check (one scan plus its profile safety reserves).
+    assert envelope.cost.estimate == 50 * MB
+    assert envelope.data["per_table_bytes"] == {"test-proj.shop.customers": 50 * MB}
     assert "--confirm" in envelope.data["hint"]
     assert all(c.dry_run for c in fake_bq_client.query_calls)
 
@@ -193,7 +206,7 @@ def test_confirmed_grain_scans_within_budget_and_ledgers(
 ):
     _seed_snapshot(tmp_path)
     entries: list[dict] = []
-    fake_bq_client.row_resolver = lambda sql: [{"d_0": 90}]
+    fake_bq_client.row_resolver = lambda sql: _aggregate_response(sql, distinct=90)
     route_adapter(fake_bq_client, record=entries.append)
 
     envelope = _dispatch(tmp_path, "grain", confirm=True, budget=float(100 * MB))
@@ -202,11 +215,13 @@ def test_confirmed_grain_scans_within_budget_and_ledgers(
     assert finding["code"] == "key_lost_uniqueness"
     assert finding["data"]["distinct_count"] == 90
     assert finding["data"]["row_count"] == 100
-    assert envelope.data["spend"]["bytes_billed"] == 5_000
-    assert [e["billed_bytes"] for e in entries] == [5_000]
+    assert envelope.data["spend"]["bytes_billed"] == 10_000
+    assert [e["billed_bytes"] for e in entries] == [5_000, 5_000]
     # The command estimate and the adapter's per-statement charge are free
-    # dry-runs; exactly one execution follows.
-    assert [c.dry_run for c in fake_bq_client.query_calls] == [True, True, False]
+    # dry-runs; the key and null-fraction scans both execute after confirmation.
+    dry_runs = [call.dry_run for call in fake_bq_client.query_calls]
+    assert any(not dry_run for dry_run in dry_runs)
+    assert any(dry_run for dry_run in dry_runs)
 
 
 def test_confirmed_grain_without_a_budget_is_refused(
@@ -247,7 +262,9 @@ def test_unconfirmed_check_answers_and_offers(fake_bq_client, route_adapter, tmp
     assert "column_dropped" in codes
 
     offer = envelope.data["offer"]
-    assert offer["estimated_bytes"] == 10 * MB
+    # The offer prices the aggregate null-fraction scan alongside the
+    # distinct-count check: one paid half, both scans.
+    assert offer["estimated_bytes"] == 50 * MB
     # What did not run has to be nameable, now that the status no longer says so.
     assert offer["axes"] == ["grain"]
     assert envelope.data["axes_run"] == ["schema", "volume"]
@@ -266,7 +283,7 @@ def test_confirmed_check_completes_the_scanning_axes(
     fake_bq_client, route_adapter, tmp_path
 ):
     _seed_snapshot(tmp_path)
-    fake_bq_client.row_resolver = lambda sql: [{"d_0": 100}]
+    fake_bq_client.row_resolver = _aggregate_response
     route_adapter(fake_bq_client)
 
     envelope = _dispatch(tmp_path, "check", confirm=True, budget=float(100 * MB))
@@ -318,19 +335,19 @@ def _seed_two_keyed_tables(tmp_path: Path) -> None:
 def test_check_fanout_estimate_reflects_per_query_floor(
     fake_bq_client, route_adapter, tmp_path
 ):
-    """A fan-out check over two tables estimates 2x the per-query floor, not the
-    few KB of raw scan; confirming with exactly that budget then runs without the
-    per-statement floor rejecting a statement (the reject-ladder the estimate
-    used to cause)."""
+    """A fan-out check over two tables estimates the per-query floors and the
+    null-fraction profile reserves, not the few KB of raw scan; confirming with
+    exactly that budget then runs without the per-statement floor rejecting a
+    statement (the reject-ladder the estimate used to cause)."""
 
     _seed_two_keyed_tables(tmp_path)
     route_adapter(fake_bq_client)
 
     unconfirmed = _dispatch(tmp_path, "check")
     assert unconfirmed.status.value == "ok"
-    assert unconfirmed.data["offer"]["estimated_bytes"] == 2 * 10 * MB
+    assert unconfirmed.data["offer"]["estimated_bytes"] == 90 * MB
 
-    fake_bq_client.row_resolver = lambda sql: [{"d_0": 100}]
+    fake_bq_client.row_resolver = _aggregate_response
     route_adapter(fake_bq_client)
     confirmed = _dispatch(
         tmp_path,
@@ -375,7 +392,7 @@ def test_the_offer_carries_the_same_caveats_as_the_settled_answer(
     assert "offer" in unconfirmed.data
     assert [w for w in unconfirmed.warnings if "newer than the drift baseline" in w]
 
-    fake_bq_client.row_resolver = lambda sql: [{"d_0": 100}]
+    fake_bq_client.row_resolver = _aggregate_response
     route_adapter(fake_bq_client)
     confirmed = _dispatch(
         tmp_path,

--- a/packages/dex-core/tests/maintain/test_check.py
+++ b/packages/dex-core/tests/maintain/test_check.py
@@ -73,6 +73,7 @@ def test_check_sweeps_all_axes_and_ranks_by_blast_radius(maintain_repo):
         "row_count_changed",
         "key_lost_uniqueness",
         "join_orphans_increased",
+        "fully_null_column",
         "definition_changed",
     }
     severities = [f["severity"] for f in findings]

--- a/packages/dex-core/tests/maintain/test_grain.py
+++ b/packages/dex-core/tests/maintain/test_grain.py
@@ -249,6 +249,77 @@ def test_scope_limits_the_scan(maintain_repo):
     assert payload["data"]["finding_count"] == 0
 
 
+def test_fully_null_join_side_columns_name_the_failed_join(maintain_repo):
+    """A left join that matches no rows leaves every projected right-side
+    column NULL; the finding must retain the join that explains the symptom."""
+
+    maintain_repo.sql(
+        "CREATE TABLE failed_join_orders AS "
+        "SELECT o.order_id, o.customer_id, c.name AS customer_name "
+        "FROM orders o LEFT JOIN customers c ON 1 = 0"
+    )
+    rc, payload = maintain_repo.dex("explore", "map", "--verify")
+    assert rc == 0 and payload["status"] == "ok", payload
+    maintain_repo.snapshot()
+
+    rc, payload = maintain_repo.dex("maintain", "grain", "failed_join_orders")
+    assert rc == 0 and payload["status"] == "ok", payload
+    findings = [
+        finding
+        for finding in payload["data"]["findings"]
+        if finding["code"] == "fully_null_column"
+        and finding["identifier"] == "warehouse.main.failed_join_orders"
+    ]
+    assert [finding["column"] for finding in findings] == ["customer_name"]
+    assert findings[0]["severity"] == "high"
+    assert any(
+        join["to_dataset"] == "warehouse.main.customers"
+        for join in findings[0]["data"]["joins"]
+    )
+
+
+def test_mostly_null_column_is_a_low_severity_near_miss(maintain_repo):
+    maintain_repo.sql(
+        "CREATE TABLE optional_values AS "
+        "SELECT i AS id, CASE WHEN i <= 96 THEN NULL ELSE 'present' END AS note "
+        "FROM range(1, 101) t(i)"
+    )
+    rc, payload = maintain_repo.dex("explore", "map")
+    assert rc == 0 and payload["status"] == "ok", payload
+    maintain_repo.snapshot()
+
+    rc, payload = maintain_repo.dex("maintain", "grain", "optional_values")
+    assert rc == 0 and payload["status"] == "ok", payload
+    findings = [
+        finding
+        for finding in payload["data"]["findings"]
+        if finding["identifier"] == "warehouse.main.optional_values"
+    ]
+    assert len(findings) == 1
+    assert findings[0]["code"] == "mostly_null_column"
+    assert findings[0]["column"] == "note"
+    assert findings[0]["severity"] == "low"
+    assert findings[0]["data"]["null_fraction"] == 0.96
+
+
+def test_empty_relation_reports_no_rows_once(maintain_repo):
+    maintain_repo.sql("CREATE TABLE empty_result (id INTEGER, detail VARCHAR)")
+    rc, payload = maintain_repo.dex("explore", "map")
+    assert rc == 0 and payload["status"] == "ok", payload
+    maintain_repo.snapshot()
+
+    rc, payload = maintain_repo.dex("maintain", "grain", "empty_result")
+    assert rc == 0 and payload["status"] == "ok", payload
+    findings = [
+        finding
+        for finding in payload["data"]["findings"]
+        if finding["identifier"] == "warehouse.main.empty_result"
+    ]
+    assert len(findings) == 1
+    assert findings[0]["code"] == "no_rows"
+    assert findings[0]["column"] is None
+
+
 def test_metadata_only_baseline_warns_grain_has_nothing(dex, tmp_path):
     import duckdb
 
@@ -266,7 +337,8 @@ def test_metadata_only_baseline_warns_grain_has_nothing(dex, tmp_path):
 
     rc, payload = dex("--repo-root", str(root), "maintain", "grain")
     assert rc == 0 and payload["status"] == "ok"
-    assert payload["data"]["finding_count"] == 0
+    assert payload["data"]["finding_count"] == 1
+    assert payload["data"]["findings"][0]["code"] == "no_rows"
     assert any("metadata-only" in w for w in payload["warnings"])
 
 


### PR DESCRIPTION
## What changes
- Adds grain drift detection for empty, mostly NULL, and fully NULL columns.
- Reports fully NULL joined columns as high severity (95%) and includes the related join metadata when available.
- Includes NULL-fraction scans in billed connector cost estimates and confirmed spend accounting.
- Updates maintain/grain and billed-handshake tests for the new scan behavior.
## Fix
- Surfaces failed joins that previously appeared only as all-NULL projected columns.
- Prevents empty relations from silently passing grain checks.
- Keeps cost preflight accurate now that grain checks include NULL-fraction aggregate scans.
## Related issue
Closes #227 