### PR TITLE
SCRUM-1235-relationship conflicts and hosted+local composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,57 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   context have a declared home instead of being dropped or smuggled into a
   neighbouring field.
 
+- **A semantic layer's own declared dataset keys now reach grain detection**
+  ([#408]). Ossie is never the transformation project `engine.project_format()`
+  resolves, so its `primary_key`/`unique_keys` declarations had no route to
+  `explore profile --use-project`'s grain channel at all: only a dbt project's
+  own tier-1 `definitions()` fed it. `SemanticLayer` gains a `declared_keys()`
+  capability, the same shape `declared_relationships()` already established;
+  every backend but Ossie's returns nothing, because a dbt-backed layer's keys
+  already reach grain through the project route and stating them twice would
+  only ever double-count. `explore commands.py` calls this capability
+  unconditionally rather than branching on which vendor is configured, honoring
+  the same architectural rule `test_no_command_carries_a_vendor_branch` already
+  enforces elsewhere. A repository with both dbt and Ossie gets both sets of
+  keys, additively, not a choice between them.
+
+- **Declared relationships that disagree about which columns join the same two
+  datasets are now flagged rather than silently doubled** ([#408]). Two
+  declarations naming the same dataset pair with different column pairs used
+  to fold into two separate, unlabeled edges with nothing to say they
+  contradict each other. `explore map` and `explore relationships` now surface
+  every such pair as a `DeclaredRelationshipConflict` in the new `conflicts`
+  field, naming every disagreeing declaration and its columns and source, with
+  a note pointing at the structured field. Every declaration is still kept as
+  its own edge: dex reports the disagreement rather than picking a winner.
+
+- **`--use-project` and `--use-hosted-semantic-layer` now compose instead of
+  one silently winning** ([#408]). Passing both used to read only the local
+  project's semantic layer; the hosted read, and its "cannot add map exposure
+  annotations" note, never ran. Both are now read and unioned: semantic
+  models, metrics, dimensions and measures merge by name (the local entry
+  wins a name both declare, since it is the side with physical relations),
+  and an entity declared on both sides merges its per-model roles and
+  re-derives its summary `type` from the wider set rather than one side's
+  declaration overwriting the other's. Relationship-edge extraction reads
+  both sources the same way, though no shipped hosted backend returns
+  physical relations there today, so every edge still comes from the local
+  read in practice. A hosted vendor with no local counterpart (or the
+  reverse, such as Ossie's own vendor having no hosted deployment) degrades
+  to whichever side actually answered instead of losing a read that already
+  succeeded.
+
+### Fixed
+
+- **A composite relationship's Mermaid label named only the child-side columns,
+  silently dropping the parent side.** ([#408]) `explore diagram`'s edge label
+  joined `from_columns` alone, so `(product_id, variant_id)` rendered as
+  `"product_id, variant_id, declared"` with no way to tell which child column
+  paired with which parent column, or that a parent side existed at all. The
+  label now pairs every column (`"product_id = id, variant_id = variant_id"`);
+  a single pair sharing one name on both sides, the common case, still renders
+  as that bare name unchanged.
+
 ## [1.9.2] - 2026-09-02
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -17,6 +17,7 @@ only to the exploration cache, so a scan is never paid for twice.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import fnmatch
 import json
 import re
@@ -24,7 +25,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import sqlglot
 from sqlglot import expressions as exp
@@ -68,7 +69,12 @@ from ..guards.query_firewall import (
 from ..guards.sql_guard import referenced_relations, split_statements
 from ..progress import ProgressReporter
 from ..results import BudgetExhaustedError, ConfirmationRequest, to_envelope
-from ..semantic_catalog import entity_joins
+from ..semantic_catalog import (
+    EntityInfo,
+    SemanticCatalogView,
+    derive_entity_type,
+    entity_joins,
+)
 from ..storage import CacheUnreadableError, Document, ExploreStore, readable_cache
 from . import cluster as cluster_mod
 from . import cumulative as cumulative_mod
@@ -79,6 +85,8 @@ from . import rank as rank_mod
 from . import relationships as rel_mod
 from .results import (
     ClusterResult,
+    ConflictingRelationshipDeclaration,
+    DeclaredRelationshipConflict,
     DiagramResult,
     InventoryEntry,
     InventoryResult,
@@ -923,11 +931,15 @@ def relationships(
     identifiers = [d.identifier for d in datasets]
     declared, declared_notes = rel_mod.declared_relationships(defs, identifiers)
     native_edges, native_edge_notes = _native_semantic_edges(
-        engine, use_project, identifiers
+        engine,
+        use_project,
+        identifiers,
+        use_hosted_semantic_layer=use_hosted_semantic_layer,
     )
     declared, _native_already_declared = _fold_semantic_edges(declared, native_edges)
     semantic_edges, semantic_edge_notes = _semantic_edges(catalog, identifiers)
     declared, semantic_already_declared = _fold_semantic_edges(declared, semantic_edges)
+    relationship_conflicts = _declared_relationship_conflicts(declared)
     rels, confirmed = _merge_relationships(declared, inferred)
 
     # A prior overlap-derived edge (issue #220) is never rediscovered by
@@ -1056,6 +1068,7 @@ def relationships(
     notes.extend(
         _semantic_join_notes(semantic_edges, semantic_already_declared, inferred)
     )
+    notes.extend(_relationship_conflict_notes(relationship_conflicts))
     notes.extend(defs.notes)
     if confirmed:
         notes.append(
@@ -1136,6 +1149,7 @@ def relationships(
         profiled_count=len(profiled),
         cache_hit_count=len(fresh_reused),
         carried_relationship_count=carried_relationships,
+        conflicts=relationship_conflicts,
         cache_path=locator,
         updated_at=now.isoformat(),
         notes=notes,
@@ -2052,11 +2066,15 @@ def map(
     identifiers = [m.identifier for m in metas]
     declared, declared_notes = rel_mod.declared_relationships(defs, identifiers)
     native_edges, native_edge_notes = _native_semantic_edges(
-        engine, use_project, identifiers
+        engine,
+        use_project,
+        identifiers,
+        use_hosted_semantic_layer=use_hosted_semantic_layer,
     )
     declared, _native_already_declared = _fold_semantic_edges(declared, native_edges)
     semantic_edges, semantic_edge_notes = _semantic_edges(catalog, identifiers)
     declared, semantic_already_declared = _fold_semantic_edges(declared, semantic_edges)
+    relationship_conflicts = _declared_relationship_conflicts(declared)
     relationship_set, confirmed = _merge_relationships(declared, inferred)
 
     # A prior overlap-derived edge (issue #220) is never rediscovered by
@@ -2211,6 +2229,7 @@ def map(
     notes.extend(
         _semantic_join_notes(semantic_edges, semantic_already_declared, inferred)
     )
+    notes.extend(_relationship_conflict_notes(relationship_conflicts))
     if semantic_exposed:
         notes.append(
             f"{semantic_exposed} object(s) are exposed through the project's "
@@ -2325,6 +2344,7 @@ def map(
         ],
         objects=view.objects,
         edges=view.edges,
+        conflicts=relationship_conflicts,
         elided_object_count=view.elided_object_count,
         elided_column_count=view.elided_column_count,
         elided_edge_count=view.elided_edge_count,
@@ -3257,7 +3277,43 @@ def _project_definitions(
     # Through the seam rather than the module: this is the one project read on the
     # explore path, and `definitions()` is the channel declared keys and joins
     # reach dex through at all. Whichever format configuration named answers here.
-    return engine.project_format().definitions()
+    defs = engine.project_format().definitions()
+    return _fold_semantic_layer_keys(engine, defs)
+
+
+def _fold_semantic_layer_keys(
+    engine: DexEngine, defs: dbt_project.ProjectDefinitions
+) -> dbt_project.ProjectDefinitions:
+    """A semantic layer's own declared dataset keys, folded into the grain
+    channel (#408), through the same capability every format already answers
+    rather than a name check on which one is configured.
+
+    Empty for a layer whose keys already reach grain through the transformation
+    project's own `definitions()` (dbt); non-empty only for a layer that is
+    itself the sole declaration channel for its repository (native Ossie
+    documents, never a transformation project). A repo may have both, and both
+    are additive, not a choice between them.
+    """
+
+    if engine.repo_root is None:
+        return defs
+    try:
+        from .semantic import resolve_semantic_layer
+
+        keys, composite_keys = resolve_semantic_layer(
+            engine, local=True
+        ).declared_keys()
+    except (DexError, ValueError, OSError):
+        return defs
+    if not keys and not composite_keys:
+        return defs
+    return defs.model_copy(
+        update={
+            "present": True,
+            "declared_keys": [*defs.declared_keys, *keys],
+            "declared_composite_keys": [*defs.declared_composite_keys, *composite_keys],
+        }
+    )
 
 
 def _semantic_catalog(
@@ -3270,6 +3326,13 @@ def _semantic_catalog(
     declared join graph and its physical exposure fold in only when
     ``--use-project`` asks for them. Without the flag the default map's payload is
     byte-identical to what it was.
+
+    With both flags, both sources are read and composed (#408) rather than one
+    winning by accidental precedence: the local read and the hosted read answer
+    different questions (a repository's own declarations versus a service's own
+    metadata) and neither subsumes the other. Composition is additive, local
+    first, so a name both declare keeps the local entry, the one with physical
+    relations.
 
     **None on every declinable condition, and it never raises**, which is the
     difference between this and calling ``semantic_catalog()`` directly. There is
@@ -3284,21 +3347,111 @@ def _semantic_catalog(
 
     if not use_project and not use_hosted_semantic_layer:
         return None
+
+    # Each side is read and caught on its own (rather than one shared try) so
+    # that a hosted read this vendor has no deployment for (Ossie has no dbt
+    # Cloud counterpart, for instance) degrades to the local view instead of
+    # discarding a local read that already succeeded.
+    local_view = None
+    if use_project:
+        try:
+            # The local override is intentional: --use-project is a free,
+            # repository-only enrichment read even when semantic execution
+            # defaults to dbt Cloud. SemanticLayer owns the catalog rather
+            # than Project.
+            layer = resolve_semantic_layer(engine, local=True)
+            local_view = layer.list_definitions().view
+        except (DexError, ValueError, OSError):
+            local_view = None
+
+    if not use_hosted_semantic_layer:
+        return local_view
+
+    hosted_view = None
     try:
-        # The local override is intentional: --use-project is a free,
-        # repository-only enrichment read even when semantic execution defaults
-        # to dbt Cloud. SemanticLayer owns the catalog rather than Project.
-        if use_project:
-            return resolve_semantic_layer(engine, local=True).list_definitions().view
-        view = resolve_semantic_layer(engine, api=True).list_definitions().view
-        view.notes.append(
+        hosted_view = resolve_semantic_layer(engine, api=True).list_definitions().view
+        hosted_view.notes.append(
             "hosted semantic metadata was read by --use-hosted-semantic-layer; "
             "this backend does not expose physical relations, so it cannot add "
-            "map exposure annotations or relationship edges"
+            "map exposure annotations or relationship edges on its own"
         )
-        return view
     except (DexError, ValueError, OSError):
-        return None
+        hosted_view = None
+
+    if local_view is not None and hosted_view is not None:
+        return _compose_semantic_catalogs(local_view, hosted_view)
+    return local_view if local_view is not None else hosted_view
+
+
+def _compose_semantic_catalogs(
+    local_view: SemanticCatalogView, hosted_view: SemanticCatalogView
+) -> SemanticCatalogView:
+    """Both sources folded into one read catalog (#408).
+
+    Additive, never a choice between them: a repository's own declarations and
+    a service's own metadata answer different questions, so a caller asking for
+    both gets the union. Identity is by name within each collection, local
+    first, since the local read is the one with physical relations
+    (``--use-project``'s own contract); a name both declare keeps the local
+    entry rather than whichever iteration order happened to reach it. Entities
+    are the one collection already merged across models by construction (see
+    :class:`~..semantic_catalog.EntityInfo`), so composing two sources means
+    combining their roles the same way and re-deriving the summary type from
+    the wider set, not picking one side's entity over the other's.
+    """
+
+    def _merge(local_items: list, hosted_items: list, key) -> list:
+        seen = {key(item) for item in local_items}
+        return list(local_items) + [
+            item for item in hosted_items if key(item) not in seen
+        ]
+
+    entities_by_name = {e.name: e for e in local_view.entities}
+    for hosted_entity in hosted_view.entities:
+        existing = entities_by_name.get(hosted_entity.name)
+        if existing is None:
+            entities_by_name[hosted_entity.name] = hosted_entity
+            continue
+        roles = list(existing.roles)
+        seen_roles = {(r.semantic_model, r.type, r.column) for r in roles}
+        roles.extend(
+            role
+            for role in hosted_entity.roles
+            if (role.semantic_model, role.type, role.column) not in seen_roles
+        )
+        entities_by_name[hosted_entity.name] = EntityInfo(
+            name=existing.name,
+            type=derive_entity_type(roles),
+            label=existing.label or hosted_entity.label,
+            description=existing.description or hosted_entity.description,
+            roles=roles,
+        )
+
+    return SemanticCatalogView(
+        semantic_models=_merge(
+            local_view.semantic_models, hosted_view.semantic_models, lambda m: m.name
+        ),
+        metrics=_merge(local_view.metrics, hosted_view.metrics, lambda m: m.name),
+        dimensions=_merge(
+            local_view.dimensions,
+            hosted_view.dimensions,
+            lambda d: (d.semantic_model, d.name),
+        ),
+        entities=list(entities_by_name.values()),
+        measures=_merge(
+            local_view.measures,
+            hosted_view.measures,
+            lambda m: (m.semantic_model, m.name),
+        ),
+        dimension_scope=local_view.dimension_scope,
+        notes=[*local_view.notes, *hosted_view.notes],
+        # Local wins a token both resolve, the same precedence every other
+        # collection here gives the source that has physical relations at all.
+        physical_columns={
+            **hosted_view.physical_columns,
+            **local_view.physical_columns,
+        },
+    )
 
 
 def _annotate_semantic_exposure(datasets: list[Dataset], catalog) -> int:
@@ -3352,20 +3505,38 @@ def _semantic_edges(
 
 
 def _native_semantic_edges(
-    engine: DexEngine, use_project: bool, identifiers: list[str]
+    engine: DexEngine,
+    use_project: bool,
+    identifiers: list[str],
+    *,
+    use_hosted_semantic_layer: bool = False,
 ) -> tuple[list[Relationship], list[str]]:
-    """Native layer declarations, including composite pairs, as cached edges."""
+    """Native layer declarations, including composite pairs, as cached edges.
 
-    if engine.repo_root is None or not use_project:
-        return [], []
-    try:
-        from .semantic import resolve_semantic_layer
+    Reads both sources when both flags ask for one, the same composition
+    :func:`_semantic_catalog` gives the rest of the catalog (#408): a hosted
+    backend that ever starts returning direct physical relations gets folded in
+    beside the local read rather than silently ignored because a local project
+    happened to be configured too. Today no shipped hosted backend returns
+    anything here (dbt Cloud has no physical relation to name), so this is a
+    no-op in practice and every edge still comes from the local layer.
+    """
 
-        declarations = resolve_semantic_layer(
-            engine, local=True
-        ).declared_relationships()
-    except (DexError, ValueError, OSError):
+    if engine.repo_root is None or not (use_project or use_hosted_semantic_layer):
         return [], []
+    from .semantic import resolve_semantic_layer
+
+    declarations: list[Any] = []
+    if use_project:
+        with contextlib.suppress(DexError, ValueError, OSError):
+            declarations.extend(
+                resolve_semantic_layer(engine, local=True).declared_relationships()
+            )
+    if use_hosted_semantic_layer:
+        with contextlib.suppress(DexError, ValueError, OSError):
+            declarations.extend(
+                resolve_semantic_layer(engine, api=True).declared_relationships()
+            )
     if not declarations:
         return [], []
     return rel_mod.declared_relationships(
@@ -3452,6 +3623,70 @@ def _relationship_edge_key(rel: Relationship) -> tuple:
         rel.to_dataset.lower(),
         tuple(c.lower() for c in rel.to_columns),
     )
+
+
+def _declared_relationship_conflicts(
+    declared: list[Relationship],
+) -> list[DeclaredRelationshipConflict]:
+    """Declarations that join the same two datasets with different columns
+    (#408): a project's own ``relationships`` test, a semantic layer's shared
+    entity, and a native declaration are three channels that can each state a
+    join between one pair of datasets, and nothing before this point notices
+    when two of them disagree about which columns it runs on.
+
+    Both edges still survive in the merged set (:func:`_fold_semantic_edges`
+    only folds an exact match); this only names the disagreement, since which
+    columns actually join is a fact about the warehouse only one declaration
+    can be right about, and picking a winner or merging one column set into
+    the other would be inventing evidence no declaration offered.
+    """
+
+    by_endpoint: dict[tuple[str, str], dict[tuple, Relationship]] = {}
+    for rel in declared:
+        if rel.kind is not RelationshipKind.DECLARED:
+            continue
+        endpoint = (rel.from_dataset.lower(), rel.to_dataset.lower())
+        by_endpoint.setdefault(endpoint, {})[_relationship_edge_key(rel)] = rel
+
+    conflicts: list[DeclaredRelationshipConflict] = []
+    for edges in by_endpoint.values():
+        if len(edges) < 2:
+            continue
+        first = next(iter(edges.values()))
+        conflicts.append(
+            DeclaredRelationshipConflict(
+                from_dataset=first.from_dataset,
+                to_dataset=first.to_dataset,
+                declarations=[
+                    ConflictingRelationshipDeclaration(
+                        column_pairs=[
+                            [frm, to]
+                            for frm, to in zip(
+                                rel.from_columns, rel.to_columns, strict=False
+                            )
+                        ],
+                        source=", ".join(rel.declaration_sources)
+                        or rel.declared_by
+                        or "unknown",
+                    )
+                    for rel in edges.values()
+                ],
+            )
+        )
+    return conflicts
+
+
+def _relationship_conflict_notes(
+    conflicts: list[DeclaredRelationshipConflict],
+) -> list[str]:
+    if not conflicts:
+        return []
+    named = ", ".join(f"{c.from_dataset} -> {c.to_dataset}" for c in conflicts[:5])
+    return [
+        f"{len(conflicts)} declared relationship(s) disagree on which columns "
+        f"join the same two datasets ({named}); every declaration is kept as "
+        "its own edge rather than dex picking a winner, see data.conflicts"
+    ]
 
 
 def _merge_relationships(

--- a/packages/dex-core/src/exmergo_dex_core/explore/diagram.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/diagram.py
@@ -277,9 +277,19 @@ def _edge_label(rel: Relationship) -> str:
     layer's shared entity. A reader looking at a solid line otherwise has no way to
     tell a foreign-key test from a declared join the semantic layer performs, and
     the entity name is the handle for looking the second one up.
+
+    The key names every pair when there is more than one (a composite join) or
+    when the two sides are spelled differently, so a reader is never left
+    matching two unpaired lists by position; a single pair sharing one name on
+    both sides (the common case) still reads as that bare name.
     """
 
-    parts = [", ".join(rel.from_columns) or "join", rel.kind.value]
+    pairs = list(zip(rel.from_columns, rel.to_columns, strict=False))
+    if len(pairs) == 1 and pairs[0][0] == pairs[0][1]:
+        key = pairs[0][0] or "join"
+    else:
+        key = ", ".join(f"{frm} = {to}" for frm, to in pairs) or "join"
+    parts = [key, rel.kind.value]
     if rel.kind is not RelationshipKind.DECLARED and rel.confidence is not None:
         parts[-1] = f"{rel.kind.value} {rel.confidence:.2f}"
     if rel.declared_by:

--- a/packages/dex-core/src/exmergo_dex_core/explore/results.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/results.py
@@ -179,6 +179,38 @@ class ProfileResult(Result):
         }
 
 
+class ConflictingRelationshipDeclaration(BaseModel):
+    """One of two or more declarations that disagree about the same join.
+
+    ``column_pairs`` is ordered ``[from_column, to_column]`` entries, exactly
+    the shape a composite join needs; ``source`` names where this particular
+    declaration came from (a ``relationships`` test, a semantic layer's shared
+    entity, or a native declaration), the same provenance a non-conflicting
+    edge already carries in ``declaration_sources``.
+    """
+
+    column_pairs: list[list[str]] = Field(default_factory=list)
+    source: str = ""
+
+
+class DeclaredRelationshipConflict(BaseModel):
+    """Two or more declarations state a join between the same two datasets
+    with different column pairs (#408).
+
+    Both edges still appear in ``relationships``/``edges``; this is the one
+    place that says they disagree, since which columns actually join is a
+    fact about the warehouse only one declaration can be right about, and dex
+    never guesses which by silently picking a winner or merging one column
+    set into the other.
+    """
+
+    from_dataset: str
+    to_dataset: str
+    declarations: list[ConflictingRelationshipDeclaration] = Field(
+        default_factory=list
+    )
+
+
 class RelationshipsResult(Result):
     """Joins across the objects in scope, with what earned each one.
 
@@ -188,6 +220,11 @@ class RelationshipsResult(Result):
     which is worth its own number because it is the one that appears only under
     ``--use-project`` on a project with a semantic layer, and a reader comparing
     two runs otherwise sees `declared_count` move with no field explaining it.
+
+    ``conflicts`` names every pair of datasets more than one declaration joins
+    with different columns; see :class:`DeclaredRelationshipConflict`. Empty is
+    the positive statement that every declaration touching the same two
+    datasets agreed.
     """
 
     relationships: list[Relationship] = Field(default_factory=list)
@@ -196,6 +233,7 @@ class RelationshipsResult(Result):
     profiled_count: int = 0
     cache_hit_count: int = 0
     carried_relationship_count: int = 0
+    conflicts: list[DeclaredRelationshipConflict] = Field(default_factory=list)
     cache_path: str = ""
     updated_at: str = ""
 
@@ -208,6 +246,7 @@ class RelationshipsResult(Result):
             "profiled_count": self.profiled_count,
             "cache_hit_count": self.cache_hit_count,
             "carried_relationship_count": self.carried_relationship_count,
+            "conflicts": [c.model_dump(mode="json") for c in self.conflicts],
             "cache_path": self.cache_path,
             "updated_at": self.updated_at,
         }
@@ -255,6 +294,7 @@ class MapResult(Result):
     top_objects: list[RankedObject] = Field(default_factory=list)
     objects: list[MapObject] = Field(default_factory=list)
     edges: list[Relationship] = Field(default_factory=list)
+    conflicts: list[DeclaredRelationshipConflict] = Field(default_factory=list)
     elided_object_count: int = 0
     elided_column_count: int = 0
     elided_edge_count: int = 0
@@ -283,6 +323,7 @@ class MapResult(Result):
             "top_objects": [o.model_dump(mode="json") for o in self.top_objects],
             "objects": [o.model_dump(mode="json") for o in self.objects],
             "edges": [e.model_dump(mode="json") for e in self.edges],
+            "conflicts": [c.model_dump(mode="json") for c in self.conflicts],
             "elided_object_count": self.elided_object_count,
             "elided_column_count": self.elided_column_count,
             "elided_edge_count": self.elided_edge_count,

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/backend.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/backend.py
@@ -68,6 +68,19 @@ class SemanticLayer(Protocol):
         """Native full-pair declarations, or an empty list when unavailable."""
         ...
 
+    def declared_keys(self) -> tuple[list[Any], list[Any]]:
+        """Dataset keys this layer declares itself, as ``(keys, composite_keys)``.
+
+        Empty for a layer whose declared keys already reach the grain channel
+        through the transformation project's own tier-1 ``definitions()`` (dbt):
+        stating them here too would risk a caller double-counting rather than
+        ever adding information. Non-empty only for a layer that is itself the
+        sole declaration channel for its repository, such as native Ossie
+        documents, which are never a transformation project and so have no
+        other route to grain detection.
+        """
+        ...
+
 
 def descriptor_from_backend(backend: Any) -> BackendDescriptor:
     """Read a descriptor, including compatibility for narrow test doubles."""

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/hosted.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/hosted.py
@@ -219,6 +219,12 @@ class HostedDbtCloudBackend:
 
         return []
 
+    def declared_keys(self) -> tuple[list[Any], list[Any]]:
+        """dbt's own declared keys already reach grain through its project
+        format's ``definitions()``; stating them here too would double them."""
+
+        return [], []
+
     # ---- query -------------------------------------------------------------
 
     def filter_refs(self, clauses: list[str]) -> list[str] | None:

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/local.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/local.py
@@ -175,6 +175,12 @@ class LocalMetricFlowBackend:
 
         return []
 
+    def declared_keys(self) -> tuple[list[Any], list[Any]]:
+        """dbt's own declared keys already reach grain through its project
+        format's ``definitions()``; stating them here too would double them."""
+
+        return [], []
+
     def _semantic_view(self):
         """The project's semantic catalog, read once per command.
 

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/ossie.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/ossie.py
@@ -120,6 +120,14 @@ class LocalOssieLayer:
 
         return self._project.declared_definitions().declared_relationships
 
+    def declared_keys(self) -> tuple[list[Any], list[Any]]:
+        """Ossie's own declared dataset keys (#408): unlike dbt, Ossie is never
+        the transformation project `engine.project_format()` resolves, so this
+        is the only route its keys have to grain detection at all."""
+
+        defs = self._project.declared_definitions()
+        return defs.declared_keys, defs.declared_composite_keys
+
     def query(self, _q: Any) -> Any:
         raise SemanticBackendError(
             f"{_NO_RUNTIME}. Read the layer with `explore semantic list`, then "

--- a/packages/dex-core/tests/explore/test_diagram.py
+++ b/packages/dex-core/tests/explore/test_diagram.py
@@ -218,6 +218,50 @@ def test_the_edge_label_states_the_kind_the_confidence_and_the_verification():
     )
 
 
+def test_a_composite_edge_label_pairs_every_column_rather_than_two_lists():
+    """A composite join's label used to join only `from_columns`, dropping the
+    parent side entirely: `product_id, variant_id` with no way to tell which
+    parent column each one pairs with. It now names every pair (#408)."""
+
+    products = _ds(
+        "shop.main.products",
+        [_col("id", is_unique=True), _col("variant_id")],
+        candidate_keys=[["id", "variant_id"]],
+        grain=["id", "variant_id"],
+    )
+    order_lines = _ds(
+        "shop.main.order_lines",
+        [_col("product_id"), _col("variant_id")],
+    )
+    rel = _rel(
+        "shop.main.order_lines",
+        ["product_id", "variant_id"],
+        "shop.main.products",
+        ["id", "variant_id"],
+        kind=RelationshipKind.DECLARED,
+        confidence=1.0,
+    )
+    rendered = render_er_mermaid(_cache([products, order_lines], [rel]))
+    assert _edge_line(rendered.mermaid).endswith(
+        ': "product_id = id, variant_id = variant_id, declared"'
+    )
+
+
+def test_a_single_pair_with_differing_names_is_also_paired():
+    rel = _rel(
+        "shop.main.orders",
+        ["cust_id"],
+        "shop.main.customers",
+        ["id"],
+        kind=RelationshipKind.DECLARED,
+        confidence=1.0,
+    )
+    customers = _ds("shop.main.customers", [_col("id", is_unique=True)])
+    orders = _ds("shop.main.orders", [_col("cust_id")])
+    rendered = render_er_mermaid(_cache([customers, orders], [rel]))
+    assert _edge_line(rendered.mermaid).endswith(': "cust_id = id, declared"')
+
+
 # --- what never crosses into the diagram --------------------------------------
 
 

--- a/packages/dex-core/tests/explore/test_relationships.py
+++ b/packages/dex-core/tests/explore/test_relationships.py
@@ -25,8 +25,10 @@ from exmergo_dex_core.config import EntityAffixes
 from exmergo_dex_core.dbt_project import DeclaredForeignKey, ProjectDefinitions
 from exmergo_dex_core.explore.commands import (
     _carry_forward_relationships,
+    _declared_relationship_conflicts,
     _fold_semantic_edges,
     _merge_relationships,
+    _relationship_conflict_notes,
     _semantic_join_notes,
 )
 from exmergo_dex_core.explore.profile import profile
@@ -2012,6 +2014,120 @@ def test_a_semantic_edge_the_project_already_declares_is_counted_once():
     # The relationships test's edge stands; the semantic channel adds nothing it
     # did not already say.
     assert merged[0].declared_by is None
+
+
+# --- declared relationship conflicts (#408) -------------------------------------
+
+
+def test_conflicting_declarations_over_the_same_endpoints_are_both_kept_and_flagged():
+    """A relationships test and the semantic layer's shared entity name the same
+    two datasets but disagree on which column joins them: dex never picks a
+    winner, so both edges survive and the disagreement is named rather than
+    one silently overwriting or merging with the other."""
+
+    declared = Relationship(
+        from_dataset="wh.main.orders",
+        from_columns=["customer_id"],
+        to_dataset="wh.main.customers",
+        to_columns=["id"],
+        kind=RelationshipKind.DECLARED,
+        confidence=1.0,
+        declaration_sources=["relationships test orders.customer_id"],
+    )
+    semantic, _ = semantic_relationships(
+        [_join(child_column="buyer_id")], ["wh.main.orders", "wh.main.customers"]
+    )
+
+    merged, already = _fold_semantic_edges([declared], semantic)
+    conflicts = _declared_relationship_conflicts(merged)
+
+    assert already == 0
+    assert len(merged) == 2, "neither declaration wins; both edges survive"
+    assert len(conflicts) == 1
+    conflict = conflicts[0]
+    assert conflict.from_dataset == "wh.main.orders"
+    assert conflict.to_dataset == "wh.main.customers"
+    pairs = {tuple(tuple(p) for p in d.column_pairs) for d in conflict.declarations}
+    assert pairs == {(("customer_id", "id"),), (("buyer_id", "id"),)}
+    sources = {d.source for d in conflict.declarations}
+    assert "relationships test orders.customer_id" in sources
+    assert any("customer" in s for s in sources)  # the semantic entity's name
+
+
+def test_agreeing_declarations_over_the_same_endpoints_are_not_a_conflict():
+    declared = Relationship(
+        from_dataset="wh.main.orders",
+        from_columns=["buyer_id"],
+        to_dataset="wh.main.customers",
+        to_columns=["id"],
+        kind=RelationshipKind.DECLARED,
+        confidence=1.0,
+    )
+    semantic, _ = semantic_relationships(
+        [_join()], ["wh.main.orders", "wh.main.customers"]
+    )
+
+    merged, _already = _fold_semantic_edges([declared], semantic)
+
+    assert _declared_relationship_conflicts(merged) == []
+
+
+def test_a_composite_conflict_carries_every_column_pair():
+    declared = Relationship(
+        from_dataset="wh.main.order_lines",
+        from_columns=["product_id"],
+        to_dataset="wh.main.products",
+        to_columns=["id"],
+        kind=RelationshipKind.DECLARED,
+        confidence=1.0,
+        declaration_sources=["relationships test order_lines.product_id"],
+    )
+    composite = Relationship(
+        from_dataset="wh.main.order_lines",
+        from_columns=["product_id", "variant_id"],
+        to_dataset="wh.main.products",
+        to_columns=["id", "variant_id"],
+        kind=RelationshipKind.DECLARED,
+        confidence=1.0,
+        declaration_sources=["native relationship 'order_lines_to_products'"],
+    )
+
+    (conflict,) = _declared_relationship_conflicts([declared, composite])
+
+    by_pairs = {tuple(tuple(p) for p in d.column_pairs): d for d in conflict.declarations}
+    assert (("product_id", "id"),) in by_pairs
+    assert (("product_id", "id"), ("variant_id", "variant_id")) in by_pairs
+
+
+def test_conflict_notes_name_the_endpoints_and_point_at_the_structured_field():
+    conflicts = _declared_relationship_conflicts(
+        [
+            Relationship(
+                from_dataset="wh.main.orders",
+                from_columns=["customer_id"],
+                to_dataset="wh.main.customers",
+                to_columns=["id"],
+                kind=RelationshipKind.DECLARED,
+                confidence=1.0,
+            ),
+            Relationship(
+                from_dataset="wh.main.orders",
+                from_columns=["buyer_id"],
+                to_dataset="wh.main.customers",
+                to_columns=["id"],
+                kind=RelationshipKind.DECLARED,
+                confidence=1.0,
+            ),
+        ]
+    )
+
+    (note,) = _relationship_conflict_notes(conflicts)
+    assert "wh.main.orders -> wh.main.customers" in note
+    assert "data.conflicts" in note
+
+
+def test_no_conflict_notes_when_nothing_disagrees():
+    assert _relationship_conflict_notes([]) == []
 
 
 def test_the_notes_name_what_inference_would_have_missed():

--- a/packages/dex-core/tests/explore/test_semantic_catalog_composition.py
+++ b/packages/dex-core/tests/explore/test_semantic_catalog_composition.py
@@ -1,0 +1,151 @@
+"""Composing a local and a hosted semantic catalog into one read view (#408).
+
+`_semantic_catalog` reads both sources when both `--use-project` and
+`--use-hosted-semantic-layer` are passed, and folds them through
+`_compose_semantic_catalogs` rather than one winning by accidental precedence.
+These tests exercise that fold directly against hand-built catalogs, since the
+fold itself needs no engine or repository.
+"""
+
+from __future__ import annotations
+
+from exmergo_dex_core.explore.commands import _compose_semantic_catalogs
+from exmergo_dex_core.semantic_catalog import (
+    DimensionInfo,
+    EntityInfo,
+    EntityRole,
+    MeasureInfo,
+    MetricInfo,
+    SemanticCatalogView,
+    SemanticModelInfo,
+)
+
+
+def test_semantic_models_metrics_dimensions_and_measures_union_by_name():
+    local = SemanticCatalogView(
+        semantic_models=[SemanticModelInfo(name="orders", relation="db.orders")],
+        metrics=[MetricInfo(name="revenue", type="simple")],
+        dimensions=[DimensionInfo(name="order_date", type="time")],
+        measures=[MeasureInfo(name="order_total", semantic_model="orders")],
+    )
+    hosted = SemanticCatalogView(
+        semantic_models=[SemanticModelInfo(name="customers", relation=None)],
+        metrics=[MetricInfo(name="active_customers", type="simple")],
+        dimensions=[DimensionInfo(name="signup_date", type="time")],
+        measures=[MeasureInfo(name="customer_count", semantic_model="customers")],
+    )
+
+    composed = _compose_semantic_catalogs(local, hosted)
+
+    assert {m.name for m in composed.semantic_models} == {"orders", "customers"}
+    assert {m.name for m in composed.metrics} == {"revenue", "active_customers"}
+    assert {d.name for d in composed.dimensions} == {"order_date", "signup_date"}
+    assert {m.name for m in composed.measures} == {"order_total", "customer_count"}
+
+
+def test_a_name_both_sides_declare_keeps_the_local_entry():
+    local = SemanticCatalogView(
+        semantic_models=[SemanticModelInfo(name="orders", relation="db.orders")]
+    )
+    hosted = SemanticCatalogView(
+        semantic_models=[SemanticModelInfo(name="orders", relation=None)]
+    )
+
+    composed = _compose_semantic_catalogs(local, hosted)
+
+    (model,) = composed.semantic_models
+    assert model.relation == "db.orders"
+
+
+def test_an_entity_declared_on_both_sides_merges_roles_and_rederives_type():
+    local = SemanticCatalogView(
+        entities=[
+            EntityInfo(
+                name="customer",
+                type="foreign",
+                roles=[EntityRole(semantic_model="orders", type="foreign")],
+            )
+        ]
+    )
+    hosted = SemanticCatalogView(
+        entities=[
+            EntityInfo(
+                name="customer",
+                type="primary",
+                roles=[EntityRole(semantic_model="customers", type="primary")],
+            )
+        ]
+    )
+
+    composed = _compose_semantic_catalogs(local, hosted)
+
+    (entity,) = composed.entities
+    assert {r.semantic_model for r in entity.roles} == {"orders", "customers"}
+    assert entity.type == "primary"
+
+
+def test_an_entity_role_declared_identically_on_both_sides_is_not_duplicated():
+    role = EntityRole(semantic_model="orders", type="foreign", column="customer_id")
+    local = SemanticCatalogView(
+        entities=[EntityInfo(name="customer", type="foreign", roles=[role])]
+    )
+    hosted = SemanticCatalogView(
+        entities=[
+            EntityInfo(
+                name="customer",
+                type="foreign",
+                roles=[
+                    EntityRole(
+                        semantic_model="orders", type="foreign", column="customer_id"
+                    )
+                ],
+            )
+        ]
+    )
+
+    composed = _compose_semantic_catalogs(local, hosted)
+
+    (entity,) = composed.entities
+    assert len(entity.roles) == 1
+
+
+def test_an_entity_declared_on_only_one_side_passes_through_unchanged():
+    local = SemanticCatalogView(
+        entities=[
+            EntityInfo(
+                name="customer",
+                type="primary",
+                roles=[EntityRole(semantic_model="customers", type="primary")],
+            )
+        ]
+    )
+    hosted = SemanticCatalogView()
+
+    composed = _compose_semantic_catalogs(local, hosted)
+
+    (entity,) = composed.entities
+    assert entity.name == "customer"
+    assert entity.type == "primary"
+
+
+def test_notes_concatenate_and_physical_columns_prefer_the_local_side():
+    local = SemanticCatalogView(
+        notes=["local note"],
+        physical_columns={"orders.order_id": ("db.orders", "order_id")},
+    )
+    hosted = SemanticCatalogView(
+        notes=["hosted note"],
+        physical_columns={
+            "orders.order_id": ("hosted.orders", "id"),
+            "customers.customer_id": ("hosted.customers", "id"),
+        },
+    )
+
+    composed = _compose_semantic_catalogs(local, hosted)
+
+    assert composed.notes == ["local note", "hosted note"]
+    assert composed.physical_columns["orders.order_id"] == ("db.orders", "order_id")
+    assert composed.physical_columns["customers.customer_id"] == (
+        "hosted.customers",
+        "id",
+    )

--- a/packages/dex-core/tests/ossie/test_commands.py
+++ b/packages/dex-core/tests/ossie/test_commands.py
@@ -12,6 +12,7 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 from exmergo_dex_core.cli import main
 from exmergo_dex_core.config import DexConfig, save_config
@@ -222,6 +223,97 @@ def test_an_unreadable_document_degrades_rather_than_failing_a_map(
     (configured / "commerce.ossie.yaml").write_text("a: [1,\n", encoding="utf-8")
 
     assert _semantic_catalog(DexEngine.from_repo(str(configured)), True) is None
+
+
+def test_use_hosted_semantic_layer_degrades_to_the_local_ossie_view(
+    configured: Path,
+):
+    """Ossie has no hosted deployment (#408): asking for both `--use-project`
+    and `--use-hosted-semantic-layer` reads what each side can actually answer
+    rather than the hosted side's refusal discarding the local read that
+    already succeeded."""
+
+    from exmergo_dex_core.explore.commands import _semantic_catalog
+
+    view = _semantic_catalog(
+        DexEngine.from_repo(str(configured)),
+        True,
+        use_hosted_semantic_layer=True,
+    )
+
+    assert view is not None
+    assert "commerce.orders" in [m.name for m in view.semantic_models]
+
+
+def test_declared_keys_reach_the_grain_channel_without_a_vendor_branch(
+    configured: Path,
+):
+    """Ossie's dataset keys have no route to grain detection except this one
+    (#408): unlike dbt, Ossie is never the transformation project `engine.
+    project_format()` resolves, so `explore profile --use-project` would see
+    no declared grain at all without it. Reached through the semantic layer's
+    own `declared_keys()` capability, the same shape `declared_relationships`
+    already uses, never a name check on which vendor is configured."""
+
+    from exmergo_dex_core.explore.commands import _project_definitions
+
+    defs = _project_definitions(DexEngine.from_repo(str(configured)), True)
+
+    assert defs.present is True
+    single = {k.model: k.column for k in defs.declared_keys}
+    assert single["commerce.orders"] == "order_id"
+    assert single["commerce.customers"] == "customer_id"
+    composite = {c.model: c.columns for c in defs.declared_composite_keys}
+    assert composite["commerce.order_items"] == ["order_id", "line_no"]
+
+
+def test_no_declared_keys_is_silent_rather_than_a_forced_presence(
+    configured: Path,
+):
+    """A document that declares no keys at all must not flip `present` on the
+    strength of nothing: an empty capability result changes nothing about the
+    definitions dbt's own tier-1 read already produced."""
+
+    from exmergo_dex_core.explore.commands import _project_definitions
+
+    (configured / "commerce.ossie.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": "0.2.0.dev0",
+                "semantic_model": [
+                    {
+                        "name": "bare",
+                        "datasets": [
+                            {
+                                "name": "events",
+                                "source": "demo.main.events",
+                                "fields": [
+                                    {
+                                        "name": "id",
+                                        "expression": {
+                                            "dialects": [
+                                                {
+                                                    "dialect": "ANSI_SQL",
+                                                    "expression": "id",
+                                                }
+                                            ]
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    defs = _project_definitions(DexEngine.from_repo(str(configured)), True)
+
+    assert defs.present is False
+    assert defs.declared_keys == []
+    assert defs.declared_composite_keys == []
 
 
 def test_no_command_carries_a_vendor_branch():

--- a/packages/dex-core/tests/ossie/test_duckdb_e2e.py
+++ b/packages/dex-core/tests/ossie/test_duckdb_e2e.py
@@ -1,0 +1,268 @@
+"""Native Ossie relationships through the actual command surface (#408).
+
+A real DuckDB warehouse, a native Ossie document declaring it, and every
+command that reads that declared graph: `relationships`, `map`, `diagram`, and
+`--verify`. Unlike the rest of the Ossie suite (which reads documents through
+narrow unit calls) this exercises the whole CLI path the way an agent actually
+runs it, over a document shaped like the "completion proof" issue #408 asks
+for: a single-column pair, a composite pair, a same-endpoint pair that
+contradicts another declaration, and an opaque query-backed dataset.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.cli import main
+from exmergo_dex_core.config import DexConfig, save_config
+
+from .conftest import dataset, document, field, model, write
+
+
+def _run(argv: list[str], capsys) -> dict:
+    rc = main(argv)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0, payload
+    assert payload["status"] == "ok", payload
+    return payload
+
+
+@pytest.fixture
+def commerce_repo(tmp_path: Path) -> Path:
+    """A DuckDB warehouse plus a native Ossie document declaring it.
+
+    ``orders -> customers`` is a clean single-column join (every customer_id
+    has a parent). ``order_item_details -> order_items`` is a clean composite
+    join on ``(order_id, line_no)``. A second, contradicting declaration
+    joins ``orders`` and ``customers`` again on different columns, the
+    same-endpoint disagreement #408's conflict detection exists for.
+    ``recent_orders`` is a query-backed dataset with no physical relation, the
+    opaque-source case.
+    """
+
+    duckdb = pytest.importorskip("duckdb")
+    db = tmp_path / "demo.duckdb"
+    conn = duckdb.connect(str(db))
+    conn.execute(
+        "CREATE TABLE orders (order_id INTEGER, customer_id INTEGER, region VARCHAR)"
+    )
+    conn.execute("INSERT INTO orders VALUES (1, 1, 'US'), (2, 2, 'EU'), (3, 1, 'US')")
+    conn.execute("CREATE TABLE customers (customer_id INTEGER, country_code VARCHAR)")
+    conn.execute("INSERT INTO customers VALUES (1, 'US'), (2, 'EU')")
+    conn.execute(
+        "CREATE TABLE order_items (order_id INTEGER, line_no INTEGER, sku VARCHAR)"
+    )
+    conn.execute("INSERT INTO order_items VALUES (1, 1, 'A'), (1, 2, 'B'), (2, 1, 'C')")
+    conn.execute(
+        "CREATE TABLE order_item_details (order_id INTEGER, line_no INTEGER, "
+        "detail VARCHAR)"
+    )
+    conn.execute(
+        "INSERT INTO order_item_details VALUES (1, 1, 'x'), (1, 2, 'y'), (2, 1, 'z')"
+    )
+    conn.close()
+
+    doc = document(
+        model(
+            "commerce",
+            dataset(
+                "orders",
+                "demo.main.orders",
+                field("order_id"),
+                field("customer_id"),
+                field("region"),
+                primary_key=["order_id"],
+            ),
+            dataset(
+                "customers",
+                "demo.main.customers",
+                field("customer_id"),
+                field("country_code"),
+                primary_key=["customer_id"],
+            ),
+            dataset(
+                "order_items",
+                "demo.main.order_items",
+                field("order_id"),
+                field("line_no"),
+                field("sku"),
+                primary_key=["order_id", "line_no"],
+            ),
+            dataset(
+                "order_item_details",
+                "demo.main.order_item_details",
+                field("order_id"),
+                field("line_no"),
+                field("detail"),
+            ),
+            dataset(
+                "recent_orders",
+                "SELECT * FROM demo.main.orders WHERE region = 'US'",
+                field("order_id"),
+            ),
+            relationships=[
+                {
+                    "name": "orders_to_customers",
+                    "from": "orders",
+                    "to": "customers",
+                    "from_columns": ["customer_id"],
+                    "to_columns": ["customer_id"],
+                },
+                {
+                    "name": "orders_to_customers_by_region",
+                    "from": "orders",
+                    "to": "customers",
+                    "from_columns": ["region"],
+                    "to_columns": ["country_code"],
+                },
+                {
+                    "name": "details_to_items",
+                    "from": "order_item_details",
+                    "to": "order_items",
+                    "from_columns": ["order_id", "line_no"],
+                    "to_columns": ["order_id", "line_no"],
+                },
+            ],
+        )
+    )
+    write(tmp_path, "commerce.ossie.yaml", doc)
+
+    save_config(
+        DexConfig(
+            connector="duckdb",
+            duckdb={"path": "demo.duckdb"},
+            semantic={"vendor": "ossie", "ossie": {"files": ["commerce.ossie.yaml"]}},
+        ),
+        tmp_path,
+    )
+    return tmp_path
+
+
+def test_declared_edges_carry_single_and_composite_pairs(commerce_repo: Path, capsys):
+    data = _run(
+        [
+            "explore",
+            "relationships",
+            "--use-project",
+            "--repo-root",
+            str(commerce_repo),
+        ],
+        capsys,
+    )["data"]
+
+    declared = {
+        r["from_dataset"]: r for r in data["relationships"] if r["kind"] == "declared"
+    }
+    single = next(
+        r
+        for r in data["relationships"]
+        if r["kind"] == "declared" and r["from_columns"] == ["customer_id"]
+    )
+    assert single["to_dataset"].endswith("customers")
+    composite = next(
+        r
+        for r in data["relationships"]
+        if r["kind"] == "declared" and set(r["from_columns"]) == {"order_id", "line_no"}
+    )
+    assert composite["to_columns"] == ["order_id", "line_no"]
+    assert declared  # sanity: at least one declared edge landed
+
+
+def test_contradicting_declarations_are_flagged_as_a_conflict(
+    commerce_repo: Path, capsys
+):
+    data = _run(
+        [
+            "explore",
+            "relationships",
+            "--use-project",
+            "--repo-root",
+            str(commerce_repo),
+        ],
+        capsys,
+    )["data"]
+
+    assert len(data["conflicts"]) == 1
+    conflict = data["conflicts"][0]
+    assert conflict["from_dataset"].endswith("orders")
+    assert conflict["to_dataset"].endswith("customers")
+    pairs = {tuple(d["column_pairs"][0]) for d in conflict["declarations"]}
+    assert pairs == {("customer_id", "customer_id"), ("region", "country_code")}
+    assert any("disagree" in n for n in data["notes"])
+    # Both contradicting edges are still kept, not collapsed into one.
+    assert (
+        sum(
+            1
+            for r in data["relationships"]
+            if r["kind"] == "declared"
+            and r["from_dataset"].endswith("orders")
+            and r["to_dataset"].endswith("customers")
+        )
+        == 2
+    )
+
+
+def test_map_persists_composite_edges_and_conflicts_to_the_cache(
+    commerce_repo: Path, capsys
+):
+    data = _run(
+        ["explore", "map", "--use-project", "--repo-root", str(commerce_repo)],
+        capsys,
+    )["data"]
+
+    assert len(data["conflicts"]) == 1
+    composite = next(
+        r for r in data["edges"] if set(r["from_columns"]) == {"order_id", "line_no"}
+    )
+    assert composite["to_columns"] == ["order_id", "line_no"]
+
+
+def test_diagram_pairs_every_composite_column_in_the_mermaid_label(
+    commerce_repo: Path, capsys
+):
+    assert (
+        main(["explore", "map", "--use-project", "--repo-root", str(commerce_repo)])
+        == 0
+    )
+    capsys.readouterr()
+
+    data = _run(["explore", "diagram", "--repo-root", str(commerce_repo)], capsys)[
+        "data"
+    ]
+
+    assert "order_id = order_id, line_no = line_no" in data["mermaid"]
+
+
+def test_verify_confirms_the_declared_joins_against_real_overlap(
+    commerce_repo: Path, capsys
+):
+    data = _run(
+        [
+            "explore",
+            "relationships",
+            "--use-project",
+            "--verify",
+            "--repo-root",
+            str(commerce_repo),
+        ],
+        capsys,
+    )["data"]
+
+    single = next(
+        r
+        for r in data["relationships"]
+        if r["kind"] == "declared" and r["from_columns"] == ["customer_id"]
+    )
+    assert single["verified"] is True
+    assert single["orphan_fraction"] == 0.0
+
+    composite = next(
+        r
+        for r in data["relationships"]
+        if r["kind"] == "declared" and set(r["from_columns"]) == {"order_id", "line_no"}
+    )
+    assert composite["verified"] is True
+    assert composite["orphan_fraction"] == 0.0


### PR DESCRIPTION
Closes #408 (relationship composition for the native Ossie
semantic layer). Three pieces were still open after the earlier
Ossie-setup work landed:

- **Conflict detection**: two declarations that join the same two
  datasets on different columns used to fold into two silent, unlabeled
  edges. `explore map` and `explore relationships` now surface every
  such disagreement as a `DeclaredRelationshipConflict` in a new
  `conflicts` field, naming each declaration's columns and source, with
  a note pointing at it. Every declaration is still kept as its own
  edge; dex reports the disagreement rather than picking a winner.

- **Hosted + local composition**: passing both `--use-project` and
  `--use-hosted-semantic-layer` used to read only the local project,
  the hosted branch never ran. Both are now read and unioned: semantic
  models, metrics, dimensions and measures merge by name (local wins a
  name both declare), and an entity declared on both sides merges its
  per-model roles and re-derives its summary `type` from the wider set.
  Relationship-edge extraction composes the same way. Each side is read
  independently, so a vendor missing one deployment (Ossie has no
  hosted counterpart) degrades to whichever side answered instead of
  losing an already-successful read.

- **Grain channel + Mermaid fix**: `SemanticLayer` gains a
  `declared_keys()` capability so a layer that is never a transformation
  project (Ossie) still reaches `explore profile --use-project`'s grain
  detection, added vendor-agnostically per
  `test_no_command_carries_a_vendor_branch`. Separately, the Mermaid
  edge label was dropping the parent side of a composite join
  (`(product_id, variant_id)` rendered as one unpaired list); it now
  pairs every column.

## Testing

- New unit tests for the conflict detector and for
  `_compose_semantic_catalogs` (name-union, entity role merge, local
  precedence).
- New `tests/ossie/test_duckdb_e2e.py`: a real DuckDB warehouse plus a
  native Ossie document exercised through the actual CLI
  (`relationships`, `map`, `diagram`, `--verify`) covering a
  single-column pair, a composite pair, a same-endpoint conflict, and
  an opaque query-backed dataset.
- Full `tests/explore/` + `tests/ossie/` suite passes (977 passed, 30
  skipped); the 5 remaining failures are pre-existing Windows-only
  environment issues (encoding, symlink privilege, path handling,
  known upstream schema drift) unrelated to this change.
- Manually verified end-to-end against a live DuckDB warehouse: conflict
  flagged in `explore relationships`, composite edge and conflict
  persisted through `explore map`, composite label rendered correctly
  in `explore diagram`, and both declared joins confirmed with
  `orphan_fraction: 0.0` under `--verify`.