### PR TITLE
--definitions-file can delete a semantic model or metric

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ credentials and no network.
 | `transform macro [name]` | no name lists the shipped dbt macros; a name proposes scaffolding it into the project's macro directory as a plan (dbt-parse-checked, applied with `transform apply`); re-running diffs the project's copy against the shipped version |
 | `transform build --target dev` | prod-looking targets refused outright; then a free dev-target preflight (refuses when `.dex/config.yml` and the rendered `profiles.yml` disagree, or when the dev database does not exist, naming the fix); then the cost preflight, priced upfront by a free `dbt compile` dry-run of each node (a partial floor when a cold dev target has not built a node's inputs yet; degrades to no estimate when dex cannot open its own connection); runs only with `--confirm` and a budget; cwd pinned to the project dir; auto-runs `dbt deps` when packages are declared but not installed |
 | `transform deps` | install/refresh dbt packages (repo-confined; no warehouse spend) |
-| `semantic define\|update\|plan ... --edits-file <f>\|--definitions-file <f>` | dbt semantic model edits as diffs; validated up to and including dbt's own parser (a throwaway project copy) before the plan is stored; `plan` accepts a mix and classifies each name `defined`, `updated`, or `unchanged`; `--definitions-file` names one definition at a time instead of a whole file; degrades to a warning when dbt is absent, `--no-parse` skips; applied with `transform apply` like any other plan |
+| `semantic define\|update\|plan ... --edits-file <f>\|--definitions-file <f>` | dbt semantic model edits as diffs; validated up to and including dbt's own parser (a throwaway project copy) before the plan is stored; `plan` accepts a mix and classifies each name `defined`, `updated`, `unchanged`, or `removed`; `--definitions-file` names one definition at a time instead of a whole file, including an `"op": "delete"` entry that removes one and is refused while the surviving project still reads it; degrades to a warning when dbt is absent, `--no-parse` skips; applied with `transform apply` like any other plan |
 | `maintain snapshot [--project-only]` | capture/refresh the known-good baseline in `.dex/snapshot.json` (pins the `.dex/` map + per-layer definition fingerprints). `--project-only` re-fingerprints only the transform and semantic project layers, carries the existing `warehouse` block, `warehouse_from`, and `cache_updated_at` forward unchanged, opens no warehouse connection, and reports that carried-forward state explicitly. It requires an existing snapshot and refuses connection-target flags (`--connector`, `--path`, `--scope`, `--project`, `--dataset`). Use it after a file-path/project-name-only refactor; it deliberately preserves warehouse staleness rather than laundering it into a fresh measurement. |
 | `maintain check` | sweep every drift axis vs the snapshot; ranked drift report (read-only); two-phase on billed connectors: the free axes complete and return `ok`, with one estimate for the scanning axes under `data.offer` |
 | `maintain schema [<objects>]` | structural drift: columns/tables added, dropped, retyped, renamed; nullability; dangling sources; a model added, removed, or content-changed since the baseline (free) |
@@ -147,7 +147,17 @@ The name is read from the content, and `path` may be omitted for a definition
 the project already declares, in which case it is rewritten where it lives. Use
 it whenever a change touches part of a shared file: the engine writes each
 definition in place and leaves every other byte, including comments, untouched,
-so the diff and the classification both describe only what changed. 
+so the diff and the classification both describe only what changed. An entry's
+`op` is `upsert` (the default) or `delete`, which carries `name` and no
+`content` and takes that one definition out of the file that declares it;
+removal is always declared, so a definition the payload does not mention is
+never removed. `semantic define` refuses a removal, `update` and `plan` accept
+one, and the envelope reports it under `removed`. A removal the surviving
+project still reads (a metric whose input is the removed metric, or a measure of
+a removed semantic model) is refused naming the reader, and is satisfied by
+putting that reader's own removal or update in the same payload; a removal that
+would leave a file declaring no semantic model or metric is refused too, since
+emptying a file is a whole-file edit. 
 `op` is `upsert` (create or update, the
 default, carrying `content`) or `delete` (remove the file, no `content`); a
 delete is a reviewable diff too, guarded so the plan is refused if any surviving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,56 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **A definition can now be removed through `--definitions-file`** ([#254]). An
+  entry carrying `"op": "delete"` names one semantic model or metric and takes it
+  out of the file that declares it. `name` is declared beside `kind`, there being
+  no body to read it from, and no `content` rides along. Deleting used to mean
+  sending the whole file back without the definition, which is the exact cost the
+  per-definition unit exists to remove: the diff then describes the file rather
+  than the change, and every restated line is a chance to corrupt a definition
+  nobody meant to touch.
+
+  Removal is declared, never inferred. A definitions payload does not remove a
+  definition for having gone unmentioned, in any circumstance: an unmentioned
+  definition is untouched, and that is the property the unit is for. `op` is
+  dbt's own edit vocabulary rather than a second spelling of it, and one payload
+  names each definition exactly once, so what it asks for cannot depend on the
+  order it is read in. `semantic define` refuses a removal, a verb that adds a
+  name being unable to take one away in the same call; `update` and `plan` accept
+  one. The envelope reports a fourth class, `removed`, beside `defined`,
+  `updated`, and `unchanged`, because a removal states no content and is the one
+  change a reviewer cannot read off the other three.
+
+  **A removal the surviving project still reads is refused**, which is the
+  decision this turned on. The whole-plan delete guard asks that question about
+  files and `ref()`, and it cannot answer it here: a definition removal deletes no
+  file, and the name it takes away is a name in YAML inside a file that survives.
+  So the same guard is repeated one namespace over. The project the payload leaves
+  behind is computed in memory and every surviving metric re-resolved against it;
+  a metric still reading a removed metric, or a measure of a removed semantic
+  model (`create_metric` included), refuses the plan and names the reader and its
+  file. Adding those definitions' own removals to the same payload satisfies it,
+  in any order, since the guard reads the end state rather than the sequence.
+  Warning instead, and leaving it to `maintain semantic`, was the alternative: a
+  dangling metric input fails `dbt parse`, the gate every semantic plan already
+  passes, so warning would differ only where that gate is off (`--no-parse`, or no
+  dbt installed) and there it would store a plan dex knows cannot be applied.
+  Detection after the fact is the tool for drift that arrived from the warehouse
+  on its own, not for a break the command is in the middle of authoring. What a
+  reference index cannot see statically, a `Metric()` call inside a filter string,
+  stays dbt's parser's to catch.
+
+  Removing the last definition in a file is refused as well, pointing at
+  `transform plan --edits-file`: emptying or deleting a file is a file-level act,
+  the semantic verbs delete no files, and whether what is left should remain as
+  plain model documentation is the caller's call rather than this unit's. The
+  removal itself lowers to the same whole-file `PlanEdit` an authored definition
+  does, so the plan format, the diffs, the conflict hashing, and `transform apply`
+  are unchanged, and every byte outside the definition removed is preserved,
+  comments included: a block's `key:` line goes only with its last item.
+  `DexEngine.semantic_update` and `semantic_plan` take the same payload through
+  `definitions=`, so removal is not a CLI feature either.
+
 - **A per-definition edit unit for the semantic layer** ([#109]).
   `semantic define|update|plan` take `--definitions-file <path|->` beside
   `--edits-file`: `{"definitions": [{"kind", "path", "content"}, ...]}`, where
@@ -93,7 +143,7 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
   It lowers to the whole-file `PlanEdit` the engine already stores, so the plan
   format, the diffs, the conflict hashing, and `transform apply` are unchanged.
-  Deleting a definition remains a whole-file edit.
+  Removing a definition came later, as a declared `op` ([#254]).
 
   The unit is not a CLI feature. `DexEngine.semantic_define`, `semantic_update`,
   and `semantic_plan` take the parsed payload as `definitions=`, so a host

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -505,7 +505,9 @@ def _build_parser() -> argparse.ArgumentParser:
                     sp.add_argument("argument", nargs="?", default=None)
                     sp.add_argument("--edits-file", default=None)
                     # The per-definition payload: name only what changes, and the
-                    # engine writes it into the file that holds it.
+                    # engine writes it into the file that holds it. An entry's `op`
+                    # removes one instead, which is the only way a definition goes
+                    # away: never by going unmentioned.
                     sp.add_argument("--definitions-file", default=None)
                     sp.add_argument("--no-parse", action="store_true", default=False)
                 # maintain detectors take an optional object scope (default: whole

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -1514,6 +1514,10 @@ def _semantic_plan(
     # classification is narrowed to it: a spliced file carries every definition
     # it already held, and those were not part of this change.
     scope: set[semantic_mod.DefinitionKey] | None = None
+    # The removals in this payload, carried past the lowering rather than read
+    # back out of it: a removal's effect is the absence of something, which the
+    # content it produces cannot state.
+    removed: list[semantic_mod.DefinitionEdit] = []
     if definitions:
         # Lowered to the whole-file unit before anything else looks at them, so
         # the validation, classification, parse gate, and plan store below stay
@@ -1523,6 +1527,7 @@ def _semantic_plan(
             for path, content in semantic_mod.splice_definitions(definitions, view)
         ]
         scope = {(d.kind, d.name) for d in definitions}
+        removed = [d for d in definitions if d.op is EditOp.DELETE]
 
     if not edits:
         raise ValueError(
@@ -1545,8 +1550,19 @@ def _semantic_plan(
 
     parsed_by_path = [(e.path, yaml.safe_load(e.new_content)) for e in edits]
     parsed_edits = [parsed for _path, parsed in parsed_by_path]
-    classification = semantic_mod.check_mode(mode, parsed_by_path, view, scope=scope)
+    classification = semantic_mod.check_mode(
+        mode,
+        parsed_by_path,
+        view,
+        scope=scope,
+        removed=[(d.kind, d.name) for d in removed],
+    )
+    # The two reference directions: what this payload's own definitions read,
+    # then what the surviving project reads out of what it removes.
     semantic_mod.check_references(parsed_edits, view)
+    semantic_mod.check_removals(
+        removed, [(e.path, e.new_content or "") for e in edits], view
+    )
     spine_warning = semantic_mod.time_spine_warning(view, parsed_edits)
 
     # The authoritative gate: a plan that dbt cannot parse is never stored.
@@ -1581,6 +1597,7 @@ def _semantic_plan(
     result.defined = classification["defined"]
     result.updated = classification["updated"]
     result.unchanged = classification["unchanged"]
+    result.removed = classification["removed"]
     # `plans.plan` emits one diff per edit whether or not the content moved, so
     # a no-op is an all-empty diff set rather than an absent one.
     if result.unchanged and all(
@@ -1617,6 +1634,11 @@ def _definitions_from_payload(
     ``kind`` is ``semantic_model`` or ``metric``; ``content`` is that one
     definition's YAML body; ``path`` may be omitted for a definition the project
     already declares, which is then rewritten where it already lives.
+
+    An entry's ``op`` is ``upsert`` (the default, carrying ``content``) or
+    ``delete``, which carries ``name`` instead and removes that one definition
+    from the file that declares it. An omitted definition is never removed: only
+    a declared delete removes anything.
     """
 
     if definitions_file is None:

--- a/packages/dex-core/src/exmergo_dex_core/transform/results.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/results.py
@@ -53,6 +53,9 @@ class PlanResult(Result):
     defined: list[str] | None = None
     updated: list[str] | None = None
     unchanged: list[str] | None = None
+    # A fourth class rather than an empty diff: a removal states no content, so
+    # it is the one change a reviewer cannot read off the other three.
+    removed: list[str] | None = None
     # Per edited model, which authored changes can move rows and what each one
     # moved. Absent (not empty) when the edit cannot change a row population at
     # all, which is the common case and deserves no key.
@@ -72,6 +75,8 @@ class PlanResult(Result):
             payload["updated"] = self.updated
         if self.unchanged is not None:
             payload["unchanged"] = self.unchanged
+        if self.removed is not None:
+            payload["removed"] = self.removed
         if self.row_attribution is not None:
             payload["row_attribution"] = self.row_attribution
         return payload

--- a/packages/dex-core/src/exmergo_dex_core/transform/semantic.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/semantic.py
@@ -15,6 +15,12 @@ has. The definition unit exists because the whole-file one forces a caller
 adding two metrics to restate the twenty-seven it is not touching, which buries
 the real change in the review and puts twenty-seven hand-copied definitions at
 risk of a typo that only ``dbt parse`` would catch.
+
+A definition can also be *removed*: an entry carrying ``"op": "delete"`` names
+one and takes it out of the file that declares it. Removal is always declared
+and never inferred from an omission, because the unit's whole promise is that a
+definition it does not mention is left alone, and a payload that deleted by
+omission would turn that promise inside out.
 """
 
 from __future__ import annotations
@@ -25,7 +31,13 @@ from typing import Any, NamedTuple
 
 import yaml
 
-from ..dbt_project import DbtProjectView
+from ..dbt_project import (
+    DbtProjectView,
+    EditOp,
+    SourceFile,
+    content_hash,
+    metric_inputs,
+)
 from .validate import EditValidationError
 
 
@@ -215,6 +227,7 @@ def check_mode(
     view: DbtProjectView,
     *,
     scope: set[DefinitionKey] | None = None,
+    removed: Sequence[DefinitionKey] | None = None,
 ) -> dict[str, list[str]]:
     """Classify every proposed name; enforce the strict modes.
 
@@ -244,7 +257,20 @@ def check_mode(
     gets here, so without it the file's other definitions would be classified
     too, and a two-definition payload would report the file's other twenty-five
     as ``unchanged``: a quieter version of the noise this class exists to remove.
+
+    ``removed`` names what the payload deletes, which is a fourth class rather
+    than a value of the other three: a removal states no content, so there is
+    nothing to compare it against, and it is the one class a reviewer has to
+    read before approving. ``define`` refuses one outright, because a verb whose
+    job is to add a name cannot coherently take one away in the same call.
     """
+
+    if removed and mode == "define":
+        raise EditValidationError(
+            "semantic define adds definitions and does not remove them: "
+            f"{', '.join(sorted(name for _kind, name in removed))}; use "
+            "`semantic update` or `semantic plan` to remove one"
+        )
 
     existing = existing_semantic_names(view)
     on_disk = project_definitions(view)
@@ -299,6 +325,7 @@ def check_mode(
         "defined": sorted(proposed - existing),
         "updated": sorted(evolving - unchanged),
         "unchanged": sorted(unchanged),
+        "removed": sorted({name for _kind, name in removed or ()}),
     }
 
 
@@ -374,6 +401,118 @@ def check_references(parsed_edits: list[dict[str, Any]], view: DbtProjectView) -
         raise EditValidationError("; ".join(problems))
 
 
+def check_removals(
+    removed: Sequence[DefinitionEdit],
+    edits: Sequence[tuple[str, str]],
+    view: DbtProjectView,
+) -> None:
+    """Refuse a removal the surviving project still reads, atomically.
+
+    The whole-plan delete guard in :mod:`.plans` asks this question about files
+    and ``ref()``; it cannot answer it here, because a definition removal deletes
+    no file, and the name it takes away is a *name in YAML* inside a file that
+    survives. So the same shape is repeated one namespace over: the project
+    *after* this payload is computed in memory (the spliced files overlaid on the
+    current ones) and every metric left standing is re-resolved against it. A
+    payload that removes a metric together with the metrics that read it is
+    accepted; removing it alone is refused, naming each reader and its file, so
+    the fix is to add those definitions' own removals or updates to this same
+    payload. Order inside the payload does not matter, because the guard reads
+    the end state rather than the sequence.
+
+    A removed semantic model takes its measures with it, and a ``create_metric``
+    measure is addressable as a metric, so both namespaces are checked. A name
+    the payload re-declares elsewhere orphans nothing and is not reported, which
+    is what makes a move expressible as a removal plus an addition.
+
+    The references read are the metric inputs, which is the same vocabulary
+    ``transform references`` reports as ``metric_input_measure`` and
+    ``metric_input_metric``, so the guard and the report agree about what counts
+    as reading a name. Anything a reference index cannot see statically is left
+    to dbt's parser, which every semantic plan runs: a ``Metric()`` call inside a
+    filter string is the case that matters, and guessing at one here would trade
+    a precise refusal for an unreliable one.
+
+    **Refusing rather than warning** is the decision, and dbt is the reason. A
+    dangling metric input fails ``dbt parse``, the gate every semantic plan
+    already passes through, so warning instead would change nothing except where
+    that gate is off (``--no-parse``, or no dbt installed), and there it would
+    store a plan dex knows cannot be applied. ``maintain semantic`` reports
+    dangling references too, but detection after the fact is the tool for drift
+    that arrived from the warehouse on its own, not for a break this command is
+    in the middle of authoring.
+
+    Scoped to *declared* removals. A whole-file payload (``--edits-file``) that
+    simply omits a definition removes it too; that stays dbt's parser's to catch,
+    because the file's own diff shows the omission, which is exactly the review a
+    per-definition payload cannot give.
+    """
+
+    if not removed:
+        return
+
+    on_disk = project_definitions(view)
+    metric_names: set[str] = set()
+    measure_names: set[str] = set()
+    for definition in removed:
+        if definition.kind == "metric":
+            metric_names.add(definition.name)
+            continue
+        _path, body = on_disk.get((definition.kind, definition.name), ("", {}))
+        for measure in body.get("measures") or []:
+            if not isinstance(measure, dict) or not measure.get("name"):
+                continue
+            measure_names.add(measure["name"])
+            if measure.get("create_metric"):
+                metric_names.add(measure["name"])
+
+    after = view.model_copy(
+        update={
+            "files": {
+                **view.files,
+                **{
+                    path: SourceFile(
+                        path=path, content=content, sha256=content_hash(content)
+                    )
+                    for path, content in edits
+                },
+            }
+        }
+    )
+    surviving = project_namespace(after)
+    gone = {
+        "metric": metric_names - surviving.metrics,
+        "measure": measure_names - surviving.measures,
+    }
+    if not any(gone.values()):
+        return
+
+    problems: list[str] = []
+    for (kind, name), (path, body) in sorted(project_definitions(after).items()):
+        if kind != "metric":
+            continue
+        measures, metrics = metric_inputs(body)
+        for role, reads in (("measure", measures), ("metric", metrics)):
+            problems.extend(
+                f"metric '{name}' in {path} still reads {role} '{read}'"
+                for read in reads
+                if read in gone[role]
+            )
+    if not problems:
+        return
+    raise EditValidationError(
+        "this payload removes "
+        + ", ".join(
+            f"{definition.kind.replace('_', ' ')} '{definition.name}'"
+            for definition in removed
+        )
+        + " but the project it leaves behind still reads what it removes: "
+        + "; ".join(problems)
+        + ". Add the definitions that drop those references to this same payload "
+        "(or keep the definition)"
+    )
+
+
 def _ref_name(value: Any) -> str | None:
     """A metric/measure input is either a bare name or {name: ...}."""
 
@@ -425,12 +564,18 @@ _TOP_LEVEL_KEY = {"semantic_model": "semantic_models", "metric": "metrics"}
 
 
 class DefinitionEdit(NamedTuple):
-    """One semantic model or metric, authored on its own.
+    """One semantic model or metric, authored (or removed) on its own.
 
     ``content`` is the entry's body as a YAML mapping, not a list item: the
     caller writes ``name: revenue`` at column zero and the splice indents it to
     match its siblings. ``path`` may be ``None`` for a definition the project
     already declares, in which case it is rewritten where it already lives.
+
+    A removal carries ``op`` ``DELETE``, and then there is no body to write:
+    ``name`` is what the caller declared rather than what a body said, and
+    ``content`` and ``parsed`` are empty. The op is dbt's own edit vocabulary
+    (:class:`~..dbt_project.EditOp`) rather than a second spelling of it, so one
+    word means the same thing in both payload units.
     """
 
     kind: str
@@ -438,16 +583,25 @@ class DefinitionEdit(NamedTuple):
     content: str
     parsed: dict[str, Any]
     path: str | None = None
+    op: EditOp = EditOp.UPSERT
 
 
 def parse_definition_payload(entries: Iterable[Any]) -> list[DefinitionEdit]:
     """Read the ``definitions`` payload into typed edits.
 
-    The name is read from the content rather than declared beside it, so the
-    two cannot disagree.
+    The name of an authored definition is read from the content rather than
+    declared beside it, so the two cannot disagree; an entry that declares one
+    anyway is held to it rather than having it quietly ignored.
+
+    ``op`` is ``upsert`` (the default: create or update, carrying ``content``)
+    or ``delete``, which declares the ``name`` and carries no content, there
+    being no body to write. A removal has to be spelled out like that: nothing
+    is ever removed for having gone unmentioned, or the property this unit
+    exists for, that an unmentioned definition is untouched, would not hold.
     """
 
     parsed_entries: list[DefinitionEdit] = []
+    seen: dict[DefinitionKey, int] = {}
     for index, entry in enumerate(entries):
         where = f"definitions[{index}]"
         if not isinstance(entry, dict):
@@ -458,22 +612,64 @@ def parse_definition_payload(entries: Iterable[Any]) -> list[DefinitionEdit]:
                 f"{where}: kind must be one of {', '.join(sorted(_TOP_LEVEL_KEY))}, "
                 f"got {kind!r}"
             )
-        content = entry.get("content")
-        if not isinstance(content, str) or not content.strip():
-            raise EditValidationError(f"{where}: needs YAML content")
         try:
-            body = yaml.safe_load(content)
-        except yaml.YAMLError as exc:
-            raise EditValidationError(f"{where}: invalid YAML: {exc}") from exc
-        if not isinstance(body, dict) or not body.get("name"):
+            op = EditOp(entry.get("op") or EditOp.UPSERT.value)
+        except ValueError as exc:
             raise EditValidationError(
-                f"{where}: content must be a YAML mapping with a name; write the "
-                "definition's body alone, without the leading '- '"
-            )
+                f"{where}: unknown op {entry.get('op')!r}: one of "
+                + ", ".join(o.value for o in EditOp)
+            ) from exc
         path = entry.get("path")
         if path is not None and not isinstance(path, str):
             raise EditValidationError(f"{where}: path must be a string")
-        parsed_entries.append(DefinitionEdit(kind, body["name"], content, body, path))
+        declared = entry.get("name")
+        if declared is not None and not isinstance(declared, str):
+            raise EditValidationError(f"{where}: name must be a string")
+
+        if op is EditOp.DELETE:
+            if entry.get("content") is not None:
+                raise EditValidationError(
+                    f"{where}: a delete names the definition to remove and carries "
+                    "no content"
+                )
+            if not declared:
+                raise EditValidationError(
+                    f"{where}: a delete needs the name of the definition to remove"
+                )
+            definition = DefinitionEdit(kind, declared, "", {}, path, op)
+        else:
+            content = entry.get("content")
+            if not isinstance(content, str) or not content.strip():
+                raise EditValidationError(f"{where}: needs YAML content")
+            try:
+                body = yaml.safe_load(content)
+            except yaml.YAMLError as exc:
+                raise EditValidationError(f"{where}: invalid YAML: {exc}") from exc
+            if not isinstance(body, dict) or not body.get("name"):
+                raise EditValidationError(
+                    f"{where}: content must be a YAML mapping with a name; write the "
+                    "definition's body alone, without the leading '- '"
+                )
+            if declared and declared != body["name"]:
+                raise EditValidationError(
+                    f"{where}: names '{declared}' but the content defines "
+                    f"'{body['name']}'; the content is the definition, so drop the "
+                    "name or correct it"
+                )
+            definition = DefinitionEdit(kind, body["name"], content, body, path, op)
+
+        # One entry per definition. Two entries for the same name would make the
+        # payload's meaning depend on the order it happens to be read in, and a
+        # delete paired with an upsert of the same name has no meaning to pick.
+        key = (definition.kind, definition.name)
+        if key in seen:
+            raise EditValidationError(
+                f"{where}: {definition.kind} '{definition.name}' is already "
+                f"definitions[{seen[key]}] in this payload; name each definition "
+                "once"
+            )
+        seen[key] = index
+        parsed_entries.append(definition)
     return parsed_entries
 
 
@@ -487,6 +683,11 @@ def splice_definitions(
     and strip the comments a hand-written semantic layer depends on, producing a
     larger diff than the whole-file payload this unit replaces.
 
+    A removal is lowered the same way, into the same unit: the file comes back
+    without that one definition, as an ordinary content edit. Nothing downstream
+    learns a second vocabulary for it, and the plan carries no file-level delete,
+    which the semantic verbs refuse on purpose.
+
     Refuses rather than guesses. A file whose structure the line scanner cannot
     span safely is reported with ``--edits-file`` named as the way to edit it,
     and the spliced result is re-parsed and compared against the incoming body
@@ -497,6 +698,20 @@ def splice_definitions(
     targets: list[tuple[str, DefinitionEdit]] = []
     for definition in definitions:
         current = on_disk.get((definition.kind, definition.name))
+        if definition.op is EditOp.DELETE:
+            if current is None:
+                raise EditValidationError(
+                    f"{definition.kind} '{definition.name}' is not declared in the "
+                    "project, so there is nothing to remove"
+                )
+            if definition.path is not None and definition.path != current[0]:
+                raise EditValidationError(
+                    f"{definition.kind} '{definition.name}' is declared in "
+                    f"'{current[0]}', not '{definition.path}'; drop the path and the "
+                    "removal lands where the definition actually lives"
+                )
+            targets.append((current[0], definition))
+            continue
         if definition.path is None:
             if current is None:
                 raise EditValidationError(
@@ -526,7 +741,28 @@ def splice_definitions(
         text = source.content if source is not None else ""
         applied = [d for target_path, d in targets if target_path == path]
         for definition in applied:
-            text = _splice_entry(path, text, definition)
+            text = (
+                _remove_entry(path, text, definition)
+                if definition.op is EditOp.DELETE
+                else _splice_entry(path, text, definition)
+            )
+        removals = [d for d in applied if d.op is EditOp.DELETE]
+        # A file emptied of its semantic content is a file-level question this
+        # unit has no answer for: whether what is left should stay as plain model
+        # documentation or go away entirely is the caller's call, and both are
+        # whole-file edits. Refusing here also gets ahead of the semantic_yml
+        # validator, which would otherwise refuse the same edit for a reason
+        # ("must declare semantic_models or metrics") that says nothing about the
+        # removal that caused it.
+        if removals and not _declares_semantics(text):
+            raise EditValidationError(
+                f"{path}: removing "
+                + ", ".join(f"{d.kind} '{d.name}'" for d in removals)
+                + " would leave this file declaring no semantic model or metric at "
+                "all. Emptying or deleting a file is a whole-file edit: use "
+                '`transform plan --edits-file` (with `"op": "delete"` to remove the '
+                "file), or keep one definition in it"
+            )
         _verify_splice(path, text, applied)
         spliced.append((path, text))
     return spliced
@@ -686,8 +922,56 @@ def _splice_entry(path: str, text: str, definition: DefinitionEdit) -> str:
     return f"{head}\n{item}{tail}"
 
 
+def _remove_entry(path: str, text: str, definition: DefinitionEdit) -> str:
+    """Take one definition out of the file that declares it, and nothing else.
+
+    The inverse of :func:`_splice_entry` in effect only. An entry's own lines go;
+    the blank lines and comments around it stay where the author put them, on the
+    reasoning :func:`_entry_spans` documents, since a banner heading the next
+    definition is not this one's to move. What does go with the last item in a
+    block is the block's own ``key:`` line and anything between the two, because
+    a ``metrics:`` with nothing under it is not how a file with no metrics reads,
+    and a banner inside an empty block heads nothing.
+    """
+
+    _reject_unspannable(path, text)
+    key = _TOP_LEVEL_KEY[definition.kind]
+    lines = text.splitlines(keepends=True)
+    block = _find_block(path, lines, key)
+    spans = _entry_spans(lines, block) if block is not None else []
+    target = next((span for span in spans if span[0] == definition.name), None)
+    if block is None or target is None:
+        # `project_definitions` said this file declares the name, so not finding
+        # it here means the layout says it in a way this scanner cannot address.
+        raise EditValidationError(
+            f"{path}: {definition.kind} '{definition.name}' is not written there as "
+            "a sequence item this editor can lift out; use --edits-file for it"
+        )
+    _name, start, end = target
+    if len(spans) > 1:
+        return "".join(lines[:start]) + "".join(lines[end:])
+    return "".join(lines[: block.start - 1]) + "".join(lines[end:])
+
+
+def _declares_semantics(text: str) -> bool:
+    """Whether this document still declares a semantic model or a metric.
+
+    A YAML error answers ``True``: what to do about an unparseable result is
+    :func:`_verify_splice`'s to report, and it says so more precisely.
+    """
+
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return True
+    return isinstance(parsed, dict) and bool(
+        parsed.get("semantic_models") or parsed.get("metrics")
+    )
+
+
 def _verify_splice(path: str, text: str, definitions: Sequence[DefinitionEdit]) -> None:
-    """The result must parse, and each definition must be exactly what was sent.
+    """The result must parse, and each definition must be exactly what was sent,
+    or, for a removal, gone.
 
     Cheap insurance against the line scanner landing a definition in the wrong
     item or the wrong block: the comparison is against the caller's own parsed
@@ -714,6 +998,13 @@ def _verify_splice(path: str, text: str, definitions: Sequence[DefinitionEdit]) 
             for entry in parsed.get(key) or []
             if isinstance(entry, dict) and entry.get("name") == definition.name
         ]
+        if definition.op is EditOp.DELETE:
+            if landed:
+                raise EditValidationError(
+                    f"{path}: {definition.kind} '{definition.name}' is still in this "
+                    "file after the removal; use --edits-file for it"
+                )
+            continue
         if len(landed) != 1 or landed[0] != definition.parsed:
             raise EditValidationError(
                 f"{path}: {definition.kind} '{definition.name}' did not write "

--- a/packages/dex-core/tests/transform/test_semantic.py
+++ b/packages/dex-core/tests/transform/test_semantic.py
@@ -1095,3 +1095,328 @@ def test_definition_mode_guards_still_apply(
     )
     assert rc == 1
     assert "already defined" in envelope["errors"][0]
+
+
+# --- removing a definition (#254) ---------------------------------------------
+
+
+def _apply_definitions(
+    tmp_path: Path, capsys, definitions: list[dict], name: str, mode: str = "plan"
+) -> tuple[dict, str]:
+    """Plan a definitions payload, apply it, and read the file back.
+
+    The file is the assertion worth making about a removal: a diff can look right
+    while the surrounding bytes have moved, and the comments a hand-written
+    semantic layer carries are exactly what a removal must not disturb.
+    """
+
+    rc, envelope = _plan_definitions(tmp_path, capsys, definitions, name, mode)
+    assert rc == 0, envelope
+    rc, applied = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+    assert rc == 0, applied
+    landed = tmp_path / "analytics" / "models" / "semantic" / "customers.yml"
+    return envelope, landed.read_text(encoding="utf-8")
+
+
+def test_a_definitions_payload_removes_the_definition_it_names(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    """The other half of the unit: name one metric, remove one metric.
+
+    Deleting used to mean sending the whole file back without it, which is the
+    ergonomic cost the per-definition unit exists to remove: the diff describes
+    the whole file, and every restated line is a chance to corrupt a definition
+    nobody meant to touch.
+    """
+
+    _land_baseline(tmp_path, capsys, _COMMENTED_YAML)
+    envelope, landed = _apply_definitions(
+        tmp_path,
+        capsys,
+        [{"kind": "metric", "name": "doubled", "op": "delete"}],
+        "remove.json",
+    )
+
+    assert envelope["data"]["removed"] == ["doubled"]
+    assert envelope["data"]["defined"] == []
+    assert envelope["data"]["updated"] == []
+    assert envelope["data"]["unchanged"] == []
+
+    diff = envelope["diffs"][0]
+    assert diff["additions"] == 0
+    assert "-  - name: doubled" in diff["unified"]
+
+    # The neighbouring metric and the semantic model are untouched, and so is
+    # every comment: the note inside the metric that stayed, and both section
+    # banners, including the one that headed the metric now gone. A banner can
+    # head several definitions, so removing one definition is no licence to take
+    # it away; a reviewer reads it in the diff's context and decides.
+    assert "name: doubled" not in landed
+    assert "- name: customer_count" in landed
+    assert "- name: customers" in landed
+    assert "# ---- volume" in landed
+    assert "# ---- ratios" in landed
+    assert "# counts rows, not distinct ids" in landed
+
+
+def test_an_unmentioned_definition_is_never_removed(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    """The property the whole unit rests on, stated as a test.
+
+    Removal is declared or it does not happen. A payload that rewrites one
+    metric and says nothing about the other leaves the other alone, and reports
+    an empty ``removed`` rather than leaving the caller to infer it.
+    """
+
+    _land_baseline(tmp_path, capsys, _COMMENTED_YAML)
+    envelope, landed = _apply_definitions(
+        tmp_path,
+        capsys,
+        [
+            {
+                "kind": "metric",
+                "content": (
+                    "name: customer_count\n"
+                    "label: Count of customers\n"
+                    "type: simple\n"
+                    "type_params:\n"
+                    "  measure: customer_count\n"
+                ),
+            }
+        ],
+        "unmentioned.json",
+    )
+
+    assert envelope["data"]["removed"] == []
+    assert envelope["data"]["updated"] == ["customer_count"]
+    assert "- name: doubled" in landed
+
+
+def test_removing_a_metric_the_project_still_reads_is_refused(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    """The guard the whole-plan delete guard cannot supply.
+
+    That one reasons about deleted *files* and `ref()`; a definition removal
+    deletes no file, and the name it takes away is a name in YAML inside a file
+    that survives. dbt refuses to parse the result either way, so this refuses
+    too, and names the reader so the fix is one entry away.
+    """
+
+    _land_baseline(tmp_path, capsys, _COMMENTED_YAML)
+    rc, envelope = _plan_definitions(
+        tmp_path,
+        capsys,
+        [{"kind": "metric", "name": "customer_count", "op": "delete"}],
+        "orphan.json",
+    )
+
+    assert rc == 1
+    assert envelope["status"] == "error"
+    assert "doubled" in envelope["errors"][0]
+    assert "still reads metric 'customer_count'" in envelope["errors"][0]
+
+
+def test_removing_a_metric_with_its_readers_is_accepted(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    """The guard is over the payload's end state, not its entries in order.
+
+    Which is what makes the refusal above actionable: the caller adds the
+    reader's own removal to the same payload and the plan goes through, the way
+    a `ref()` delete is satisfied by putting the referrer's edit in one plan.
+    """
+
+    _land_baseline(tmp_path, capsys, _COMMENTED_YAML)
+    envelope, landed = _apply_definitions(
+        tmp_path,
+        capsys,
+        [
+            {"kind": "metric", "name": "customer_count", "op": "delete"},
+            {"kind": "metric", "name": "doubled", "op": "delete"},
+        ],
+        "both-gone.json",
+    )
+
+    assert envelope["data"]["removed"] == ["customer_count", "doubled"]
+    assert "metrics:" not in landed  # the emptied block goes with its last item
+    assert "- name: customers" in landed  # the semantic model is untouched
+
+
+def test_removing_a_semantic_model_takes_its_measures_with_it(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    """A measure is addressed inside its model, so removing the model removes
+    every measure in it, and a metric grounded in one of those is orphaned."""
+
+    _land_baseline(tmp_path, capsys, _COMMENTED_YAML)
+    rc, envelope = _plan_definitions(
+        tmp_path,
+        capsys,
+        [{"kind": "semantic_model", "name": "customers", "op": "delete"}],
+        "model-gone.json",
+    )
+
+    assert rc == 1
+    assert "still reads measure 'customer_count'" in envelope["errors"][0]
+
+
+def test_removing_the_last_definition_in_a_file_is_refused(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    """Emptying a file is a file-level act and stays a whole-file edit.
+
+    Whether what is left should remain as plain model documentation or go away
+    entirely is the caller's call, and the semantic verbs do not delete files at
+    all, so guessing either way here would be this unit deciding something it
+    was never given.
+    """
+
+    _land_baseline(tmp_path, capsys, _COMMENTED_YAML)
+    extra = [
+        {
+            "kind": "metric",
+            "path": "models/semantic/extra.yml",
+            "content": (
+                "name: tripled\n"
+                "type: derived\n"
+                "type_params:\n"
+                "  expr: customer_count * 3\n"
+                "  metrics:\n"
+                "    - name: customer_count\n"
+            ),
+        }
+    ]
+    rc, envelope = _plan_definitions(tmp_path, capsys, extra, "extra.json")
+    assert rc == 0, envelope
+    rc, applied = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+    assert rc == 0, applied
+
+    rc, envelope = _plan_definitions(
+        tmp_path,
+        capsys,
+        [{"kind": "metric", "name": "tripled", "op": "delete"}],
+        "empty.json",
+    )
+    assert rc == 1
+    assert "models/semantic/extra.yml" in envelope["errors"][0]
+    assert "transform plan" in envelope["errors"][0]
+
+
+def test_semantic_define_will_not_remove(dbt_project_dir: Path, tmp_path: Path, capsys):
+    """A verb whose job is to add a name cannot take one away in the same call."""
+
+    _land_baseline(tmp_path, capsys, _COMMENTED_YAML)
+    rc, envelope = _plan_definitions(
+        tmp_path,
+        capsys,
+        [{"kind": "metric", "name": "doubled", "op": "delete"}],
+        "define-delete.json",
+        mode="define",
+    )
+    assert rc == 1
+    assert "semantic define adds definitions" in envelope["errors"][0]
+    assert "semantic update" in envelope["errors"][0]
+
+
+def test_removing_a_definition_the_project_does_not_declare_is_refused(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    _land_baseline(tmp_path, capsys, _COMMENTED_YAML)
+    rc, envelope = _plan_definitions(
+        tmp_path,
+        capsys,
+        [{"kind": "metric", "name": "never_existed", "op": "delete"}],
+        "absent.json",
+    )
+    assert rc == 1
+    assert "nothing to remove" in envelope["errors"][0]
+
+
+def test_a_delete_entry_is_a_name_and_no_content(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    """There is no body to write, so the name is declared rather than read out
+    of one, and content beside it would mean two different things at once."""
+
+    _land_baseline(tmp_path, capsys, _COMMENTED_YAML)
+    rc, envelope = _plan_definitions(
+        tmp_path,
+        capsys,
+        [{"kind": "metric", "op": "delete"}],
+        "nameless-delete.json",
+    )
+    assert rc == 1
+    assert "needs the name" in envelope["errors"][0]
+
+    rc, envelope = _plan_definitions(
+        tmp_path,
+        capsys,
+        [
+            {
+                "kind": "metric",
+                "name": "doubled",
+                "op": "delete",
+                "content": "name: doubled\n",
+            }
+        ],
+        "content-delete.json",
+    )
+    assert rc == 1
+    assert "carries no content" in envelope["errors"][0]
+
+
+def test_one_payload_names_each_definition_once(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    """Otherwise what the payload asks for depends on the order it is read in,
+    and a delete paired with an upsert of the same name has no answer at all."""
+
+    _land_baseline(tmp_path, capsys, _COMMENTED_YAML)
+    rc, envelope = _plan_definitions(
+        tmp_path,
+        capsys,
+        [
+            {"kind": "metric", "name": "doubled", "op": "delete"},
+            {
+                "kind": "metric",
+                "content": (
+                    "name: doubled\n"
+                    "type: derived\n"
+                    "type_params:\n"
+                    "  expr: customer_count * 2\n"
+                    "  metrics:\n"
+                    "    - name: customer_count\n"
+                ),
+            },
+        ],
+        "twice.json",
+    )
+    assert rc == 1
+    assert "already definitions[0]" in envelope["errors"][0]
+
+
+def test_the_removal_unit_reaches_the_engine_surface_too(
+    dbt_project_dir: Path, tmp_path: Path, capsys
+):
+    """A flag the CLI parses into a keyword the engine cannot pass would be a
+    capability only one of the two surfaces has, and `semantic update` is where
+    a removal belongs beside the evolutions it usually travels with."""
+
+    from exmergo_dex_core.engine import DexEngine
+    from exmergo_dex_core.transform.semantic import parse_definition_payload
+
+    _land_baseline(tmp_path, capsys, _COMMENTED_YAML)
+
+    definitions = parse_definition_payload(
+        [{"kind": "metric", "name": "doubled", "op": "delete"}]
+    )
+    with DexEngine.from_repo(tmp_path, connector="duckdb") as engine:
+        result = engine.semantic_update(
+            "drop the derived metric", [], definitions=definitions, no_parse=True
+        )
+
+    assert result.removed == ["doubled"]
+    assert result.updated == []
+    assert len(result.diffs) == 1

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -508,9 +508,9 @@ replace) inlines a literal credential, so no secret ever reaches the diff.
   with a pointer to the full log when anything was trimmed.
 - `semantic define` refuses names that already exist in the project (use
   `update`); `update` refuses names that do not (use `define`); `semantic plan`
-  accepts a mix and classifies per name, reporting `defined`, `updated`, and
-  `unchanged` in the envelope. `updated` means the definition's parsed content
-  actually differs from the project's; a definition re-stated identically in the
+  accepts a mix and classifies per name, reporting `defined`, `updated`,
+  `unchanged`, and `removed` in the envelope. `updated` means the definition's
+  parsed content actually differs from the project's; a definition re-stated identically in the
   file that already holds it is `unchanged`. The distinction matters because a
   whole-file payload restates every definition in the file, so without it a
   two-metric change reports thirty objects as updated and the real blast radius
@@ -531,10 +531,9 @@ replace) inlines a literal credential, so no secret ever reaches the diff.
   layout it cannot span safely (a flow-style sequence, anchors or aliases,
   multiple documents, tab indentation) is refused with `--edits-file` named as
   the way to edit it. Classification is scoped to the definitions named, so a
-  spliced file's other definitions are reported in no class at all. Removing a
-  definition is still a whole-file edit; the semantic verbs author and do not
-  delete. Names implicitly created by `create_metric: true` measures count
-  as existing metrics everywhere. Beyond MetricFlow's schemas, the engine
+  spliced file's other definitions are reported in no class at all. Names
+  implicitly created by `create_metric: true` measures count as existing metrics
+  everywhere. Beyond MetricFlow's schemas, the engine
   resolves every metric input (ratio and derived inputs must reference metrics,
   not measures) and then runs the emitted YAML through dbt's own parser against
   a throwaway copy of the project; a plan that fails parse is never stored.
@@ -542,6 +541,25 @@ replace) inlines a literal credential, so no secret ever reaches the diff.
   degrades to a warning; `--no-parse` skips it. A stored semantic plan is applied
   with `transform apply` like any other plan (no id applies the latest unapplied
   one).
+- **Removing a definition** is an entry with `"op": "delete"`, which carries the
+  `name` (there is no body to read one from) and no `content`. It is always
+  declared: a definitions payload never removes a definition for having gone
+  unmentioned, because an unmentioned definition is what the unit promises to
+  leave alone. `semantic define` refuses a removal; `update` and `plan` accept
+  one, and it is reported as a fourth class, `removed`. One payload names each
+  definition once, so what it asks for cannot depend on the order it is read in.
+  A removal the surviving project still reads is refused, naming the reader and
+  its file: a metric whose input is a removed metric, or a measure of a removed
+  semantic model (`create_metric` names included). The check is over the state
+  the payload leaves behind, so adding those readers' own removals or updates to
+  the same payload satisfies it, in any order; what a reference index cannot
+  resolve statically (a `Metric()` call inside a filter string) is left to dbt's
+  parser. A removal that would leave a file declaring no semantic model or metric
+  is refused as well, pointing at `transform plan --edits-file`: emptying or
+  deleting a file is a file-level act, and the semantic verbs delete no files.
+  The file comes back without that one definition, as an ordinary content edit,
+  so the plan store, the diffs, and `transform apply` see the unit they always
+  have.
 
 Skill-to-subcommand mapping: `explore` fronts `connect`/`explore`; `transform`
 fronts `transform`, `semantic`, and `viz`; `maintain` fronts the whole

--- a/skills/transform/SKILL.md
+++ b/skills/transform/SKILL.md
@@ -412,7 +412,7 @@ database, which is fine for model-only builds.
   do not (use `define`). For one logical change that mixes both (evolve existing
   metrics and add the helpers they depend on), use `semantic plan ...`: it
   accepts mixed intent and classifies each name, and the envelope reports the
-  split as `defined`, `updated`, and `unchanged`.
+  split as `defined`, `updated`, `unchanged`, and `removed`.
 - **Prefer `--definitions-file` over `--edits-file` for the semantic layer.** A
   real project keeps its metrics in one shared file, so a whole-file payload
   means retyping every definition you are not touching: the diff and the
@@ -424,9 +424,23 @@ database, which is fine for model-only builds.
   body with no leading `- `. The name comes from the content, and `path` can be
   omitted for anything the project already declares (the engine rewrites it
   where it lives). Everything else in the file, comments included, is preserved
-  byte for byte. Reach for `--edits-file` when you are creating a file, removing
-  a definition, or moving one between files, and when the engine refuses a
-  layout it will not splice into.
+  byte for byte. Reach for `--edits-file` when you are creating a file, moving a
+  definition between files, or emptying one, and when the engine refuses a layout
+  it will not splice into.
+- **Removing one definition is the same payload with `"op": "delete"`**:
+  `{"definitions": [{"kind": "metric", "name": "doubled", "op": "delete"}]}`, the
+  name declared (there is no content to read it from) and no `content` beside it.
+  Nothing is removed for going unmentioned, so you can send a removal and an
+  edit in one payload and everything you did not name stays as it is. Use
+  `semantic update` or `semantic plan`, not `define`. The envelope reports it
+  under `removed`.
+- If a metric still reads what you are removing (its input is that metric, or a
+  measure of the semantic model you are removing), the plan is refused and the
+  reader is named: add that reader's own delete or update to the same payload,
+  in any order, and it goes through. A removal that would leave a file with no
+  semantic model or metric in it is refused too, because deleting or emptying a
+  file is a whole-file edit: do that with `transform plan --edits-file` and
+  `"op": "delete"`.
 - `unchanged` means you re-stated a definition exactly as the project already
   has it. It is not an error, but if a plan is entirely `unchanged` it changes
   nothing, and the envelope warns as much: check whether you meant to edit


### PR DESCRIPTION
## Problem
--definitions-file can create and evolve a semantic model or metric, but not remove one. Deleting means sending the whole file back without the definition, which is the cost the per-definition unit exists to remove.

The design question was what a dangling metric reference should do at plan time. The whole-plan delete guard reasons about deleted files and ref(); a definition removal deletes no file, and the name it takes away lives in a file that survives, so that guard cannot see it.

## What changes
A definitions entry can carry "op": "delete", naming the definition and no content:

{"definitions": [{"kind": "metric", "name": "doubled", "op": "delete"}]}
Removal is always declared. Nothing is removed for going unmentioned, and one payload names each definition once, so the result cannot depend on read order.
semantic define refuses a removal; update and plan accept one, reported as a fourth class, removed.
A removal the surviving project still reads is refused, naming the reader and its file. Adding that reader's own delete or update to the same payload satisfies it.
A removal that would empty a file of semantic content is refused, pointing at transform plan --edits-file: deleting a file is a file-level act.
Comments and every other byte survive. A block's key: line goes only with its last item. DexEngine takes the same payload through definitions=.
## Fix
Refuse rather than warn, because dbt would refuse anyway: a dangling metric input fails dbt parse, the gate every semantic plan already passes, so warning would only matter where that gate is off (--no-parse, no dbt) and would store a plan dex knows cannot be applied. maintain semantic stays the tool for drift that arrived on its own, not for a break this command is authoring.

check_removals repeats the delete guard's shape one namespace over: the project the payload leaves behind is built in memory and every surviving metric re-resolved against it, so the check reads the end state rather than the sequence. A removed semantic model takes its measures (create_metric included); a name re-declared elsewhere in the payload orphans nothing. Filter-string Metric() calls stay dbt's parser's to catch.

Known gap for its own issue: deleting a whole semantic YAML through transform plan still bypasses this guard, since validate_deletions reasons about ref().

## Related issue
Closes #254 