### PR TITLE
SCRUM-1236-Reach tier 2 for native Ossie: maintain snapshot and drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,49 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   context have a declared home instead of being dropped or smuggled into a
   neighbouring field.
 
+- **Native Ossie documents reach maintain's tier 2, so `maintain snapshot` and
+  `maintain check` get a real drift baseline for a semantic vendor that is not
+  dbt** ([#409]). `OssieSemanticLayer` now answers `transform_layer()` (file
+  hashes only; Ossie declares no build step) and `semantic_layer()` (named
+  definitions, each with a content hash and the physical column behind it),
+  the same two methods `DbtProject` already implements.
+
+  The snapshot shape gained two things it could not hold before, both additive
+  and both defaulted so a committed `.dex/snapshot.json` from before this
+  change still loads: `SemanticModelDef.relation` (the semantic model's own
+  physical relation, for a format with no build step to name a `model_ref`
+  through) and `.keys` (every declared unique key, one list of columns per
+  declaration regardless of arity), plus a new `SemanticLayerSnapshot.
+  relationships` list carrying full composite ordered column pairs. None of
+  it bumps `SNAPSHOT_SCHEMA_VERSION`.
+
+  The hazard the issue named directly: an old baseline's empty `relationships`
+  and `keys` is indistinguishable from "this layer declares none", which would
+  make relationship and key drift report a false clean bill instead of "not
+  checked". `SemanticLayerSnapshot.relationships_and_keys_captured` (default
+  `False`) is the guard, the same role `warehouse_from` already plays for the
+  warehouse side: `semantic_free_drift`'s two new finding classes,
+  `broken_relationship` (a relationship whose model or column pair no longer
+  resolves) and the key-column analogue of `dangling_reference`, run only when
+  the *current* read set it; relationship added/removed/changed detection
+  (folded into the existing generic diff) runs only when *both* the baseline
+  and the current read did, so a baseline that never captured relationships
+  never reads every current one as freshly added. dbt's own snapshots leave
+  the flag `False`: it has no composite-relationship or multi-column-key
+  concept at the semantic-model level to capture, and that is an honest
+  narrower answer, not a regression.
+
+  The two layers are read independently now (`maintain/commands.py`'s
+  `_read_layers`), through the same seam #408 added on the explore side: the
+  semantic half comes from whichever format answers `semantic.vendor`
+  (`SEMANTIC_PROJECT_FORMATS`, a table lookup rather than a name check), not
+  always from the configured `project.format`. A repository with no dbt
+  project at all and `semantic.vendor: ossie` gets a semantic baseline even
+  though the transform half has nothing to answer with, and a repository that
+  keeps dbt for its models with Ossie's semantics declared beside it gets both,
+  each degrading on its own rather than one absence hiding the other's
+  presence.
+
 ## [1.9.2] - 2026-09-02
 
 ### Added

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -52,6 +52,7 @@ from .results import (
 )
 
 if TYPE_CHECKING:
+    from ..adapters.project import MaintainProject
     from ..engine import DexEngine
     from .snapshot import SemanticLayer, TransformLayer
 
@@ -76,10 +77,14 @@ def _read_layers(
 ) -> tuple[TransformLayer | None, SemanticLayer | None, str | None]:
     """The current project's snapshot layers, or why there are none.
 
-    Returns ``(transform, semantic, reason)``. ``reason`` is ``None`` on success
-    and otherwise a clause each command folds into its own warning, so the four
-    detection commands share one definition of "read the project" while keeping
-    the sentence that says what *this* command loses without it.
+    Returns ``(transform, semantic, reason)``. ``reason`` describes why the
+    layer ``semantic`` actually asked for is unavailable (the transform half
+    when ``semantic=False``, otherwise the semantic half), which is what each
+    command's warning names and what ``check`` gates its semantic axis on. It
+    is ``None`` whenever that layer is present, even if the *other* one is
+    not: the two are read independently (#409), so a repository whose
+    semantic vendor answers on its own is not blocked by a transformation
+    project neither it nor that vendor needs.
 
     ``semantic=False`` skips the second layer rather than reading and discarding
     it. `maintain schema` needs only the transform half, and on the dbt format
@@ -95,15 +100,68 @@ def _read_layers(
     same reason ``definitions()`` may not raise.
     """
 
+    project: MaintainProject | None = None
+    transform: TransformLayer | None = None
+    transform_reason: str | None = None
     try:
         project = engine.maintain_project()
         if project is None:
-            return None, None, engine.project_tier_note()
-        transform = project.transform_layer()
-        current = project.semantic_layer() if semantic else None
+            transform_reason = engine.project_tier_note()
+        else:
+            transform = project.transform_layer()
     except (ProjectError, RepoRootRequiredError, ValidationError) as exc:
-        return None, None, str(exc)
-    return transform, current, None
+        transform_reason = str(exc)
+
+    if not semantic:
+        return transform, None, transform_reason
+
+    current: SemanticLayer | None = None
+    semantic_reason: str | None = None
+    try:
+        current = _semantic_layer(engine, project)
+    except (ProjectError, RepoRootRequiredError, ValidationError) as exc:
+        semantic_reason = str(exc)
+
+    # `semantic_reason` names why the semantic-vendor substitute (#409) came
+    # back empty; when there was none to try, `transform_reason` is the only
+    # explanation on hand (the same project answered, or failed to build,
+    # for both), and a caller must still see *some* reason rather than a
+    # blank one that reads as success.
+    reason = (semantic_reason or transform_reason) if current is None else None
+    return transform, current, reason
+
+
+def _semantic_layer(
+    engine: DexEngine, project: MaintainProject | None
+) -> SemanticLayer | None:
+    """The semantic-axis snapshot, from whichever format answers it (#409).
+
+    Usually ``project`` itself: the semantic vendor defaults to dbt, the same
+    format ``transform_layer()`` just came from. A repository that configures
+    a different semantic vendor beside it (``semantic.vendor: ossie``) gets
+    that format's own fingerprint instead, through the identical seam
+    ``_semantic_catalog`` already reads on the explore side for #408, rather
+    than a second, vendor-specific snapshot section: a table lookup against
+    ``SEMANTIC_PROJECT_FORMATS``, not a name check on which vendor is
+    configured.
+
+    Read independently of ``project``, which may be ``None`` or may have
+    failed to build its own transform layer: a repository with no dbt project
+    at all and ``semantic.vendor: ossie`` still gets a semantic baseline, even
+    though the transform half has nothing to answer with.
+    """
+
+    from ..adapters.project import MaintainProject as _MaintainProject
+    from ..config import SEMANTIC_PROJECT_FORMATS
+
+    vendor = (getattr(engine.config.semantic, "vendor", None) or "dbt").lower()
+    if vendor in SEMANTIC_PROJECT_FORMATS:
+        semantic_format = engine.semantic_catalog_format()
+        if isinstance(semantic_format, _MaintainProject):
+            return semantic_format.semantic_layer()
+    if project is None:
+        return None
+    return project.semantic_layer()
 
 
 class NoBaselineError(PrerequisiteError):

--- a/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/drift.py
@@ -29,7 +29,7 @@ from ..adapters.base import Adapter, distinct_combination_sql
 from ..cache import Dataset, Relationship, match_identifier
 from ..dbt_project import ProjectDefinitions
 from ..explore import relationships as rel_mod
-from .snapshot import SemanticLayer, Snapshot, TransformLayer
+from .snapshot import SemanticLayer, SemanticModelDef, Snapshot, TransformLayer
 
 #: Deliberately without the supported-set gate `SUPPORTED_SNAPSHOT_SCHEMA_VERSIONS`
 #: gives the baseline, and this is where that decision is recorded rather than
@@ -967,6 +967,17 @@ def grain_drift(
     return findings
 
 
+def _matched_identifier(sm: SemanticModelDef, dataset_ids: list[str]) -> list[str]:
+    """The live warehouse identifier(s) this semantic model resolves to, by
+    whichever of ``model_ref``/``relation`` it states (#409): the same
+    fallback :func:`semantic_free_drift` applies inline for its own column
+    check, shared here so the relationship check resolves each endpoint the
+    same way rather than by a second rule."""
+
+    target = sm.model_ref or sm.relation
+    return match_identifier(target, dataset_ids) if target else []
+
+
 def semantic_free_drift(
     current_transform: TransformLayer | None,
     current_semantic: SemanticLayer | None,
@@ -985,6 +996,18 @@ def semantic_free_drift(
     base_defs.update({("metric", m.name): m for m in baseline.metrics})
     cur_defs = {("semantic_model", d.name): d for d in current.semantic_models}
     cur_defs.update({("metric", m.name): m for m in current.metrics})
+    # Relationships join the same generic added/removed/changed diff below,
+    # but only when both sides actually captured them (#409): a baseline
+    # pinned before this field existed has none, and comparing that against a
+    # populated current layer would report every real relationship as
+    # freshly added rather than as a baseline gap.
+    relationships_comparable = (
+        baseline.relationships_and_keys_captured
+        and current.relationships_and_keys_captured
+    )
+    if relationships_comparable:
+        base_defs.update({("relationship", r.name): r for r in baseline.relationships})
+        cur_defs.update({("relationship", r.name): r for r in current.relationships})
 
     for kind, name in sorted(cur_defs.keys() - base_defs.keys()):
         findings.append(
@@ -1054,7 +1077,14 @@ def semantic_free_drift(
                 )
             )
             continue
-        matches = match_identifier(sm.model_ref, dataset_ids) if sm.model_ref else []
+        # A model whose semantic layer states its own physical relation
+        # directly (#409: `relation`, populated by a format with no build
+        # step between a semantic model and a warehouse relation) is matched
+        # against the warehouse the same way `model_ref` is, once a model_ref
+        # is absent to try first: the two name the same kind of thing to this
+        # comparison, a physical relation this semantic model sits on.
+        match_target = sm.model_ref or sm.relation
+        matches = match_identifier(match_target, dataset_ids) if match_target else []
         if len(matches) != 1:
             continue  # not built (or ambiguous): nothing to check columns against
         available = columns_by_id[matches[0]]
@@ -1084,8 +1114,76 @@ def semantic_free_drift(
                             f"{matches[0]}"
                         ),
                         data={"semantic_model": sm.name, "role": role, "name": name},
-                        impacted_models=[sm.model_ref],
+                        impacted_models=[sm.model_ref] if sm.model_ref else [],
                         impacted_metrics=_metrics_from_measures(current, impacted),
+                    )
+                )
+        if not current.relationships_and_keys_captured:
+            continue
+        for columns in sm.keys:
+            missing = [c for c in columns if c not in available]
+            if not missing:
+                continue
+            findings.append(
+                DriftFinding(
+                    axis="semantic",
+                    code="dangling_reference",
+                    identifier=matches[0],
+                    severity="high",
+                    detail=(
+                        f"a declared key on semantic model '{sm.name}' names "
+                        f"column(s) {', '.join(missing)}, which "
+                        f"{'is' if len(missing) == 1 else 'are'} gone from "
+                        f"{matches[0]}"
+                    ),
+                    data={"semantic_model": sm.name, "role": "key", "columns": columns},
+                )
+            )
+
+    if current.relationships_and_keys_captured:
+        models_by_name = {sm.name: sm for sm in current.semantic_models}
+        for rel in current.relationships:
+            left = models_by_name.get(rel.model)
+            right = models_by_name.get(rel.to_model)
+            if left is None or right is None:
+                missing_side = rel.model if left is None else rel.to_model
+                findings.append(
+                    DriftFinding(
+                        axis="semantic",
+                        code="broken_relationship",
+                        severity="high",
+                        detail=(
+                            f"relationship '{rel.name}' names '{missing_side}', "
+                            "which is no longer a semantic model"
+                        ),
+                        data={"relationship": rel.name, "missing_model": missing_side},
+                    )
+                )
+                continue
+            left_matches = _matched_identifier(left, dataset_ids)
+            right_matches = _matched_identifier(right, dataset_ids)
+            if len(left_matches) != 1 or len(right_matches) != 1:
+                continue  # not built (or ambiguous): nothing to check columns against
+            left_available = columns_by_id[left_matches[0]]
+            right_available = columns_by_id[right_matches[0]]
+            broken = [
+                [frm, to]
+                for frm, to in rel.column_pairs
+                if frm not in left_available or to not in right_available
+            ]
+            if broken:
+                findings.append(
+                    DriftFinding(
+                        axis="semantic",
+                        code="broken_relationship",
+                        identifier=left_matches[0],
+                        severity="high",
+                        detail=(
+                            f"relationship '{rel.name}' from '{rel.model}' to "
+                            f"'{rel.to_model}' names column pair(s) that no "
+                            f"longer resolve: {broken}"
+                        ),
+                        data={"relationship": rel.name, "missing_pairs": broken},
                     )
                 )
 

--- a/packages/dex-core/src/exmergo_dex_core/maintain/snapshot.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/snapshot.py
@@ -172,16 +172,29 @@ class SemanticModelDef(BaseModel):
     dangling-ref finding. ``path`` is ``None`` on the same principle: it is
     provenance carried on the ``definition_changed`` finding, absent for a format
     whose definitions are objects rather than files, and never opened.
+
+    ``relation`` and ``keys`` are additive, #409 fields (empty/``None`` for
+    every baseline pinned before this field existed, and for dbt, which has no
+    populated analogue for either): a format whose semantic model *is* a
+    direct relation reference, rather than a name a transformation project
+    later builds, records that relation here so drift can match it straight
+    against the warehouse without a ``model_ref``. ``keys`` is every column
+    combination the format declares independently unique, one list per
+    declaration regardless of arity, so a single-column and a composite key
+    are recorded the same way instead of one being disguised as several
+    single ones.
     """
 
     name: str
     path: str | None = None
     content_sha256: str
     model_ref: str | None = None
+    relation: str | None = None
     entities: dict[str, str | None] = Field(default_factory=dict)
     dimensions: dict[str, str | None] = Field(default_factory=dict)
     categorical_dimensions: dict[str, str] = Field(default_factory=dict)
     measures: dict[str, str | None] = Field(default_factory=dict)
+    keys: list[list[str]] = Field(default_factory=list)
 
     def referenced_columns(self) -> set[str]:
         return {
@@ -189,19 +202,19 @@ class SemanticModelDef(BaseModel):
             for mapping in (self.entities, self.dimensions, self.measures)
             for column in mapping.values()
             if column is not None
-        }
+        } | {column for combo in self.keys for column in combo}
 
     def structural_columns(self) -> set[str]:
-        """Columns whose loss breaks the model as a whole (entities and
-        dimensions), as opposed to a measure column that breaks only the
-        measures on it."""
+        """Columns whose loss breaks the model as a whole (entities,
+        dimensions, and declared keys), as opposed to a measure column that
+        breaks only the measures on it."""
 
         return {
             column
             for mapping in (self.entities, self.dimensions)
             for column in mapping.values()
             if column is not None
-        }
+        } | {column for combo in self.keys for column in combo}
 
 
 class MetricDef(BaseModel):
@@ -220,6 +233,31 @@ class MetricDef(BaseModel):
     input_metrics: list[str] = Field(default_factory=list)
 
 
+class RelationshipDef(BaseModel):
+    """One declared join between two semantic models, with its full ordered
+    column pairs (#409).
+
+    Composite and single-column joins are recorded the same way: dropping a
+    pair's second column here would be the exact partial-edge risk #408
+    refused at the read-catalog layer, one level down. It sits beside
+    :class:`SemanticModelDef` rather than on it because a join names two
+    models, not one.
+
+    ``name`` is never ``None``: a format whose declarations are themselves
+    unnamed (Ossie's relationships are optional to name) synthesizes a stable
+    one from the endpoints and columns, because this is the identity
+    ``semantic_free_drift`` diffs added/removed/changed by, and an identity
+    that is absent for some rows would silently exclude them from that diff.
+    """
+
+    name: str
+    path: str | None = None
+    content_sha256: str
+    model: str
+    to_model: str
+    column_pairs: list[tuple[str, str]] = Field(default_factory=list)
+
+
 class SemanticLayerSnapshot(BaseModel):
     """The semantic layer's fingerprint: every named definition the project holds.
 
@@ -227,10 +265,26 @@ class SemanticLayerSnapshot(BaseModel):
     same reason: this is a return type a non-dbt project format fills in, and a
     layer that is narrower than a dbt one needs somewhere to say so that travels
     with the value rather than sitting beside it.
+
+    ``relationships_and_keys_captured`` is #409's answer to the hazard its own
+    fields create: ``relationships`` and every ``SemanticModelDef.keys`` entry
+    are additive fields a baseline pinned before they existed carries empty,
+    and empty there is indistinguishable from "this layer declares no
+    relationships or keys" -- which would read as a clean bill rather than as
+    "not checked". This flag is what ``semantic_free_drift`` reads instead of
+    trusting the emptiness: ``False`` (the default, so an old baseline and a
+    format that has never populated these -- dbt included, which has no
+    composite-relationship or multi-column-key concept at the semantic-model
+    level -- both land here) skips every relationship/key finding rather than
+    reporting false drift or a false clean bill; only a layer that set it
+    ``True`` on both sides of a comparison is one the two new checks run
+    against.
     """
 
     semantic_models: list[SemanticModelDef] = Field(default_factory=list)
     metrics: list[MetricDef] = Field(default_factory=list)
+    relationships: list[RelationshipDef] = Field(default_factory=list)
+    relationships_and_keys_captured: bool = False
     notes: list[str] = Field(default_factory=list)
 
 

--- a/packages/dex-core/src/exmergo_dex_core/ossie/project.py
+++ b/packages/dex-core/src/exmergo_dex_core/ossie/project.py
@@ -9,11 +9,13 @@ Ossie is configured through ``semantic.vendor: ossie`` and
 The semantic backend builds this reader from those coordinates; dbt, when
 present, remains responsible for the transformation-project tiers.
 
-**The tier reached today is tier 1 plus the catalog channel**, and no more.
-Tier 2 needs a snapshot shape that can hold composite relationships and dataset
-keys, and tier 3 needs a preservation contract for writing documents back. Both
-are their own work, and claiming them here structurally, by growing the methods,
-would be claiming them to `maintain reconcile` as well.
+**The tier reached today is tier 2 plus the catalog channel** (#409): this
+class also answers ``transform_layer()``/``semantic_layer()``, the snapshot
+fingerprints ``maintain snapshot``/``maintain check`` diff against a baseline,
+so a repository whose semantic vendor is Ossie gets a real drift baseline for
+its declared keys and relationships. Tier 3 (a preservation contract for
+writing documents back) is not claimed here: growing the write methods would
+claim them to ``maintain reconcile`` as well, and that is its own work.
 """
 
 from __future__ import annotations
@@ -28,6 +30,7 @@ from .loader import DOCUMENT_SUFFIXES, LoadResult, OssieDependencyError, load_do
 
 if TYPE_CHECKING:
     from ..adapters.project import ProjectContext
+    from ..maintain.snapshot import SemanticLayer, TransformLayer
     from ..project_definitions import ProjectDefinitions
     from ..semantic_catalog import SemanticCatalogView
 
@@ -158,6 +161,48 @@ class OssieSemanticLayer:
         return catalog_mod.semantic_catalog(
             loaded.documents, connector=self.connector, notes=loaded.notes()
         )
+
+    # --- tier 2 -----------------------------------------------------------
+
+    def transform_layer(self) -> TransformLayer:
+        """The document set's own fingerprint (#409): file hashes and nothing
+        else, since Ossie declares no build step. See
+        :func:`.snapshot.transform_layer` for what that means for the rest of
+        the shape.
+
+        **This must not raise**, matching tier 1's promise rather than
+        dbt's tier-2 contract of raising when there is no project: an unreadable
+        document is exactly the ordinary condition tier 1 already degrades
+        around, and a repository whose semantic vendor is Ossie should not
+        lose its whole drift baseline because one file could not be hashed.
+        """
+
+        from . import snapshot as snapshot_mod
+
+        return snapshot_mod.transform_layer(self.repo_root, self.files)
+
+    def semantic_layer(self) -> SemanticLayer:
+        """The documents' own fingerprint (#409): named definitions, declared
+        keys, and composite relationships, each with a content hash.
+
+        Degrades the same way :meth:`declared_definitions` does, for the same
+        reason: every failure this format has is a state a user reaches by an
+        ordinary typo or a missing extra, not a wiring mistake that should
+        propagate.
+        """
+
+        from ..maintain.snapshot import SemanticLayer as _SemanticLayerSnapshot
+        from . import snapshot as snapshot_mod
+
+        try:
+            loaded = self._load()
+        except OssieDependencyError as exc:
+            return _SemanticLayerSnapshot(notes=[str(exc)])
+        except (OSError, ValueError) as exc:
+            return _SemanticLayerSnapshot(
+                notes=[f"native Ossie documents could not be read: {exc}"]
+            )
+        return snapshot_mod.semantic_layer(loaded, connector=self.connector)
 
     def _load(self) -> LoadResult:
         if self._loaded is None:

--- a/packages/dex-core/src/exmergo_dex_core/ossie/snapshot.py
+++ b/packages/dex-core/src/exmergo_dex_core/ossie/snapshot.py
@@ -1,0 +1,207 @@
+"""Ossie's own tier-2 fingerprint: the maintain snapshot channel (#409).
+
+Builds the same format-neutral shapes `maintain.snapshot` defines for dbt
+(`TransformLayer`, `SemanticLayerSnapshot`), from Ossie's own validated
+documents. This module never imports `dbt_project` or anything MetricFlow
+shaped, and `maintain.snapshot` never imports this one: the two formats read
+their own sources into one shared shape rather than one depending on the
+other's reader.
+
+Reuses `catalog.py`'s column-resolution and relationship-resolution helpers
+rather than re-deriving them, so a field's link to a physical column, and a
+relationship's ordered pairs, are decided by exactly one piece of logic
+whether a caller reads the catalog or fingerprints it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from ..maintain.snapshot import (
+    MetricDef,
+    RelationshipDef,
+    SemanticLayerSnapshot,
+    SemanticModelDef,
+    TransformLayer,
+)
+from ..project_definitions import DeclaredRelationship
+from . import catalog as catalog_mod
+from .loader import LoadResult
+
+
+def _content_hash(text: str) -> str:
+    """A definition's fingerprint. Deliberately not `dbt_project.content_hash`:
+    importing a one-line sha256 wrapper across the format boundary would still
+    be a dependency on the dbt module, which #409's own constraint refuses."""
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _definition_hash(entry: Any) -> str:
+    return _content_hash(json.dumps(entry, sort_keys=True, default=str))
+
+
+def transform_layer(repo_root: Path, files: list[str]) -> TransformLayer:
+    """The document set's own fingerprint: file hashes and nothing else.
+
+    ``models``, ``model_paths``, ``sources``, ``model_sources``, and
+    ``model_refs`` all stay empty: Ossie documents declare no build step, and
+    a dataset's source is already the physical relation its semantic model
+    records on ``SemanticModelDef.relation`` (#409), not a name a
+    transformation project resolves later the way a dbt ``ref()``/``source()``
+    does. The note says this once here rather than leaving five empty
+    collections to be misread as "this format has none of these to declare".
+    """
+
+    hashed: dict[str, str] = {}
+    for name in files:
+        try:
+            hashed[name] = _content_hash((repo_root / name).read_text(encoding="utf-8"))
+        except OSError:
+            # Absent or unreadable: declared_definitions()/semantic_layer()
+            # already carry the diagnostic naming this file, so a missing
+            # hash here is that same fact, not a second one to explain.
+            continue
+    return TransformLayer(
+        files=hashed,
+        notes=[
+            "native Ossie documents declare no build step, so `models` and "
+            "`model_refs` stay empty: a dataset's source is already the "
+            "physical relation its semantic model records, not a name a "
+            "transformation project resolves later"
+        ],
+    )
+
+
+def semantic_layer(
+    loaded: LoadResult, *, connector: str | None
+) -> SemanticLayerSnapshot:
+    """Fingerprint the semantic layer from the validated documents."""
+
+    if not loaded.documents:
+        return SemanticLayerSnapshot(notes=loaded.notes())
+
+    semantic_models: list[SemanticModelDef] = []
+    metrics: list[MetricDef] = []
+    relationships: list[RelationshipDef] = []
+    notes: list[str] = list(loaded.notes())
+
+    for document in loaded.documents:
+        for model in document.data.get("semantic_model") or []:
+            model_name = model.get("name")
+            by_name: dict[str, str] = {}
+            relations: dict[str, str] = {}
+            for dataset in model.get("datasets") or []:
+                dataset_name = dataset.get("name")
+                qualified = f"{model_name}.{dataset_name}"
+                by_name[str(dataset_name)] = qualified
+                sm_def, sm_notes = _semantic_model_def(
+                    dataset, qualified, document.file, connector
+                )
+                # A dataset with no fields and no keys has nothing semantic
+                # declared about it yet: a bare relation reference is a
+                # schema-axis fact, not a semantic-model definition, and
+                # recording one here would make an unadorned dataset
+                # indistinguishable from a real, populated one for the
+                # generic added/removed/changed diff.
+                if sm_def.dimensions or sm_def.keys:
+                    semantic_models.append(sm_def)
+                    notes.extend(sm_notes)
+                if sm_def.relation:
+                    relations[qualified] = sm_def.relation
+
+            for rel in model.get("relationships") or []:
+                declared, note = catalog_mod._declared_relationship(
+                    rel, by_name, relations
+                )
+                if note:
+                    notes.append(note)
+                if declared is not None:
+                    relationships.append(_relationship_def(declared, document.file))
+
+            metrics.extend(
+                _metric_def(metric, document.file)
+                for metric in model.get("metrics") or []
+                if isinstance(metric, dict) and isinstance(metric.get("name"), str)
+            )
+
+    return SemanticLayerSnapshot(
+        semantic_models=semantic_models,
+        metrics=metrics,
+        relationships=relationships,
+        relationships_and_keys_captured=True,
+        notes=notes,
+    )
+
+
+def _semantic_model_def(
+    dataset: dict[str, Any], qualified: str, path: str, connector: str | None
+) -> tuple[SemanticModelDef, list[str]]:
+    """One dataset as a semantic model, plus any linkage notes its fields raised."""
+
+    dataset_name = dataset.get("name")
+    relation = catalog_mod._relation(dataset.get("source"), connector)
+    dimensions: dict[str, str | None] = {}
+    notes: list[str] = []
+    for field_ in dataset.get("fields") or []:
+        if not isinstance(field_, dict) or not isinstance(field_.get("name"), str):
+            continue
+        dimension, note = catalog_mod._dimension(
+            field_, dataset_name, qualified, connector, relation
+        )
+        dimensions[str(field_["name"])] = dimension.column
+        if note:
+            notes.append(note)
+
+    keys: list[list[str]] = []
+    for declared in (dataset.get("primary_key"), *(dataset.get("unique_keys") or [])):
+        columns = [c for c in (declared or []) if isinstance(c, str) and c]
+        if columns:
+            keys.append(columns)
+
+    return (
+        SemanticModelDef(
+            name=qualified,
+            path=path,
+            content_sha256=_definition_hash(dataset),
+            relation=relation,
+            dimensions=dimensions,
+            keys=keys,
+        ),
+        notes,
+    )
+
+
+def _relationship_def(declared: DeclaredRelationship, path: str) -> RelationshipDef:
+    name = declared.name or (
+        f"{declared.model}->{declared.to_model}:"
+        + ",".join(f"{frm}={to}" for frm, to in declared.column_pairs)
+    )
+    entry = {
+        "model": declared.model,
+        "to_model": declared.to_model,
+        "column_pairs": [list(pair) for pair in declared.column_pairs],
+    }
+    return RelationshipDef(
+        name=name,
+        path=path,
+        content_sha256=_definition_hash(entry),
+        model=declared.model,
+        to_model=declared.to_model,
+        column_pairs=declared.column_pairs,
+    )
+
+
+def _metric_def(metric: dict[str, Any], path: str) -> MetricDef:
+    # `input_measures`/`input_metrics` stay empty: Ossie metrics carry lineage
+    # (which datasets an expression touches), not measure/metric composition,
+    # and inventing either here would be a MetricFlow-shaped fact this format
+    # never states.
+    return MetricDef(
+        name=str(metric["name"]),
+        path=path,
+        content_sha256=_definition_hash(metric),
+    )

--- a/packages/dex-core/tests/maintain/test_semantic_relationships_and_keys.py
+++ b/packages/dex-core/tests/maintain/test_semantic_relationships_and_keys.py
@@ -1,0 +1,271 @@
+"""Composite relationships and dataset keys on the semantic drift axis (#409).
+
+`semantic_free_drift` is a pure comparison, so these drive it directly with
+hand-built snapshots rather than through a warehouse, the same style
+`test_semantic.py::test_a_pathless_definition_omits_its_provenance` uses.
+"""
+
+from __future__ import annotations
+
+from exmergo_dex_core.cache import ColumnProfile, Dataset
+from exmergo_dex_core.maintain.drift import semantic_free_drift
+from exmergo_dex_core.maintain.snapshot import (
+    RelationshipDef,
+    SemanticLayer,
+    SemanticModelDef,
+    Snapshot,
+)
+
+
+def _dataset(identifier: str, *columns: str) -> Dataset:
+    return Dataset(
+        identifier=identifier,
+        columns=[ColumnProfile(name=c, data_type="VARCHAR") for c in columns],
+    )
+
+
+def _snap(baseline: SemanticLayer | None) -> Snapshot:
+    return Snapshot(created_at="2026-01-01T00:00:00", semantic_layer=baseline)
+
+
+def test_a_model_with_no_model_ref_is_matched_by_its_own_relation():
+    """A format with no build step (Ossie) states `relation` instead of
+    `model_ref`; the column check has to fall back to it or it never runs at
+    all for that format's own semantic models."""
+
+    current = SemanticLayer(
+        semantic_models=[
+            SemanticModelDef(
+                name="shop.orders",
+                content_sha256="x",
+                relation="db.main.orders",
+                dimensions={"status": "status"},
+            )
+        ],
+        relationships_and_keys_captured=True,
+    )
+    datasets = [_dataset("db.main.orders", "order_id")]  # "status" is gone
+
+    findings = semantic_free_drift(None, current, datasets, _snap(current))
+
+    dangling = [f for f in findings if f.code == "dangling_reference"]
+    assert len(dangling) == 1
+    assert dangling[0].data == {
+        "semantic_model": "shop.orders",
+        "role": "dimension",
+        "name": "status",
+    }
+    assert dangling[0].impacted_models == []  # no model_ref to name
+
+
+def test_a_missing_key_column_is_flagged_when_captured():
+    current = SemanticLayer(
+        semantic_models=[
+            SemanticModelDef(
+                name="shop.orders",
+                content_sha256="x",
+                relation="db.main.orders",
+                keys=[["order_id", "line_no"]],
+            )
+        ],
+        relationships_and_keys_captured=True,
+    )
+    datasets = [_dataset("db.main.orders", "order_id")]  # "line_no" is gone
+
+    findings = semantic_free_drift(None, current, datasets, _snap(current))
+
+    key_findings = [f for f in findings if f.data.get("role") == "key"]
+    assert len(key_findings) == 1
+    assert key_findings[0].code == "dangling_reference"
+    assert key_findings[0].severity == "high"
+    assert key_findings[0].identifier == "db.main.orders"
+    assert key_findings[0].data["columns"] == ["order_id", "line_no"]
+    assert "line_no" in key_findings[0].detail
+
+
+def test_a_missing_key_column_is_silent_when_not_captured():
+    """The #409 hazard, guarded directly: a layer that never captured keys
+    (every baseline pinned before this field existed, and dbt today) must not
+    report a false "missing column" for a key it never actually recorded."""
+
+    current = SemanticLayer(
+        semantic_models=[
+            SemanticModelDef(
+                name="shop.orders",
+                content_sha256="x",
+                relation="db.main.orders",
+                keys=[["order_id", "line_no"]],
+            )
+        ],
+        relationships_and_keys_captured=False,
+    )
+    datasets = [_dataset("db.main.orders", "order_id")]
+
+    findings = semantic_free_drift(None, current, datasets, _snap(current))
+
+    assert [f for f in findings if f.data.get("role") == "key"] == []
+
+
+def test_a_relationship_naming_a_vanished_model_is_broken():
+    current = SemanticLayer(
+        semantic_models=[
+            SemanticModelDef(
+                name="shop.orders", content_sha256="x", relation="db.main.orders"
+            )
+        ],
+        relationships=[
+            RelationshipDef(
+                name="orders_to_customers",
+                content_sha256="y",
+                model="shop.orders",
+                to_model="shop.customers",
+                column_pairs=[("customer_id", "customer_id")],
+            )
+        ],
+        relationships_and_keys_captured=True,
+    )
+    datasets = [_dataset("db.main.orders", "customer_id")]
+
+    findings = semantic_free_drift(None, current, datasets, _snap(current))
+
+    broken = [f for f in findings if f.code == "broken_relationship"]
+    assert len(broken) == 1
+    assert broken[0].data == {
+        "relationship": "orders_to_customers",
+        "missing_model": "shop.customers",
+    }
+
+
+def test_a_relationship_whose_column_pair_no_longer_resolves_is_broken():
+    current = SemanticLayer(
+        semantic_models=[
+            SemanticModelDef(
+                name="shop.orders", content_sha256="x", relation="db.main.orders"
+            ),
+            SemanticModelDef(
+                name="shop.customers", content_sha256="z", relation="db.main.customers"
+            ),
+        ],
+        relationships=[
+            RelationshipDef(
+                name="orders_to_customers",
+                content_sha256="y",
+                model="shop.orders",
+                to_model="shop.customers",
+                column_pairs=[("customer_id", "customer_id")],
+            )
+        ],
+        relationships_and_keys_captured=True,
+    )
+    datasets = [
+        _dataset("db.main.orders", "order_id"),  # customer_id is gone
+        _dataset("db.main.customers", "customer_id"),
+    ]
+
+    findings = semantic_free_drift(None, current, datasets, _snap(current))
+
+    broken = [f for f in findings if f.code == "broken_relationship"]
+    assert len(broken) == 1
+    assert broken[0].identifier == "db.main.orders"
+    assert broken[0].data["relationship"] == "orders_to_customers"
+    assert broken[0].data["missing_pairs"] == [["customer_id", "customer_id"]]
+
+
+def test_an_intact_relationship_over_captured_layers_is_silent():
+    current = SemanticLayer(
+        semantic_models=[
+            SemanticModelDef(
+                name="shop.orders", content_sha256="x", relation="db.main.orders"
+            ),
+            SemanticModelDef(
+                name="shop.customers", content_sha256="z", relation="db.main.customers"
+            ),
+        ],
+        relationships=[
+            RelationshipDef(
+                name="orders_to_customers",
+                content_sha256="y",
+                model="shop.orders",
+                to_model="shop.customers",
+                column_pairs=[("customer_id", "customer_id")],
+            )
+        ],
+        relationships_and_keys_captured=True,
+    )
+    datasets = [
+        _dataset("db.main.orders", "customer_id"),
+        _dataset("db.main.customers", "customer_id"),
+    ]
+
+    findings = semantic_free_drift(None, current, datasets, _snap(current))
+
+    assert [f for f in findings if f.code == "broken_relationship"] == []
+
+
+def test_relationship_added_removed_changed_only_when_both_sides_captured():
+    rel = RelationshipDef(
+        name="orders_to_customers",
+        content_sha256="y",
+        model="shop.orders",
+        to_model="shop.customers",
+        column_pairs=[("customer_id", "customer_id")],
+    )
+    baseline = SemanticLayer(relationships_and_keys_captured=True)
+    current = SemanticLayer(relationships=[rel], relationships_and_keys_captured=True)
+
+    findings = semantic_free_drift(None, current, [], _snap(baseline))
+
+    added = [f for f in findings if f.code == "definition_added"]
+    assert added and added[0].data == {
+        "kind": "relationship",
+        "name": "orders_to_customers",
+    }
+
+
+def test_an_uncaptured_baseline_does_not_report_a_relationship_as_added():
+    """The exact hazard the issue names: an old baseline's empty relationship
+    list must never be compared as if it meant "declares none"."""
+
+    rel = RelationshipDef(
+        name="orders_to_customers",
+        content_sha256="y",
+        model="shop.orders",
+        to_model="shop.customers",
+        column_pairs=[("customer_id", "customer_id")],
+    )
+    baseline = SemanticLayer(relationships_and_keys_captured=False)
+    current = SemanticLayer(relationships=[rel], relationships_and_keys_captured=True)
+
+    findings = semantic_free_drift(None, current, [], _snap(baseline))
+
+    assert [
+        f for f in findings if f.code in ("definition_added", "definition_removed")
+    ] == []
+
+
+def test_a_changed_relationship_is_reported_when_both_sides_captured():
+    baseline_rel = RelationshipDef(
+        name="orders_to_customers",
+        content_sha256="before",
+        model="shop.orders",
+        to_model="shop.customers",
+        column_pairs=[("customer_id", "customer_id")],
+    )
+    current_rel = RelationshipDef(
+        name="orders_to_customers",
+        content_sha256="after",
+        model="shop.orders",
+        to_model="shop.customers",
+        column_pairs=[("region", "country_code")],
+    )
+    baseline = SemanticLayer(
+        relationships=[baseline_rel], relationships_and_keys_captured=True
+    )
+    current = SemanticLayer(
+        relationships=[current_rel], relationships_and_keys_captured=True
+    )
+
+    findings = semantic_free_drift(None, current, [], _snap(baseline))
+
+    changed = [f for f in findings if f.code == "definition_changed"]
+    assert changed and changed[0].data["kind"] == "relationship"

--- a/packages/dex-core/tests/ossie/test_conformance.py
+++ b/packages/dex-core/tests/ossie/test_conformance.py
@@ -7,9 +7,11 @@ also means a later change to the contract reaches this format automatically,
 which is exactly what a format built as the second implementation of a seam
 needs.
 
-The tier contracts stop at tier 1 on purpose. Subclassing a wider contract than
-the format implements is how you find out you have not finished, so the narrow
-class is a feature.
+The tier contracts stop where the format's own implementation does. Subclassing
+a wider contract than the format implements is how you find out you have not
+finished, so a narrow class is a feature: `TestOssieProject` now reaches tier 2
+(#409), and stops there rather than also mixing in the tier-3 write contract,
+which Ossie does not implement.
 """
 
 from __future__ import annotations
@@ -20,9 +22,10 @@ import pytest
 
 from exmergo_dex_core.adapters.conformance import (
     DeclaringProjectContract,
-    ExploreProjectContract,
+    MaintainProjectContract,
     ProjectFactoryContract,
     SemanticCatalogContract,
+    SemanticProjectContract,
 )
 from exmergo_dex_core.adapters.project import ExploreProject, ProjectContext
 from exmergo_dex_core.explore.semantic.conformance import SemanticBackendContract
@@ -46,9 +49,12 @@ def _declaring(root: Path, name: str, doc) -> OssieProject:
 
 
 class TestOssieProject(
-    ProjectFactoryContract, DeclaringProjectContract, ExploreProjectContract
+    ProjectFactoryContract,
+    DeclaringProjectContract,
+    MaintainProjectContract,
+    SemanticProjectContract,
 ):
-    """Tier 1, the factory, and the declarations dex reads a project *for*."""
+    """Tier 1 and 2, the factory, and the declarations dex reads a project *for*."""
 
     @pytest.fixture(autouse=True)
     def _root(self, tmp_path: Path) -> None:
@@ -188,6 +194,34 @@ class TestOssieProject(
             "buyer_ref",
             "s.customers",
             "customer_id",
+        )
+
+    def a_project_declaring_a_semantic_model(self):
+        """One direct field and one computed, so the snapshot's column mapping
+        is asserted in both directions, the same reason the catalog hook one
+        section over uses the same shape."""
+
+        project = _declaring(
+            self.root,
+            "snapshot.ossie.yaml",
+            document(
+                model(
+                    "snap",
+                    dataset(
+                        "orders",
+                        "demo.main.orders",
+                        field("order_id"),
+                        field("net_total", "order_total - discount"),
+                        primary_key=["order_id"],
+                    ),
+                )
+            ),
+        )
+        return (
+            project,
+            "snap.orders",
+            {"order_id": "order_id", "net_total": None},
+            {},
         )
 
     def a_project_declaring_a_composite_key(self):

--- a/packages/dex-core/tests/ossie/test_maintain_e2e.py
+++ b/packages/dex-core/tests/ossie/test_maintain_e2e.py
@@ -1,0 +1,199 @@
+"""Ossie reaching maintain's tier 2 through the actual command surface (#409).
+
+A repository with no dbt project at all, `semantic.vendor: ossie`, and a real
+DuckDB warehouse: `maintain snapshot` has to succeed and persist Ossie's own
+fingerprint (keys, a composite-shaped relationship, `relationships_and_keys_
+captured`), and `maintain check`/`maintain semantic` have to detect a broken
+relationship once the warehouse changes under it. This is the standalone case
+`_semantic_layer`'s independent-degrade design exists for: the transform half
+(no dbt project) has nothing to answer with, and the semantic half still does.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from exmergo_dex_core.cli import main
+from exmergo_dex_core.storage import FilesystemStore
+
+
+@pytest.fixture
+def ossie_repo(tmp_path: Path) -> Path:
+    duckdb = pytest.importorskip("duckdb")
+
+    root = tmp_path
+    db_path = root / "demo.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE TABLE orders (order_id INTEGER, customer_id INTEGER)")
+    conn.execute("INSERT INTO orders VALUES (1, 1), (2, 2), (3, 1)")
+    conn.execute("CREATE TABLE customers (customer_id INTEGER, country_code VARCHAR)")
+    conn.execute("INSERT INTO customers VALUES (1, 'US'), (2, 'EU')")
+    conn.close()
+
+    doc = {
+        "version": "0.2.0.dev0",
+        "semantic_model": [
+            {
+                "name": "commerce",
+                "datasets": [
+                    {
+                        "name": "orders",
+                        "source": "demo.main.orders",
+                        "fields": [
+                            {
+                                "name": "order_id",
+                                "expression": {
+                                    "dialects": [
+                                        {
+                                            "dialect": "ANSI_SQL",
+                                            "expression": "order_id",
+                                        }
+                                    ]
+                                },
+                            },
+                            {
+                                "name": "customer_id",
+                                "expression": {
+                                    "dialects": [
+                                        {
+                                            "dialect": "ANSI_SQL",
+                                            "expression": "customer_id",
+                                        }
+                                    ]
+                                },
+                            },
+                        ],
+                        "primary_key": ["order_id"],
+                    },
+                    {
+                        "name": "customers",
+                        "source": "demo.main.customers",
+                        "fields": [
+                            {
+                                "name": "customer_id",
+                                "expression": {
+                                    "dialects": [
+                                        {
+                                            "dialect": "ANSI_SQL",
+                                            "expression": "customer_id",
+                                        }
+                                    ]
+                                },
+                            }
+                        ],
+                        "primary_key": ["customer_id"],
+                    },
+                ],
+                "relationships": [
+                    {
+                        "name": "orders_to_customers",
+                        "from": "orders",
+                        "to": "customers",
+                        "from_columns": ["customer_id"],
+                        "to_columns": ["customer_id"],
+                    }
+                ],
+            }
+        ],
+    }
+    (root / "commerce.ossie.yaml").write_text(
+        yaml.safe_dump(doc, sort_keys=False), encoding="utf-8"
+    )
+
+    (root / ".dex").mkdir()
+    (root / ".dex" / "config.yml").write_text(
+        "connector: duckdb\n"
+        f"duckdb:\n  path: {db_path}\n"
+        "semantic:\n"
+        "  vendor: ossie\n"
+        "  ossie:\n"
+        "    files: [commerce.ossie.yaml]\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _cli(repo: Path, *argv: str, capsys) -> dict:
+    rc = main(["--repo-root", str(repo), *argv])
+    payload = json.loads(capsys.readouterr().out)
+    payload["_exit"] = rc
+    return payload
+
+
+def test_snapshot_succeeds_with_no_dbt_project_at_all(ossie_repo: Path, capsys):
+    payload = _cli(ossie_repo, "maintain", "snapshot", capsys=capsys)
+
+    assert payload["_exit"] == 0, payload
+    assert payload["status"] == "ok", payload
+    assert payload["data"]["semantic_layer"] is not None
+    assert payload["data"]["semantic_layer"]["semantic_model_count"] == 2
+
+
+def test_the_persisted_snapshot_carries_ossie_keys_and_relationships(
+    ossie_repo: Path, capsys
+):
+    _cli(ossie_repo, "maintain", "snapshot", capsys=capsys)
+
+    snap = FilesystemStore(str(ossie_repo)).load_snapshot()
+    assert snap is not None
+    assert snap.semantic_layer is not None
+    assert snap.semantic_layer.relationships_and_keys_captured is True
+
+    by_name = {m.name: m for m in snap.semantic_layer.semantic_models}
+    assert by_name["commerce.orders"].keys == [["order_id"]]
+    assert by_name["commerce.orders"].relation == "demo.main.orders"
+
+    (relationship,) = snap.semantic_layer.relationships
+    assert relationship.model == "commerce.orders"
+    assert relationship.to_model == "commerce.customers"
+    assert relationship.column_pairs == [("customer_id", "customer_id")]
+
+
+def test_check_flags_a_relationship_broken_by_a_dropped_column(
+    ossie_repo: Path, capsys
+):
+    _cli(ossie_repo, "maintain", "snapshot", capsys=capsys)
+
+    import duckdb
+
+    conn = duckdb.connect(str(ossie_repo / "demo.duckdb"))
+    conn.execute("ALTER TABLE orders DROP COLUMN customer_id")
+    conn.close()
+
+    payload = _cli(ossie_repo, "maintain", "check", capsys=capsys)
+
+    assert payload["_exit"] == 0, payload
+    findings = payload["data"]["findings"]
+    broken = [f for f in findings if f["code"] == "broken_relationship"]
+    assert len(broken) == 1
+    assert broken[0]["data"]["relationship"] == "orders_to_customers"
+    assert broken[0]["data"]["missing_pairs"] == [["customer_id", "customer_id"]]
+
+
+def test_check_runs_schema_and_volume_findings_with_no_transform_project(
+    ossie_repo: Path, capsys
+):
+    """The transform half degrades independently (#409): a repository with no
+    dbt project at all still gets the free axes that do not need one."""
+
+    _cli(ossie_repo, "maintain", "snapshot", capsys=capsys)
+
+    import duckdb
+
+    conn = duckdb.connect(str(ossie_repo / "demo.duckdb"))
+    conn.execute("CREATE TABLE new_table (id INTEGER)")
+    conn.close()
+
+    payload = _cli(ossie_repo, "maintain", "check", capsys=capsys)
+
+    assert payload["_exit"] == 0, payload
+    added = [
+        f
+        for f in payload["data"]["findings"]
+        if f["code"] == "table_added" and f["identifier"].endswith("new_table")
+    ]
+    assert len(added) == 1


### PR DESCRIPTION
Completes issue #409: native Ossie documents reach `MaintainProject` tier 2,
so `maintain snapshot` and `maintain check` get a real drift baseline for a
semantic vendor that is not dbt.

- **`OssieSemanticLayer` implements `transform_layer()` and
  `semantic_layer()`** — the same two methods `DbtProject` already has.
  `transform_layer()` is file hashes only (Ossie declares no build step);
  `semantic_layer()` fingerprints named definitions, each with a content hash
  and the physical column behind it. Neither raises, matching tier 1's
  degrade-gracefully contract rather than dbt's "raise if no project" tier-2
  behavior, since every Ossie failure mode is an ordinary user-facing state
  (bad file, missing extra), not a wiring mistake.

- **The snapshot shape gains two things it couldn't hold before, both
  additive, neither bumping `SNAPSHOT_SCHEMA_VERSION`**: `SemanticModelDef`
  gets `relation` (for a format with no build step to name a `model_ref`
  through) and `keys` (every declared unique key, one column list per
  declaration regardless of arity); a new `SemanticLayerSnapshot.relationships`
  list carries full composite ordered column pairs.

- **The hazard the issue named directly, guarded explicitly**: an old
  baseline's empty `relationships`/`keys` is indistinguishable from "this
  layer declares none," which would report a false clean bill instead of "not
  checked." `SemanticLayerSnapshot.relationships_and_keys_captured` (default
  `False`) gates the two new finding classes — `broken_relationship` and the
  key-column analogue of `dangling_reference` — and gates relationship
  added/removed/changed detection on *both* sides of a comparison, so a
  pre-#409 baseline never reads every current relationship as freshly added.
  dbt's own snapshots leave the flag `False`: it has no composite-relationship
  or multi-column-key concept at the semantic-model level, and that's an
  honest narrower answer, not a regression.

- **`maintain`'s two layers are now read independently** (`_read_layers` in
  `maintain/commands.py`), through the same seam #408 added on the explore
  side: the semantic half comes from whichever format answers
  `semantic.vendor` (a `SEMANTIC_PROJECT_FORMATS` table lookup, not a name
  check), rather than always from `project.format`. A repository with no dbt
  project at all and `semantic.vendor: ossie` gets a semantic baseline even
  though the transform half has nothing to answer with; a repository that
  keeps dbt for its models with Ossie's semantics beside it gets both, each
  degrading on its own.

## Testing

- Extended `TestOssieProject` with `MaintainProjectContract` and
  `SemanticProjectContract`, plus the required fixture hooks — verifies tier
  2, the empty-project shape, the transform/definitions model agreement, and
  a full snapshot JSON round trip.
- 9 new unit tests (`tests/maintain/test_semantic_relationships_and_keys.py`)
  driving `semantic_free_drift` directly: the `relation`-based column-match
  fallback, missing-key-column detection (and its silence when not
  captured), `broken_relationship` for a vanished model and for a broken
  column pair, and the added/removed/changed guard against an uncaptured
  baseline.
- 4 end-to-end tests (`tests/ossie/test_maintain_e2e.py`) against a real
  DuckDB warehouse with **no dbt project at all** — the hardest case the
  routing fix exists for: `maintain snapshot` succeeds and persists Ossie's
  keys/relationships, `maintain check` flags a relationship broken by a
  dropped column, and schema/volume findings still run independently of the
  missing transform project.
- Full regression sweep: `tests/ossie/`, `tests/maintain/`, `tests/explore/`,
  `tests/adapters/` — 1836 passed, 36 skipped. The 5 remaining failures are
  the same pre-existing Windows-only environment issues already documented
  (encoding, symlink privilege, path handling, upstream schema drift),
  unrelated to this change.
- Ruff check/format clean on every touched file, no em-dashes, and a direct
  grep confirms no new violation of `test_no_command_carries_a_vendor_branch`
  (the `SEMANTIC_PROJECT_FORMATS` lookup is a table membership check, not a
  vendor-name comparison).