### PR TITLE
SCRUM-1237-Verify Ossie keys through governed grain checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,28 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   each degrading on its own rather than one absence hiding the other's
   presence.
 
+- **`maintain grain`/`maintain check` verify Ossie's declared primary and
+  unique keys, composite ones included** ([#410]). `grain_plan` read declared
+  composite keys exclusively from `engine.project_format().definitions()`,
+  which is never Ossie, so its `primary_key`/`unique_keys` declarations never
+  reached the one code path that actually probes a declared grain against the
+  live warehouse (`declared_grain_not_unique`), no matter how the connector
+  was configured. A new `_composed_definitions` folds in a differing semantic
+  vendor's own keys additively, the same seam #408's `_fold_semantic_layer_keys`
+  and #409's `_semantic_layer` already use, so a repository with no dbt
+  project at all and `semantic.vendor: ossie` now gets its declared grain
+  checked as the never-measured declaration it is (`declared_grain_not_unique`,
+  never the demoted "was unique, no longer is" `key_lost_uniqueness` a
+  measurement it never earned would read as), and priced and
+  confirmation-gated through the identical billed handshake every other
+  connector already goes through. Relationship
+  verification needed no change: #408 already routed Ossie's composite
+  declarations through the same neutral `Relationship`/`--verify` path any
+  other format's do. Nothing here proposes an edit; a failed declaration
+  surfaces only as a finding, the existing behavior for every format and,
+  for Ossie specifically, also true because it has no write tier to edit at
+  all.
+
 - **A semantic layer's own declared dataset keys now reach grain detection**
   ([#408]). Ossie is never the transformation project `engine.project_format()`
   resolves, so its `primary_key`/`unique_keys` declarations had no route to

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -53,6 +53,7 @@ from .results import (
 
 if TYPE_CHECKING:
     from ..adapters.project import MaintainProject
+    from ..dbt_project import ProjectDefinitions
     from ..engine import DexEngine
     from .snapshot import SemanticLayer, TransformLayer
 
@@ -162,6 +163,48 @@ def _semantic_layer(
     if project is None:
         return None
     return project.semantic_layer()
+
+
+def _composed_definitions(engine: DexEngine) -> ProjectDefinitions:
+    """Declared keys and joins, with a differing semantic vendor's own keys
+    folded in additively (#410).
+
+    Grain verification (`maintain grain`/`maintain check`) reads declared
+    composite keys off ``ProjectDefinitions.declared_composite_keys``, which
+    ``engine.project_format().definitions()`` alone never carries for Ossie:
+    Ossie is never the transformation project that method resolves (the same
+    fact #408 already worked around for the explore-side grain channel, in
+    `explore.commands._fold_semantic_layer_keys`). Mirrored here rather than
+    imported from there, the way #409's `_semantic_layer` is its own
+    implementation beside `explore.commands._semantic_catalog`: each module
+    composes through the same neutral `SemanticLayer.declared_keys()` seam
+    rather than one reaching into the other's private helper.
+
+    Additive and silent on every declinable condition, matching
+    ``declared_keys()``'s own contract: a format with nothing to add (dbt,
+    whose keys already reach here through this same call) returns empty and
+    changes nothing.
+    """
+
+    defs = engine.project_format().definitions()
+    if engine.repo_root is None:
+        return defs
+    try:
+        from ..explore.semantic import resolve_semantic_layer
+
+        layer = resolve_semantic_layer(engine, local=True)
+        keys, composite_keys = layer.declared_keys()
+    except (DexError, ValueError, OSError):
+        return defs
+    if not keys and not composite_keys:
+        return defs
+    return defs.model_copy(
+        update={
+            "present": True,
+            "declared_keys": [*defs.declared_keys, *keys],
+            "declared_composite_keys": [*defs.declared_composite_keys, *composite_keys],
+        }
+    )
 
 
 class NoBaselineError(PrerequisiteError):
@@ -536,9 +579,7 @@ def grain_drift(engine: DexEngine, objects: list[str] | None = None) -> DriftRes
         if scope_names
         else None
     )
-    plan = drift_mod.grain_plan(
-        adapter, snap, scope, engine.project_format().definitions()
-    )
+    plan = drift_mod.grain_plan(adapter, snap, scope, _composed_definitions(engine))
     if (
         plan.key_checks
         or plan.fanout_pairs
@@ -828,9 +869,7 @@ def check(engine: DexEngine, objects: list[str] | None = None) -> DriftResult:
         else []
     )
 
-    plan = drift_mod.grain_plan(
-        adapter, snap, scope, engine.project_format().definitions()
-    )
+    plan = drift_mod.grain_plan(adapter, snap, scope, _composed_definitions(engine))
     # Added before both returns, so a declared grain the survey could not reach
     # is reported whether the scans run or stop at the handshake.
     warnings.extend(plan.notes)
@@ -1007,8 +1046,11 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
     # What the project declares, which is a different question from what its
     # files contain. `view` carries the bytes an edit is pinned against; this
     # carries the grain, and an edit that contradicts a declared grain is one no
-    # format is obliged to keep. Tier 1, so it cannot raise.
-    definitions = engine.project_format().definitions()
+    # format is obliged to keep. Tier 1, so it cannot raise. Composed with a
+    # differing semantic vendor's own keys (#410), so a proposal for a column
+    # Ossie already covers via a declared composite is not suggested as if
+    # nothing declared it.
+    definitions = _composed_definitions(engine)
     proposals, edits, build_warnings = reconcile_mod.build(
         findings,
         snap,

--- a/packages/dex-core/tests/ossie/test_maintain_grain_e2e.py
+++ b/packages/dex-core/tests/ossie/test_maintain_grain_e2e.py
@@ -1,0 +1,171 @@
+"""Ossie's declared keys reach `maintain grain`/`maintain check` (#410).
+
+Reuses the existing governed grain-verification machinery (`grain_plan`'s
+declared-composite survey, already billed and confirmation-gated the same
+way for every format) rather than building anything new: the only gap #410
+closes is that `grain_plan` used to read declared keys exclusively from
+`engine.project_format().definitions()`, which is never Ossie. A repository
+with no dbt project at all and `semantic.vendor: ossie` is the case that
+proves the fix, since there is nothing else that could feed the check.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from exmergo_dex_core.cli import main
+
+
+def _field(name: str) -> dict:
+    return {
+        "name": name,
+        "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": name}]},
+    }
+
+
+def _repo(tmp_path: Path, *, duplicate_line_no: bool) -> Path:
+    duckdb = pytest.importorskip("duckdb")
+
+    root = tmp_path
+    db_path = root / "demo.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE order_items (order_id INTEGER, line_no INTEGER, sku VARCHAR)"
+    )
+    rows = [(1, 1, "A"), (1, 2, "B"), (2, 1, "C")]
+    if duplicate_line_no:
+        # (order_id=1, line_no=1) now appears twice: the declared composite
+        # key is no longer unique.
+        rows.append((1, 1, "A2"))
+    conn.executemany("INSERT INTO order_items VALUES (?, ?, ?)", rows)
+    conn.close()
+
+    doc = {
+        "version": "0.2.0.dev0",
+        "semantic_model": [
+            {
+                "name": "commerce",
+                "datasets": [
+                    {
+                        "name": "order_items",
+                        "source": "demo.main.order_items",
+                        "fields": [
+                            _field("order_id"),
+                            _field("line_no"),
+                            _field("sku"),
+                        ],
+                        # An array of arrays, per the issue's own wording: one
+                        # independent unique-key declaration, itself composite.
+                        "unique_keys": [["order_id", "line_no"]],
+                    }
+                ],
+            }
+        ],
+    }
+    (root / "commerce.ossie.yaml").write_text(
+        yaml.safe_dump(doc, sort_keys=False), encoding="utf-8"
+    )
+
+    (root / ".dex").mkdir()
+    (root / ".dex" / "config.yml").write_text(
+        "connector: duckdb\n"
+        f"duckdb:\n  path: {db_path}\n"
+        "semantic:\n"
+        "  vendor: ossie\n"
+        "  ossie:\n"
+        "    files: [commerce.ossie.yaml]\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _cli(repo: Path, *argv: str, capsys) -> dict:
+    rc = main(["--repo-root", str(repo), *argv])
+    payload = json.loads(capsys.readouterr().out)
+    payload["_exit"] = rc
+    return payload
+
+
+def test_grain_flags_a_declared_composite_key_that_is_not_unique(
+    tmp_path: Path, capsys
+):
+    repo = _repo(tmp_path, duplicate_line_no=True)
+    _cli(repo, "maintain", "snapshot", capsys=capsys)
+
+    payload = _cli(repo, "maintain", "grain", capsys=capsys)
+
+    assert payload["_exit"] == 0, payload
+    findings = payload["data"]["findings"]
+    broken = [f for f in findings if f["code"] == "declared_grain_not_unique"]
+    assert len(broken) == 1
+    assert broken[0]["identifier"].endswith("order_items")
+    assert sorted(broken[0]["data"]["columns"]) == ["line_no", "order_id"]
+
+
+def test_grain_is_silent_when_the_declared_composite_key_is_actually_unique(
+    tmp_path: Path, capsys
+):
+    repo = _repo(tmp_path, duplicate_line_no=False)
+    _cli(repo, "maintain", "snapshot", capsys=capsys)
+
+    payload = _cli(repo, "maintain", "grain", capsys=capsys)
+
+    assert payload["_exit"] == 0, payload
+    codes = {f["code"] for f in payload["data"]["findings"]}
+    assert "declared_grain_not_unique" not in codes
+
+
+def test_check_also_surfaces_the_declared_grain_finding(tmp_path: Path, capsys):
+    """The same routing fix has to reach `maintain check`'s grain axis, not
+    only the focused `maintain grain` detector."""
+
+    repo = _repo(tmp_path, duplicate_line_no=True)
+    _cli(repo, "maintain", "snapshot", capsys=capsys)
+
+    payload = _cli(repo, "maintain", "check", capsys=capsys)
+
+    assert payload["_exit"] == 0, payload
+    broken = [
+        f
+        for f in payload["data"]["findings"]
+        if f["code"] == "declared_grain_not_unique"
+    ]
+    assert len(broken) == 1
+
+
+def test_reconcile_proposes_no_edit_for_a_failed_declared_grain(tmp_path: Path, capsys):
+    """A failed declaration is a finding, never an automatic rewrite (#410):
+    Ossie has no write tier at all, and `declared_grain_not_unique` is
+    advisory-only for every format regardless, so this holds twice over.
+
+    `maintain reconcile` needs an actual dbt project to load even when every
+    proposal it produces ends up advisory (it is the write tier's own
+    prerequisite, unrelated to #410), so this uses a minimal empty one beside
+    the Ossie document rather than the no-dbt-project fixture the other tests
+    in this file use.
+    """
+
+    repo = _repo(tmp_path, duplicate_line_no=True)
+    (repo / "dbt_project.yml").write_text(
+        'name: ossie_grain_test\nversion: "1.0.0"\nmodel-paths: ["models"]\n',
+        encoding="utf-8",
+    )
+    (repo / "models").mkdir()
+    _cli(repo, "maintain", "snapshot", capsys=capsys)
+    _cli(repo, "maintain", "grain", capsys=capsys)
+
+    payload = _cli(repo, "maintain", "reconcile", capsys=capsys)
+
+    assert payload["_exit"] == 0, payload
+    proposals = [
+        p
+        for p in payload["data"]["proposals"]
+        if p["finding_code"] == "declared_grain_not_unique"
+    ]
+    assert len(proposals) == 1
+    assert proposals[0]["kind"] == "advisory"
+    assert payload["data"].get("plan_id") is None


### PR DESCRIPTION
Completes issue #410: Ossie's declared primary/unique keys and explicit
relationships are verified through the existing governed warehouse
machinery, reused rather than rebuilt.

- **Research first, since the issue explicitly says to reuse what exists.**
  Relationship verification was already fully working for Ossie: #408
  routed its composite `DeclaredRelationship` through the neutral
  `Relationship`/`probe_candidates`/`verify_relationships` path, which
  already handles N-ary composite joins, the cost guard, and the
  confirmation/budget/ledger handshake identically to any other format —
  already proven by `test_duckdb_e2e.py`. The `unique_keys: array of arrays`
  shape the issue warns to check was also already handled correctly:
  `ossie/catalog.py`'s `_keys()` already decomposes it into one
  `DeclaredKey`/`DeclaredCompositeKey` per declaration, and `drift.py`'s
  `_declared_composites` already accumulates multiple composites per
  identifier.

- **The one real gap: routing.** `grain_plan` — the one code path in the
  whole tree that actually probes a *declared* composite key against the
  live warehouse (`declared_grain_not_unique`) — read declared keys
  exclusively from `engine.project_format().definitions()`, which is never
  Ossie. So no matter what a repository's Ossie document declared, it never
  reached this check.

- **The fix**: a new `_composed_definitions(engine)` in `maintain/commands.py`
  folds a differing semantic vendor's own declared keys into the transform
  project's definitions, additively — the identical pattern #408's
  `_fold_semantic_layer_keys` and #409's `_semantic_layer` already
  established for their own consumers. Wired into `grain_drift()`, `check()`,
  and `reconcile()` (the last one for correct advisory text, even though
  Ossie has no write tier to act on regardless).

- **Nothing else needed changing.** The declaration/cached-evidence/new-
  measurement distinction already exists on both axes (`RelationshipKind`
  +`verified` for relationships, the `key_lost_uniqueness`/
  `declared_grain_not_unique` code split for keys). The advisory-only
  behavior for a failed declaration was already an existing, held invariant
  (`reconcile.py`'s advisory table), and Ossie has no write tier at all to
  auto-edit into even if something tried.

## Testing

- 4 new end-to-end tests (`tests/ossie/test_maintain_grain_e2e.py`) against
  a real DuckDB warehouse, no dbt project at all:
  - a declared composite key that is actually broken fires
    `declared_grain_not_unique` via both `maintain grain` and the aggregate
    `maintain check` sweep;
  - a declared composite key that is genuinely unique stays silent (and free
    on DuckDB, no confirmation needed);
  - `maintain reconcile` treats the failure as `kind: advisory` with no
    `plan_id`, never an edit.
- Full regression sweep: `tests/ossie/`, `tests/maintain/`, `tests/explore/`
  — 1207 passed, 30 skipped. The 5 remaining failures are the same
  pre-existing Windows-only environment issues already documented
  (encoding, symlink privilege, path handling, upstream schema drift),
  unrelated to this change.
- Ruff check/format clean, no em-dashes.