### PR TITLE
SCRUM-1239-Validate Ossie authoring against cached physical evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **Native Ossie authoring plans are validated against cached exploration
+  evidence before they are stored, with no warehouse connection opened**
+  ([#412]). `semantic ossie define|update|plan` now checks each dataset's
+  source relation, direct field columns, declared keys, and relationship
+  endpoint columns against `.dex/cache.json`, reusing the exact same
+  `normalize_relation`/`match_identifier`/`column_reference` primitives the
+  read catalog already uses, so a reference dex would call invalid while
+  reading is checked by the identical rule at plan time.
+
+  The distinction the issue asks for is structural, not a judgment call: a
+  relation is refused only when it is absent from a namespace the cache
+  completely inventoried (a new `CacheProvenance.inventory_namespaces`,
+  populated from the same observed-namespace bookkeeping issue #149 already
+  established for carry-forward, not a new concept); a column is refused only
+  when it is missing from a relation the cache actually profiled. Everything
+  else, an unprofiled relation, a namespace never inventoried, a query-backed
+  or quoted source, a computed field expression, is a note, never a refusal:
+  absence of evidence is not evidence of absence. A refused reference stores
+  no plan, exactly like every other validation failure this command already
+  has.
+
 - **Native Ossie semantic documents can now be authored as reviewable plans**
   with `semantic ossie define|update|plan` and applied through the existing
   `transform apply` command ([#411]). The new `semantic_document` edit kind is

--- a/packages/dex-core/src/exmergo_dex_core/cache.py
+++ b/packages/dex-core/src/exmergo_dex_core/cache.py
@@ -379,6 +379,12 @@ class CacheProvenance(BaseModel):
     created_at: str | None = None
     updated_at: str | None = None
     tool_version: str | None = Field(default_factory=tool_version)
+    #: Namespaces whose complete object inventory contributed to this cache.
+    #: A named relation absent from one of these namespaces is known missing;
+    #: absence elsewhere is only unknown because ``explore profile`` may write
+    #: a deliberately partial cache.  Kept as provenance rather than inferred
+    #: from ``datasets`` so a partial profile can never masquerade as inventory.
+    inventory_namespaces: list[str] = Field(default_factory=list)
 
 
 class DexCache(BaseModel):

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -1136,7 +1136,14 @@ def relationships(
     # set is authoritative for every identifier it examined; anything with an
     # endpoint outside that (a narrower --scope/--dataset than a prior run) is
     # carried forward above rather than dropped, same as the profiles are.
-    cache, stats = _merge_profiles(prior, datasets, connector, now, relationships=rels)
+    cache, stats = _merge_profiles(
+        prior,
+        datasets,
+        connector,
+        now,
+        relationships=rels,
+        observed_namespaces=observed_namespaces,
+    )
     if catalog is not None:
         _annotate_semantic_exposure(cache.datasets, catalog)
     locator = store.save_cache(cache, now=now)
@@ -2215,6 +2222,12 @@ def map(
 
     cache = DexCache(datasets=datasets, relationships=relationship_set)
     cache.provenance.connector = adapter.name
+    cache.provenance.inventory_namespaces = sorted(
+        {
+            *(reusable.provenance.inventory_namespaces if reusable else []),
+            *observed_namespaces,
+        }
+    )
     cache.provenance.created_at = (
         prior.provenance.created_at
         if prior and prior.provenance.created_at
@@ -4363,6 +4376,7 @@ def _merge_profiles(
     now: datetime,
     *,
     relationships=_KEEP_RELATIONSHIPS,
+    observed_namespaces: set[str] | None = None,
 ) -> tuple[DexCache, dict]:
     """Fold freshly profiled datasets into a prior cache, keyed by identifier.
 
@@ -4401,6 +4415,12 @@ def _merge_profiles(
         rels = relationships
     cache = DexCache(datasets=datasets, relationships=rels)
     cache.provenance.connector = connector
+    cache.provenance.inventory_namespaces = sorted(
+        {
+            *(reusable.provenance.inventory_namespaces if reusable else []),
+            *(observed_namespaces or set()),
+        }
+    )
     cache.provenance.created_at = (
         reusable.provenance.created_at
         if reusable and reusable.provenance.created_at

--- a/packages/dex-core/src/exmergo_dex_core/ossie/authoring.py
+++ b/packages/dex-core/src/exmergo_dex_core/ossie/authoring.py
@@ -20,6 +20,7 @@ from ..errors import ProjectError
 from .loader import ERROR, LoadedDocument, validate_document_contents
 
 if TYPE_CHECKING:
+    from ..cache import DexCache
     from ..transform.plans import PlanEdit
     from .project import OssieSemanticLayer
 
@@ -61,8 +62,12 @@ def load_edit_view(layer: OssieSemanticLayer) -> SemanticDocumentView:
 
 
 def validate_plan(
-    layer: OssieSemanticLayer, edits: list[PlanEdit], mode: str
-) -> tuple[dict[str, list[str]], list[str]]:
+    layer: OssieSemanticLayer,
+    edits: list[PlanEdit],
+    mode: str,
+    *,
+    cache: DexCache | None = None,
+) -> tuple[dict[str, list[str]], list[str], list[str]]:
     """Validate the prospective configured set and classify model names."""
 
     configured = set(layer.files)
@@ -133,11 +138,26 @@ def validate_plan(
         )
 
     warnings = [d.render() for d in validated.diagnostics if d.severity != ERROR]
+    from .cache_validation import validate_cached_references
+
+    cache_validation = validate_cached_references(
+        validated.documents, cache, connector=layer.connector
+    )
+    if cache_validation.errors:
+        raise ValueError(
+            "the prospective Ossie semantic layer has references contradicted "
+            "by the exploration cache, so no plan was stored: "
+            + "; ".join(cache_validation.errors)
+        )
     warnings.append(
         "Ossie edits are whole-document replacements written byte-for-byte; dex "
         "does not reformat YAML/JSON or modify unedited configured documents"
     )
-    return {"defined": defined, "updated": updated}, warnings
+    return (
+        {"defined": defined, "updated": updated},
+        cache_validation.notes,
+        warnings,
+    )
 
 
 def write_edits(

--- a/packages/dex-core/src/exmergo_dex_core/ossie/cache_validation.py
+++ b/packages/dex-core/src/exmergo_dex_core/ossie/cache_validation.py
@@ -1,0 +1,193 @@
+"""Validate native Ossie references using stored exploration evidence only.
+
+The cache is evidence, not the source of truth.  A positive inventory or column
+profile can therefore prove that a reference exists, and a complete inventory
+of one namespace can prove that a relation does not.  Every other absence is an
+unknown, never a refusal.  Nothing in this module accepts an adapter or opens a
+connection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..adapters import normalize_relation
+from ..cache import DexCache, match_identifier
+from ..semantic_catalog import column_reference
+from .dialects import select_expression
+from .loader import LoadedDocument
+
+
+@dataclass
+class CacheValidation:
+    """What the cache proved, could not settle, or contradicted."""
+
+    errors: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    checked_relations: int = 0
+    checked_columns: int = 0
+
+
+def validate_cached_references(
+    documents: list[LoadedDocument],
+    cache: DexCache | None,
+    *,
+    connector: str | None,
+) -> CacheValidation:
+    """Check cache-provable sources and columns without opening a connector."""
+
+    result = CacheValidation()
+    if cache is None:
+        result.notes.append(
+            "cache validation could not check physical Ossie references because "
+            "there is no exploration cache; they remain unknown and no warehouse "
+            "connection was opened"
+        )
+        return result
+
+    cached_connector = cache.provenance.connector
+    if connector is None or (
+        cached_connector is not None and cached_connector != connector
+    ):
+        expected = connector or "an unconfigured connector"
+        actual = cached_connector or "an unknown connector"
+        result.notes.append(
+            f"cache validation did not use the exploration cache for {actual} "
+            f"against {expected}; physical references remain unknown and no "
+            "warehouse connection was opened"
+        )
+        return result
+
+    by_identifier = {dataset.identifier: dataset for dataset in cache.datasets}
+    identifiers = list(by_identifier)
+    inventoried = {
+        namespace.lower() for namespace in cache.provenance.inventory_namespaces
+    }
+    unknown_relations: set[str] = set()
+    unprofiled: set[str] = set()
+    opaque_sources = 0
+    computed_fields = 0
+
+    for document in documents:
+        for model_index, model in enumerate(document.data.get("semantic_model") or []):
+            model_name = str(model.get("name"))
+            datasets = model.get("datasets") or []
+            endpoint_columns = _endpoint_columns(model)
+
+            for dataset_index, dataset in enumerate(datasets):
+                dataset_name = str(dataset.get("name"))
+                location = (
+                    f"{document.file}: semantic_model[{model_index}] "
+                    f"'{model_name}' dataset[{dataset_index}] '{dataset_name}'"
+                )
+                relation = normalize_relation(connector, dataset.get("source"))
+                if relation is None:
+                    opaque_sources += 1
+                    continue
+
+                matches = match_identifier(relation, identifiers)
+                if len(matches) != 1:
+                    namespace = relation.rpartition(".")[0].lower()
+                    if not matches and namespace in inventoried:
+                        result.errors.append(
+                            f"{location} names source '{relation}', but the cached "
+                            f"inventory for namespace '{namespace}' does not contain it"
+                        )
+                    else:
+                        unknown_relations.add(relation)
+                    continue
+
+                cached = by_identifier[matches[0]]
+                result.checked_relations += 1
+                references, skipped = _column_references(
+                    dataset,
+                    endpoint_columns.get(dataset.get("name"), []),
+                    connector=connector,
+                )
+                computed_fields += skipped
+                if not cached.columns:
+                    if references:
+                        unprofiled.add(cached.identifier)
+                    continue
+
+                known_columns = {column.name.lower() for column in cached.columns}
+                for column, role in references:
+                    result.checked_columns += 1
+                    if column.lower() not in known_columns:
+                        result.errors.append(
+                            f"{location} {role} names column '{column}', but the "
+                            f"cached profile for '{cached.identifier}' does not "
+                            "contain it"
+                        )
+
+    if unknown_relations:
+        result.notes.append(
+            "cache validation could not settle direct source(s) outside a "
+            "completely inventoried namespace: " + ", ".join(sorted(unknown_relations))
+        )
+    if unprofiled:
+        result.notes.append(
+            "cache validation found relation(s) whose columns are unprofiled, so "
+            "their field, key, and relationship-column references remain unknown: "
+            + ", ".join(sorted(unprofiled))
+        )
+    if opaque_sources:
+        result.notes.append(
+            f"cache validation skipped {opaque_sources} query-backed, quoted, or "
+            "otherwise opaque dataset source(s); dex does not guess a physical relation"
+        )
+    if computed_fields:
+        result.notes.append(
+            f"cache validation skipped {computed_fields} computed or non-SQL field "
+            "expression(s); dex validates only a direct physical column reference"
+        )
+    result.notes.append(
+        f"cache validation checked {result.checked_relations} direct relation(s) "
+        f"and {result.checked_columns} physical column reference(s) using stored "
+        "evidence only; no warehouse connection was opened"
+    )
+    return result
+
+
+def _endpoint_columns(model: dict[str, Any]) -> dict[Any, list[tuple[str, str]]]:
+    columns: dict[Any, list[tuple[str, str]]] = {}
+    for relationship in model.get("relationships") or []:
+        name = str(relationship.get("name"))
+        for side, key in (("from", "from_columns"), ("to", "to_columns")):
+            dataset = relationship.get(side)
+            columns.setdefault(dataset, []).extend(
+                (str(column), f"relationship '{name}' {key}")
+                for column in relationship.get(key) or []
+            )
+    return columns
+
+
+def _column_references(
+    dataset: dict[str, Any],
+    endpoints: list[tuple[str, str]],
+    *,
+    connector: str,
+) -> tuple[list[tuple[str, str]], int]:
+    references = list(endpoints)
+    skipped = 0
+    for field_ in dataset.get("fields") or []:
+        expression, _dialect, _declared = select_expression(
+            field_.get("expression"), connector
+        )
+        column = column_reference(expression, None) if expression else None
+        if column is None:
+            skipped += 1
+        else:
+            references.append((column, f"field '{field_.get('name')}'"))
+    references.extend(
+        (str(column), "primary_key")
+        for column in dataset.get("primary_key") or []
+    )
+    for key_index, key in enumerate(dataset.get("unique_keys") or []):
+        references.extend(
+            (str(column), f"unique_keys[{key_index}]") for column in key
+        )
+    # The same physical column may be a field, key, and endpoint.  Each role is
+    # useful in a refusal, but duplicate declarations of one role are only noise.
+    return list(dict.fromkeys(references)), skipped

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -1099,8 +1099,11 @@ def semantic_ossie(
         )
 
     from ..ossie.authoring import validate_plan
+    from ..storage import readable_cache
 
-    classification, validation_warnings = validate_plan(layer, edits, mode)
+    classification, validation_notes, validation_warnings = validate_plan(
+        layer, edits, mode, cache=readable_cache(engine.store)
+    )
     repo_root = engine.require_repo_root("storing a native semantic plan")
     stored, diffs, plan_warnings = plans_mod.plan(
         intent,
@@ -1118,6 +1121,7 @@ def semantic_ossie(
             stored.plan_id
         ),
         diffs=diffs,
+        notes=validation_notes,
         warnings=[*plan_warnings, *validation_warnings],
         defined=classification["defined"],
         updated=classification["updated"],

--- a/packages/dex-core/tests/ossie/test_authoring.py
+++ b/packages/dex-core/tests/ossie/test_authoring.py
@@ -7,12 +7,15 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
+from exmergo_dex_core.cache import CacheProvenance, ColumnProfile, Dataset, DexCache
 from exmergo_dex_core.cli import main
 from exmergo_dex_core.config import DexConfig, save_config
 from exmergo_dex_core.edits import SemanticEditTarget
 from exmergo_dex_core.ossie import OssieSemanticLayer
+from exmergo_dex_core.storage import FilesystemStore
 
 from .conftest import dataset, document, field, model, write
 
@@ -50,6 +53,30 @@ def _yaml(name: str) -> str:
             )
         ),
         sort_keys=False,
+    )
+
+
+def _save_cache(
+    root: Path,
+    *datasets: Dataset,
+    inventory_namespaces: list[str] | None = None,
+    connector: str = "duckdb",
+) -> None:
+    FilesystemStore(root).save_cache(
+        DexCache(
+            datasets=list(datasets),
+            provenance=CacheProvenance(
+                connector=connector,
+                inventory_namespaces=inventory_namespaces or [],
+            ),
+        )
+    )
+
+
+def _profile(identifier: str, *columns: str) -> Dataset:
+    return Dataset(
+        identifier=identifier,
+        columns=[ColumnProfile(name=name, data_type="VARCHAR") for name in columns],
     )
 
 
@@ -94,9 +121,7 @@ def test_define_plans_a_configured_missing_document_and_apply_writes_exact_bytes
     assert (tmp_path / "semantics/new.ossie.yaml").read_text("utf-8") == authored
 
 
-def test_define_and_update_enforce_the_semantic_model_namespace(
-    tmp_path: Path, capsys
-):
+def test_define_and_update_enforce_the_semantic_model_namespace(tmp_path: Path, capsys):
     write(
         tmp_path,
         "existing.ossie.yaml",
@@ -259,9 +284,7 @@ def test_stale_edit_refuses_the_whole_apply(tmp_path: Path, capsys):
     assert (tmp_path / second).read_text("utf-8") == before_second
 
 
-def test_apply_revalidates_unedited_documents_before_writing(
-    tmp_path: Path, capsys
-):
+def test_apply_revalidates_unedited_documents_before_writing(tmp_path: Path, capsys):
     first = write(
         tmp_path,
         "first.ossie.yaml",
@@ -335,3 +358,274 @@ def test_native_authoring_needs_no_sql_dbt_or_metricflow_runtime(tmp_path: Path)
     result = json.loads(completed.stdout)
     assert result["status"] == "ok"
     assert any("syntax was not checked" in note for note in result["warnings"])
+
+
+def test_absent_cache_is_an_unknown_note_not_a_refusal(tmp_path: Path, capsys):
+    _configure(tmp_path, ["new.ossie.yaml"])
+    payload = _payload(
+        tmp_path,
+        [{"path": "new.ossie.yaml", "content": _yaml("commerce")}],
+    )
+
+    result = _run(
+        tmp_path,
+        capsys,
+        "semantic",
+        "ossie",
+        "define",
+        "without cache",
+        "--edits-file",
+        str(payload),
+    )
+
+    assert result["_exit"] == 0, result
+    assert any(
+        "there is no exploration cache" in note for note in result["data"]["notes"]
+    )
+    assert any(
+        "no warehouse connection was opened" in note for note in result["data"]["notes"]
+    )
+
+
+def test_unprofiled_columns_are_an_unknown_note(tmp_path: Path, capsys):
+    _configure(tmp_path, ["new.ossie.yaml"])
+    _save_cache(
+        tmp_path,
+        Dataset(identifier="demo.main.orders"),
+        inventory_namespaces=["demo.main"],
+    )
+    payload = _payload(
+        tmp_path,
+        [{"path": "new.ossie.yaml", "content": _yaml("commerce")}],
+    )
+
+    result = _run(
+        tmp_path,
+        capsys,
+        "semantic",
+        "ossie",
+        "define",
+        "unprofiled",
+        "--edits-file",
+        str(payload),
+    )
+
+    assert result["_exit"] == 0, result
+    assert any("columns are unprofiled" in note for note in result["data"]["notes"])
+
+
+def test_relation_absent_from_a_complete_cached_namespace_refuses_the_plan(
+    tmp_path: Path, capsys
+):
+    _configure(tmp_path, ["new.ossie.yaml"])
+    _save_cache(
+        tmp_path,
+        _profile("demo.main.customers", "customer_id"),
+        inventory_namespaces=["demo.main"],
+    )
+    payload = _payload(
+        tmp_path,
+        [{"path": "new.ossie.yaml", "content": _yaml("commerce")}],
+    )
+
+    result = _run(
+        tmp_path,
+        capsys,
+        "semantic",
+        "ossie",
+        "define",
+        "missing relation",
+        "--edits-file",
+        str(payload),
+    )
+
+    assert result["_exit"] == 1
+    assert "cached inventory" in result["errors"][0]
+    assert "demo.main.orders" in result["errors"][0]
+    assert "no plan was stored" in result["errors"][0]
+    assert not list((tmp_path / ".dex" / "plans").glob("*.json"))
+
+
+@pytest.mark.parametrize(
+    ("authored", "expected"),
+    [
+        (
+            document(
+                model(
+                    "commerce",
+                    dataset(
+                        "orders",
+                        "demo.main.orders",
+                        field("missing_field"),
+                    ),
+                )
+            ),
+            "field 'missing_field' names column 'missing_field'",
+        ),
+        (
+            document(
+                model(
+                    "commerce",
+                    dataset(
+                        "orders",
+                        "demo.main.orders",
+                        field("order_id"),
+                        primary_key=["missing_key"],
+                    ),
+                )
+            ),
+            "primary_key names column 'missing_key'",
+        ),
+        (
+            document(
+                model(
+                    "commerce",
+                    dataset(
+                        "orders",
+                        "demo.main.orders",
+                        field("order_id"),
+                    ),
+                    dataset(
+                        "customers",
+                        "demo.main.customers",
+                        field("customer_id"),
+                        primary_key=["customer_id"],
+                    ),
+                    relationships=[
+                        {
+                            "name": "orders_to_customers",
+                            "from": "orders",
+                            "to": "customers",
+                            "from_columns": ["missing_fk"],
+                            "to_columns": ["customer_id"],
+                        }
+                    ],
+                )
+            ),
+            "relationship 'orders_to_customers' from_columns names column 'missing_fk'",
+        ),
+    ],
+    ids=["field", "key", "relationship-endpoint"],
+)
+def test_columns_known_missing_from_cached_profiles_refuse_the_plan(
+    tmp_path: Path, capsys, authored, expected
+):
+    _configure(tmp_path, ["new.ossie.yaml"])
+    _save_cache(
+        tmp_path,
+        _profile("demo.main.orders", "order_id", "customer_id"),
+        _profile("demo.main.customers", "customer_id"),
+        inventory_namespaces=["demo.main"],
+    )
+    payload = _payload(
+        tmp_path,
+        [
+            {
+                "path": "new.ossie.yaml",
+                "content": yaml.safe_dump(authored, sort_keys=False),
+            }
+        ],
+    )
+
+    result = _run(
+        tmp_path,
+        capsys,
+        "semantic",
+        "ossie",
+        "define",
+        "bad column",
+        "--edits-file",
+        str(payload),
+    )
+
+    assert result["_exit"] == 1
+    assert expected in result["errors"][0]
+    assert "no plan was stored" in result["errors"][0]
+    assert not list((tmp_path / ".dex" / "plans").glob("*.json"))
+
+
+def test_computed_fields_and_query_sources_are_not_overvalidated(
+    tmp_path: Path, capsys
+):
+    _configure(tmp_path, ["new.ossie.yaml"])
+    _save_cache(
+        tmp_path,
+        _profile("demo.main.orders", "order_id", "amount", "discount"),
+        inventory_namespaces=["demo.main"],
+    )
+    authored = document(
+        model(
+            "commerce",
+            dataset(
+                "orders",
+                "demo.main.orders",
+                field("order_id"),
+                field("net", "amount - discount"),
+            ),
+            dataset(
+                "recent",
+                "SELECT * FROM demo.main.missing",
+                field("not_cache_provable"),
+            ),
+        )
+    )
+    payload = _payload(
+        tmp_path,
+        [
+            {
+                "path": "new.ossie.yaml",
+                "content": yaml.safe_dump(authored, sort_keys=False),
+            }
+        ],
+    )
+
+    result = _run(
+        tmp_path,
+        capsys,
+        "semantic",
+        "ossie",
+        "define",
+        "opaque references",
+        "--edits-file",
+        str(payload),
+    )
+
+    assert result["_exit"] == 0, result
+    notes = " ".join(result["data"]["notes"])
+    assert "query-backed" in notes
+    assert "computed" in notes
+
+
+def test_cache_validation_never_opens_a_warehouse_connection(
+    tmp_path: Path, capsys, monkeypatch
+):
+    _configure(tmp_path, ["new.ossie.yaml"])
+    _save_cache(
+        tmp_path,
+        _profile("demo.main.orders", "order_id"),
+        inventory_namespaces=["demo.main"],
+    )
+    payload = _payload(
+        tmp_path,
+        [{"path": "new.ossie.yaml", "content": _yaml("commerce")}],
+    )
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("cache validation opened a warehouse connection")
+
+    monkeypatch.setattr("exmergo_dex_core.connect.open_adapter", forbidden)
+    result = _run(
+        tmp_path,
+        capsys,
+        "semantic",
+        "ossie",
+        "define",
+        "cache only",
+        "--edits-file",
+        str(payload),
+    )
+
+    assert result["_exit"] == 0, result
+    assert any(
+        "no warehouse connection was opened" in note for note in result["data"]["notes"]
+    )


### PR DESCRIPTION
Closes : #412: `semantic ossie define|update|plan` validates the
prospective document set against cached exploration evidence (`.dex/cache.json`)
before storing a plan, without opening a warehouse connection.

- **New `ossie/cache_validation.py`** checks every dataset's source relation,
  direct (bare-identifier) field columns, declared primary/unique keys, and
  relationship endpoint columns against the cache. It deliberately reuses the
  exact same `normalize_relation`/`match_identifier`/`column_reference`/
  `select_expression` primitives the read catalog already uses, so a
  reference this rejects at plan time is checked by the identical rule
  `explore semantic list` already applies when reading.

- **The known-invalid vs. unknown split is structural, not heuristic.** A
  relation is refused only when it's absent from a namespace the cache
  *completely inventoried*; a column is refused only when it's missing from a
  relation the cache actually *profiled*. A new `CacheProvenance.
  inventory_namespaces` field carries that provenance, populated by reusing
  the `observed_namespaces` bookkeeping issue #149 already established for
  carry-forward detection, not a new concept. Everything else, an unprofiled
  relation, a namespace never inventoried, a query-backed or quoted source, a
  computed field expression, is a note. No plan is stored on a refusal.

- **Wiring is minimal**: `transform/commands.py`'s `semantic_ossie()` reads
  the cache via `readable_cache(engine.store)` (a store read, never
  `connect.open_adapter`) and passes it into `validate_plan()`, which raises
  before any plan is stored when the cache contradicts a reference. Notes
  flow through the existing `Result.notes` mechanism with no new plumbing.

## Testing

- 16 tests in `tests/ossie/test_authoring.py` (8 pre-existing from #411, 8 new
  for this issue): absent-cache note, unprofiled-columns note, a relation
  confirmed missing from a completely-inventoried namespace refuses the plan,
  a column confirmed missing from a profiled relation refuses the plan
  (parametrized across field/key/relationship-endpoint), computed and
  opaque-source references are left unvalidated, and a hard guarantee test
  that monkeypatches `connect.open_adapter` to raise if cache validation ever
  tries to open a connection.
- Full `tests/ossie/` + `tests/explore/` sweep: 1013 passed, only the 5
  pre-existing Windows-only environment failures already documented on prior
  PRs in this series (encoding, symlink privilege, path handling, upstream
  schema drift), unrelated to this change.
- Ruff check/format clean, no em-dashes.

## Notes

Stacked on `SCRUM-1238-issue-411` per #412's own dependency on #411 (the
authoring/plan machinery this validates didn't exist before that branch).