### PR TITLE
BigQuery measures a TIMESTAMP column's month gap in dates, and the table keeps its aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,28 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Fixed
 
+- **BigQuery `explore map` profiles a table with a `TIMESTAMP` column again**
+  ([#430]). Temporal continuity asked for a month-grain gap on every non-PII
+  `TIMESTAMP` column as `TIMESTAMP_DIFF(period, prev_period, MONTH)`, and
+  BigQuery's `TIMESTAMP_DIFF` stops at `DAY`, so the statement was refused at
+  job insert. The continuity subqueries ride the same flat `SELECT` as the
+  batch's other aggregates, and the `BadRequest` fallback in `column_aggregates`
+  degrades the whole batch, so one optional fraction took every column's null
+  fraction, distinct count, min and max, key detection and grain with it, and
+  recorded `aggregate profiling failed and was skipped` in `data_quality`. The
+  run still returned `ok`. Present since 1.6.6 shipped the feature ([#206]);
+  `DATETIME` and `DATE` columns were never affected because their diff
+  families accept `MONTH`.
+
+  The month gap on a `TIMESTAMP` column is now
+  `DATE_DIFF(DATE(period), DATE(prev_period), MONTH)`. Both operands are
+  already `TIMESTAMP_TRUNC(..., MONTH)` periods, so their UTC dates are month
+  boundaries and the diff is exact; day and hour keep `TIMESTAMP_DIFF`, and
+  the other two temporal types render as before. Whether the batch should
+  retry without the optional temporal expressions before degrading to
+  metadata-only is left open on the issue: it is a change to the fallback
+  contract, not to the expression that broke it.
+
 - **`maintain` stops refusing an engine that was never given a repo root.**
   `check`, `grain`, and `reconcile` each read the project format without
   guarding the construction, and the shipped dbt format correctly refuses to

--- a/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/bigquery.py
@@ -142,6 +142,13 @@ def _date_trunc_expr(qcol: str, unit: str, data_type: str) -> str:
 
 
 def _date_diff_expr(unit: str, later: str, earlier: str, data_type: str) -> str:
+    # TIMESTAMP_DIFF stops at DAY: BigQuery refuses MONTH (and every coarser
+    # part) for TIMESTAMP arguments, at job insert, so the whole aggregate
+    # statement failed and the table degraded to metadata-only (issue #430).
+    # Both operands here are TIMESTAMP_TRUNC(..., MONTH) periods, so their UTC
+    # dates are month boundaries and DATE_DIFF at MONTH is exact.
+    if unit == "month" and "TIMESTAMP" in data_type.upper():
+        return f"DATE_DIFF(DATE({later}), DATE({earlier}), MONTH)"
     return f"{_diff_family(data_type)}({later}, {earlier}, {unit.upper()})"
 
 

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -3085,6 +3085,42 @@ def test_bigquery_generated_sql_is_select_only(fake_bq_client):
     assert assert_select_only(sql, dialect="bigquery") == sql
 
 
+def test_bigquery_month_gap_on_a_timestamp_column_never_asks_timestamp_diff():
+    # TIMESTAMP_DIFF supports MICROSECOND through DAY only, so a MONTH part on
+    # a TIMESTAMP column is refused at job insert, and because the continuity
+    # subqueries ride the same flat SELECT as every other aggregate, that one
+    # expression degraded the entire table to metadata-only (#430). The
+    # expected form diffs the periods' UTC dates instead; day and hour keep
+    # TIMESTAMP_DIFF, and DATETIME and DATE columns are untouched.
+    from exmergo_dex_core.adapters import bigquery as bq
+    from exmergo_dex_core.adapters.base import ColumnMeta
+    from exmergo_dex_core.guards.sql_guard import assert_select_only
+
+    adapter = bq.BigQueryAdapter.__new__(bq.BigQueryAdapter)
+
+    def build(data_type: str) -> str:
+        col = ColumnMeta(name="t", data_type=data_type, nullable=True, ordinal=1)
+        sql, _plan = bq.BigQueryAdapter._build_aggregate_sql(
+            adapter, "p.d.t", [col], set(), set(), set(), set(), {"t"}
+        )
+        assert assert_select_only(sql, dialect="bigquery") == sql
+        return sql
+
+    ts = build("TIMESTAMP")
+    assert "TIMESTAMP_DIFF(period, prev_period, MONTH)" not in ts
+    assert "DATE_DIFF(DATE(period), DATE(prev_period), MONTH)" in ts
+    assert "TIMESTAMP_DIFF(period, prev_period, DAY)" in ts
+    assert "TIMESTAMP_DIFF(period, prev_period, HOUR)" in ts
+
+    dt = build("DATETIME")
+    assert "DATETIME_DIFF(period, prev_period, MONTH)" in dt
+    assert "DATE_DIFF(DATE(" not in dt
+
+    d = build("DATE")
+    assert "DATE_DIFF(period, prev_period, MONTH)" in d
+    assert "DATE_DIFF(DATE(" not in d
+
+
 def test_select_only_guard_rejects_bigquery_writes_and_scripts():
     # Family 1: BigQuery scripting, DML/DDL, and multi-statement forms are all
     # refused when parsed in the bigquery dialect.


### PR DESCRIPTION
# BigQuery measures a TIMESTAMP column's month gap in dates, and the table keeps its aggregates

Closes #430.

## The defect

On BigQuery, `explore map` requests temporal continuity for every non-PII `TIMESTAMP` column at
the `month` grain, and the adapter rendered it as `TIMESTAMP_DIFF(period, prev_period, MONTH)`.
BigQuery's `TIMESTAMP_DIFF` supports `MICROSECOND` through `DAY` only, so the statement was refused
at job insert with a 400:

```
TIMESTAMP_DIFF does not support the MONTH date part when the argument is TIMESTAMP type
```

The continuity subqueries are spliced into the same flat `SELECT` as the batch's other aggregates,
so the `BadRequest` fallback in `column_aggregates` degraded the **whole batch** to metadata-only.
Every column lost its null fraction, distinct count, min and max, key detection and grain, not only
the temporal fractions, and `data_quality` recorded `aggregate profiling failed and was skipped`.
The run still returned `ok`. A 400 at insert creates no job, so nothing downstream of that note
changes.

Present since 1.6.6 shipped the feature (#206); `temporal_units_for` and `_date_diff_expr` are
identical in 1.9.1 and 1.9.2. `DATETIME` and `DATE` columns were never affected because
`DATETIME_DIFF` and `DATE_DIFF` both accept `MONTH`.

## The fix

`_date_diff_expr` renders the month gap on a `TIMESTAMP` column as
`DATE_DIFF(DATE(period), DATE(prev_period), MONTH)`. Both operands are already
`TIMESTAMP_TRUNC(..., MONTH)` periods, so their UTC dates are month boundaries and the diff is exact.
Day and hour keep `TIMESTAMP_DIFF`; `DATETIME` and `DATE` render byte-identically to before.

## Verification

- New test builds the aggregate statement for one `TIMESTAMP`, one `DATETIME` and one `DATE` column
  and pins the diff family per unit. The `TIMESTAMP` arm fails on `main` (it is the reproducer from
  the issue) and passes here; the other two arms pin that nothing else moved. The existing BigQuery
  temporal test still passes, since day and hour still use `TIMESTAMP_DIFF`.
- The assembled statement still passes `assert_select_only` in the bigquery dialect for all three
  types.
- `uv run pytest` in `packages/dex-core`: `2872 passed, 202 skipped, 23 failed`. The 23 are the same 23 that fail on an untouched `main` checkout on this Windows machine (demo path-separator assertions and `transform/test_dev_target.py`), so none is from this change. The new test fails on `main` with the fix stashed and passes with it.
- `uvx ruff@0.15.19 check .` and `format --check .` clean; the em-dash gate clean.
- `uvx pytest evals`: 6 wrapper tests fail identically on an untouched `main` checkout on this
  Windows machine, so they are unrelated to this change.
- Live, since this path has no `TIMESTAMP` coverage upstream: a BigQuery dry run of `TIMESTAMP_DIFF(period, prev_period, MONTH)` over `TIMESTAMP_TRUNC(..., MONTH)` periods is refused with the issue's exact message, and the same dry run of `DATE_DIFF(DATE(period), DATE(prev_period), MONTH)` validates. On literals, `2025-11-01` to `2026-03-15` at MONTH gives `4`, and the day arm still gives `3` for `02-27` to `03-02`. Both reproducible from `bq query --dry_run` with no table.

## Not in this PR

Retrying the batch without the optional temporal expressions before degrading to metadata-only.
One optional fraction taking every column's core aggregates with it is the part that hurt, but
that is a change to the fallback contract, not to the expression that broke it, and it costs a
second statement and a second cost-gate pass. The issue leaves it open for a maintainer's call.

Related: #315, since the same adapter path has no live `TIMESTAMP` coverage, which is how this
shipped green.
