### PR TITLE
Release notes get a Downstream-visible changes heading, keyed on one label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+# Release notes are GitHub's generated "What's Changed" list: one line per merged
+# pull request, in merge order. This file adds one heading to that list so a
+# consumer can tell, before bumping, which lines change something they store,
+# pin, or compare. Everything without the label renders exactly as today.
+#
+# When to apply `downstream-visible`: a consumer who stores or compares this
+# command's output would observe a difference. That is broader than "breaking":
+# it covers a key that moves (#250), a bug fix that changes what a profile
+# contains (#431 returned full aggregates to every BigQuery table with a
+# TIMESTAMP column, against baselines that held the empty shape), and a new
+# finding class that fires on the first run after a bump (#421). It does not
+# cover a docstring, a refactor, or a fix whose only observable is the absence
+# of an error.
+changelog:
+  categories:
+    - title: Downstream-visible changes
+      labels:
+        - downstream-visible
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
## What this changes

Adds `.github/release.yml` so the release notes GitHub already generates carry one extra heading, **Downstream-visible changes**, populated by pull requests labelled `downstream-visible`. Every other pull request renders under **Other changes** exactly as it does today. No code, no CHANGELOG entry, no behaviour: GitHub reads this file when a release is drafted.

## Why

The release notes are the one place a consumer reads before bumping, and today a change that moves a stored shape is indistinguishable there from a docstring fix. `v1.10.0` is the concrete case, with both shapes three lines apart:

- #250 says **Breaking** in its title and moves `data["estimated_bytes"]` to `data["offer"]["estimated_bytes"]`. A consumer's pinned test goes red on bump day, which is the good outcome; the title is what made it findable.
- #431 (ours) is a seven-line fix in the BigQuery adapter with no interface change and a title that reads as a fix. It returns full aggregates to every BigQuery table with a `TIMESTAMP` column, all of which had been metadata-only since 1.6.6. On our estate that is 28 columns of a billing export regaining `null_fraction`, distinct counts, min and max, key detection and grain in one night, against a drift baseline that holds the empty shape. Nothing a consumer pins goes red; the next morning's drift digest is what changes. We found this by reading the diff, and only because we had written the fix.
- #421 is a third shape: three new grain finding codes that need no baseline and fire on the first run after a bump. Not a rename, not a fix, and equally invisible in the list.

A heading does not stop any of that. It lets a consumer read the notes and know which pins to expect red, or which baseline to re-pin the same night.

## The criterion for the label, in one sentence

Apply `downstream-visible` when a consumer who stores or compares this command's output would observe a difference. That covers the three shapes above and excludes a docstring, a refactor, or a fix whose only observable is the absence of an error. The comment at the top of the file carries the same sentence, so the rule travels with the mechanism.

## What this asks of maintainers

One label, `downstream-visible`, created once in the repository's label set (a pull request cannot create labels), and the habit of applying it. The template enforces nothing; a release cut with no labelled pull requests renders as today.

## Related issues

None here. Tracked on our side as catincloud-labs/dagster-dex#76, where the two cases were recorded when they happened.

## Checklist

- [x] Tests pass (`uv run pytest` in `packages/dex-core`): not run, no Python touched; the file is read by GitHub, not by the engine
- [x] Eval scoring-core tests pass (`uvx pytest evals`): same
- [x] If a safety path is touched, the spine still holds: no safety path touched
- [ ] `CHANGELOG.md` updated under `[Unreleased]`: deliberately not, since the changelog is keyed by engine version and this changes no engine behaviour; happy to add a line if you prefer it recorded there
- [x] Prose is em-dash free
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures
