### PR TITLE
Make Ossie a Semantic Source. Add testing fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,61 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ### Added
 
+- **Native Apache Ossie is constructed as a semantic source rather than through
+  the transformation-project factory, and can no longer be used as a project at
+  all** ([#413]). Ossie was already absent from the shipped project registry and
+  `project.format: ossie` was already refused, but every consumer except the
+  explore route still built the reader through `build_project()`, which enforces
+  `ExploreProject`. That is why the reader carried a `name` attribute and a
+  `definitions()` alias: two vestigial members whose only job was getting past a
+  check meant for formats that own a model graph.
+
+  A new `exmergo_dex_core.semantic_source` module is the seam instead:
+  `SemanticSourceContext` (repository, connector, and the vendor's own
+  coordinates, with no transformation-project directory) plus two
+  runtime-checkable capabilities, `SemanticCatalogSource` for the read catalog
+  and `SemanticSnapshotSource` for the drift fingerprint. `DexEngine.
+  semantic_catalog_source()` is the canonical accessor and
+  `semantic_catalog_format()` forwards to it. `maintain` now asks for the
+  snapshot *capability* rather than the project tier, so an Ossie-only
+  repository keeps its semantic baseline, and the reader satisfies none of
+  `ExploreProject`, `MaintainProject`, `EditableProject` or `PlacingProject`,
+  which is asserted rather than documented. `SEMANTIC_PROJECT_FORMATS` is
+  renamed `SEMANTIC_SOURCE_FACTORIES`; configuration keys, CLI commands,
+  envelope fields, and the stored snapshot schema are unchanged.
+
+- **A reviewed Ossie fixture corpus and a compatibility matrix, gated on the
+  pinned schema** ([#413]). `packages/dex-core/tests/ossie/fixtures/` holds
+  native documents a person can read plus a case manifest saying what each one
+  means: expected diagnostic rules and severities, whether each rule comes from
+  the pinned schema, upstream's integrity judgment or a dex restriction, and the
+  expected physical links, key tuples and relationship pairs. The expectations
+  are authored rather than captured, because a golden recorded from a run
+  asserts only that the implementation still does what it did.
+
+  `references/ossie-compatibility.md` states the same ground for a reader: what
+  is accepted, what is checked and at what severity, which expression dialect
+  dex reads, what links to a warehouse column and what deliberately does not,
+  and what dex does not claim (no converter interoperability, no execution
+  assurance, and a missing SQL check disclosed rather than passed). It names the
+  pin and the known deltas from upstream's current schema, including the
+  post-pin `THOUGHTSPOT` dialect, which is refused under this pin. An offline
+  test asserts that the loader constant, `PROVENANCE.md`, the corpus manifest
+  and the matrix carry the same hash, and that every claim in the matrix names a
+  case that exists.
+
+- **Shipped conformance contracts for a semantic source**
+  (`exmergo_dex_core.semantic_source_conformance`, under the existing
+  `[semantic-conformance]` extra) ([#413]). Four contracts covering
+  construction, declarations, the drift fingerprint, and the read catalog. The
+  assertions are extracted from the project contracts rather than copied, and
+  those contracts now compose them, so a project format and a semantic source
+  are held to one implementation of each shared rule. The runtime
+  `SemanticBackendContract` also gained descriptor-to-payload agreement, gap
+  declarations that name real fields and are not contradicted by the payload
+  they ship in, and shape checks on the declared-key and declared-relationship
+  channels.
+
 - **Native Ossie authoring plans are validated against cached exploration
   evidence before they are stored, with no warehouse connection opened**
   ([#412]). `semantic ossie define|update|plan` now checks each dataset's
@@ -49,13 +104,13 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   those protocols identify transformation projects, and the semantic-layer
   architecture requires Ossie to remain independent of that axis.
 
-- **Native Apache Ossie semantic models are readable, as a project format rather
-  than a set of vendor branches** ([#405], [#406], [#407]). `semantic.vendor:
-  ossie` beside a dbt project, or `project.format: ossie` for a repository with
-  no dbt project at all, reads native `.ossie.yaml` / `.ossie.yml` /
+- **Native Apache Ossie semantic models are readable, through the semantic axis
+  rather than a set of vendor branches** ([#405], [#406], [#407]).
+  `semantic.vendor: ossie` reads native `.ossie.yaml` / `.ossie.yml` /
   `.ossie.json` documents into the same catalog `explore semantic list` has
-  always returned. Neither arrangement involves MetricFlow, and neither format
-  imports the other's reader.
+  always returned, beside a dbt project or in a repository that has none.
+  Neither arrangement involves MetricFlow, and neither reader imports the
+  other's.
 
   Ossie is [entering ASF maturity](https://github.com/apache/ossie) and every one
   of its upstream converters converts *into* it from a vendor format, so this is
@@ -213,6 +268,17 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   succeeded.
 
 ### Fixed
+
+- **`transform apply` refused a native semantic plan on an install carrying only
+  `[ossie]`** ([#413]). The command router asserted the dialect engine before
+  dispatching every authoring verb, and `transform.commands` imported it
+  eagerly, so an install with a semantic reader and no connector extra could
+  author a plan it could never apply, which is the one command that install
+  exists to run. The two dialect-engine imports in `transform.commands` are now
+  reached at the point of use, and the router reads the stored plan's edit
+  target and asserts the dialect engine only for the plans that author SQL. It
+  fails toward asserting it, so an apply that cannot resolve a plan still
+  refuses with the message it always did.
 
 - **A composite relationship's Mermaid label named only the child-side columns,
   silently dropping the parent side.** ([#408]) `explore diagram`'s edge label

--- a/packages/dex-core/README.md
+++ b/packages/dex-core/README.md
@@ -31,16 +31,23 @@ exmergo-dex-core[clickhouse]
 exmergo-dex-core[all]          # every optional capability at once
 ```
 
-Two capabilities sit behind their own extras rather than a connector's:
+Some capabilities sit behind their own extras rather than a connector's:
 `[semantic]` and `[semantic-api]` for the local and hosted semantic-layer query
-backends, and `[cluster]` for `explore cluster`. `[all]` covers all of these too.
+backends, `[ossie]` for reading native Apache Ossie semantic documents out of the
+repository, and `[cluster]` for `explore cluster`. `[all]` covers all of these
+too.
 
-`[semantic-api]` is the one extra that stands completely alone: dbt Cloud owns the
-warehouse connection and executes server-side, so a deployment that only queries a
-hosted semantic layer needs no connector, no dbt-core, and no SQL parser. Every
-other command validates SQL before running it, which is why the connector extras
-carry the dialect engine; run one without a connector installed and dex refuses
-with the install to use rather than guessing.
+Two of them stand alone, and for different reasons. `[semantic-api]` needs no
+connector, no dbt-core, and no SQL parser, because dbt Cloud owns the warehouse
+connection and executes server-side. `[ossie]` needs none of those either,
+because a native semantic layer is files in the repository: reading, validating,
+snapshotting, and authoring them all happen without a warehouse. Checking that an
+authored SQL expression parses is the one part that wants the dialect engine, and
+without it that check names itself as skipped rather than passing silently.
+
+Every command that generates or runs SQL validates it first, which is why the
+connector extras carry the dialect engine; run one without a connector installed
+and dex refuses with the install to use rather than guessing.
 
 ## First run, with nothing to point it at
 

--- a/packages/dex-core/pyproject.toml
+++ b/packages/dex-core/pyproject.toml
@@ -121,9 +121,9 @@ semantic = ["metricflow>=0.211,<0.212", "exmergo-dex-core[sql]"]
 # dbt Cloud owns the warehouse connection and executes server-side, so a
 # pure-remote user (no local dbt project) installs only this.
 semantic-api = ["httpx>=0.27"]
-# Native Apache Ossie documents (`semantic.vendor: ossie`, `project.format:
-# ossie`). One dependency: a Draft 2020-12 JSON Schema validator, used against
-# the Ossie schema dex vendors and pins by content hash. Deliberately does NOT
+# Native Apache Ossie documents (`semantic.vendor: ossie`). One dependency: a
+# Draft 2020-12 JSON Schema validator, used against the Ossie schema dex vendors
+# and pins by content hash. Deliberately does NOT
 # self-reference [sql]: structure and integrity validation are the layers that
 # decide whether a document is readable at all, and they are pure. Expression
 # syntax checking is the third layer and rides on [sql], which every connector
@@ -164,17 +164,20 @@ storage-conformance = ["pytest>=8", "exmergo-dex-core[sql]"]
 # holds it true, because the cheapest way for this to acquire a heavier floor is for
 # an assertion to start building something that parses SQL.
 project-conformance = ["pytest>=8"]
-# The semantic-backend conformance contract
-# (`exmergo_dex_core.explore.semantic.conformance`), for anyone implementing a
-# semantic-layer backend outside this distribution. Named on the same rule as the
-# two above: an install line answers "conformance to what?" alone.
+# The two semantic conformance contracts
+# (`exmergo_dex_core.explore.semantic.conformance` for a runtime backend and
+# `exmergo_dex_core.semantic_source_conformance` for the source that supplies the
+# layer), for anyone implementing either outside this distribution. Named on the
+# same rule as the two above: an install line answers "conformance to what?"
+# alone, and both answer "the semantic layer", so they share one extra rather
+# than splitting a hair an install line cannot express.
 #
 # Pytest and nothing else, and that floor is the point rather than a coincidence.
-# The contract reads a catalog and asserts on its shape, so it reaches neither the
-# dialect engine nor a warehouse client, and it does not need either semantic
-# extra: the reference layer is data in the module, so an implementer runs the
-# suite against their own backend without installing MetricFlow or httpx to do it.
-# A packaging test holds that true.
+# They read a catalog, a declaration set and a fingerprint and assert on their
+# shape, so they reach neither the dialect engine nor a warehouse client, and
+# they need neither semantic extra: the reference layer is data in the module, so
+# an implementer runs the suite against their own backend without installing
+# MetricFlow or httpx to do it. Packaging tests hold that true for both.
 semantic-conformance = ["pytest>=8"]
 # One command for users who want every optional capability at once: every
 # connector, both semantic-layer backends, and clustering. Self-references the

--- a/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/adapters/conformance.py
@@ -53,6 +53,15 @@ the tiers for the same reason it is separate in storage, and a format that passe
 the behavioral suite can still be unreachable from configuration, so "the suite is
 green" should mean correct *and* constructable.
 
+**Some assertions here are shared with the semantic axis and live there.** A
+project format and a semantic source make the same promises about the layer they
+hold, through differently named methods, so the declaration, fingerprint and
+catalog assertions live once in
+:mod:`exmergo_dex_core.semantic_source_conformance` and the contracts below
+compose them. Nothing changes for an implementer: the hooks keep their names and
+the tests keep running. It is worth knowing where to read an assertion's own
+reasoning, and worth knowing that changing one changes it for both.
+
 This module imports pytest, so it is deliberately not imported by
 :mod:`exmergo_dex_core.adapters`: a bare ``import exmergo_dex_core`` must not
 require a test framework. Install the ``[project-conformance]`` extra to get what
@@ -69,6 +78,11 @@ import pytest
 
 from ..dbt_project import EditOp, ProjectDefinitions
 from ..maintain.snapshot import Snapshot
+from ..semantic_source_conformance import (
+    SemanticCatalogSourceContract,
+    SemanticDeclarationContract,
+    SemanticFingerprintContract,
+)
 from .project import ExploreProject, ProjectContext, tier_of
 
 if TYPE_CHECKING:
@@ -223,7 +237,7 @@ class ExploreProjectContract:
         assert project.definitions().notes
 
 
-class DeclaringProjectContract:
+class DeclaringProjectContract(SemanticDeclarationContract):
     """Opt-in: the declarations dex reads a project *for* actually arrive.
 
     Mix in beside the contract for your tier::
@@ -236,7 +250,41 @@ class DeclaringProjectContract:
     Separate from the tier contract because the two answer different questions. The
     tier contract asks whether dex can safely call your format at all; this asks
     whether reading it was worth doing.
+
+    The assertions live in
+    :class:`~..semantic_source_conformance.SemanticDeclarationContract`, because
+    a semantic source contributes the same declarations through a differently
+    named method and the two would otherwise be one behaviour asserted twice.
+    The hooks stay spelled the way they always were: a project format implements
+    ``a_project_declaring_*`` and reads through ``definitions()``, which is its
+    tier-1 contract and has been public since v1.
     """
+
+    def make_semantic_source(self):
+        """The tier contract's own fixture: a project with nothing declared."""
+
+        return self.make_project()
+
+    def declarations_of(self, source: Any) -> ProjectDefinitions:
+        """Tier 1's own method, which is how a project states what it declares."""
+
+        return source.definitions()
+
+    def a_source_declaring_a_unique_key(self) -> tuple[ExploreProject, str, str]:
+        return self.a_project_declaring_a_unique_key()
+
+    def a_source_declaring_a_join(self) -> tuple[ExploreProject, str, str, str, str]:
+        return self.a_project_declaring_a_join()
+
+    def a_source_declaring_a_composite_key(
+        self,
+    ) -> tuple[ExploreProject, str, tuple[str, ...]] | None:
+        return self.a_project_declaring_a_composite_key()
+
+    def a_source_declaring_a_join_with_differently_named_sides(
+        self,
+    ) -> tuple[ExploreProject, str, str, str, str] | None:
+        return self.a_project_declaring_a_join_with_differently_named_sides()
 
     def a_project_declaring_a_unique_key(self) -> tuple[ExploreProject, str, str]:
         """A project declaring one single-column unique key.
@@ -308,139 +356,8 @@ class DeclaringProjectContract:
 
         return None
 
-    def test_a_declared_unique_key_reaches_the_engine(self) -> None:
-        project, model, column = self.a_project_declaring_a_unique_key()
 
-        declared = project.definitions().declared_keys
-        matching = [k for k in declared if k.model == model and k.column == column]
-
-        assert matching, f"expected a declared key on {model}.{column}, got {declared}"
-        assert matching[0].unique, (
-            "a key declared unique must arrive with unique=True; a grain that "
-            "arrives without it is read as an ordinary column"
-        )
-
-    def test_a_declared_join_carries_both_sides(self) -> None:
-        """Both ends, because a half-read join is worse than an unread one.
-
-        A join naming the wrong side sends the relationship detector looking for a
-        key that is not there, and the finding it produces reads like a data
-        problem rather than a misread declaration.
-        """
-
-        project, model, column, to_model, to_column = self.a_project_declaring_a_join()
-
-        declared = project.definitions().foreign_keys
-        matching = [
-            fk
-            for fk in declared
-            if fk.model == model
-            and fk.column == column
-            and fk.to_model == to_model
-            and fk.to_column == to_column
-        ]
-
-        assert matching, (
-            f"expected a declared join {model}.{column} -> {to_model}.{to_column}, "
-            f"got {declared}"
-        )
-
-    def test_a_composite_grain_keeps_every_column_and_their_order(self) -> None:
-        """A truncated composite key is silent, which is what makes it expensive.
-
-        It does not read as a missing declaration. It reads as a declared grain
-        that is simply narrower than the truth, so every check downstream runs
-        against a grain the author never claimed and the findings look like data
-        problems rather than a misread declaration.
-        """
-
-        supplied = self.a_project_declaring_a_composite_key()
-        if supplied is None:
-            pytest.skip(
-                "a_project_declaring_a_composite_key() returned None: this format "
-                "declares it cannot express a multi-column grain, so "
-                "declared_composite_keys goes unchecked"
-            )
-        project, model, columns = supplied
-
-        declared = project.definitions().declared_composite_keys
-        matching = [k for k in declared if k.model == model]
-
-        assert matching, (
-            f"expected a composite key on {model}, got {declared}. A multi-column "
-            "grain belongs in declared_composite_keys, not as several entries in "
-            "declared_keys: those say each column is unique on its own, which is a "
-            "different and much stronger claim"
-        )
-        assert tuple(matching[0].columns) == tuple(columns), (
-            f"expected columns {tuple(columns)} in order, got "
-            f"{tuple(matching[0].columns)}"
-        )
-        assert len(matching) == 1, (
-            f"expected one composite key on {model}, got {len(matching)}: "
-            f"{matching}. One declaration is one grain, and splitting it across "
-            "entries makes the grain axis verify combinations the project never "
-            "declared"
-        )
-        leaked = sorted(
-            key.column
-            for key in project.definitions().declared_keys
-            if key.model == model
-            and key.unique
-            and key.column.lower() in {c.lower() for c in columns}
-        )
-        assert not leaked, (
-            f"{model} reports {leaked} as unique on their own while also declaring "
-            f"the composite grain {tuple(columns)}. The fixture's grain needs every "
-            "one of those columns, so no single one of them is unique, and the "
-            "stronger claim is the one that gets acted on: reconcile reads it as a "
-            "grain the project already asserts and proposes edits against it"
-        )
-
-    def test_a_join_keeps_its_two_sides_apart_when_they_are_named_differently(
-        self,
-    ) -> None:
-        """The case :meth:`test_a_declared_join_carries_both_sides` cannot reach.
-
-        An implementation that mirrors the source column onto the target passes
-        that one whenever the fixture's two ends share a name, and this is the
-        assertion that separates them.
-        """
-
-        supplied = self.a_project_declaring_a_join_with_differently_named_sides()
-        if supplied is None:
-            pytest.skip(
-                "a_project_declaring_a_join_with_differently_named_sides() returned "
-                "None: a join whose ends are spelled differently goes unchecked, so "
-                "an implementation that mirrors one side onto the other would pass "
-                "this suite"
-            )
-        project, model, column, to_model, to_column = supplied
-
-        assert column != to_column, (
-            "this fixture has to name its two sides differently, or it cannot "
-            "detect the mirroring it exists to detect"
-        )
-
-        declared = project.definitions().foreign_keys
-        matching = [
-            fk
-            for fk in declared
-            if fk.model == model and fk.column == column and fk.to_model == to_model
-        ]
-
-        assert matching, (
-            f"expected a declared join from {model}.{column} to {to_model}, "
-            f"got {declared}"
-        )
-        assert matching[0].to_column == to_column, (
-            f"the join's target column arrived as {matching[0].to_column!r}, "
-            f"expected {to_column!r}. Reading it as {column!r} is the mirroring "
-            "failure: the far side is a column the target may not even have"
-        )
-
-
-class SemanticProjectContract:
+class SemanticProjectContract(SemanticFingerprintContract):
     """Opt-in, tier 2: a populated semantic layer keeps the column behind each field.
 
     Mix in beside :class:`MaintainProjectContract` when your format declares
@@ -476,7 +393,23 @@ class SemanticProjectContract:
     reached the tier the attribute belongs to. The tier is asserted against the
     project this contract is actually given rather than against ``make_project()``,
     so the mixin keeps depending only on the one fixture it declares.
+
+    The content assertions live in
+    :class:`~..semantic_source_conformance.SemanticFingerprintContract`: a
+    semantic source produces the identical fingerprint through the identical
+    method, and one behaviour asserted in two places is one behaviour that can
+    disagree with itself. The hook keeps its published spelling here.
     """
+
+    def make_semantic_source(self):
+        """The tier contract's own fixture: a project with nothing declared."""
+
+        return self.make_project()
+
+    def a_source_declaring_a_semantic_model(
+        self,
+    ) -> tuple[Any, Mapping[str, str | None], Mapping[str, str | None]] | Any:
+        return self.a_project_declaring_a_semantic_model()
 
     def test_declaring_semantics_presupposes_the_maintain_tier(self) -> None:
         project, _, _, _ = self.a_project_declaring_a_semantic_model()
@@ -512,59 +445,8 @@ class SemanticProjectContract:
             "measures), mapping each field to the warehouse column behind it"
         )
 
-    def test_a_semantic_field_carries_the_column_behind_it(self) -> None:
-        project, name, dimensions, measures = (
-            self.a_project_declaring_a_semantic_model()
-        )
 
-        layer = project.semantic_layer()
-        matching = [m for m in layer.semantic_models if m.name == name]
-
-        assert matching, (
-            f"expected a semantic model named {name!r}, got "
-            f"{[m.name for m in layer.semantic_models]}"
-        )
-        model = matching[0]
-        assert dict(model.dimensions) == dict(dimensions), (
-            "the dimension to column mapping did not survive. A layer whose columns "
-            "are all None still validates and still compares clean, so the drift "
-            "check simply never runs"
-        )
-        assert dict(model.measures) == dict(measures), (
-            "the measure to column mapping did not survive; see above"
-        )
-
-    def test_a_categorical_dimension_maps_only_to_a_real_column(self) -> None:
-        """``categorical_dimensions`` takes ``str``, not ``str | None``.
-
-        So a field that is categorical *and* unresolved cannot be represented
-        there, and the two properties have to stay independent: being categorical
-        says how the field behaves, having a column says whether it can be checked.
-        A format that collapses them either drops a categorical field that happens
-        to lack a column, or supplies an invented column to keep it. Both are worse
-        than leaving it out of this one mapping, which is what the typing asks for.
-        """
-
-        project, name, _, _ = self.a_project_declaring_a_semantic_model()
-
-        model = next(
-            m for m in project.semantic_layer().semantic_models if m.name == name
-        )
-
-        columns = model.categorical_dimensions.values()
-        assert all(isinstance(c, str) and c for c in columns), (
-            "categorical_dimensions holds a null or empty column: its values are "
-            f"required strings, got {model.categorical_dimensions!r}. Leave an "
-            "unresolved categorical field out of this mapping rather than "
-            "inventing a column to keep it in"
-        )
-        assert set(model.categorical_dimensions) <= set(model.dimensions), (
-            "categorical_dimensions names a field that is not a dimension: "
-            f"{sorted(set(model.categorical_dimensions) - set(model.dimensions))}"
-        )
-
-
-class SemanticCatalogContract:
+class SemanticCatalogContract(SemanticCatalogSourceContract):
     """Opt-in, beside tier 2: the read catalog keeps what the fingerprint drops.
 
     Mix in when your format implements
@@ -594,6 +476,12 @@ class SemanticCatalogContract:
     picks is iteration order rather than a fact. Both of dex's own backends got
     this wrong, in opposite directions, on one identical layer, which is why it is
     asserted here rather than left to a reviewer to notice.
+
+    The catalog assertions themselves live in
+    :class:`~..semantic_source_conformance.SemanticCatalogSourceContract`, since
+    a semantic source answers the same read view and the assertions are about the
+    view rather than about who holds it. What stays here is the one thing that is
+    genuinely about a project: that the format declares the optional channel.
     """
 
     def make_project(self):  # pragma: no cover - provided by the subclass
@@ -602,6 +490,12 @@ class SemanticCatalogContract:
     def a_project_declaring_a_semantic_model(self):
         # pragma: no cover - provided by the subclass
         raise NotImplementedError
+
+    def make_semantic_source(self):
+        return self.make_project()
+
+    def a_source_declaring_a_semantic_model(self):
+        return self.a_project_declaring_a_semantic_model()
 
     def test_the_format_declares_the_catalog_channel(self) -> None:
         from .project import SemanticCatalogProject
@@ -613,146 +507,6 @@ class SemanticCatalogContract:
             "the member is refused by name at the command rather than here. Drop "
             "this mixin if the format reads no semantic layer"
         )
-
-    def test_the_catalog_keeps_what_the_fingerprint_reduces_away(self) -> None:
-        project, name, _, _ = self.a_project_declaring_a_semantic_model()
-        catalog = project.semantic_catalog()
-
-        assert [m.name for m in catalog.semantic_models], (
-            "the catalog carries no semantic models. The layer's organizing unit "
-            "is the semantic model, and a caller with none of them holds one "
-            "undifferentiated list of dimension names"
-        )
-        assert any(m.name == name for m in catalog.semantic_models), (
-            f"expected a semantic model named {name!r}, got "
-            f"{[m.name for m in catalog.semantic_models]}"
-        )
-        assert all(d.type for d in catalog.dimensions), (
-            "a dimension arrived with no type. Whether a dimension is time or "
-            "categorical decides how it can be grouped by, so a caller that has "
-            "to guess cannot build a valid query from this catalog"
-        )
-        assert all(m.agg for m in catalog.measures), (
-            "a measure arrived with no aggregation. A measure without its "
-            "aggregation cannot say what the number counts, which is the question "
-            "the catalog exists to answer"
-        )
-
-    def test_an_entity_carries_a_declaration_per_semantic_model(self) -> None:
-        project, _, _, _ = self.a_project_declaring_a_semantic_model()
-        catalog = project.semantic_catalog()
-
-        for entity in catalog.entities:
-            assert entity.roles, (
-                f"entity {entity.name!r} carries no declarations. Its `type` is "
-                "then a single value with nothing behind it, and a value chosen "
-                "per entity rather than per declaration is iteration order"
-            )
-            assert all(r.semantic_model for r in entity.roles), (
-                f"a declaration of entity {entity.name!r} names no semantic "
-                "model, so a caller cannot tell which model it is primary in"
-            )
-            declared = {r.type for r in entity.roles}
-            expected = "primary" if "primary" in declared else next(iter(declared))
-            assert entity.type == expected, (
-                f"entity {entity.name!r} reports type {entity.type!r} while its "
-                f"declarations say {sorted(declared)}. The single value is derived: "
-                "primary wherever any declaration is primary"
-            )
-
-    def test_the_catalog_resolves_a_semantic_model_to_its_relation(self) -> None:
-        """A semantic model that names no relation leaves the layer disconnected.
-
-        The catalog and the physical catalog are two views of one warehouse, and
-        the relation on a semantic model is the whole join between them: it is what
-        answers "which table is behind this metric", what lets ``explore map`` say
-        an object is exposed, and what an entity's declared join is drawn between.
-        A format that reads a layer but resolves none of it to a relation returns a
-        catalog that cannot be connected to anything the rest of ``explore``
-        describes.
-
-        Declining is still possible and is not this: a backend that structurally
-        cannot know the relation declares that gap, which is a different statement
-        from a format that could and did not.
-        """
-
-        project, name, _, _ = self.a_project_declaring_a_semantic_model()
-        catalog = project.semantic_catalog()
-
-        model = next(m for m in catalog.semantic_models if m.name == name)
-        assert model.relation, (
-            f"semantic model {name!r} resolves to no physical relation, so nothing "
-            "connects this layer to the objects explore profiles and maps"
-        )
-
-    def test_an_element_carries_its_column_and_never_invents_one(self) -> None:
-        """The same rule the fingerprint follows, on the read catalog.
-
-        Two failures, opposite in direction and both live. A catalog whose columns
-        are all absent cannot reach a physical column at all, which is what the PII
-        gate needs to adjudicate a dimension from evidence rather than from the
-        shape of its name. A catalog that invents a column out of an expression is
-        worse: the gate then screens a column that is not the one behind the
-        element and reports the verdict as evidence-backed.
-
-        The fixture's own mapping is the oracle, including its ``None`` entries, so
-        a format is held to what it said its layer contains rather than to a shape.
-        """
-
-        project, name, dimensions, measures = (
-            self.a_project_declaring_a_semantic_model()
-        )
-        catalog = project.semantic_catalog()
-
-        for element, expected in (
-            (
-                {
-                    d.definition: d.column
-                    for d in catalog.dimensions
-                    if d.semantic_model == name
-                },
-                dimensions,
-            ),
-            (
-                {
-                    m.name: m.column
-                    for m in catalog.measures
-                    if m.semantic_model == name
-                },
-                measures,
-            ),
-        ):
-            for field, column in expected.items():
-                assert field in element, (
-                    f"the catalog carries no entry for {field!r} on {name!r}; the "
-                    "fixture declares it, so the read dropped it"
-                )
-                assert element[field] == column, (
-                    f"{field!r} on {name!r} carries column {element[field]!r} where "
-                    f"the fixture says {column!r}. None is the honest answer for an "
-                    "expression: a column guessed out of one makes the PII gate "
-                    "screen the wrong column and call it evidence"
-                )
-
-    def test_a_dimension_row_names_the_token_a_query_groups_by(self) -> None:
-        """The catalog's ``name`` is a query token, not a display name.
-
-        A caller builds a group-by out of it, so a format that returns the bare
-        declared name where the layer requires a qualified path hands back a
-        catalog whose every dimension fails at query time.
-        """
-
-        project, _, _, _ = self.a_project_declaring_a_semantic_model()
-        catalog = project.semantic_catalog()
-
-        listed = {d.name for d in catalog.dimensions}
-        for metric in catalog.metrics:
-            missing = sorted(set(metric.dimensions) - listed - {"metric_time"})
-            assert not missing, (
-                f"metric {metric.name!r} says it can be grouped by {missing}, and "
-                "no dimension row carries those names. The two must be the same "
-                "vocabulary or neither can be acted on"
-            )
 
 
 class MaintainProjectContract(ExploreProjectContract):

--- a/packages/dex-core/src/exmergo_dex_core/cli.py
+++ b/packages/dex-core/src/exmergo_dex_core/cli.py
@@ -23,10 +23,11 @@ from __future__ import annotations
 import argparse
 import contextlib
 import sys
+from typing import Any
 
 from . import command_args
 from . import envelope as env
-from .config import SEMANTIC_PROJECT_FORMATS
+from .config import SEMANTIC_SOURCE_FACTORIES
 from .engine import DexEngine
 from .guards.cost_guard import ConfirmationRequiredError, CostGuardError
 from .guards.dialect import DialectDependencyError
@@ -73,7 +74,7 @@ COMMAND_SURFACE: dict[str, list[str]] = {
     # `define`/`update`/`plan` author the dbt semantic layer; each vendor whose
     # semantic layer is its own project format gets a subcommand of its own name
     # for authoring that layer's native documents.
-    "semantic": ["define", "update", "plan", *SEMANTIC_PROJECT_FORMATS],
+    "semantic": ["define", "update", "plan", *SEMANTIC_SOURCE_FACTORIES],
     # maintain: keep the dbt project correct as the world drifts. `snapshot`
     # captures the known-good baseline; `check` sweeps every axis against it;
     # `schema`/`volume`/`grain`/`semantic` are the per-axis deep detectors;
@@ -520,7 +521,7 @@ def _build_parser() -> argparse.ArgumentParser:
                     # away: never by going unmentioned.
                     sp.add_argument("--definitions-file", default=None)
                     sp.add_argument("--no-parse", action="store_true", default=False)
-                if group == "semantic" and name in SEMANTIC_PROJECT_FORMATS:
+                if group == "semantic" and name in SEMANTIC_SOURCE_FACTORIES:
                     # Whole documents in, so no `--definitions-file`: a native
                     # document is authored as a unit, and the mode the dbt
                     # routes carry in their subcommand name is an argument here.
@@ -693,10 +694,23 @@ def _run(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
     # vendor's extra. Parsing a SQL expression inside a document is optional and
     # names its own skip when the dialect engine is absent, which is a weaker
     # floor than the dbt authoring routes below can accept.
-    if args.group == "semantic" and args.subcommand in SEMANTIC_PROJECT_FORMATS:
+    if args.group == "semantic" and args.subcommand in SEMANTIC_SOURCE_FACTORIES:
         from .transform.native_semantic import cmd_semantic_ossie
 
         return cmd_semantic_ossie(args, engine)
+
+    # `transform apply` writes bytes a plan already validated, so what it needs
+    # depends on the plan rather than on the verb. A semantic-document plan
+    # authors no SQL and reaches no dialect engine; gating it on sqlglot anyway
+    # would let an install that carries only a semantic reader author a plan it
+    # could never apply, which is the one command that install exists to run.
+    # The stored plan says which it is, so ask it and gate only what needs it.
+    if args.group == "transform" and args.subcommand == "apply":
+        if _apply_authors_sql(args, engine):
+            ensure_dialect_available()
+        from .transform.commands import cmd_apply
+
+        return cmd_apply(args, engine)
 
     handler = authoring.get((args.group, args.subcommand))
     if handler is not None:
@@ -707,6 +721,28 @@ def _run(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
 
     # Everything else is scaffolded against the contract but not yet built.
     return env.not_implemented(command_args.command_name(args))
+
+
+def _apply_authors_sql(args: argparse.Namespace, engine: Any) -> bool:
+    """Whether the plan this apply would write reaches the dialect engine.
+
+    Fails toward gating. Every reason this cannot answer (no store, no plan, an
+    unreadable one) is a reason the apply is about to refuse anyway, and it
+    should refuse with the message it always did rather than with a new one from
+    a route that was only trying to decide whether to check a dependency.
+    """
+
+    try:
+        store = engine.require_full_store("applying a plan")
+        plan_id = getattr(args, "argument", None)
+        if not plan_id:
+            latest = store.latest_plan(None)
+            if latest is None:
+                return True
+            plan_id = latest.plan_id
+        return store.load_plan(plan_id).edit_target != "semantic"
+    except Exception:
+        return True
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/packages/dex-core/src/exmergo_dex_core/config.py
+++ b/packages/dex-core/src/exmergo_dex_core/config.py
@@ -505,19 +505,25 @@ SEMANTIC_DEPLOYMENTS: dict[str, tuple[str, ...]] = {
     "ossie": ("local",),
 }
 
-#: The project format that answers a vendor's semantic catalog, where the vendor
-#: is not the project itself. A table rather than a branch, and this is the
-#: mechanism that lets `semantic.vendor: ossie` sit beside `project.format: dbt`
-#: without any command learning a vendor name: the engine builds the named format
-#: and injects it, and the backend reads a catalog through the same seam it
-#: always did. `dbt` is absent because the configured project format already
-#: answers for it.
+#: The factory that builds a vendor's own semantic source, for the vendors whose
+#: layer is not the transformation project. A table rather than a branch, and
+#: this is the mechanism that lets `semantic.vendor: ossie` sit beside
+#: `project.format: dbt` without any command learning a vendor name: the engine
+#: builds the named source and injects it, and every reader downstream asks for a
+#: catalog through the same seam it always did. `dbt` is absent because the
+#: configured project already answers for it.
 #:
-#: A vendor listed here reads its format's coordinates from the `SemanticConfig`
-#: field named after the vendor (`semantic.ossie` for `ossie`), which is passed
-#: through to the format as its options verbatim. That convention is what keeps
-#: the engine from growing a per-vendor coordinate reader.
-SEMANTIC_PROJECT_FORMATS: dict[str, str] = {
+#: The value is a dotted `module:callable` path resolved through
+#: :mod:`.semantic_source`, which checks that what comes back can answer a
+#: catalog. It deliberately does not go through the project resolver: a semantic
+#: source owns no model graph and no write surface, so holding it to the project
+#: tiers would make it claim capabilities it does not have.
+#:
+#: A vendor listed here reads its coordinates from the `SemanticConfig` field
+#: named after the vendor (`semantic.ossie` for `ossie`), which is passed through
+#: as the source's options verbatim. That convention is what keeps the engine
+#: from growing a per-vendor coordinate reader.
+SEMANTIC_SOURCE_FACTORIES: dict[str, str] = {
     "ossie": "exmergo_dex_core.ossie.project:build_semantic_layer"
 }
 _SEMANTIC_DEPLOYMENT_SPELLINGS: dict[str, str] = {
@@ -693,15 +699,15 @@ class SemanticConfig(BaseModel):
 
 
 def _vendor_sections(semantic: SemanticConfig) -> list[tuple[str, Any]]:
-    """Every ``(vendor, its config section)`` pair a project format reads.
+    """Every ``(vendor, its config section)`` pair a semantic source reads.
 
     The section is the `SemanticConfig` field named after the vendor, which is
-    the convention `SEMANTIC_PROJECT_FORMATS` documents and the engine relies on
-    when it passes a section through as a format's options.
+    the convention `SEMANTIC_SOURCE_FACTORIES` documents and the engine relies on
+    when it passes a section through as a source's options.
     """
 
     pairs = []
-    for named in SEMANTIC_PROJECT_FORMATS:
+    for named in SEMANTIC_SOURCE_FACTORIES:
         section = getattr(semantic, named, None)
         if section is not None:
             pairs.append((named, section))

--- a/packages/dex-core/src/exmergo_dex_core/engine.py
+++ b/packages/dex-core/src/exmergo_dex_core/engine.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
         VerifyResult,
     )
     from .references import ReferencesResult
+    from .semantic_source import SemanticCatalogSource
     from .transform.plans import PlanEdit
     from .transform.results import (
         ApplyResult,
@@ -713,55 +714,70 @@ class DexEngine:
             ),
         )
 
-    def semantic_catalog_format(self) -> ExploreProject:
-        """The project format that answers the semantic catalog.
+    def semantic_catalog_source(self) -> SemanticCatalogSource:
+        """The source that answers the semantic catalog.
 
-        #408 infrastructure: this is the shared catalog route for the backend
-        and ``--use-project``. When it differs from ``project.format``, #408
-        must compose native tier-1 declarations with dbt rather than replacing it.
-
-        Usually :meth:`project_format`, and the reason this method exists is the
+        Usually the configured project, and the reason this method exists is the
         case where it is not. The semantic layer and the transformation project
         are two axes: a repository can keep dbt for its models and author its
-        semantics as native Apache Ossie documents beside them, and in that
-        arrangement dbt keeps serving tier 1 while a second format answers the
+        semantics as native Apache Ossie documents beside them, or have the
+        documents and no dbt at all. In either arrangement dbt keeps serving the
+        project tiers, or serves nothing, while a separate source answers the
         catalog.
 
         **A table lookup rather than a vendor branch, and that is the whole
         point.** The alternative shape, an `if vendor == ...` at each call site,
         was what this replaced: it put a vendor name inside two commands and the
-        backend resolver, and the next format would have added three more. Here
-        the vendor names a *format*, the format is built through the same
-        resolver and the same context as any other, and every caller downstream
-        keeps asking a project for a catalog without knowing who answered.
+        backend resolver, and the next vendor would have added three more. Here
+        the vendor names a *factory*, the factory is resolved and checked through
+        :mod:`.semantic_source`, and every caller downstream keeps asking for a
+        catalog without knowing who answered.
 
-        The format is built per call for the same reason :meth:`project_format`
-        builds per command: its source is a file a later command may rewrite.
+        **Not the project resolver, deliberately.** A semantic source owns no
+        model graph, no compilation, and no write surface, so routing it through
+        `build_project` would make it satisfy `ExploreProject` to get built, which
+        is a format claiming capabilities it does not have. The two seams check
+        different things because they promise different things.
+
+        Not to be confused with ``self.semantic_source``, which is a *credential*
+        for the hosted dbt Cloud Semantic Layer. This builds a *reader*.
+
+        The source is built per call for the same reason :meth:`project_format`
+        builds per command: it reads a file a later command may rewrite.
         """
 
-        from .adapters.project import ProjectContext
-        from .adapters.project_resolver import build_project
-        from .config import SEMANTIC_PROJECT_FORMATS
+        from .config import SEMANTIC_SOURCE_FACTORIES
+        from .semantic_source import SemanticSourceContext, build_semantic_source
 
         vendor = (getattr(self.config.semantic, "vendor", None) or "dbt").lower()
-        named = SEMANTIC_PROJECT_FORMATS.get(vendor)
+        named = SEMANTIC_SOURCE_FACTORIES.get(vendor)
         if named is None:
             return self.project_format()
         # The vendor's own coordinates, read from the config section named after
         # it (`semantic.ossie` for `vendor: ossie`) and passed through as the
-        # format's options. They live on the semantic axis because that is the
-        # axis the user is configuring; the format sees the same options from
-        # either route, which is what makes the two one implementation.
+        # source's options. They live on the semantic axis because that is the
+        # axis the user is configuring.
         section = getattr(self.config.semantic, vendor, None)
         options = section.model_dump() if section is not None else {}
-        return build_project(
+        return build_semantic_source(
             named,
-            ProjectContext(
+            SemanticSourceContext(
                 repo_root=self.repo_root,
                 connector=self.connector or self.config.connector,
                 options=options,
             ),
         )
+
+    def semantic_catalog_format(self) -> SemanticCatalogSource:
+        """Compatibility spelling of :meth:`semantic_catalog_source`.
+
+        Public since the release that introduced the second semantic axis, and
+        kept because an integration may hold it. The name is wrong now: what it
+        returns is a semantic source, and only in the dbt case is it also a
+        project format.
+        """
+
+        return self.semantic_catalog_source()
 
     def maintain_project(self) -> MaintainProject | None:
         """The project when it can serve as a drift baseline, else ``None``.

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/conformance.py
@@ -63,6 +63,7 @@ from . import (
     EXECUTION_VENDOR,
     SemanticQueryRefusedError,
 )
+from .backend import descriptor_from_backend
 
 __all__ = [
     "REFERENCE_LAYER",
@@ -558,6 +559,168 @@ class SemanticBackendContract:
         for axis in ("backend", "vendor", "deployment", "execution"):
             assert payload[axis], f"{axis} is empty in the payload"
 
+    def test_the_descriptor_and_the_payload_say_the_same_thing(self) -> None:
+        """The descriptor is what a resolver reads before a catalog exists, and
+        the payload is what a caller reads after. A backend where the two
+        disagree reports one provenance to the machinery that selects it and a
+        different one to the person reading the answer, and only the second one
+        is ever looked at again.
+
+        ``catalog_gaps`` is the field this matters most for: it is declared once
+        on the descriptor and consumed off the catalog, so a gap that reaches one
+        and not the other is a structural absence a caller is never told about.
+        """
+
+        backend = self.make_backend()
+        descriptor = descriptor_from_backend(backend)
+        catalog = backend.list_definitions()
+        payload = catalog.to_data()
+
+        assert payload["backend"] == descriptor.name
+        assert payload["vendor"] == descriptor.vendor
+        assert payload["deployment"] == descriptor.deployment
+        assert payload["execution"] == descriptor.execution
+
+        declared = {k: sorted(v) for k, v in (descriptor.catalog_gaps or {}).items()}
+        reported = {k: sorted(v) for k, v in (catalog.unavailable or {}).items() if v}
+        assert reported == {k: v for k, v in declared.items() if v}, (
+            "the gaps the descriptor declares and the gaps the catalog reports "
+            f"disagree: descriptor {declared}, catalog {reported}. A caller reads "
+            "the catalog, so a gap that lives only on the descriptor is one "
+            "nobody is told about"
+        )
+
+    def test_a_declared_gap_names_a_real_field_of_a_real_element_kind(self) -> None:
+        """A misspelled gap is worse than none.
+
+        It reads as a declaration a consumer can branch on and matches nothing it
+        will ever look for, so the field it was meant to cover goes back to being
+        an unexplained absence. Layer-independent, unlike the reference-layer
+        assertions in :class:`SemanticCatalogContract`: this asks only that a
+        declaration name something real.
+        """
+
+        catalog = self.make_backend().list_definitions()
+
+        for kind, gaps in (catalog.unavailable or {}).items():
+            assert kind in _DECLARED_FIELDS, (
+                f"catalog_gaps names element kind {kind!r}, which is not one of "
+                f"{', '.join(sorted(_DECLARED_FIELDS))}"
+            )
+            for field_name in gaps:
+                assert field_name in declared_fields(kind), (
+                    f"catalog_gaps declares {kind}.{field_name}, which is not a "
+                    f"field of a {kind} element, so nothing can check it"
+                )
+
+    def test_a_declared_gap_is_not_a_field_the_backend_populates_anyway(self) -> None:
+        """The other direction, and the more expensive one to get wrong.
+
+        A gap says "this format has nowhere to put this". A caller that reads it
+        stops looking, so declaring one for a field the backend does fill hides
+        real data behind a claim that it cannot exist. Checked against the
+        backend's own layer rather than a reference one, which is what makes it
+        applicable to a format the reference layer cannot describe.
+
+        **Content, not presence.** A field named as a gap still holds its type's
+        neutral value in the payload, because a dataclass has to hold something,
+        and an empty list there is the absence the gap already explained rather
+        than a second claim. What fails is a gap over a field carrying actual
+        content, which is the case where the declaration and the data disagree.
+        Note the asymmetry with the forward assertion in
+        :class:`SemanticCatalogContract`, which treats an empty list as an
+        answer: there the question is whether a backend *stayed silent*, and
+        `[]` is a stated fact ("no queryable grain"); here the question is
+        whether it *contradicted itself*, and `[]` contradicts nothing.
+        """
+
+        catalog = self.make_backend().list_definitions()
+        elements = {
+            "semantic_models": catalog.semantic_models,
+            "metrics": catalog.metrics,
+            "dimensions": catalog.dimensions,
+            "entities": catalog.entities,
+            "measures": catalog.measures,
+        }
+
+        contradicted = sorted(
+            {
+                f"{kind}.{field_name}"
+                for kind, gaps in (catalog.unavailable or {}).items()
+                for field_name in gaps
+                if any(
+                    getattr(element, field_name, None)
+                    for element in elements.get(kind, ())
+                )
+            }
+        )
+
+        assert not contradicted, (
+            "these fields are declared unavailable and carry content anyway, so a "
+            "caller is told data cannot exist while it sits in the same payload: "
+            f"{', '.join(contradicted)}"
+        )
+
+    # --- the declaration channels, which feed grain and relationships ---------
+
+    def test_declared_relationships_carry_complete_ordered_pairs(self) -> None:
+        """Declared joins reach the relationship channel at confidence 1.0, so a
+        half-read one is acted on rather than ignored.
+
+        A composite join is atomic: every ordered pair or none. A backend that
+        returned the pairs as two unpaired lists, or dropped the far side of one,
+        would have the verifier probe a predicate the author never wrote and
+        report the mismatch as a data problem.
+
+        A backend with no relationship channel answers empty, which is a fact
+        about the format and passes here without inventing one.
+        """
+
+        declared = self.make_backend().declared_relationships()
+
+        assert isinstance(declared, list)
+        for relationship in declared:
+            assert relationship.model and relationship.to_model, (
+                f"a declared relationship names no endpoint: {relationship!r}"
+            )
+            assert relationship.column_pairs, (
+                f"declared relationship {relationship!r} carries no column pairs, "
+                "so nothing can be probed and nothing can be drawn"
+            )
+            for pair in relationship.column_pairs:
+                assert len(pair) == 2 and all(pair), (
+                    f"a column pair of {relationship!r} is incomplete: {pair!r}. "
+                    "The far side is a column the target may not even have"
+                )
+            assert relationship.source, (
+                f"declared relationship {relationship!r} names no source, so a "
+                "conflict between two declarations cannot say who said what"
+            )
+
+    def test_declared_keys_keep_single_and_composite_grains_apart(self) -> None:
+        """Two lists, because the claims are different strengths.
+
+        A single key says one column is unique on its own; a composite key says a
+        combination is, and none of its members are. Collapsing a composite into
+        several single keys makes the grain axis verify combinations the layer
+        never declared, and reconcile propose ``unique`` tests on columns that are
+        not.
+        """
+
+        keys, composite = self.make_backend().declared_keys()
+
+        assert isinstance(keys, list)
+        assert isinstance(composite, list)
+        for key in keys:
+            assert key.model and key.column and key.source
+        for key in composite:
+            assert key.model and key.source
+            assert len(key.columns) > 1, (
+                f"composite key {key!r} carries {len(key.columns)} column(s). A "
+                "one-column grain is a single key: putting it here says a "
+                "combination is unique where the layer claimed a column is"
+            )
+
     def test_a_catalog_names_its_own_provenance_not_the_instance(self) -> None:
         """``name`` identifies the backend, so two instances agree on it.
 
@@ -966,27 +1129,6 @@ class SemanticCatalogContract:
             "element, and named in no catalog gap, so a caller cannot tell a "
             f"structural absence from an undeclared field: {', '.join(undeclared)}"
         )
-
-    def test_a_declared_gap_is_a_field_the_catalog_could_have_carried(self) -> None:
-        """The reverse direction: a gap names a real field of a real element kind.
-
-        A misspelled gap is worse than none. It reads as a declaration a consumer
-        can branch on and matches nothing it will ever look for, so the field it
-        was meant to cover goes back to being an unexplained absence.
-        """
-
-        catalog = self.make_reference_backend().list_definitions()
-
-        for kind, gaps in catalog.unavailable.items():
-            assert kind in _DECLARED_FIELDS, (
-                f"catalog_gaps names element kind {kind!r}, which is not one of "
-                f"{', '.join(sorted(_DECLARED_FIELDS))}"
-            )
-            for field_name in gaps:
-                assert field_name in declared_fields(kind), (
-                    f"catalog_gaps declares {kind}.{field_name}, which the "
-                    "reference layer does not declare, so nothing can check it"
-                )
 
     def test_the_shared_entity_carries_a_declaration_per_model_with_its_own_key(
         self,

--- a/packages/dex-core/src/exmergo_dex_core/explore/semantic/ossie.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/semantic/ossie.py
@@ -1,8 +1,8 @@
-"""The catalog-only semantic backend for native Apache Ossie documents.
+"""The catalog-only semantic layer for native Apache Ossie documents.
 
-Thin on purpose. The reading is the project format's job and reaches this
-backend through the same injected-format seam `LocalMetricFlowBackend` uses, so
-what is left here is provenance, the capability declarations, and two refusals.
+Thin on purpose. The reading is the semantic source's job and reaches this layer
+through the same injected-source seam `LocalMetricFlowBackend` uses, so what is
+left here is provenance, the capability declarations, and two refusals.
 
 **The refusals are the honest answer, not a gap to be closed later by this
 class.** Ossie specifies interchange metadata and not a portable query runtime:
@@ -83,34 +83,34 @@ class LocalOssieLayer:
         catalog_gaps=OSSIE_CATALOG_GAPS,
     )
 
-    def __init__(self, project: Any) -> None:
-        self._project = project
+    def __init__(self, source: Any) -> None:
+        self._source = source
 
     @classmethod
     def from_engine(cls, engine: Any) -> LocalOssieLayer:
-        """Build directly from semantic configuration, never a project format."""
+        """Build through the engine's semantic-source seam, never a project.
+
+        One construction path rather than two. This used to call the reader's
+        constructor directly, which meant the coordinates were validated on the
+        maintain and authoring routes and not on this one, so a configuration
+        dex would refuse elsewhere read fine here.
+        """
 
         if engine.repo_root is None:
+            # Caught here rather than left to the source, because this is the
+            # surface the message is for: a caller who built the engine without a
+            # repository gets told which constructor to use.
             raise SemanticBackendError(
                 "reading native Apache Ossie documents needs a repository to "
                 "read them from: they are git-reviewable files, so build the "
                 "engine with DexEngine.from_repo(repo_root)"
             )
-        from ...ossie import OssieSemanticLayer
-
-        semantic = engine.config.semantic
-        return cls(
-            OssieSemanticLayer(
-                engine.repo_root,
-                semantic.ossie.files,
-                engine.connector or engine.config.connector,
-            )
-        )
+        return cls(engine.semantic_catalog_source())
 
     def list_definitions(self) -> SemanticCatalog:
-        project = self._project
+        source = self._source
         try:
-            view = project.semantic_catalog()
+            view = source.semantic_catalog()
         except ProjectError as exc:
             raise SemanticBackendError(str(exc)) from exc
         return SemanticCatalog.from_view(view, self)
@@ -118,14 +118,14 @@ class LocalOssieLayer:
     def declared_relationships(self) -> list[Any]:
         """The native declaration channel, including composite ordered pairs."""
 
-        return self._project.declared_definitions().declared_relationships
+        return self._source.declared_definitions().declared_relationships
 
     def declared_keys(self) -> tuple[list[Any], list[Any]]:
-        """Ossie's own declared dataset keys (#408): unlike dbt, Ossie is never
-        the transformation project `engine.project_format()` resolves, so this
-        is the only route its keys have to grain detection at all."""
+        """Ossie's own declared dataset keys. Unlike dbt, Ossie is never the
+        transformation project `engine.project_format()` resolves, so this is the
+        only route its keys have to grain detection at all."""
 
-        defs = self._project.declared_definitions()
+        defs = self._source.declared_definitions()
         return defs.declared_keys, defs.declared_composite_keys
 
     def query(self, _q: Any) -> Any:

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -116,7 +116,7 @@ def _read_layers(
     when ``semantic=False``, otherwise the semantic half), which is what each
     command's warning names and what ``check`` gates its semantic axis on. It
     is ``None`` whenever that layer is present, even if the *other* one is
-    not: the two are read independently (#409), so a repository whose
+    not: the two are read independently, so a repository whose
     semantic vendor answers on its own is not blocked by a transformation
     project neither it nor that vendor needs.
 
@@ -156,7 +156,7 @@ def _read_layers(
     except (ProjectError, RepoRootRequiredError, ValidationError) as exc:
         semantic_reason = str(exc)
 
-    # `semantic_reason` names why the semantic-vendor substitute (#409) came
+    # `semantic_reason` names why the semantic-vendor substitute came
     # back empty; when there was none to try, `transform_reason` is the only
     # explanation on hand (the same project answered, or failed to build,
     # for both), and a caller must still see *some* reason rather than a
@@ -168,31 +168,38 @@ def _read_layers(
 def _semantic_layer(
     engine: DexEngine, project: MaintainProject | None
 ) -> SemanticLayer | None:
-    """The semantic-axis snapshot, from whichever format answers it (#409).
+    """The semantic-axis snapshot, from whichever source answers it.
 
     Usually ``project`` itself: the semantic vendor defaults to dbt, the same
-    format ``transform_layer()`` just came from. A repository that configures
-    a different semantic vendor beside it (``semantic.vendor: ossie``) gets
-    that format's own fingerprint instead, through the identical seam
-    ``_semantic_catalog`` already reads on the explore side for #408, rather
-    than a second, vendor-specific snapshot section: a table lookup against
-    ``SEMANTIC_PROJECT_FORMATS``, not a name check on which vendor is
+    format ``transform_layer()`` just came from. A repository that configures a
+    different semantic vendor beside it (``semantic.vendor: ossie``) gets that
+    source's own fingerprint instead, through the identical seam
+    ``_semantic_catalog`` reads on the explore side, rather than a second,
+    vendor-specific snapshot section: a table lookup against
+    ``SEMANTIC_SOURCE_FACTORIES``, not a name check on which vendor is
     configured.
 
-    Read independently of ``project``, which may be ``None`` or may have
-    failed to build its own transform layer: a repository with no dbt project
-    at all and ``semantic.vendor: ossie`` still gets a semantic baseline, even
-    though the transform half has nothing to answer with.
+    Read independently of ``project``, which may be ``None`` or may have failed
+    to build its own transform layer: a repository with no dbt project at all and
+    ``semantic.vendor: ossie`` still gets a semantic baseline, even though the
+    transform half has nothing to answer with.
+
+    The capability is asked for rather than the type: a source that can produce a
+    fingerprint satisfies ``SemanticSnapshotSource``, and one that answers only a
+    read catalog declines here and is reported as absent by the caller. Asking
+    for a *project* tier instead would be asking a semantic source to claim a
+    model graph it does not own, and would silently drop the baseline for the
+    vendors that correctly refuse to.
     """
 
-    from ..adapters.project import MaintainProject as _MaintainProject
-    from ..config import SEMANTIC_PROJECT_FORMATS
+    from ..config import SEMANTIC_SOURCE_FACTORIES
+    from ..semantic_source import SemanticSnapshotSource
 
     vendor = (getattr(engine.config.semantic, "vendor", None) or "dbt").lower()
-    if vendor in SEMANTIC_PROJECT_FORMATS:
-        semantic_format = engine.semantic_catalog_format()
-        if isinstance(semantic_format, _MaintainProject):
-            return semantic_format.semantic_layer()
+    if vendor in SEMANTIC_SOURCE_FACTORIES:
+        source = engine.semantic_catalog_source()
+        if isinstance(source, SemanticSnapshotSource):
+            return source.semantic_layer()
     if project is None:
         return None
     return project.semantic_layer()
@@ -202,7 +209,7 @@ def _composed_definitions(
     engine: DexEngine, project: ExploreProject | None
 ) -> ProjectDefinitions | None:
     """Declared keys and joins, with a differing semantic vendor's own keys
-    folded in additively (#410).
+    folded in additively.
 
     Takes the project the caller already read rather than resolving one of its
     own: the format is built once per command, and a repo-less host has no
@@ -211,11 +218,11 @@ def _composed_definitions(
 
     Grain verification (`maintain grain`/`maintain check`) reads declared
     composite keys off ``ProjectDefinitions.declared_composite_keys``, which
-    the project's own ``definitions()`` alone never carries for Ossie:
-    Ossie is never the transformation project that method resolves (the same
-    fact #408 already worked around for the explore-side grain channel, in
-    `explore.commands._fold_semantic_layer_keys`). Mirrored here rather than
-    imported from there, the way #409's `_semantic_layer` is its own
+    the project's own ``definitions()`` alone never carries for a semantic
+    vendor that is not the project: it is never the transformation project that
+    method resolves, which is the same fact the explore-side grain channel works
+    around in `explore.commands._fold_semantic_layer_keys`. Mirrored here rather
+    than imported from there, the way `_semantic_layer` above is its own
     implementation beside `explore.commands._semantic_catalog`: each module
     composes through the same neutral `SemanticLayer.declared_keys()` seam
     rather than one reaching into the other's private helper.
@@ -1164,7 +1171,7 @@ def reconcile(engine: DexEngine, drift_class: str | None = None) -> ReconcileRes
     # carries the grain, and an edit that contradicts a declared grain is one no
     # format is obliged to keep. Tier 1, so the read cannot raise; `None` is the
     # answer when there was no format to read it from. Composed with a
-    # differing semantic vendor's own keys (#410), so a proposal for a column
+    # differing semantic vendor's own keys, so a proposal for a column
     # Ossie already covers via a declared composite is not suggested as if
     # nothing declared it.
     definitions = _composed_definitions(engine, project)

--- a/packages/dex-core/src/exmergo_dex_core/ossie/__init__.py
+++ b/packages/dex-core/src/exmergo_dex_core/ossie/__init__.py
@@ -1,11 +1,16 @@
 """Native Apache Ossie support: the document reader, validator, and format.
 
 Apache Ossie (incubating) is a portable interchange format for semantic models.
-dex reads it as a **project format** behind the existing project-adapter tiers,
-so no command has to know which vendor answered, and it depends neither on
-MetricFlow nor on the upstream Ossie package: the schema it validates against is
-vendored and pinned by content hash, and nothing here requires a checkout of
-Apache Ossie at runtime.
+dex reads it as a **semantic source** behind the seam in
+:mod:`..semantic_source`, so no command has to know which vendor answered, and it
+depends neither on MetricFlow nor on the upstream Ossie package: the schema it
+validates against is vendored and pinned by content hash, and nothing here
+requires a checkout of Apache Ossie at runtime.
+
+It is not a project format and cannot be selected as one. A transformation
+project owns a model graph, compilation, packages, targets, and a write surface;
+Ossie documents own semantic metadata. The two axes sit beside each other, and
+`project.format: ossie` is refused rather than translated.
 
 What Ossie is and is not shapes what this package does. It specifies interchange
 metadata, not a portable query runtime, so the semantic catalog is read and
@@ -29,20 +34,19 @@ from .loader import (
     OssieDependencyError,
     load_documents,
 )
-from .project import FORMAT_NAME, OssieProject, OssieSemanticLayer
+from .project import VENDOR_NAME, OssieSemanticLayer
 
 __all__ = [
     "DOCUMENT_SUFFIXES",
-    "FORMAT_NAME",
     "NON_SQL_DIALECTS",
     "PORTABLE_DIALECT",
     "SCHEMA_SHA256",
     "SQL_DIALECTS",
+    "VENDOR_NAME",
     "Diagnostic",
     "LoadResult",
     "LoadedDocument",
     "OssieDependencyError",
-    "OssieProject",
     "OssieSemanticLayer",
     "load_documents",
 ]

--- a/packages/dex-core/src/exmergo_dex_core/ossie/catalog.py
+++ b/packages/dex-core/src/exmergo_dex_core/ossie/catalog.py
@@ -5,7 +5,7 @@ project two different questions and the answers are shaped differently:
 
 - :func:`semantic_catalog` builds the neutral read catalog `explore semantic
   list` renders, which carries labels, types, dialects and lineage.
-- :func:`definitions` builds the tier-1 declarations channel, which carries
+- :func:`definitions` builds the declarations channel, which carries
   declared keys and joins and nothing else.
 
 **The rule running through both is that dex claims less than it could.** Ossie
@@ -414,7 +414,7 @@ def definitions(
     notes: Sequence[str] = (),
     present: bool = True,
 ) -> ProjectDefinitions:
-    """The tier-1 declarations channel: declared keys, joins, and relations.
+    """The declarations channel: declared keys, joins, and relations.
 
     Separate from the catalog because the consumers are separate. This is what
     `explore profile --use-project` reads to override a heuristic grain and what
@@ -530,10 +530,13 @@ def _join(
     Ossie writes `from` as the many side and `to` as the one side, which is the
     direction `DeclaredForeignKey` already uses, so no side-swapping is needed.
 
-    **#405--#407 preserve a composite relationship as a note rather than a
-    dangerous partial edge.** #408 must carry its full ordered column pairs
-    through the neutral relationship/`EntityJoin` path before map,
-    relationships, and diagram can render it.
+    **A composite relationship becomes a note here rather than a partial
+    edge.** ``DeclaredForeignKey`` carries one column per side, so half of a
+    composite join written into it would be a join the author never declared and
+    a predicate the verifier would probe as though they had. The full ordered
+    pairs reach map, relationships, and diagram through
+    :func:`_declared_relationship` instead, which is the shape that can hold
+    them.
     """
 
     name = rel.get("name")
@@ -568,7 +571,11 @@ def _join(
 def _declared_relationship(
     rel: dict[str, Any], by_name: dict[str, str], relations: dict[str, str]
 ) -> tuple[DeclaredRelationship | None, str | None]:
-    """Preserve an Ossie relationship's full ordered pairs for #408 consumers."""
+    """Preserve an Ossie relationship's full ordered pairs.
+
+    The neutral shape a composite join survives in: every pair, in declared
+    order, so a consumer probes the complete tuple rather than a component.
+    """
 
     name = rel.get("name")
     child = by_name.get(str(rel.get("from")))

--- a/packages/dex-core/src/exmergo_dex_core/ossie/dialects.py
+++ b/packages/dex-core/src/exmergo_dex_core/ossie/dialects.py
@@ -130,7 +130,7 @@ def _declared(expression: object) -> dict[str, str]:
     """Every ``dialect -> expression`` pair, in the document's own order.
 
     Shape-guarded rather than trusting, because the catalog reads documents the
-    validator has already judged *and* the tier-1 declarations channel may not
+    validator has already judged *and* the declarations channel may not
     raise, so this has to survive being handed something malformed.
     """
 

--- a/packages/dex-core/src/exmergo_dex_core/ossie/loader.py
+++ b/packages/dex-core/src/exmergo_dex_core/ossie/loader.py
@@ -190,7 +190,7 @@ def load_documents(
 ) -> LoadResult:
     """Read, validate, and return every configured document.
 
-    Never raises for a bad document: a caller on the tier-1 channel may not
+    Never raises for a bad document: a caller on the declarations channel may not
     raise, and a caller on the catalog channel wants to decide for itself
     whether an error is fatal. The one thing that does raise is the missing
     extra, because that is a wiring problem rather than a document problem and no

--- a/packages/dex-core/src/exmergo_dex_core/ossie/project.py
+++ b/packages/dex-core/src/exmergo_dex_core/ossie/project.py
@@ -1,17 +1,21 @@
-"""Native Apache Ossie documents behind the semantic-layer seam.
+"""Native Apache Ossie documents behind the semantic-source seam.
 
 Ossie is a **semantic layer**, not a transformation project. Its documents own
 semantic metadata and declared relationships; they do not own dbt models,
-snapshots, or writeback.
+snapshots, or writeback, and this class implements none of the project tiers.
+What it implements is the two source capabilities in :mod:`..semantic_source`,
+:class:`~..semantic_source.SemanticCatalogSource` for the read catalog and
+:class:`~..semantic_source.SemanticSnapshotSource` for the drift fingerprint
+``maintain snapshot`` and ``maintain check`` compare against, plus
+:class:`~..edits.SemanticEditTarget` for authoring.
 
 Ossie is configured through ``semantic.vendor: ossie`` and
 ``semantic.ossie.files``, whether or not the repository also has a dbt project.
-The semantic backend builds this reader from those coordinates; dbt, when
-present, remains responsible for the transformation-project tiers.
+The engine builds this reader from those coordinates; dbt, when present, remains
+responsible for the transformation-project tiers, and where dbt is absent nobody
+serves them rather than this class pretending to.
 
-The class also answers ``transform_layer()``/``semantic_layer()``, the snapshot
-fingerprints ``maintain snapshot``/``maintain check`` diff against a baseline.
-Its authoring methods deliberately use semantic-document names rather than the
+The authoring methods deliberately use semantic-document names rather than the
 ``Project`` tier protocols: Ossie can receive semantic edits without becoming a
 transformation project or claiming dbt model writeback.
 """
@@ -27,19 +31,21 @@ from . import catalog as catalog_mod
 from .loader import DOCUMENT_SUFFIXES, LoadResult, OssieDependencyError, load_documents
 
 if TYPE_CHECKING:
-    from ..adapters.project import ProjectContext
-    from ..maintain.snapshot import SemanticLayer, TransformLayer
+    from ..maintain.snapshot import SemanticLayerSnapshot
     from ..project_definitions import ProjectDefinitions
     from ..semantic_catalog import SemanticCatalogView
+    from ..semantic_source import SemanticSourceContext
 
 __all__ = [
-    "FORMAT_NAME",
-    "OssieProject",
+    "VENDOR_NAME",
     "OssieSemanticLayer",
     "build_semantic_layer",
 ]
 
-FORMAT_NAME = "ossie"
+#: The semantic vendor this reader answers for, as `semantic.vendor` spells it.
+#: Not a project format name: `project.format: ossie` is refused, and nothing
+#: here is reachable through the project resolver.
+VENDOR_NAME = "ossie"
 
 
 class OssieSemanticLayer:
@@ -56,10 +62,6 @@ class OssieSemanticLayer:
     documents as they were before the write.
     """
 
-    # This identifies the semantic format; it is not a transformation project
-    # format and is never selected by project.format.
-    name = FORMAT_NAME
-
     def __init__(
         self,
         repo_root: Path | str,
@@ -73,20 +75,20 @@ class OssieSemanticLayer:
         self._semantic_edit_view: Any = None
 
     @classmethod
-    def from_context(cls, context: ProjectContext) -> OssieSemanticLayer:
+    def from_context(cls, context: SemanticSourceContext) -> OssieSemanticLayer:
         """Build from configuration, refusing coordinates it cannot honor.
 
         Every refusal here is about a committed config line, so each one names
         the line to fix. Nothing is read: a file that is named but absent, or
         named and malformed, is a *document* problem and is reported through
-        `definitions()` and `semantic_catalog()`, which are the channels whose
-        callers can degrade. Refusing it here would make `explore map` on a raw
-        warehouse fail because of a typo in a semantic-layer path.
+        `declared_definitions()` and `semantic_catalog()`, which are the channels
+        whose callers can degrade. Refusing it here would make `explore map` on a
+        raw warehouse fail because of a typo in a semantic-layer path.
         """
 
         if context.repo_root is None:
             raise RepoRootRequiredError(
-                "the ossie project format needs a repo root: its documents are "
+                "the Ossie semantic source needs a repo root: its documents are "
                 "git-reviewable files in the repository, so build the engine "
                 "with DexEngine.from_repo(repo_root) or pass repo_root="
             )
@@ -95,14 +97,14 @@ class OssieSemanticLayer:
         if unknown := sorted(options):
             named = ", ".join(unknown)
             raise ConfigurationError(
-                f"the ossie project format takes one option, `files`, and got: "
+                f"the Ossie semantic source takes one option, `files`, and got: "
                 f"{named}. An option dex accepted and ignored would be "
                 "indistinguishable from one it honored, right up until dex was "
-                "reading a different project than the configuration named"
+                "reading different documents than the configuration named"
             )
         return cls(Path(context.repo_root), files, context.connector)
 
-    # --- tier 1 ---------------------------------------------------------------
+    # --- the declaration channel ----------------------------------------------
 
     def declared_definitions(self) -> ProjectDefinitions:
         """What the documents declare: dataset keys, joins, and relations.
@@ -110,7 +112,7 @@ class OssieSemanticLayer:
         **This must not raise**, and here that is a promise with real work
         behind it rather than a formality. Exploration runs against raw
         warehouses where a semantic layer is absent, and every failure this
-        format has (a missing file, a path escaping the repository, unparseable
+        source has (a missing file, a path escaping the repository, unparseable
         YAML, a document that fails the schema, the `[ossie]` extra not
         installed) is a state a user will reach. Each one yields the empty view
         with a note naming the file and the fix.
@@ -132,22 +134,17 @@ class OssieSemanticLayer:
             loaded.documents, connector=self.connector, notes=loaded.notes()
         )
 
-    def definitions(self) -> ProjectDefinitions:
-        """Deprecated alias for :meth:`declared_definitions`."""
-
-        return self.declared_definitions()
-
-    # --- the catalog channel, beside tier 2 -----------------------------------
+    # --- the catalog channel ---------------------------------------------------
 
     def semantic_catalog(self) -> SemanticCatalogView:
         """The documents as a read catalog.
 
-        **Raises where tier 1 degrades**, and the asymmetry is the contract
-        rather than an inconsistency. A caller here asked what the semantic layer
-        contains, so an unreadable document is the answer to their question and
-        an empty catalog would read as "this layer declares nothing". A caller on
-        tier 1 asked about a warehouse and happens to have a project; there, the
-        same condition is a footnote.
+        **Raises where the declaration channel degrades**, and the asymmetry is
+        the contract rather than an inconsistency. A caller here asked what the
+        semantic layer contains, so an unreadable document is the answer to their
+        question and an empty catalog would read as "this layer declares
+        nothing". A caller on the declaration channel asked about a warehouse and
+        happens to have a layer; there, the same condition is a footnote.
         """
 
         loaded = self._load()
@@ -161,44 +158,33 @@ class OssieSemanticLayer:
             loaded.documents, connector=self.connector, notes=loaded.notes()
         )
 
-    # --- tier 2 -----------------------------------------------------------
+    # --- the snapshot channel --------------------------------------------------
 
-    def transform_layer(self) -> TransformLayer:
-        """The document set's own fingerprint (#409): file hashes and nothing
-        else, since Ossie declares no build step. See
-        :func:`.snapshot.transform_layer` for what that means for the rest of
-        the shape.
+    def semantic_layer(self) -> SemanticLayerSnapshot:
+        """The documents' own fingerprint: named definitions, declared keys, and
+        composite relationships, each with a content hash.
 
-        **This must not raise**, matching tier 1's promise rather than
-        dbt's tier-2 contract of raising when there is no project: an unreadable
-        document is exactly the ordinary condition tier 1 already degrades
-        around, and a repository whose semantic vendor is Ossie should not
-        lose its whole drift baseline because one file could not be hashed.
-        """
-
-        from . import snapshot as snapshot_mod
-
-        return snapshot_mod.transform_layer(self.repo_root, self.files)
-
-    def semantic_layer(self) -> SemanticLayer:
-        """The documents' own fingerprint (#409): named definitions, declared
-        keys, and composite relationships, each with a content hash.
+        There is no transformation half beside this one, and its absence is a
+        fact about Ossie rather than a gap. Ossie declares no build step, so
+        there is nothing for a transform baseline to be a baseline *of*; a
+        repository with dbt beside Ossie gets its transform layer from dbt, and
+        one without gets none.
 
         Degrades the same way :meth:`declared_definitions` does, for the same
-        reason: every failure this format has is a state a user reaches by an
+        reason: every failure this source has is a state a user reaches by an
         ordinary typo or a missing extra, not a wiring mistake that should
         propagate.
         """
 
-        from ..maintain.snapshot import SemanticLayer as _SemanticLayerSnapshot
+        from ..maintain.snapshot import SemanticLayerSnapshot
         from . import snapshot as snapshot_mod
 
         try:
             loaded = self._load()
         except OssieDependencyError as exc:
-            return _SemanticLayerSnapshot(notes=[str(exc)])
+            return SemanticLayerSnapshot(notes=[str(exc)])
         except (OSError, ValueError) as exc:
-            return _SemanticLayerSnapshot(
+            return SemanticLayerSnapshot(
                 notes=[f"native Ossie documents could not be read: {exc}"]
             )
         return snapshot_mod.semantic_layer(loaded, connector=self.connector)
@@ -234,11 +220,7 @@ class OssieSemanticLayer:
         return self._loaded
 
 
-# Historical public name for integrations that construct the reader directly.
-OssieProject = OssieSemanticLayer
-
-
-def build_semantic_layer(context: ProjectContext) -> OssieSemanticLayer:
+def build_semantic_layer(context: SemanticSourceContext) -> OssieSemanticLayer:
     """Build the native reader from the semantic configuration coordinates."""
 
     return OssieSemanticLayer.from_context(context)
@@ -255,26 +237,26 @@ def _files(value: Any) -> list[str]:
 
     if value is None:
         raise ConfigurationError(
-            "the Ossie semantic reader needs `files`: native documents named "
+            "the Ossie semantic source needs `files`: native documents named "
             "relative to the repository root. Configure them under "
             "`semantic.ossie.files` in .dex/config.yml"
         )
     if isinstance(value, str) or not isinstance(value, Sequence | Mapping):
         raise ConfigurationError(
-            "`files` for the ossie project format is a list of document paths, "
+            "`files` for the Ossie semantic source is a list of document paths, "
             f"and got {type(value).__name__}. One document is a list of one"
         )
     if isinstance(value, Mapping):
         raise ConfigurationError(
-            "`files` for the ossie project format is a list of document paths, "
+            "`files` for the Ossie semantic source is a list of document paths, "
             "and got a mapping"
         )
     files = [str(item) for item in value]
     if not files:
         raise ConfigurationError(
-            "`files` for the ossie project format is empty. A format configured "
-            "to read no documents declares nothing, which is what leaving "
-            "`project.format` unset already does"
+            "`files` for the Ossie semantic source is empty. A source "
+            "configured to read no documents declares nothing, which is what "
+            "leaving `semantic.vendor` unset already does"
         )
     listed = ", ".join(DOCUMENT_SUFFIXES)
     for name in files:
@@ -282,7 +264,7 @@ def _files(value: Any) -> list[str]:
             raise ConfigurationError(
                 f"'{name}' is not a native Ossie document: they are named "
                 f"{listed}. The suffix is what tells dex a repository file is "
-                "one of the documents this format owns"
+                "one of the documents this source owns"
             )
         if Path(name).is_absolute() or ".." in Path(name).parts:
             raise ConfigurationError(
@@ -292,7 +274,7 @@ def _files(value: Any) -> list[str]:
             )
     if duplicated := sorted({n for n in files if files.count(n) > 1}):
         raise ConfigurationError(
-            f"the ossie project format was given the same document twice: "
+            f"the Ossie semantic source was given the same document twice: "
             f"{', '.join(duplicated)}. Reading one document twice declares "
             "everything in it twice, which is a duplicate-name refusal rather "
             "than a larger layer"

--- a/packages/dex-core/src/exmergo_dex_core/ossie/schema/PROVENANCE.md
+++ b/packages/dex-core/src/exmergo_dex_core/ossie/schema/PROVENANCE.md
@@ -30,11 +30,26 @@ reviewed diff in a commit rather than a quiet update. The document's own
 `version` field is still required and still checked, because upstream requires
 it, and the schema itself is what checks it.
 
+## What this pin promises
+
+The compatibility matrix in `references/ossie-compatibility.md` states, row by
+row, what dex accepts from a document under this pin, which checks run at which
+severity, where each rule comes from, what links to a warehouse column, and what
+dex does not claim. Each row names a case in the reviewed corpus at
+`packages/dex-core/tests/ossie/fixtures/`, and an offline test asserts that the
+hash above, the constant in the loader, the corpus manifest, and the matrix all
+agree.
+
 ## Upgrading
 
 1. Copy the new `core-spec/ossie-schema.json` in verbatim.
 2. Update the commit, hash, and declared version in the table above.
-3. Update `SCHEMA_SHA256` in `exmergo_dex_core/ossie/loader.py`.
+3. Update `SCHEMA_SHA256` in `exmergo_dex_core/ossie/loader.py`, the `schema:`
+   block in the corpus manifest, and the table in the compatibility matrix.
 4. Run the Ossie fixture suite and read the diffs. A fixture that changes
-   verdict is the upgrade telling you what moved; record it in the changelog
-   with the behavior it changes.
+   verdict is the upgrade telling you what moved; decide for each one whether
+   the new verdict is what upstream now intends, record it in the changelog with
+   the behavior it changes, and update the matrix and its known-deltas list.
+
+Updating the hash alone is not an upgrade. The offline test checks that the four
+places agree; it cannot check that anybody read the diff.

--- a/packages/dex-core/src/exmergo_dex_core/ossie/snapshot.py
+++ b/packages/dex-core/src/exmergo_dex_core/ossie/snapshot.py
@@ -1,11 +1,19 @@
-"""Ossie's own tier-2 fingerprint: the maintain snapshot channel (#409).
+"""Ossie's own drift fingerprint: the maintain snapshot channel.
 
-Builds the same format-neutral shapes `maintain.snapshot` defines for dbt
-(`TransformLayer`, `SemanticLayerSnapshot`), from Ossie's own validated
-documents. This module never imports `dbt_project` or anything MetricFlow
-shaped, and `maintain.snapshot` never imports this one: the two formats read
-their own sources into one shared shape rather than one depending on the
-other's reader.
+Builds the same neutral shape `maintain.snapshot` defines for dbt
+(`SemanticLayerSnapshot`) from Ossie's own validated documents. This module
+never imports `dbt_project` or anything MetricFlow shaped, and
+`maintain.snapshot` never imports this one: the two read their own sources into
+one shared shape rather than one depending on the other's reader.
+
+There is no `transform_layer` counterpart here, and its absence is deliberate.
+Ossie declares no build step, so a transform baseline would be a baseline of
+nothing: a dataset's source is already the physical relation its semantic model
+records, not a name a transformation project resolves later the way a dbt
+`ref()`/`source()` does. A repository with dbt beside Ossie gets its transform
+layer from dbt; one without gets none, which is the honest answer rather than a
+set of empty collections that read as "this source has none of these to
+declare".
 
 Reuses `catalog.py`'s column-resolution and relationship-resolution helpers
 rather than re-deriving them, so a field's link to a physical column, and a
@@ -17,7 +25,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-from pathlib import Path
 from typing import Any
 
 from ..maintain.snapshot import (
@@ -25,7 +32,6 @@ from ..maintain.snapshot import (
     RelationshipDef,
     SemanticLayerSnapshot,
     SemanticModelDef,
-    TransformLayer,
 )
 from ..project_definitions import DeclaredRelationship
 from . import catalog as catalog_mod
@@ -34,46 +40,14 @@ from .loader import LoadResult
 
 def _content_hash(text: str) -> str:
     """A definition's fingerprint. Deliberately not `dbt_project.content_hash`:
-    importing a one-line sha256 wrapper across the format boundary would still
-    be a dependency on the dbt module, which #409's own constraint refuses."""
+    importing a one-line sha256 wrapper across the boundary would still be a
+    dependency on the dbt module, which the independence constraint refuses."""
 
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
 def _definition_hash(entry: Any) -> str:
     return _content_hash(json.dumps(entry, sort_keys=True, default=str))
-
-
-def transform_layer(repo_root: Path, files: list[str]) -> TransformLayer:
-    """The document set's own fingerprint: file hashes and nothing else.
-
-    ``models``, ``model_paths``, ``sources``, ``model_sources``, and
-    ``model_refs`` all stay empty: Ossie documents declare no build step, and
-    a dataset's source is already the physical relation its semantic model
-    records on ``SemanticModelDef.relation`` (#409), not a name a
-    transformation project resolves later the way a dbt ``ref()``/``source()``
-    does. The note says this once here rather than leaving five empty
-    collections to be misread as "this format has none of these to declare".
-    """
-
-    hashed: dict[str, str] = {}
-    for name in files:
-        try:
-            hashed[name] = _content_hash((repo_root / name).read_text(encoding="utf-8"))
-        except OSError:
-            # Absent or unreadable: declared_definitions()/semantic_layer()
-            # already carry the diagnostic naming this file, so a missing
-            # hash here is that same fact, not a second one to explain.
-            continue
-    return TransformLayer(
-        files=hashed,
-        notes=[
-            "native Ossie documents declare no build step, so `models` and "
-            "`model_refs` stay empty: a dataset's source is already the "
-            "physical relation its semantic model records, not a name a "
-            "transformation project resolves later"
-        ],
-    )
 
 
 def semantic_layer(

--- a/packages/dex-core/src/exmergo_dex_core/semantic_source.py
+++ b/packages/dex-core/src/exmergo_dex_core/semantic_source.py
@@ -1,0 +1,230 @@
+"""What supplies a semantic layer, and how dex constructs one.
+
+A semantic layer and a transformation project are two axes, and this module is
+the seam for the first. A repository may keep dbt for its models and author its
+semantics as native Apache Ossie documents beside them, or have Ossie and no dbt
+at all. Neither arrangement makes the semantic source a project: it owns no model
+graph, no compilation, no packages, no targets, and no dbt write surface, so
+holding it to the project tiers would be claiming capabilities it does not have.
+
+**Two capabilities rather than a tier ladder.** A source that can answer a read
+catalog implements :class:`SemanticCatalogSource`; one that can also produce a
+drift fingerprint implements :class:`SemanticSnapshotSource`. They are separate
+because declining the second is an answer rather than a shortfall, the same
+reason :class:`~.adapters.project.SemanticCatalogProject` sits beside the project
+tiers rather than inside them. Both are ``runtime_checkable``, so a caller asks
+what a source can do instead of asking what it is.
+
+**Name disambiguation, because three nearby names read alike.**
+``SemanticSource`` in :mod:`.connect` is a *credential*: the hosted dbt Cloud
+Semantic Layer's service coordinates, reachable as ``engine.semantic_source``.
+:class:`SemanticSourceContext` here is what a *reader* is built from, reachable
+as ``engine.semantic_catalog_source()``. ``SemanticSourceFile`` in
+:mod:`.ossie.authoring` is one document's bytes and hash. Different concepts,
+adjacent words; the qualifier in each name is the part that matters.
+
+A leaf module, like :mod:`.semantic_catalog` beside it: the protocol types are
+imported only for typing, so importing this costs no reader, no validator, and no
+optional dependency.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from .errors import ConfigurationError
+
+if TYPE_CHECKING:
+    from .maintain.snapshot import SemanticLayerSnapshot
+    from .semantic_catalog import SemanticCatalogView
+
+__all__ = [
+    "SemanticCatalogSource",
+    "SemanticSnapshotSource",
+    "SemanticSourceContext",
+    "build_semantic_source",
+    "construct_semantic_source",
+    "resolve_semantic_source_factory",
+]
+
+
+@dataclass(frozen=True)
+class SemanticSourceContext:
+    """Everything a semantic source gets to build itself from.
+
+    Nullable slots for the same reason :class:`~.adapters.project.ProjectContext`
+    has them: the sources disagree about what keys them. Native documents are
+    keyed by a repository and a file list; a hosted layer has service coordinates
+    and no repository at all.
+
+    **There is no ``project_dir``, and its absence is the point.** A semantic
+    source is not pinned inside a transformation project, so a slot for one would
+    invite a reader to go looking for models it has no business owning.
+
+    ``repo_root`` is the directory dex was pointed at, or ``None`` when there is
+    no repository in the picture. ``connector`` is the name of the warehouse dex
+    resolved, never a live adapter and never a credential: a source may have to
+    read an authored relation name the way the active warehouse would, and
+    identifier arity, quoting, and unquoted-case folding are the connector's
+    rules. ``options`` is the source's own non-secret coordinates, passed through
+    verbatim from the configuration section named after the vendor, and it is the
+    source's job to refuse an option it cannot honor rather than accept and
+    ignore it.
+
+    **Construction has to be cheap and must read nothing.** dex builds a source
+    per command rather than holding one, because a document is an artifact a
+    previous command may have just rewritten and a stale read is a wrong drift
+    report. Parse lazily on first use.
+
+    **No secret ever arrives here**, for the reason it never arrives in a project
+    context: these coordinates come from a committed file.
+    """
+
+    repo_root: str | None = None
+    connector: str | None = None
+    options: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class SemanticCatalogSource(Protocol):
+    """A source that can answer the semantic layer as a read catalog.
+
+    The narrowest useful capability, and the floor for anything a vendor names:
+    a source that cannot say what the layer contains cannot serve
+    `explore semantic list`, `explore map --use-project`, or anything downstream
+    of them.
+    """
+
+    def semantic_catalog(self) -> SemanticCatalogView:
+        """The semantic layer as a read catalog.
+
+        May raise :class:`~.errors.ProjectError`, and should where the layer
+        cannot be read *yet* as opposed to being empty. An unreadable document
+        and a layer that declares nothing are different answers, and only one of
+        them is fixed by editing a file.
+        """
+        ...
+
+
+@runtime_checkable
+class SemanticSnapshotSource(Protocol):
+    """A source that can also produce the drift fingerprint `maintain` diffs.
+
+    Beside :class:`SemanticCatalogSource` rather than extending it in the tier
+    sense: the catalog is a *read view* carrying types, labels, descriptions and
+    the token a query groups by, while the snapshot is a *fingerprint*, a content
+    hash per definition plus the physical column behind each field, sized for
+    detecting change and stable across tool upgrades. Widening either to serve
+    the other costs the property it exists for, so a source performs both
+    reductions or declines the second.
+    """
+
+    def semantic_layer(self) -> SemanticLayerSnapshot:
+        """The layer reduced to what a comparison needs.
+
+        **This must not raise.** `maintain` already treats an unreadable source
+        as a handled state and carries a note saying so, and every failure a
+        file-backed source has (a missing file, unparseable content, an optional
+        extra not installed) is a state a user reaches by an ordinary typo.
+        """
+        ...
+
+
+def resolve_semantic_source_factory(path: str) -> Any:
+    """The factory ``path`` names, imported but not called.
+
+    Resolution only, so a caller that wants to inspect or wrap what a name
+    selects can do so without constructing anything.
+    :func:`build_semantic_source` is the one that constructs.
+    """
+
+    from importlib import import_module
+
+    selected = (path or "").strip()
+    module_name, _, attribute = selected.partition(":")
+    if not module_name or not attribute:
+        raise ConfigurationError(
+            f"'{path}' is not a usable dotted path for a semantic source; write "
+            "it as 'module.path:name', with a colon between the module and the "
+            "factory"
+        )
+    try:
+        module = import_module(module_name)
+    except ImportError as exc:
+        raise ConfigurationError(
+            f"the semantic source '{path}' names a module that will not import: "
+            f"{exc}. Check the spelling, and that the distribution providing it "
+            "is installed in the environment running dex"
+        ) from exc
+
+    resolved: Any = module
+    for part in attribute.split("."):
+        try:
+            resolved = getattr(resolved, part)
+        except AttributeError as exc:
+            raise ConfigurationError(
+                f"the semantic source '{path}' imported {module_name} but it has "
+                f"no '{attribute}'"
+            ) from exc
+
+    if not callable(resolved):
+        raise ConfigurationError(
+            f"the semantic source '{path}' resolved to a "
+            f"{type(resolved).__name__}, which cannot be called. Name a factory: "
+            "a function taking a SemanticSourceContext, a class whose __init__ "
+            "takes one, or a classmethod like OssieSemanticLayer.from_context"
+        )
+    return resolved
+
+
+def construct_semantic_source(
+    name: str, factory: Any, context: SemanticSourceContext
+) -> SemanticCatalogSource:
+    """Call an already-resolved factory, checking what comes back reads a catalog.
+
+    The check is on the constructed object rather than on the factory, for the
+    reason the project seam checks there too: a callable protocol can only verify
+    that ``__call__`` exists, which every callable satisfies, so building first is
+    what makes the check mean anything.
+
+    It checks :class:`SemanticCatalogSource` and nothing wider. A source that
+    declines the snapshot capability is complete rather than partial, and
+    `maintain` reports the absence itself.
+    """
+
+    try:
+        source = factory(context)
+    except ConfigurationError:
+        # The source refused its own coordinates and said why. Re-wrapping would
+        # bury the specific message under a generic one.
+        raise
+    except Exception as exc:
+        raise ConfigurationError(
+            f"the semantic source '{name}' failed to build: {exc}. A factory "
+            "takes one SemanticSourceContext and returns a source; check that it "
+            "accepts the context dex passes and reads its coordinates out of "
+            "context.options"
+        ) from exc
+
+    if not isinstance(source, SemanticCatalogSource):
+        raise ConfigurationError(
+            f"the semantic source '{name}' built a {type(source).__name__}, which "
+            "cannot answer a semantic catalog: it is missing semantic_catalog(). "
+            "Every semantic source has to satisfy at least "
+            "exmergo_dex_core.semantic_source.SemanticCatalogSource; run the "
+            "shipped conformance suite against it "
+            "(exmergo_dex_core.semantic_source_conformance)"
+        )
+    return source
+
+
+def build_semantic_source(
+    name: str, context: SemanticSourceContext
+) -> SemanticCatalogSource:
+    """Resolve ``name`` and construct it, checking what comes back is a source."""
+
+    return construct_semantic_source(
+        name, resolve_semantic_source_factory(name), context
+    )

--- a/packages/dex-core/src/exmergo_dex_core/semantic_source_conformance.py
+++ b/packages/dex-core/src/exmergo_dex_core/semantic_source_conformance.py
@@ -1,0 +1,781 @@
+"""The executable contract a semantic source is held to.
+
+A semantic source supplies the layer: what it declares, what a caller can read
+off it, and what a drift baseline compares against. It is not a transformation
+project, so the project tiers in :mod:`.adapters.conformance` are the wrong
+standard for one, and the shipped project contracts exist for formats that own a
+model graph. What the two have in common is the *behaviour* around a layer, and
+that half lives here so there is one implementation of each assertion rather than
+two that drift.
+
+```python
+from exmergo_dex_core.semantic_source_conformance import (
+    SemanticCatalogSourceContract,
+    SemanticDeclarationContract,
+    SemanticFingerprintContract,
+    SemanticSourceFactoryContract,
+)
+
+
+class TestMySource(
+    SemanticSourceFactoryContract,
+    SemanticDeclarationContract,
+    SemanticFingerprintContract,
+    SemanticCatalogSourceContract,
+):
+    def build_source(self, context): ...
+    def empty_source_context(self): ...
+    def a_source_declaring_a_unique_key(self): ...
+```
+
+```
+pip install "exmergo-dex-core[semantic-conformance]"
+```
+
+That extra is pytest and nothing else, and the floor is the point rather than a
+coincidence: nothing here reaches the dialect engine, a warehouse client, or
+either semantic extra. A packaging test holds it true.
+
+**Four contracts, because a source may legitimately answer only some of them.**
+:class:`SemanticSourceFactoryContract` is construction.
+:class:`SemanticDeclarationContract` is the keys and joins a layer contributes to
+exploration. :class:`SemanticFingerprintContract` is the reduction a drift
+baseline stores. :class:`SemanticCatalogSourceContract` is the read view
+`explore semantic list` returns. Declining one is an answer: a source with no
+snapshot capability is complete rather than partial, and the command reports the
+absence itself.
+
+**The declaration hook is named rather than fixed**, through
+:meth:`SemanticDeclarationContract.declarations_of`. A semantic source spells the
+call ``declared_definitions()``; a transformation project spells it
+``definitions()``, because for a project that same method is the tier-1 contract
+and has been public since v1. One override reconciles them, which is what lets
+the shipped project contracts run these exact assertions rather than a copy.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from .maintain.snapshot import Snapshot
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from .project_definitions import ProjectDefinitions
+    from .semantic_source import SemanticSourceContext
+
+__all__ = [
+    "SemanticCatalogSourceContract",
+    "SemanticDeclarationContract",
+    "SemanticFingerprintContract",
+    "SemanticSourceFactoryContract",
+]
+
+
+class SemanticDeclarationContract:
+    """Opt-in: the keys and joins a layer declares actually arrive.
+
+    A layer's declarations are worth reading because they reach the grain and
+    relationship channels at confidence 1.0. A source that reads every name and
+    drops the columns behind them contributes nothing there while appearing to
+    work, so these assert the content rather than the shape.
+    """
+
+    def make_semantic_source(self) -> Any:  # pragma: no cover - subclass supplies
+        """A source with nothing declared in it."""
+
+        raise NotImplementedError
+
+    def declarations_of(self, source: Any) -> ProjectDefinitions:
+        """How this implementation is asked what it declares.
+
+        Overridden by the project contracts, which spell it ``definitions()``.
+        Semantic sources spell it ``declared_definitions()``, which is the
+        default here.
+        """
+
+        return source.declared_definitions()
+
+    def a_source_declaring_a_unique_key(self) -> tuple[Any, str, str]:
+        """A source declaring one single-column unique key.
+
+        Returns ``(source, model, column)``: the source, and what dex should see
+        in it. Naming the expectation here rather than fixing it in the suite
+        keeps your own vocabulary out of the assertion.
+        """
+
+        raise NotImplementedError
+
+    def a_source_declaring_a_join(self) -> tuple[Any, str, str, str, str]:
+        """A source declaring one single-column join between two models.
+
+        Returns ``(source, model, column, to_model, to_column)``.
+        """
+
+        raise NotImplementedError
+
+    def a_source_declaring_a_composite_key(
+        self,
+    ) -> tuple[Any, str, tuple[str, ...]] | None:
+        """A grain needing more than one column, or ``None``.
+
+        Returns ``(source, model, columns)`` with ``columns`` in declared order.
+
+        **Declare more than two columns.** An implementation that handles a
+        composite key by special-casing the pair satisfies a two-column fixture
+        and fails a four-column one, so a pair cannot tell you what you came to
+        find out.
+
+        ``None`` skips, because a format may genuinely have no way to express a
+        multi-column grain and is then differently shaped rather than incomplete.
+        """
+
+        return None
+
+    def a_source_declaring_a_join_with_differently_named_sides(
+        self,
+    ) -> tuple[Any, str, str, str, str] | None:
+        """A join whose two ends are spelled differently, or ``None``.
+
+        Returns ``(source, model, column, to_model, to_column)``, and ``column``
+        must not equal ``to_column``: this contract checks that and refuses a
+        mirrored fixture, because a mirrored one cannot fail for the right
+        reason. An implementation that reads one side and copies it onto the
+        other satisfies a mirrored fixture exactly, and the defect ships.
+        """
+
+        return None
+
+    def test_a_source_declaring_nothing_answers_without_raising(self) -> None:
+        """Exploration runs against raw warehouses, so a layer that declares
+        nothing is the ordinary case rather than an error state.
+
+        A source that raised here would turn every unremarkable repository into
+        an outage on a command that was only ever asking about tables.
+        """
+
+        declarations = self.declarations_of(self.make_semantic_source())
+
+        assert declarations.declared_keys == []
+        assert declarations.declared_composite_keys == []
+        assert declarations.foreign_keys == []
+
+    def test_reading_the_declarations_twice_agrees(self) -> None:
+        """Rules out a read that consumes, which surfaces as a second command
+        mysteriously seeing less than the first."""
+
+        source = self.make_semantic_source()
+
+        assert self.declarations_of(source) == self.declarations_of(source)
+
+    def test_a_declared_unique_key_reaches_the_engine(self) -> None:
+        source, model, column = self.a_source_declaring_a_unique_key()
+
+        declared = self.declarations_of(source).declared_keys
+        matching = [k for k in declared if k.model == model and k.column == column]
+
+        assert matching, f"expected a declared key on {model}.{column}, got {declared}"
+        assert matching[0].unique, (
+            "a key declared unique must arrive with unique=True; a grain that "
+            "arrives without it is read as an ordinary column"
+        )
+
+    def test_a_declared_join_carries_both_sides(self) -> None:
+        """Both ends, because a half-read join is worse than an unread one.
+
+        A join naming the wrong side sends the relationship detector looking for
+        a key that is not there, and the finding it produces reads like a data
+        problem rather than a misread declaration.
+        """
+
+        source, model, column, to_model, to_column = self.a_source_declaring_a_join()
+
+        declared = self.declarations_of(source).foreign_keys
+        matching = [
+            fk
+            for fk in declared
+            if fk.model == model
+            and fk.column == column
+            and fk.to_model == to_model
+            and fk.to_column == to_column
+        ]
+
+        assert matching, (
+            f"expected a declared join {model}.{column} -> {to_model}.{to_column}, "
+            f"got {declared}"
+        )
+
+    def test_a_composite_grain_keeps_every_column_and_their_order(self) -> None:
+        """A truncated composite key is silent, which is what makes it expensive.
+
+        It does not read as a missing declaration. It reads as a declared grain
+        that is simply narrower than the truth, so every check downstream runs
+        against a grain the author never claimed and the findings look like data
+        problems rather than a misread declaration.
+        """
+
+        supplied = self.a_source_declaring_a_composite_key()
+        if supplied is None:
+            pytest.skip(
+                "a_source_declaring_a_composite_key() returned None: this "
+                "implementation declares it cannot express a multi-column grain, "
+                "so declared_composite_keys goes unchecked"
+            )
+        source, model, columns = supplied
+        declarations = self.declarations_of(source)
+
+        declared = declarations.declared_composite_keys
+        matching = [k for k in declared if k.model == model]
+
+        assert matching, (
+            f"expected a composite key on {model}, got {declared}. A multi-column "
+            "grain belongs in declared_composite_keys, not as several entries in "
+            "declared_keys: those say each column is unique on its own, which is a "
+            "different and much stronger claim"
+        )
+        assert tuple(matching[0].columns) == tuple(columns), (
+            f"expected columns {tuple(columns)} in order, got "
+            f"{tuple(matching[0].columns)}"
+        )
+        assert len(matching) == 1, (
+            f"expected one composite key on {model}, got {len(matching)}: "
+            f"{matching}. One declaration is one grain, and splitting it across "
+            "entries makes the grain axis verify combinations the source never "
+            "declared"
+        )
+        leaked = sorted(
+            key.column
+            for key in declarations.declared_keys
+            if key.model == model
+            and key.unique
+            and key.column.lower() in {c.lower() for c in columns}
+        )
+        assert not leaked, (
+            f"{model} reports {leaked} as unique on their own while also declaring "
+            f"the composite grain {tuple(columns)}. The fixture's grain needs every "
+            "one of those columns, so no single one of them is unique, and the "
+            "stronger claim is the one that gets acted on: reconcile reads it as a "
+            "grain the source already asserts and proposes edits against it"
+        )
+
+    def test_a_join_keeps_its_two_sides_apart_when_they_are_named_differently(
+        self,
+    ) -> None:
+        """The case :meth:`test_a_declared_join_carries_both_sides` cannot reach.
+
+        An implementation that mirrors the source column onto the target passes
+        that one whenever the fixture's two ends share a name, and this is the
+        assertion that separates them.
+        """
+
+        supplied = self.a_source_declaring_a_join_with_differently_named_sides()
+        if supplied is None:
+            pytest.skip(
+                "a_source_declaring_a_join_with_differently_named_sides() returned "
+                "None: a join whose ends are spelled differently goes unchecked, so "
+                "an implementation that mirrors one side onto the other would pass "
+                "this suite"
+            )
+        source, model, column, to_model, to_column = supplied
+
+        assert column != to_column, (
+            "this fixture has to name its two sides differently, or it cannot "
+            "detect the mirroring it exists to detect"
+        )
+
+        declared = self.declarations_of(source).foreign_keys
+        matching = [
+            fk
+            for fk in declared
+            if fk.model == model and fk.column == column and fk.to_model == to_model
+        ]
+
+        assert matching, (
+            f"expected a declared join from {model}.{column} to {to_model}, "
+            f"got {declared}"
+        )
+        assert matching[0].to_column == to_column, (
+            f"the join's target column arrived as {matching[0].to_column!r}, "
+            f"expected {to_column!r}. Reading it as {column!r} is the mirroring "
+            "failure: the far side is a column the target may not even have"
+        )
+
+
+class SemanticFingerprintContract:
+    """Opt-in: the drift fingerprint keeps the column behind each field.
+
+    The fingerprint's job is to make a change detectable, so it reduces the layer
+    to a hash per definition plus the physical column behind each field. Nothing
+    in a capability check looks at a populated one, so an implementation that
+    reads every dimension and measure name and drops the column behind each
+    passes everything else completely.
+
+    That is not a hypothetical shape. ``SemanticModelDef`` keys every field to a
+    warehouse column, and ``maintain``'s drift detector skips any field whose
+    column is ``None``, correctly, because it cannot resolve what it was not
+    given. So a layer mapped entirely to ``None`` validates, serializes, and
+    compares clean forever: the check does not fail, it never runs, and a dropped
+    warehouse column that should raise ``dangling_reference`` at high severity
+    raises nothing. The absence is indistinguishable from agreement, which is the
+    worst property a check can have.
+    """
+
+    def make_semantic_source(self) -> Any:  # pragma: no cover - subclass supplies
+        """A source with nothing declared in it."""
+
+        raise NotImplementedError
+
+    def fingerprint_of(self, source: Any) -> Any:
+        """How this implementation is asked for its drift fingerprint."""
+
+        return source.semantic_layer()
+
+    def test_a_fingerprint_is_produced_with_nothing_declared(self) -> None:
+        """The baseline has to be capturable on the first run.
+
+        That run is the one every later drift report compares against, so a
+        source that only produces a fingerprint once something is declared can
+        never be snapshotted at the moment somebody first reaches for it.
+        """
+
+        layer = self.fingerprint_of(self.make_semantic_source())
+
+        assert layer.semantic_models == []
+        assert layer.metrics == []
+
+    def a_source_declaring_a_semantic_model(
+        self,
+    ) -> tuple[Any, str, Mapping[str, str | None], Mapping[str, str | None]]:
+        """A source declaring one semantic model.
+
+        Returns ``(source, name, dimensions, measures)``, where the two mappings
+        are ``field name -> the warehouse column behind it``, exactly as you
+        expect them to arrive on ``SemanticModelDef``.
+
+        **Map a field to ``None`` when there is no bare column behind it**, and
+        include at least one such field if the format can produce one: a computed
+        field, or one whose expression is not a plain column name. ``None`` is
+        the honest answer there and an invented column is not, because a consumer
+        resolving column names would treat a fabricated one as a reference that no
+        longer resolves.
+        """
+
+        raise NotImplementedError(
+            "a semantic fingerprint subclass must implement "
+            "a_source_declaring_a_semantic_model() -> (source, name, dimensions, "
+            "measures), mapping each field to the warehouse column behind it"
+        )
+
+    def test_a_semantic_field_carries_the_column_behind_it(self) -> None:
+        source, name, dimensions, measures = self.a_source_declaring_a_semantic_model()
+
+        layer = self.fingerprint_of(source)
+        matching = [m for m in layer.semantic_models if m.name == name]
+
+        assert matching, (
+            f"expected a semantic model named {name!r}, got "
+            f"{[m.name for m in layer.semantic_models]}"
+        )
+        model = matching[0]
+        assert dict(model.dimensions) == dict(dimensions), (
+            "the dimension to column mapping did not survive. A layer whose columns "
+            "are all None still validates and still compares clean, so the drift "
+            "check simply never runs"
+        )
+        assert dict(model.measures) == dict(measures), (
+            "the measure to column mapping did not survive; see above"
+        )
+
+    def test_a_categorical_dimension_maps_only_to_a_real_column(self) -> None:
+        """``categorical_dimensions`` takes ``str``, not ``str | None``.
+
+        So a field that is categorical *and* unresolved cannot be represented
+        there, and the two properties have to stay independent: being categorical
+        says how the field behaves, having a column says whether it can be
+        checked. An implementation that collapses them either drops a categorical
+        field that happens to lack a column, or supplies an invented column to
+        keep it. Both are worse than leaving it out of this one mapping, which is
+        what the typing asks for.
+        """
+
+        source, name, _, _ = self.a_source_declaring_a_semantic_model()
+
+        model = next(
+            m for m in self.fingerprint_of(source).semantic_models if m.name == name
+        )
+
+        columns = model.categorical_dimensions.values()
+        assert all(isinstance(c, str) and c for c in columns), (
+            "categorical_dimensions holds a null or empty column: its values are "
+            f"required strings, got {model.categorical_dimensions!r}. Leave an "
+            "unresolved categorical field out of this mapping rather than "
+            "inventing a column to keep it in"
+        )
+        assert set(model.categorical_dimensions) <= set(model.dimensions), (
+            "categorical_dimensions names a field that is not a dimension: "
+            f"{sorted(set(model.categorical_dimensions) - set(model.dimensions))}"
+        )
+
+    def test_the_fingerprint_survives_a_snapshot_round_trip(self) -> None:
+        """A fingerprint that cannot be persisted is not a baseline.
+
+        The layer goes into a `Snapshot`, a store serializes it, and a later
+        command loads it and diffs against it. A layer that cannot survive that
+        trip fails on the *next* run rather than the one that produced it, which
+        is the run whose output someone is reading.
+
+        Equality after a JSON round trip specifically, not a deep copy: the
+        in-memory store copies rather than serializing, and would hide the whole
+        class of defect this catches, a value the source chose that the model
+        accepts in Python and rejects on the way back.
+        """
+
+        source, _, _, _ = self.a_source_declaring_a_semantic_model()
+
+        snap = Snapshot(
+            created_at="2026-01-01T00:00:00+00:00",
+            semantic_layer=self.fingerprint_of(source),
+        )
+        restored = Snapshot.model_validate_json(snap.model_dump_json())
+
+        assert restored.semantic_layer == snap.semantic_layer
+
+
+class SemanticCatalogSourceContract:
+    """Opt-in: the read catalog keeps what the fingerprint drops.
+
+    **Why this is a separate contract from** :class:`SemanticFingerprintContract`.
+    That one checks the reduction a comparison needs: a hash, and the column
+    behind each field. This checks the opposite reduction. `explore semantic list`
+    reads the catalog to answer "what can I query, how, and what will the number
+    mean", and every field that answers it is a field the fingerprint correctly
+    throws away: element types, the author's own labels and descriptions, a
+    measure's aggregation, a metric's composition, and the token a query actually
+    groups by.
+
+    An implementation can therefore pass the fingerprint contract in full and
+    return a catalog of bare names, which reads to a caller as a layer nobody
+    documented and reduces the discovery surface to the thing it exists to
+    replace.
+
+    **The entity assertion is the load-bearing one.** An entity's type is a
+    property of the (entity, semantic model) declaration, not of the entity: it is
+    primary in the model that keys it and foreign in every model that joins to it.
+    An implementation that returns one record per entity has to pick, and
+    whichever it picks is iteration order rather than a fact. Both of dex's own
+    backends got this wrong, in opposite directions, on one identical layer.
+
+    A source that has no entities at all satisfies these vacuously, which is
+    correct: what is asserted is that a declared entity is shaped honestly, not
+    that entities exist.
+    """
+
+    def make_semantic_source(self) -> Any:  # pragma: no cover - subclass supplies
+        """A source with nothing declared in it."""
+
+        raise NotImplementedError
+
+    def a_source_declaring_a_semantic_model(
+        self,
+    ) -> tuple[Any, str, Mapping[str, str | None], Mapping[str, str | None]]:
+        # pragma: no cover - subclass supplies
+        raise NotImplementedError
+
+    def catalog_of(self, source: Any) -> Any:
+        """How this implementation is asked for its read catalog."""
+
+        return source.semantic_catalog()
+
+    def an_unreadable_semantic_source(self) -> Any | None:
+        """A source whose documents genuinely cannot be read, or ``None``.
+
+        ``None`` skips the degradation assertions, which is right for an
+        implementation with no such state: a layer reduced from something already
+        in memory cannot fail to parse. Override it wherever the source is
+        file-backed, because a file is a thing that gets truncated, merged badly,
+        and hand-edited, and that path is the one users actually reach.
+        """
+
+        return None
+
+    def test_the_source_answers_a_catalog(self) -> None:
+        from .semantic_source import SemanticCatalogSource
+
+        source = self.make_semantic_source()
+        assert isinstance(source, SemanticCatalogSource), (
+            "semantic_catalog() is what `explore semantic list` reads, and it is "
+            "checked structurally rather than declared, so a source missing the "
+            "member is refused by name at the command rather than here"
+        )
+
+    def test_reading_the_catalog_twice_agrees(self) -> None:
+        """Rules out a read that consumes, which surfaces as a second command
+        mysteriously seeing less than the first."""
+
+        source, name, _, _ = self.a_source_declaring_a_semantic_model()
+
+        first = self.catalog_of(source)
+        second = self.catalog_of(source)
+
+        assert [m.name for m in first.semantic_models] == [
+            m.name for m in second.semantic_models
+        ]
+        assert [m.name for m in first.metrics] == [m.name for m in second.metrics]
+        assert any(m.name == name for m in first.semantic_models)
+
+    def test_the_catalog_keeps_what_the_fingerprint_reduces_away(self) -> None:
+        source, name, _, _ = self.a_source_declaring_a_semantic_model()
+        catalog = self.catalog_of(source)
+
+        assert [m.name for m in catalog.semantic_models], (
+            "the catalog carries no semantic models. The layer's organizing unit "
+            "is the semantic model, and a caller with none of them holds one "
+            "undifferentiated list of dimension names"
+        )
+        assert any(m.name == name for m in catalog.semantic_models), (
+            f"expected a semantic model named {name!r}, got "
+            f"{[m.name for m in catalog.semantic_models]}"
+        )
+        assert all(d.type for d in catalog.dimensions), (
+            "a dimension arrived with no type. Whether a dimension is time or "
+            "categorical decides how it can be grouped by, so a caller that has "
+            "to guess cannot build a valid query from this catalog"
+        )
+        assert all(m.agg for m in catalog.measures), (
+            "a measure arrived with no aggregation. A measure without its "
+            "aggregation cannot say what the number counts, which is the question "
+            "the catalog exists to answer"
+        )
+
+    def test_an_entity_carries_a_declaration_per_semantic_model(self) -> None:
+        source, _, _, _ = self.a_source_declaring_a_semantic_model()
+        catalog = self.catalog_of(source)
+
+        for entity in catalog.entities:
+            assert entity.roles, (
+                f"entity {entity.name!r} carries no declarations. Its `type` is "
+                "then a single value with nothing behind it, and a value chosen "
+                "per entity rather than per declaration is iteration order"
+            )
+            assert all(r.semantic_model for r in entity.roles), (
+                f"a declaration of entity {entity.name!r} names no semantic "
+                "model, so a caller cannot tell which model it is primary in"
+            )
+            declared = {r.type for r in entity.roles}
+            expected = "primary" if "primary" in declared else next(iter(declared))
+            assert entity.type == expected, (
+                f"entity {entity.name!r} reports type {entity.type!r} while its "
+                f"declarations say {sorted(declared)}. The single value is derived: "
+                "primary wherever any declaration is primary"
+            )
+
+    def test_the_catalog_resolves_a_semantic_model_to_its_relation(self) -> None:
+        """A semantic model that names no relation leaves the layer disconnected.
+
+        The semantic catalog and the physical catalog are two views of one
+        warehouse, and the relation on a semantic model is the whole join between
+        them: it is what answers "which table is behind this metric", what lets
+        ``explore map`` say an object is exposed, and what an entity's declared
+        join is drawn between.
+
+        Declining is still possible and is not this: a source that structurally
+        cannot know the relation declares that gap, which is a different statement
+        from one that could and did not.
+        """
+
+        source, name, _, _ = self.a_source_declaring_a_semantic_model()
+        catalog = self.catalog_of(source)
+
+        model = next(m for m in catalog.semantic_models if m.name == name)
+        assert model.relation, (
+            f"semantic model {name!r} resolves to no physical relation, so nothing "
+            "connects this layer to the objects explore profiles and maps"
+        )
+
+    def test_an_element_carries_its_column_and_never_invents_one(self) -> None:
+        """The same rule the fingerprint follows, on the read catalog.
+
+        Two failures, opposite in direction and both live. A catalog whose columns
+        are all absent cannot reach a physical column at all, which is what the
+        PII gate needs to adjudicate a dimension from evidence rather than from
+        the shape of its name. A catalog that invents a column out of an
+        expression is worse: the gate then screens a column that is not the one
+        behind the element and reports the verdict as evidence-backed.
+
+        The fixture's own mapping is the oracle, including its ``None`` entries,
+        so an implementation is held to what it said its layer contains rather
+        than to a shape.
+        """
+
+        source, name, dimensions, measures = self.a_source_declaring_a_semantic_model()
+        catalog = self.catalog_of(source)
+
+        for element, expected in (
+            (
+                {
+                    d.definition: d.column
+                    for d in catalog.dimensions
+                    if d.semantic_model == name
+                },
+                dimensions,
+            ),
+            (
+                {
+                    m.name: m.column
+                    for m in catalog.measures
+                    if m.semantic_model == name
+                },
+                measures,
+            ),
+        ):
+            for field, column in expected.items():
+                assert field in element, (
+                    f"the catalog carries no entry for {field!r} on {name!r}; the "
+                    "fixture declares it, so the read dropped it"
+                )
+                assert element[field] == column, (
+                    f"{field!r} on {name!r} carries column {element[field]!r} where "
+                    f"the fixture says {column!r}. None is the honest answer for a "
+                    "computed expression: a column guessed out of one makes the PII "
+                    "gate screen the wrong column and call it evidence"
+                )
+
+    def test_a_dimension_row_names_the_token_a_query_groups_by(self) -> None:
+        """The catalog's ``name`` is a query token, not a display name.
+
+        A caller builds a group-by out of it, so an implementation that returns
+        the bare declared name where the layer requires a qualified path hands
+        back a catalog whose every dimension fails at query time.
+        """
+
+        source, _, _, _ = self.a_source_declaring_a_semantic_model()
+        catalog = self.catalog_of(source)
+
+        listed = {d.name for d in catalog.dimensions}
+        for metric in catalog.metrics:
+            missing = sorted(set(metric.dimensions) - listed - {"metric_time"})
+            assert not missing, (
+                f"metric {metric.name!r} says it can be grouped by {missing}, and "
+                "no dimension row carries those names. The two must be the same "
+                "vocabulary or neither can be acted on"
+            )
+
+    def test_an_unreadable_source_says_why_rather_than_returning_an_empty_layer(
+        self,
+    ) -> None:
+        """An empty layer and an unreadable one are different answers.
+
+        Only one of them is fixed by editing a file, and a caller that cannot tell
+        them apart reads "this layer declares nothing" and stops looking. The
+        catalog channel may raise or it may answer with notes; what it may not do
+        is answer empty and silent.
+        """
+
+        source = self.an_unreadable_semantic_source()
+        if source is None:
+            pytest.skip(
+                "an_unreadable_semantic_source() returned None: this "
+                "implementation declares it has no unreadable state, so the "
+                "degradation path goes unchecked"
+            )
+
+        from .errors import DexError
+
+        try:
+            catalog = self.catalog_of(source)
+        except DexError as exc:
+            assert str(exc).strip(), (
+                "the catalog refused an unreadable source with an empty message, "
+                "so the caller learns that something is wrong and nothing about "
+                "which file to open"
+            )
+            return
+
+        assert catalog.notes, (
+            "an unreadable source answered with a catalog carrying no notes. An "
+            "empty result with no note is indistinguishable from a layer that "
+            "genuinely declares nothing, and the two need different actions"
+        )
+
+
+class SemanticSourceFactoryContract:
+    """Construction: cheap, coordinate-checked, and reading nothing.
+
+    Separate from the capability contracts above for the reason the project seam
+    separates them: what a source *does* once built and whether dex can build one
+    from a committed config line are different questions, and a source handed to
+    dex ready-made never goes through this half at all.
+    """
+
+    def build_source(self, context: SemanticSourceContext) -> Any:
+        """Build the source from a context, the way the engine will."""
+
+        raise NotImplementedError
+
+    def empty_source_context(self) -> SemanticSourceContext:
+        """Coordinates for a source with nothing declared in it."""
+
+        raise NotImplementedError
+
+    def absent_document_context(self) -> SemanticSourceContext | None:
+        """Coordinates naming content that does not exist yet, or ``None``.
+
+        ``None`` skips the read-nothing assertion. Override it for a file-backed
+        source, where this is the case that matters: a typo in a semantic-layer
+        path must not make ``explore map`` on a raw warehouse fail.
+        """
+
+        return None
+
+    def test_the_factory_builds_a_source_that_answers_a_catalog(self) -> None:
+        from .semantic_source import SemanticCatalogSource
+
+        built = self.build_source(self.empty_source_context())
+
+        assert isinstance(built, SemanticCatalogSource), (
+            f"the factory built a {type(built).__name__}, which cannot answer a "
+            "semantic catalog. Answering one is the floor for anything a vendor "
+            "names, because every read downstream goes through it"
+        )
+
+    def test_an_option_the_source_cannot_honor_is_refused(self) -> None:
+        """Accepted and ignored is indistinguishable from honored, right up until
+        dex is reading different documents than the configuration named."""
+
+        import dataclasses
+
+        context = self.empty_source_context()
+        probe = "dex_conformance_unknown_option"
+        context = dataclasses.replace(
+            context, options={**dict(context.options or {}), probe: "x"}
+        )
+
+        with pytest.raises(Exception) as caught:
+            self.build_source(context)
+
+        assert probe in str(caught.value), (
+            "the refusal does not name the option it refused, so someone reading "
+            f"it cannot tell which config line to delete. Got: {caught.value}"
+        )
+
+    def test_construction_reads_nothing(self) -> None:
+        """Cheap by contract: dex builds a source per command, and a factory that
+        parsed would charge every command that never looks at a semantic layer.
+
+        Also why content that is *named but absent* is not a construction error:
+        refusing here would make `explore map` on a raw warehouse fail over a typo
+        in a semantic-layer path.
+        """
+
+        context = self.absent_document_context()
+        if context is None:
+            pytest.skip(
+                "absent_document_context() returned None: this implementation "
+                "declares it has no named-but-absent state, so construction is "
+                "not checked for reading eagerly"
+            )
+
+        self.build_source(context)

--- a/packages/dex-core/src/exmergo_dex_core/transform/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/commands.py
@@ -22,7 +22,7 @@ import argparse
 import contextlib
 import json
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -35,7 +35,6 @@ from ..errors import DexError
 from ..results import to_envelope
 from ..storage import Store, readable_cache
 from . import plans as plans_mod
-from . import semantic as semantic_mod
 from .native_semantic import edits_from_payload, plan_hint, read_payload_file
 from .plans import EditKind, PlanEdit, PlanError
 from .results import (
@@ -51,10 +50,25 @@ from .results import (
     PropagationResult,
     TestScaffoldResult,
 )
-from .validate import EditValidationError
 
 if TYPE_CHECKING:
     from ..engine import DexEngine
+    from . import semantic as semantic_mod
+
+# Two of this module's neighbours reach the dialect engine at import (`.semantic`
+# for MetricFlow-shaped YAML, `.validate` for SQL), and importing either here
+# would put sqlglot behind every verb this module serves. Most of them need it;
+# `apply` does not, and `transform apply` is how a native semantic plan is
+# written. An install carrying only a semantic reader has no sqlglot, so an
+# eager import here would let that install author a plan it could never apply.
+# Reached at the point of use instead, which is where the dependency is real.
+
+
+def _semantic() -> Any:
+    from . import semantic
+
+    return semantic
+
 
 # What actually caps a dbt statement server-side, per compute-time connector:
 # a per-connector fact, kept out of the shared build arm so the next connector
@@ -731,7 +745,7 @@ def apply(engine: DexEngine, plan_id: str | None = None) -> ApplyResult:
     stored = store.load_plan(plan_id)
     semantic_layer = None
     if stored.edit_target == "semantic":
-        candidate = engine.semantic_catalog_format()
+        candidate = engine.semantic_catalog_source()
         if isinstance(candidate, SemanticEditTarget):
             semantic_layer = candidate
     outcome: PlanApplyResult = plans_mod.apply(
@@ -1090,6 +1104,14 @@ def cmd_semantic_plan(args: argparse.Namespace, engine: DexEngine) -> env.Envelo
     return _semantic_envelope(args, engine, "plan")
 
 
+def _validation_error() -> type[Exception]:
+    """`.validate`'s error, reached lazily for the reason above it."""
+
+    from .validate import EditValidationError
+
+    return EditValidationError
+
+
 def _semantic_envelope(
     args: argparse.Namespace, engine: DexEngine, mode: str
 ) -> env.Envelope:
@@ -1105,7 +1127,7 @@ def _semantic_envelope(
             ),
             no_parse=bool(getattr(args, "no_parse", False)),
         )
-    except EditValidationError as exc:
+    except _validation_error() as exc:
         return env.error_for(exc)
     except DbtParseError as exc:
         return env.error_for(exc, warnings=exc.warnings)
@@ -1531,7 +1553,7 @@ def _semantic_plan(
         # on one code path regardless of how the caller expressed the change.
         edits = [
             PlanEdit(path=path, kind=EditKind.SEMANTIC_YML, new_content=content)
-            for path, content in semantic_mod.splice_definitions(definitions, view)
+            for path, content in _semantic().splice_definitions(definitions, view)
         ]
         scope = {(d.kind, d.name) for d in definitions}
         removed = [d for d in definitions if d.op is EditOp.DELETE]
@@ -1557,7 +1579,7 @@ def _semantic_plan(
 
     parsed_by_path = [(e.path, yaml.safe_load(e.new_content)) for e in edits]
     parsed_edits = [parsed for _path, parsed in parsed_by_path]
-    classification = semantic_mod.check_mode(
+    classification = _semantic().check_mode(
         mode,
         parsed_by_path,
         view,
@@ -1566,11 +1588,11 @@ def _semantic_plan(
     )
     # The two reference directions: what this payload's own definitions read,
     # then what the surviving project reads out of what it removes.
-    semantic_mod.check_references(parsed_edits, view)
-    semantic_mod.check_removals(
+    _semantic().check_references(parsed_edits, view)
+    _semantic().check_removals(
         removed, [(e.path, e.new_content or "") for e in edits], view
     )
-    spine_warning = semantic_mod.time_spine_warning(view, parsed_edits)
+    spine_warning = _semantic().time_spine_warning(view, parsed_edits)
 
     # The authoritative gate: a plan that dbt cannot parse is never stored.
     # Skipped when the time-spine warning fires (dbt would refuse to parse for
@@ -1662,4 +1684,4 @@ def _definitions_from_payload(
     entries = payload.get("definitions") if isinstance(payload, dict) else None
     if not isinstance(entries, list):
         raise ValueError('definitions payload must be {"definitions": [...]}')
-    return semantic_mod.parse_definition_payload(entries)
+    return _semantic().parse_definition_payload(entries)

--- a/packages/dex-core/src/exmergo_dex_core/transform/native_semantic.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/native_semantic.py
@@ -1,12 +1,12 @@
 """Native semantic-document authoring: whole documents in, a reviewable plan out.
 
 Its own module rather than a branch inside :mod:`.commands`, for the reason
-``transform references`` is one: a vendor whose semantic layer is its own
-project format (:data:`..config.SEMANTIC_PROJECT_FORMATS`) authors documents,
-not SQL, so this route owes nothing to the dialect engine or to dbt. Importing
-`.commands` would pull the whole dbt authoring surface and sqlglot with it,
-which an install carrying only the vendor's own reader does not have, and the
-one command that install exists to run would be unreachable.
+``transform references`` is one: a vendor whose semantic layer is its own source
+(:data:`..config.SEMANTIC_SOURCE_FACTORIES`) authors documents, not SQL, so this
+route owes nothing to the dialect engine or to dbt. Importing `.commands` would
+pull the whole dbt authoring surface and sqlglot with it, which an install
+carrying only the vendor's own reader does not have, and the one command that
+install exists to run would be unreachable.
 
 The edits payload reader lives here for the same reason and is imported back by
 `.commands`: turning ``{"edits": [...]}`` into plan edits parses nothing.
@@ -63,9 +63,12 @@ def semantic_ossie(
             + ", ".join(deleted)
         )
 
-    layer = engine.semantic_catalog_format()
+    layer = engine.semantic_catalog_source()
     if not isinstance(layer, SemanticEditTarget):
-        named = getattr(layer, "name", type(layer).__name__)
+        # The vendor, not the class: the caller configured a vendor name and that
+        # is the line they would edit. A class name would send someone reading
+        # this into the engine looking for a setting that is not there.
+        named = getattr(engine.config.semantic, "vendor", None) or "dbt"
         raise ValueError(
             f"the configured '{named}' semantic layer does not support native "
             "semantic-document authoring; configure `semantic.vendor: ossie`"

--- a/packages/dex-core/tests/adapters/test_project_parity.py
+++ b/packages/dex-core/tests/adapters/test_project_parity.py
@@ -154,6 +154,19 @@ class TestDbtProject(
         (project / "dbt_project.yml").write_text("name: [unclosed\n", encoding="utf-8")
         return DbtProject(self.root, project)
 
+    def an_unreadable_semantic_source(self) -> DbtProject:
+        # An uncompiled project rather than a broken one: this is the state a dbt
+        # user reaches every time, and it is the one where "no metrics" and "not
+        # compiled yet" are easiest to confuse. Only one of them is fixed by
+        # running `dbt parse`.
+        project = self.root / "uncompiled"
+        project.mkdir()
+        (project / "dbt_project.yml").write_text(
+            "name: uncompiled\nprofile: uncompiled\nversion: '1.0'\n",
+            encoding="utf-8",
+        )
+        return DbtProject(self.root, project)
+
     def a_project_declaring_a_unique_key(self) -> tuple[DbtProject, str, str]:
         project = _project(
             self.root,

--- a/packages/dex-core/tests/ossie/fixtures/cases.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/cases.yaml
@@ -1,0 +1,236 @@
+# The reviewed Ossie corpus: one entry per case, each naming the documents it
+# reads and what dex is expected to make of them.
+#
+# The expectations here are authored from the documented rules, not captured
+# from a run. A golden file recorded from the implementation asserts that the
+# implementation still does what it did, which is a different and much weaker
+# statement than that it does what it is supposed to. That is also why there are
+# no full-envelope goldens: an envelope carries plan ids, absolute paths and
+# timestamps, and a corpus that has to be regenerated whenever one of those
+# moves stops being read.
+#
+# `origin` says where a rule comes from, which decides what an upgrade means:
+#
+#   schema     the pinned Apache Ossie JSON Schema decides it. A schema upgrade
+#              may legitimately change the verdict.
+#   integrity  upstream's own validation judgment, ported rather than reinvented.
+#   dex        dex's own restriction, and a candidate to carry upstream.
+#
+# `severity` is one of three, and they are not three strengths of one verdict:
+#
+#   error      dex could not read the document. It is absent from the layer.
+#   warning    dex read it and has something to say about what it found.
+#   note       dex read it and is saying what it did not check, which is the
+#              honest answer where a silent pass would be a false one.
+#
+# Every path is relative to this file's `documents/` directory. The offline
+# consistency test refuses a case naming a document that does not exist, and
+# refuses a document no case names.
+
+schema:
+  # Pinned here as well as in the loader and PROVENANCE.md, so a hash bumped in
+  # one place and not the others fails rather than drifting quietly.
+  sha256: 27aab111647b1e8d2229a2413e4682e459f43edc62e0eaadd497317754089e42
+  upstream_commit: b5da5d66f0da4a0cd3388d52201dbf5523221a77
+  declared_version: 0.2.0.dev0
+
+cases:
+  - id: minimal_yaml
+    documents: [minimal.ossie.yaml]
+    connector: duckdb
+    diagnostics: []
+    semantic_models: [shop.orders]
+    physical_columns:
+      orders__order_id: [demo.main.orders, order_id]
+    composite_keys: []
+    single_keys:
+      - {model: shop.orders, column: order_id}
+
+  - id: minimal_yml
+    documents: [minimal.ossie.yml]
+    connector: duckdb
+    diagnostics: []
+    semantic_models: [shop.orders]
+    physical_columns:
+      orders__order_id: [demo.main.orders, order_id]
+
+  - id: minimal_json
+    documents: [minimal.ossie.json]
+    connector: duckdb
+    diagnostics: []
+    semantic_models: [shop.orders]
+    physical_columns:
+      orders__order_id: [demo.main.orders, order_id]
+
+  - id: compose_two_documents
+    documents: [compose_a.ossie.yaml, compose_b.ossie.yaml]
+    connector: duckdb
+    diagnostics: []
+    semantic_models: [shop.orders, logistics.shipments]
+
+  - id: duplicate_model_across_files
+    documents: [compose_a.ossie.yaml, compose_clash.ossie.yaml]
+    connector: duckdb
+    diagnostics:
+      - {rule: duplicate_semantic_model_across_files, severity: error, origin: dex}
+
+  - id: yaml_stream_in_one_file
+    documents: [stream.ossie.yaml]
+    connector: duckdb
+    # One configured file is one document, and a `---` stream inside one is
+    # refused rather than read as several. Configuring a file is what puts its
+    # content in the layer and what makes it writable by `semantic ossie`, so a
+    # stream would put documents in the layer that no config line names and that
+    # the authoring surface has no way to address.
+    diagnostics:
+      - {rule: malformed, severity: error, origin: dex}
+    semantic_models: []
+
+  - id: unparseable
+    documents: [unparseable.ossie.yaml]
+    connector: duckdb
+    # `malformed`, not `unreadable`: the file opened and its bytes are not YAML.
+    # `unreadable` is the separate rule for a file dex could not open at all,
+    # and keeping them apart is what lets a caller tell a missing document from
+    # a broken one.
+    diagnostics:
+      - {rule: malformed, severity: error, origin: dex}
+    semantic_models: []
+
+  - id: wrong_version
+    documents: [wrong_version.ossie.yaml]
+    connector: duckdb
+    diagnostics:
+      - {rule: version, severity: error, origin: schema}
+    semantic_models: []
+
+  - id: unknown_structural_key
+    documents: [unknown_key.ossie.yaml]
+    connector: duckdb
+    diagnostics:
+      - {rule: unknown_key, severity: error, origin: schema}
+    semantic_models: []
+
+  - id: duplicate_names_within_a_document
+    documents: [duplicate_names.ossie.yaml]
+    connector: duckdb
+    diagnostics:
+      - {rule: duplicate_dataset, severity: error, origin: integrity}
+      - {rule: duplicate_field, severity: error, origin: integrity}
+      - {rule: duplicate_metric, severity: error, origin: integrity}
+
+  - id: relationship_endpoint_missing
+    documents: [missing_endpoint.ossie.yaml]
+    connector: duckdb
+    diagnostics:
+      - {rule: unknown_dataset, severity: error, origin: integrity}
+
+  - id: relationship_arity_unequal
+    documents: [unequal_arity.ossie.yaml]
+    connector: duckdb
+    diagnostics:
+      - {rule: key_arity, severity: error, origin: dex}
+
+  - id: target_key_coverage_warns
+    documents: [weak_target_key.ossie.yaml]
+    connector: duckdb
+    diagnostics:
+      - {rule: key_coverage, severity: warning, origin: integrity}
+    # A warning retains the document: it is readable, and the fanout may be what
+    # the author meant.
+    semantic_models: [shop.orders, shop.customers]
+
+  - id: dialect_selection
+    documents: [dialects.ossie.yaml]
+    connector: bigquery
+    diagnostics: []
+    physical_columns:
+      orders__connector_wins: [demo.main.orders, bigquery_column]
+      orders__ansi_next: [demo.main.orders, ansi_column]
+      orders__first_supported: [demo.main.orders, databricks_column]
+
+  - id: dialect_selection_falls_back_to_portable
+    documents: [dialects.ossie.yaml]
+    # DuckDB has no token in Ossie's enum, so it falls to the portable dialect
+    # rather than to something close. A wrong dialect is a worse answer.
+    connector: duckdb
+    diagnostics: []
+    physical_columns:
+      orders__connector_wins: [demo.main.orders, ansi_column]
+      orders__ansi_next: [demo.main.orders, ansi_column]
+      orders__first_supported: [demo.main.orders, databricks_column]
+
+  - id: non_sql_dialects_are_metadata
+    documents: [non_sql.ossie.yaml]
+    connector: duckdb
+    # A note rather than a warning: nothing is wrong with the document. dex is
+    # saying which expressions it did not check, so a caller never reads
+    # "skipped" as "validated".
+    diagnostics:
+      - {rule: non_sql_dialect, severity: note, origin: dex}
+    # Only the field that also declares SQL resolves to a column. The three
+    # non-SQL-only fields are preserved and carry none.
+    physical_columns:
+      orders__mixed: [demo.main.orders, order_id]
+
+  - id: post_pin_thoughtspot_is_refused
+    documents: [post_pin_dialect.ossie.yaml]
+    connector: duckdb
+    diagnostics:
+      - {rule: enum, severity: error, origin: schema}
+    semantic_models: []
+
+  - id: physical_linkage_is_direct_only
+    documents: [linkage.ossie.yaml]
+    connector: duckdb
+    diagnostics: []
+    # The only entry: a bare identifier on a three-part relation. Everything
+    # else in the document is a shape dex refuses to read a column out of.
+    physical_columns:
+      direct__bare: [demo.main.orders, order_total]
+
+  - id: keys_and_relationships
+    documents: [keys.ossie.yaml]
+    connector: duckdb
+    diagnostics: []
+    composite_keys:
+      - {model: grain.allocations, columns: [order_id, line_no, warehouse_id]}
+      - {model: grain.customers, columns: [tenant_id, external_ref]}
+    single_keys:
+      - {model: grain.customers, column: customer_id}
+      - {model: grain.customers, column: email}
+      - {model: grain.orders, column: order_id}
+    relationships:
+      - model: grain.orders
+        to_model: grain.customers
+        pairs: [[buyer_tenant, tenant_id], [buyer_ref, external_ref]]
+      - model: grain.allocations
+        to_model: grain.orders
+        pairs: [[order_id, order_id]]
+
+  - id: adversarial_composite
+    documents: [adversarial_composite.ossie.yaml]
+    connector: duckdb
+    diagnostics: []
+    relationships:
+      - model: adversarial.child
+        to_model: adversarial.parent
+        pairs: [[c_one, p_one], [c_two, p_two], [c_three, p_three]]
+
+  - id: drift_baseline
+    documents: [drift_before.ossie.yaml]
+    connector: duckdb
+    diagnostics: []
+    semantic_models: [drift.orders, drift.customers]
+    composite_keys:
+      - {model: drift.orders, columns: [order_id, tenant_id]}
+
+  - id: drift_changed
+    documents: [drift_after.ossie.yaml]
+    connector: duckdb
+    diagnostics: []
+    semantic_models: [drift.orders, drift.customers]
+    composite_keys: []
+    single_keys:
+      - {model: drift.orders, column: order_id}
+      - {model: drift.customers, column: customer_id}

--- a/packages/dex-core/tests/ossie/fixtures/documents/adversarial_composite.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/adversarial_composite.ossie.yaml
@@ -1,0 +1,38 @@
+# The case a per-column overlap measurement gets wrong.
+#
+# Child tuples (1, 10, 100) and (2, 20, 200); parent tuples (1, 20, 200) and
+# (2, 10, 100). Every component overlaps independently, so a probe that measures
+# one column at a time reports a healthy join three times over. No complete
+# tuple matches, so the join finds nothing.
+#
+# The two sides are named differently on purpose: copying one side's columns
+# onto the other would otherwise satisfy the assertion.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: adversarial
+    datasets:
+      - name: child
+        source: demo.main.child
+        fields:
+          - name: c_one
+            expression: {dialects: [{dialect: ANSI_SQL, expression: c_one}]}
+          - name: c_two
+            expression: {dialects: [{dialect: ANSI_SQL, expression: c_two}]}
+          - name: c_three
+            expression: {dialects: [{dialect: ANSI_SQL, expression: c_three}]}
+      - name: parent
+        source: demo.main.parent
+        primary_key: [p_one, p_two, p_three]
+        fields:
+          - name: p_one
+            expression: {dialects: [{dialect: ANSI_SQL, expression: p_one}]}
+          - name: p_two
+            expression: {dialects: [{dialect: ANSI_SQL, expression: p_two}]}
+          - name: p_three
+            expression: {dialects: [{dialect: ANSI_SQL, expression: p_three}]}
+    relationships:
+      - name: child_to_parent
+        from: child
+        to: parent
+        from_columns: [c_one, c_two, c_three]
+        to_columns: [p_one, p_two, p_three]

--- a/packages/dex-core/tests/ossie/fixtures/documents/compose_a.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/compose_a.ossie.yaml
@@ -1,0 +1,16 @@
+# Half of a two-document layer. Its sibling declares a different model, so the
+# two compose; compose_clash.ossie.yaml declares this same model name, which is
+# the cross-file collision dex refuses.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        primary_key: [order_id]
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id

--- a/packages/dex-core/tests/ossie/fixtures/documents/compose_b.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/compose_b.ossie.yaml
@@ -1,0 +1,13 @@
+version: "0.2.0.dev0"
+semantic_model:
+  - name: logistics
+    datasets:
+      - name: shipments
+        source: demo.main.shipments
+        primary_key: [shipment_id]
+        fields:
+          - name: shipment_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: shipment_id

--- a/packages/dex-core/tests/ossie/fixtures/documents/compose_clash.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/compose_clash.ossie.yaml
@@ -1,0 +1,15 @@
+# Declares `shop` a second time. Two files each valid on their own, and a layer
+# that is not: a name resolved to two definitions has no answer.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: returns
+        source: demo.main.returns
+        primary_key: [return_id]
+        fields:
+          - name: return_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: return_id

--- a/packages/dex-core/tests/ossie/fixtures/documents/dialects.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/dialects.ossie.yaml
@@ -1,0 +1,37 @@
+# One field per selection rule, so a change to the order shows up as a specific
+# failure rather than as "the dialect test broke". Every declared expression is
+# preserved whichever one dex reads.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: dialects
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        fields:
+          # The active connector's own dialect wins where the document has one.
+          - name: connector_wins
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ansi_column
+                - dialect: BIGQUERY
+                  expression: bigquery_column
+                - dialect: SNOWFLAKE
+                  expression: snowflake_column
+          # No connector dialect declared, so the portable one answers.
+          - name: ansi_next
+            expression:
+              dialects:
+                - dialect: SNOWFLAKE
+                  expression: snowflake_only
+                - dialect: ANSI_SQL
+                  expression: ansi_column
+          # Neither the connector's nor the portable one: the first supported
+          # SQL dialect in declaration order.
+          - name: first_supported
+            expression:
+              dialects:
+                - dialect: DATABRICKS
+                  expression: databricks_column
+                - dialect: SNOWFLAKE
+                  expression: snowflake_column

--- a/packages/dex-core/tests/ossie/fixtures/documents/drift_after.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/drift_after.ossie.yaml
@@ -1,0 +1,29 @@
+version: "0.2.0.dev0"
+semantic_model:
+  - name: drift
+    datasets:
+      - name: orders
+        # The key lost a column: a two-column grain is now a one-column claim.
+        source: demo.main.orders
+        primary_key: [order_id]
+        fields:
+          - name: order_id
+            expression: {dialects: [{dialect: ANSI_SQL, expression: order_id}]}
+          - name: tenant_id
+            expression: {dialects: [{dialect: ANSI_SQL, expression: tenant_id}]}
+          # The definition changed: the discount is no longer subtracted.
+          - name: net_total
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_total
+      - name: customers
+        source: demo.main.customers
+        primary_key: [customer_id]
+        fields:
+          - name: customer_id
+            expression: {dialects: [{dialect: ANSI_SQL, expression: customer_id}]}
+    metrics:
+      - name: revenue
+        expression:
+          dialects: [{dialect: ANSI_SQL, expression: SUM(orders.net_total)}]

--- a/packages/dex-core/tests/ossie/fixtures/documents/drift_before.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/drift_before.ossie.yaml
@@ -1,0 +1,36 @@
+# The baseline half of the drift pair. Its `after` twin changes a definition,
+# drops a key column, and breaks a relationship endpoint, so one comparison
+# exercises three drift classes against one baseline.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: drift
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        primary_key: [order_id, tenant_id]
+        fields:
+          - name: order_id
+            expression: {dialects: [{dialect: ANSI_SQL, expression: order_id}]}
+          - name: tenant_id
+            expression: {dialects: [{dialect: ANSI_SQL, expression: tenant_id}]}
+          - name: net_total
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_total - discount
+      - name: customers
+        source: demo.main.customers
+        primary_key: [customer_id]
+        fields:
+          - name: customer_id
+            expression: {dialects: [{dialect: ANSI_SQL, expression: customer_id}]}
+    relationships:
+      - name: orders_to_customers
+        from: orders
+        to: customers
+        from_columns: [order_id]
+        to_columns: [customer_id]
+    metrics:
+      - name: revenue
+        expression:
+          dialects: [{dialect: ANSI_SQL, expression: SUM(orders.net_total)}]

--- a/packages/dex-core/tests/ossie/fixtures/documents/duplicate_names.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/duplicate_names.ossie.yaml
@@ -1,0 +1,38 @@
+# Two datasets and two fields sharing a name inside one model, and two metrics
+# sharing one. Each is a name that resolves to two definitions.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: id
+      - name: orders
+        source: demo.main.orders_v2
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id
+    metrics:
+      - name: revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.total)
+      - name: revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.net)

--- a/packages/dex-core/tests/ossie/fixtures/documents/keys.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/keys.ossie.yaml
@@ -1,0 +1,72 @@
+# Keys and relationships in the shapes that separate a real implementation from
+# one that special-cases the pair.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: grain
+    datasets:
+      # Three columns, because a pair cannot tell you what you came to find out:
+      # an implementation that special-cases the pair passes a two-column
+      # fixture and fails a four-column one.
+      - name: allocations
+        source: demo.main.allocations
+        primary_key: [order_id, line_no, warehouse_id]
+        fields:
+          - name: order_id
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: order_id}]
+          - name: line_no
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: line_no}]
+          - name: warehouse_id
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: warehouse_id}]
+      # A primary key beside two further independent unique keys: three separate
+      # claims about one relation, none of which implies another.
+      - name: customers
+        source: demo.main.customers
+        primary_key: [customer_id]
+        unique_keys:
+          - [email]
+          - [tenant_id, external_ref]
+        fields:
+          - name: customer_id
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: customer_id}]
+          - name: email
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: email}]
+          - name: tenant_id
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: tenant_id}]
+          - name: external_ref
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: external_ref}]
+      - name: orders
+        source: demo.main.orders
+        primary_key: [order_id]
+        fields:
+          - name: order_id
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: order_id}]
+          - name: buyer_ref
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: buyer_ref}]
+          - name: buyer_tenant
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: buyer_tenant}]
+    relationships:
+      # Differently named sides, which is the ordinary case rather than the
+      # exotic one: a mirrored fixture cannot detect an implementation that
+      # reads one side and copies it onto the other.
+      - name: orders_to_customers
+        from: orders
+        to: customers
+        from_columns: [buyer_tenant, buyer_ref]
+        to_columns: [tenant_id, external_ref]
+      # Declaration order is the tuple order. Reversing it probes a different
+      # predicate than the author wrote.
+      - name: allocations_to_orders
+        from: allocations
+        to: orders
+        from_columns: [order_id]
+        to_columns: [order_id]

--- a/packages/dex-core/tests/ossie/fixtures/documents/linkage.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/linkage.ossie.yaml
@@ -1,0 +1,57 @@
+# Every physical-linkage rule in one document, because the rules are only
+# meaningful against each other: what makes `bare` a link is the same thing that
+# makes `computed` not one.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: linkage
+    datasets:
+      # A plain relation and a bare identifier: the only shape that links.
+      - name: direct
+        source: demo.main.orders
+        fields:
+          - name: bare
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_total
+          - name: computed
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_total - COALESCE(discount, 0)
+          - name: quoted
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: '"Region"'
+          - name: qualified
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: orders.order_id
+          - name: non_sql_only
+            expression:
+              dialects:
+                - dialect: MDX
+                  expression: "[Order].[Total]"
+      # A query-valued source. Ossie documents a source as database.schema.table
+      # OR a query, with no portable discriminator, and a query read as a
+      # relation would reach the PII gate as a relation that does not exist.
+      - name: query_backed
+        source: SELECT * FROM demo.main.orders WHERE placed_at > '2026-01-01'
+        fields:
+          - name: bare
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id
+      # A source that is not three parts, so not a relation this connector can
+      # address. Opaque rather than guessed at.
+      - name: opaque
+        source: orders
+        fields:
+          - name: bare
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id

--- a/packages/dex-core/tests/ossie/fixtures/documents/minimal.ossie.json
+++ b/packages/dex-core/tests/ossie/fixtures/documents/minimal.ossie.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0.dev0",
+  "semantic_model": [
+    {
+      "name": "shop",
+      "datasets": [
+        {
+          "name": "orders",
+          "source": "demo.main.orders",
+          "primary_key": ["order_id"],
+          "fields": [
+            {
+              "name": "order_id",
+              "expression": {
+                "dialects": [{"dialect": "ANSI_SQL", "expression": "order_id"}]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/dex-core/tests/ossie/fixtures/documents/minimal.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/minimal.ossie.yaml
@@ -1,0 +1,16 @@
+# The smallest complete layer: one model, one dataset, one bare direct field.
+# Its .yml and .json twins carry byte-different serializations of the same
+# document, which is what makes the suffix-equivalence case mean something.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        primary_key: [order_id]
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id

--- a/packages/dex-core/tests/ossie/fixtures/documents/minimal.ossie.yml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/minimal.ossie.yml
@@ -1,0 +1,10 @@
+version: "0.2.0.dev0"
+semantic_model:
+- name: shop
+  datasets:
+  - name: orders
+    source: demo.main.orders
+    fields:
+    - name: order_id
+      expression: {dialects: [{dialect: ANSI_SQL, expression: order_id}]}
+    primary_key: [order_id]

--- a/packages/dex-core/tests/ossie/fixtures/documents/missing_endpoint.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/missing_endpoint.ossie.yaml
@@ -1,0 +1,20 @@
+# A relationship naming a dataset the model does not declare. The endpoint is
+# unresolvable, so the join cannot be drawn and cannot be probed.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        fields:
+          - name: customer_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: customer_id
+    relationships:
+      - name: orders_to_absent
+        from: orders
+        to: customers
+        from_columns: [customer_id]
+        to_columns: [customer_id]

--- a/packages/dex-core/tests/ossie/fixtures/documents/non_sql.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/non_sql.ossie.yaml
@@ -1,0 +1,34 @@
+# MDX, TABLEAU and MAQL are expression languages, not SQL. They are preserved
+# verbatim, never parsed, never a source of a physical column, and never
+# reported as SQL-validated. A bare token in MAQL that looks like a column
+# identifier means something else entirely, which is why reading one would be
+# worse than reading none.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: bi
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        fields:
+          - name: mdx_only
+            expression:
+              dialects:
+                - dialect: MDX
+                  expression: "[Order].[Placed At]"
+          - name: tableau_only
+            expression:
+              dialects:
+                - dialect: TABLEAU
+                  expression: "[Order Total]"
+          - name: maql_only
+            expression:
+              dialects:
+                - dialect: MAQL
+                  expression: "SELECT SUM({metric/total})"
+          - name: mixed
+            expression:
+              dialects:
+                - dialect: MDX
+                  expression: "[Order].[Id]"
+                - dialect: ANSI_SQL
+                  expression: order_id

--- a/packages/dex-core/tests/ossie/fixtures/documents/post_pin_dialect.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/post_pin_dialect.ossie.yaml
@@ -1,0 +1,16 @@
+# THOUGHTSPOT was added upstream after the schema dex pins, so under this pin it
+# is not a member of the enum and the document is refused. Recorded as a known
+# delta rather than accommodated: accepting a token the pinned schema does not
+# define would make the pin decorative.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: post_pin
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: THOUGHTSPOT
+                  expression: order_id

--- a/packages/dex-core/tests/ossie/fixtures/documents/stream.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/stream.ossie.yaml
@@ -1,0 +1,28 @@
+# A YAML `---` stream in one configured file. Configuring a file is what makes
+# its content a document; a stream inside one is not a second configured file,
+# and the loader's existing behavior for it is what this case pins.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: first
+    datasets:
+      - name: things
+        source: demo.main.things
+        fields:
+          - name: thing_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: thing_id
+---
+version: "0.2.0.dev0"
+semantic_model:
+  - name: second
+    datasets:
+      - name: others
+        source: demo.main.others
+        fields:
+          - name: other_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: other_id

--- a/packages/dex-core/tests/ossie/fixtures/documents/unequal_arity.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/unequal_arity.ossie.yaml
@@ -1,0 +1,35 @@
+# dex's own rule, not upstream's: the schema constrains both arrays but not
+# their lengths against each other, and a relationship whose two sides differ in
+# arity has no complete tuple to probe.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: order_items
+        source: demo.main.order_items
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id
+          - name: line_no
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: line_no
+      - name: orders
+        source: demo.main.orders
+        primary_key: [order_id]
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id
+    relationships:
+      - name: items_to_orders
+        from: order_items
+        to: orders
+        from_columns: [order_id, line_no]
+        to_columns: [order_id]

--- a/packages/dex-core/tests/ossie/fixtures/documents/unknown_key.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/unknown_key.ossie.yaml
@@ -1,0 +1,17 @@
+# A structural key the pinned schema does not define. Refused rather than
+# ignored: a key dex accepted and dropped is indistinguishable from one it
+# honored, and the next schema may give it a meaning.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id
+    unexpected_section:
+      - anything

--- a/packages/dex-core/tests/ossie/fixtures/documents/unparseable.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/unparseable.ossie.yaml
@@ -1,0 +1,2 @@
+version: "0.2.0.dev0"
+semantic_model: [ {name: truncated,

--- a/packages/dex-core/tests/ossie/fixtures/documents/weak_target_key.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/weak_target_key.ossie.yaml
@@ -1,0 +1,36 @@
+# Upstream integrity, at warning severity: the target's declared key does not
+# cover the columns the relationship joins on, so the join may fan out. A
+# warning rather than a refusal, because the document is still readable and the
+# fanout may be what the author meant.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        fields:
+          - name: customer_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: customer_id
+      - name: customers
+        source: demo.main.customers
+        primary_key: [tenant_id]
+        fields:
+          - name: customer_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: customer_id
+          - name: tenant_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: tenant_id
+    relationships:
+      - name: orders_to_customers
+        from: orders
+        to: customers
+        from_columns: [customer_id]
+        to_columns: [customer_id]

--- a/packages/dex-core/tests/ossie/fixtures/documents/wrong_version.ossie.yaml
+++ b/packages/dex-core/tests/ossie/fixtures/documents/wrong_version.ossie.yaml
@@ -1,0 +1,14 @@
+# The pin is on content, but the document's own version is still required and
+# still checked, because upstream requires it and the schema is what checks it.
+version: "0.1.0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id

--- a/packages/dex-core/tests/ossie/test_boundaries.py
+++ b/packages/dex-core/tests/ossie/test_boundaries.py
@@ -24,13 +24,29 @@ import exmergo_dex_core
 ROOT = Path(exmergo_dex_core.__file__).parent
 
 
-def imported_by(module: str) -> set[str]:
-    """Every dex module a fresh interpreter pulls in to import ``module``."""
+#: Third-party module prefixes worth naming when they arrive, alongside dex's
+#: own. The dex half catches a reader importing the other format's reader; this
+#: half catches the same mistake arriving one level down, through a library. A
+#: probe that only reported `exmergo_dex_core` modules would pass a change that
+#: imported `dbt.contracts` directly, which is the heavier dependency of the two.
+WATCHED_PREFIXES = ("exmergo_dex_core", "dbt", "metricflow", "sqlglot", "jsonschema")
+
+
+def imported_by(
+    module: str, *, prefixes: tuple[str, ...] = WATCHED_PREFIXES
+) -> set[str]:
+    """Every watched module a fresh interpreter pulls in to import ``module``.
+
+    A fresh interpreter, and the module graph rather than the import lines,
+    because an import that arrives transitively breaks a boundary exactly as
+    thoroughly as one written by hand and a grep cannot see it.
+    """
 
     probe = (
         f"import {module}; import sys;"
+        f"watched = {prefixes!r};"
         "print('\\n'.join(sorted("
-        "m for m in sys.modules if m.startswith('exmergo_dex_core'))))"
+        "m for m in sys.modules if m.startswith(watched))))"
     )
     out = subprocess.run(  # noqa: S603  (a fixed argv, no shell)
         [sys.executable, "-c", probe], capture_output=True, text=True, check=True
@@ -38,9 +54,20 @@ def imported_by(module: str) -> set[str]:
     return set(out.stdout.split())
 
 
+def top_level(modules: set[str]) -> set[str]:
+    """The distributions behind a set of module names, for a readable failure."""
+
+    return {name.split(".")[0] for name in modules}
+
+
 def test_ossie_imports_no_dbt_or_metricflow_reader():
     """Ossie is the portability blueprint for the next semantic integration, so
-    it must be readable without the format it is meant to be independent of."""
+    it must be readable without the format it is meant to be independent of.
+
+    Both levels: dex's own dbt and MetricFlow readers, and the third-party
+    libraries behind them. The second is the one a `[ossie]`-only install
+    actually cannot satisfy, since neither library is there to import.
+    """
 
     pulled = imported_by("exmergo_dex_core.ossie")
     forbidden = {
@@ -51,6 +78,7 @@ def test_ossie_imports_no_dbt_or_metricflow_reader():
     }
 
     assert not pulled & forbidden, sorted(pulled & forbidden)
+    assert not top_level(pulled) & {"dbt", "metricflow"}, sorted(pulled)
 
 
 def test_ossie_authoring_imports_no_transformation_reader():
@@ -65,13 +93,32 @@ def test_ossie_authoring_imports_no_transformation_reader():
     }
 
     assert not pulled & forbidden, sorted(pulled & forbidden)
+    assert not top_level(pulled) & {"dbt", "metricflow"}, sorted(pulled)
+
+
+def test_the_semantic_source_seam_pulls_in_no_reader_at_all():
+    """The seam every semantic source is constructed through has to be
+    importable without any of them.
+
+    It resolves a factory by dotted path, so importing it must not import what
+    it can resolve: a base install that eagerly loaded the Ossie reader to define
+    the seam would pull the schema validator that install does not have.
+    """
+
+    pulled = imported_by("exmergo_dex_core.semantic_source")
+
+    assert "exmergo_dex_core.ossie" not in pulled, sorted(pulled)
+    assert not top_level(pulled) - {"exmergo_dex_core"}, sorted(pulled)
 
 
 def test_the_dbt_reader_does_not_import_ossie():
     """The other direction, which is the one that would make an existing dbt
     deployment depend on a draft interchange schema."""
 
-    assert "exmergo_dex_core.ossie" not in imported_by("exmergo_dex_core.dbt_project")
+    pulled = imported_by("exmergo_dex_core.dbt_project")
+
+    assert "exmergo_dex_core.ossie" not in pulled, sorted(pulled)
+    assert "jsonschema" not in top_level(pulled), sorted(pulled)
 
 
 def test_the_tier_one_type_is_reachable_without_either_format():
@@ -140,11 +187,11 @@ def test_no_source_file_carries_a_blanket_line_length_suppression():
 
 @pytest.mark.parametrize("suffix", [".yaml", ".yml", ".json"])
 def test_every_documented_suffix_is_accepted(suffix, tmp_path: Path):
-    from exmergo_dex_core.adapters.project import ProjectContext
-    from exmergo_dex_core.ossie import OssieProject
+    from exmergo_dex_core.ossie import OssieSemanticLayer
+    from exmergo_dex_core.semantic_source import SemanticSourceContext
 
-    OssieProject.from_context(
-        ProjectContext(
+    OssieSemanticLayer.from_context(
+        SemanticSourceContext(
             repo_root=str(tmp_path),
             connector="duckdb",
             options={"files": [f"a.ossie{suffix}"]},

--- a/packages/dex-core/tests/ossie/test_catalog.py
+++ b/packages/dex-core/tests/ossie/test_catalog.py
@@ -12,15 +12,15 @@ from pathlib import Path
 
 import pytest
 
-from exmergo_dex_core.adapters.project import ProjectContext
-from exmergo_dex_core.ossie import OssieProject
+from exmergo_dex_core.ossie import OssieSemanticLayer
+from exmergo_dex_core.semantic_source import SemanticSourceContext
 
 from .conftest import dataset, document, expression, field, model, write
 
 
-def build(root: Path, *names: str, connector: str = "duckdb") -> OssieProject:
-    return OssieProject.from_context(
-        ProjectContext(
+def build(root: Path, *names: str, connector: str = "duckdb") -> OssieSemanticLayer:
+    return OssieSemanticLayer.from_context(
+        SemanticSourceContext(
             repo_root=str(root), connector=connector, options={"files": list(names)}
         )
     )
@@ -33,7 +33,7 @@ def catalog(repo: Path):
 
 @pytest.fixture
 def declared(repo: Path):
-    return build(repo, "commerce.ossie.yaml").definitions()
+    return build(repo, "commerce.ossie.yaml").declared_definitions()
 
 
 def dimension(catalog, name):
@@ -465,7 +465,7 @@ def test_relationship_columns_need_not_be_declared_fields(tmp_path: Path):
         ),
     )
 
-    declared = build(tmp_path, "undeclared.ossie.yaml").definitions()
+    declared = build(tmp_path, "undeclared.ossie.yaml").declared_definitions()
 
     assert declared.foreign_keys[0].column == "parent_fk"
 

--- a/packages/dex-core/tests/ossie/test_commands.py
+++ b/packages/dex-core/tests/ossie/test_commands.py
@@ -56,15 +56,26 @@ def test_the_vendor_resolves_to_the_ossie_backend(configured: Path):
     assert backend.descriptor.execution == "dex"
 
 
-def test_the_backend_reads_its_catalog_through_the_injected_format(
+def test_the_layer_reads_its_catalog_through_the_injected_source(
     configured: Path,
 ):
-    """The backend never constructs a reader, which is what lets one class serve
-    both configuration routes without this class knowing which it is in."""
+    """The runtime layer never constructs a reader, which is what lets one class
+    serve both configuration routes without knowing which it is in.
+
+    It holds a semantic *source*, not a project: the object it was handed
+    answers a catalog and declines every project tier, which is what stops the
+    explore surface reasoning about a document set as a model graph.
+    """
+
+    from exmergo_dex_core.adapters.project import ExploreProject
+    from exmergo_dex_core.ossie import OssieSemanticLayer
+    from exmergo_dex_core.semantic_source import SemanticCatalogSource
 
     backend = resolve_backend(DexEngine.from_repo(str(configured)))
 
-    assert backend._project.name == "ossie"
+    assert isinstance(backend._source, OssieSemanticLayer)
+    assert isinstance(backend._source, SemanticCatalogSource)
+    assert not isinstance(backend._source, ExploreProject)
 
 
 def test_a_hosted_source_is_refused_for_a_local_only_vendor(configured: Path):

--- a/packages/dex-core/tests/ossie/test_conformance.py
+++ b/packages/dex-core/tests/ossie/test_conformance.py
@@ -1,17 +1,28 @@
 """The shipped contracts, subclassed for Ossie.
 
-Five bindings rather than hand-written parallel assertions. The contracts are
-the standard the other formats and backends are already held to, they are
-already written, and each one is a fixture hook or two away. Subclassing them
-also means a later change to the contract reaches this format automatically,
-which is exactly what a format built as the second implementation of a seam
-needs.
+Bindings rather than hand-written parallel assertions. The contracts are the
+standard the other sources and layers are already held to, they are already
+written, and each one is a hook or two away. Subclassing them also means a later
+change to a contract reaches this implementation automatically, which is what a
+second implementation of a seam needs.
 
-The tier contracts stop where the format's own implementation does. Subclassing
-a wider contract than the format implements is how you find out you have not
-finished, so a narrow class is a feature: `TestOssieProject` now reaches tier 2
-(#409), and stops there rather than also mixing in the tier-3 write contract,
-which Ossie does not implement.
+**Semantic-source contracts, not project ones.** Ossie is a semantic layer: it
+owns no model graph, no compilation, no targets, and no dbt write surface, so
+the project tiers are the wrong standard for it and satisfying them would be
+claiming capabilities it does not have. What it does own is a set of
+declarations, a read catalog, a drift fingerprint, and a write surface over its
+own configured documents, and there is a contract for each. The assertions are
+the same ones the project contracts run, extracted rather than copied, so dbt and
+Ossie cannot drift apart on behaviour they share.
+
+Which contracts are absent is the other half of the statement.
+`SemanticCatalogContract` from `explore.semantic.conformance` is not here: it
+asserts the content of a dbt-shaped reference layer, and Ossie has no entities,
+no measures, and no metric groupability to answer it with. Manufacturing them to
+pass would be inventing a layer the document's author never wrote. The catalog
+*shape* rules that do apply reach Ossie through `SemanticBackendContract` and the
+source contracts below, and the applicability boundary is written down in
+`references/ossie-compatibility.md` rather than left as a gap someone rediscovers.
 """
 
 from __future__ import annotations
@@ -20,44 +31,43 @@ from pathlib import Path
 
 import pytest
 
-from exmergo_dex_core.adapters.conformance import (
-    DeclaringProjectContract,
-    MaintainProjectContract,
-    ProjectFactoryContract,
-    SemanticCatalogContract,
-    SemanticProjectContract,
-)
-from exmergo_dex_core.adapters.project import ExploreProject, ProjectContext
 from exmergo_dex_core.edits import EditOp, content_hash
 from exmergo_dex_core.edits_conformance import SemanticEditTargetContract
 from exmergo_dex_core.explore.semantic.conformance import SemanticBackendContract
 from exmergo_dex_core.explore.semantic.ossie import LocalOssieBackend
-from exmergo_dex_core.ossie import OssieProject
+from exmergo_dex_core.ossie import OssieSemanticLayer
+from exmergo_dex_core.semantic_source import SemanticSourceContext
+from exmergo_dex_core.semantic_source_conformance import (
+    SemanticCatalogSourceContract,
+    SemanticDeclarationContract,
+    SemanticFingerprintContract,
+    SemanticSourceFactoryContract,
+)
 from exmergo_dex_core.transform.plans import EditKind, PlanEdit
 
 from .conftest import dataset, document, expression, field, model, write
 
 
-def _project(root: Path, *names: str) -> OssieProject:
-    return OssieProject.from_context(
-        ProjectContext(
+def _source(root: Path, *names: str) -> OssieSemanticLayer:
+    return OssieSemanticLayer.from_context(
+        SemanticSourceContext(
             repo_root=str(root), connector="duckdb", options={"files": list(names)}
         )
     )
 
 
-def _declaring(root: Path, name: str, doc) -> OssieProject:
+def _declaring(root: Path, name: str, doc) -> OssieSemanticLayer:
     write(root, name, doc)
-    return _project(root, name)
+    return _source(root, name)
 
 
-class TestOssieProject(
-    ProjectFactoryContract,
-    DeclaringProjectContract,
-    MaintainProjectContract,
-    SemanticProjectContract,
+class TestOssieSemanticSource(
+    SemanticSourceFactoryContract,
+    SemanticDeclarationContract,
+    SemanticFingerprintContract,
+    SemanticCatalogSourceContract,
 ):
-    """Tier 1 and 2, the factory, and the declarations dex reads a project *for*."""
+    """Construction, declarations, the fingerprint, and the read catalog."""
 
     @pytest.fixture(autouse=True)
     def _root(self, tmp_path: Path) -> None:
@@ -65,14 +75,14 @@ class TestOssieProject(
         # fixtures, so the root is stashed on the instance for them to reach.
         self.root = tmp_path
 
-    def build(self, context: ProjectContext):
-        return OssieProject.from_context(context)
+    def build_source(self, context: SemanticSourceContext):
+        return OssieSemanticLayer.from_context(context)
 
-    def empty_context(self) -> ProjectContext:
-        """A project with nothing declared in it.
+    def empty_source_context(self) -> SemanticSourceContext:
+        """A layer with nothing declared in it.
 
         A document declaring one dataset and nothing about it, which is what
-        "nothing declared" means for a format whose documents *are* the
+        "nothing declared" means for a source whose documents *are* the
         declarations: an empty file is not a valid Ossie document at all, since
         the schema requires at least one dataset per semantic model.
         """
@@ -82,17 +92,34 @@ class TestOssieProject(
             "empty.ossie.yaml",
             document(model("empty", dataset("thing", "demo.main.thing"))),
         )
-        return ProjectContext(
+        return SemanticSourceContext(
             repo_root=str(self.root),
             connector="duckdb",
             options={"files": ["empty.ossie.yaml"]},
         )
 
-    def make_unreadable_project(self) -> ExploreProject:
-        """A document the format genuinely cannot parse.
+    def absent_document_context(self) -> SemanticSourceContext:
+        """A configured document that is not on disk.
 
-        Overridden rather than left to skip, because this is the hook behind the
-        contract's most valuable assertion and Ossie has a real unparseable
+        Overridden rather than left to skip: this is the ordinary state between
+        committing a path to config and authoring the file, and refusing it at
+        construction would make `explore map` on a raw warehouse fail over a typo
+        in a semantic-layer path.
+        """
+
+        return SemanticSourceContext(
+            repo_root=str(self.root),
+            connector="duckdb",
+            options={"files": ["absent.ossie.yaml"]},
+        )
+
+    def make_semantic_source(self):
+        return self.build_source(self.empty_source_context())
+
+    def an_unreadable_semantic_source(self) -> OssieSemanticLayer:
+        """A document the source genuinely cannot parse.
+
+        Overridden rather than left to skip, because Ossie has a real unparseable
         state: a YAML file is a file, and files get truncated, merged badly, and
         hand-edited.
         """
@@ -100,9 +127,30 @@ class TestOssieProject(
         (self.root / "unreadable.ossie.yaml").write_text(
             "version: '0.2.0.dev0'\nsemantic_model: [ {name: x,\n", encoding="utf-8"
         )
-        return _project(self.root, "unreadable.ossie.yaml")
+        return _source(self.root, "unreadable.ossie.yaml")
 
-    def a_project_declaring_a_unique_key(self):
+    def test_the_declaration_channel_never_raises_on_an_unreadable_document(
+        self,
+    ) -> None:
+        """The asymmetry the catalog contract's own assertion implies, asserted
+        from the other side.
+
+        A caller reading the catalog asked what the layer contains, so refusing
+        is the answer to their question. A caller on the declaration channel
+        asked about a *warehouse* and happens to have a layer beside it, and
+        exploration runs against raw warehouses where a semantic layer is absent
+        or broken. Raising there turns an ordinary condition into an outage.
+        """
+
+        definitions = self.an_unreadable_semantic_source().declared_definitions()
+
+        assert definitions.declared_keys == []
+        assert definitions.notes, (
+            "an empty result with no note is indistinguishable from a layer that "
+            "genuinely declares nothing"
+        )
+
+    def a_source_declaring_a_unique_key(self):
         return (
             _declaring(
                 self.root,
@@ -123,7 +171,7 @@ class TestOssieProject(
             "order_id",
         )
 
-    def a_project_declaring_a_join(self):
+    def a_source_declaring_a_join(self):
         return (
             _declaring(
                 self.root,
@@ -160,7 +208,7 @@ class TestOssieProject(
             "customer_id",
         )
 
-    def a_project_declaring_a_join_with_differently_named_sides(self):
+    def a_source_declaring_a_join_with_differently_named_sides(self):
         """The ordinary case, not the exotic one.
 
         A mirrored fixture cannot fail for the right reason: an implementation
@@ -199,12 +247,12 @@ class TestOssieProject(
             "customer_id",
         )
 
-    def a_project_declaring_a_semantic_model(self):
+    def a_source_declaring_a_semantic_model(self):
         """One direct field and one computed, so the snapshot's column mapping
         is asserted in both directions, the same reason the catalog hook one
         section over uses the same shape."""
 
-        project = _declaring(
+        source = _declaring(
             self.root,
             "snapshot.ossie.yaml",
             document(
@@ -221,13 +269,13 @@ class TestOssieProject(
             ),
         )
         return (
-            project,
+            source,
             "snap.orders",
             {"order_id": "order_id", "net_total": None},
             {},
         )
 
-    def a_project_declaring_a_composite_key(self):
+    def a_source_declaring_a_composite_key(self):
         """Three columns, because a pair cannot tell you what you came to find
         out: an implementation that special-cases the pair passes a two-column
         fixture and fails a four-column one."""
@@ -255,57 +303,7 @@ class TestOssieProject(
         )
 
 
-class TestOssieSemanticCatalog(SemanticCatalogContract):
-    """The read catalog keeps what a drift fingerprint would reduce away."""
-
-    @pytest.fixture(autouse=True)
-    def _root(self, tmp_path: Path) -> None:
-        self.root = tmp_path
-
-    def make_project(self):
-        write(
-            self.root,
-            "catalog.ossie.yaml",
-            document(model("c", dataset("thing", "demo.main.thing", field("a")))),
-        )
-        return _project(self.root, "catalog.ossie.yaml")
-
-    def a_project_declaring_a_semantic_model(self):
-        """One direct field and one computed, so the column assertion runs in
-        both directions: `None` is the honest answer for an expression, and an
-        invented column is what makes the PII gate screen the wrong one."""
-
-        project = _declaring(
-            self.root,
-            "semantics.ossie.yaml",
-            document(
-                model(
-                    "shop",
-                    dataset(
-                        "orders",
-                        "demo.main.orders",
-                        field("order_id"),
-                        field("net_total", "order_total - discount"),
-                        primary_key=["order_id"],
-                    ),
-                    metrics=[
-                        {
-                            "name": "revenue",
-                            "expression": expression(ANSI_SQL="SUM(orders.net_total)"),
-                        }
-                    ],
-                )
-            ),
-        )
-        return (
-            project,
-            "shop.orders",
-            {"order_id": "order_id", "net_total": None},
-            {},
-        )
-
-
-class TestLocalOssieBackend(SemanticBackendContract):
+class TestLocalOssieLayer(SemanticBackendContract):
     """Provenance, idempotency, declared scope, and the payload rules."""
 
     @pytest.fixture(autouse=True)
@@ -340,7 +338,7 @@ class TestLocalOssieBackend(SemanticBackendContract):
                 )
             ),
         )
-        return LocalOssieBackend(_project(self.root, "backend.ossie.yaml"))
+        return LocalOssieBackend(_source(self.root, "backend.ossie.yaml"))
 
 
 class TestOssieSemanticEditing(SemanticEditTargetContract):
@@ -363,7 +361,7 @@ class TestOssieSemanticEditing(SemanticEditTargetContract):
             second,
             document(model("second", dataset("things", "demo.main.things"))),
         )
-        return _project(self.root, first, second), first, second
+        return _source(self.root, first, second), first, second
 
     def make_semantic_edit_target(self):
         target, _first, _second = self._documents()

--- a/packages/dex-core/tests/ossie/test_corpus.py
+++ b/packages/dex-core/tests/ossie/test_corpus.py
@@ -1,0 +1,335 @@
+"""The reviewed Ossie corpus: real documents, and what dex should make of them.
+
+The documents in `fixtures/documents/` are native Ossie files a person can read,
+and `fixtures/cases.yaml` says what each one means. Both halves are authored
+rather than captured: an expectation recorded from a run asserts only that the
+implementation still does what it did, and the question worth asking is whether
+it does what it is supposed to.
+
+Why a manifest and not one test per case. The corpus is the artifact a schema
+upgrade is reviewed against: bump the pin, run this, and every case whose verdict
+moved is the upgrade telling you what changed. That review is only possible if
+the verdicts are in one place, in a form a person can read next to the diff, and
+`origin` on each expected diagnostic is what says whether a moved verdict is
+upstream's decision or ours to explain.
+
+Everything here is offline. The corpus never reaches a warehouse, never fetches
+upstream, and validates against the bundled schema alone.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from exmergo_dex_core.ossie import OssieSemanticLayer
+from exmergo_dex_core.ossie.loader import SCHEMA_SHA256, load_documents, schema_sha256
+from exmergo_dex_core.semantic_source import SemanticSourceContext
+
+FIXTURES = Path(__file__).parent / "fixtures"
+DOCUMENTS = FIXTURES / "documents"
+MANIFEST = FIXTURES / "cases.yaml"
+
+
+def _manifest() -> dict[str, Any]:
+    return yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+
+
+CASES = _manifest()["cases"]
+
+
+def _staged(case: dict[str, Any], tmp_path: Path) -> tuple[Path, list[str]]:
+    """The case's documents copied into a repository of their own.
+
+    Copied rather than read in place, because a semantic source is confined to a
+    repository root and the corpus has to exercise it the way a repository does.
+    """
+
+    names = []
+    for name in case["documents"]:
+        shutil.copyfile(DOCUMENTS / name, tmp_path / name)
+        names.append(name)
+    return tmp_path, names
+
+
+def _source(case: dict[str, Any], tmp_path: Path) -> OssieSemanticLayer:
+    root, names = _staged(case, tmp_path)
+    return OssieSemanticLayer.from_context(
+        SemanticSourceContext(
+            repo_root=str(root),
+            connector=case.get("connector", "duckdb"),
+            options={"files": names},
+        )
+    )
+
+
+def declaring(*fields: str) -> Any:
+    """Parametrize over the cases that declare one of ``fields``.
+
+    Rather than parametrizing over every case and skipping the ones with nothing
+    to say: the matrix is deliberately sparse, so skipping would make two thirds
+    of the corpus's output be cases opting out of an assertion they were never
+    in. What comes out instead is a list of the cases each rule is actually held
+    against, which is the thing a reviewer wants to read.
+    """
+
+    selected = [c for c in CASES if any(f in c for f in fields)]
+    assert selected, f"no case declares any of {fields}"
+    return pytest.mark.parametrize("case", selected, ids=[c["id"] for c in selected])
+
+
+@declaring("diagnostics")
+def test_the_diagnostics_a_case_declares_are_the_diagnostics_it_gets(
+    case: dict[str, Any], tmp_path: Path
+) -> None:
+    """Both directions, and the second one is the one that catches a regression.
+
+    A case naming a rule dex no longer raises is an obvious failure. A case that
+    quietly acquires an *extra* error is the expensive one: the document is still
+    refused, the suite is still green somewhere, and the reason it is refused has
+    changed underneath a corpus that says why.
+    """
+
+    root, names = _staged(case, tmp_path)
+    loaded = load_documents(root, names, connector=case.get("connector", "duckdb"))
+
+    seen = {(d.rule, d.severity) for d in loaded.diagnostics}
+    expected = {(d["rule"], d["severity"]) for d in case["diagnostics"]}
+
+    missing = sorted(expected - seen)
+    assert not missing, (
+        f"{case['id']} expects {missing} and got "
+        f"{sorted(seen)}: {[d.render() for d in loaded.diagnostics]}"
+    )
+
+    unexpected = sorted(
+        (rule, severity)
+        for rule, severity in seen
+        if severity == "error" and (rule, severity) not in expected
+    )
+    assert not unexpected, (
+        f"{case['id']} was refused for reasons it does not declare: {unexpected}. "
+        "A corpus that records why a document is refused is worth nothing if the "
+        f"reason can change under it: {[d.render() for d in loaded.diagnostics]}"
+    )
+
+
+@declaring("semantic_models")
+def test_the_catalog_carries_the_semantic_models_a_case_declares(
+    case: dict[str, Any], tmp_path: Path
+) -> None:
+    source = _source(case, tmp_path)
+    if case["semantic_models"] == []:
+        # A document that cannot be read is not a layer that declares nothing,
+        # so the catalog channel refuses rather than answering empty.
+        from exmergo_dex_core.errors import ProjectError
+
+        with pytest.raises(ProjectError):
+            source.semantic_catalog()
+        return
+
+    names = [m.name for m in source.semantic_catalog().semantic_models]
+
+    assert sorted(names) == sorted(case["semantic_models"]), (
+        f"{case['id']} expected {sorted(case['semantic_models'])}, got {sorted(names)}"
+    )
+
+
+@declaring("physical_columns")
+def test_the_physical_link_is_exactly_what_a_case_declares(
+    case: dict[str, Any], tmp_path: Path
+) -> None:
+    """Equality, not containment, and that is the whole point of the case.
+
+    Physical linkage is the input to the PII gate: a token resolves to a relation
+    and a column, and the gate reads that column's evidence. A link too few costs
+    a screening. A link too many screens the wrong column and reports the verdict
+    as evidence-backed, which is worse, and containment would not catch it.
+    """
+
+    view = _source(case, tmp_path).semantic_catalog()
+    expected = {token: tuple(pair) for token, pair in case["physical_columns"].items()}
+
+    assert view.physical_columns == expected, (
+        f"{case['id']} expected {expected}, got {view.physical_columns}"
+    )
+
+
+@declaring("composite_keys", "single_keys")
+def test_the_declared_keys_are_exactly_what_a_case_declares(
+    case: dict[str, Any], tmp_path: Path
+) -> None:
+    """Composite and single kept apart, because the claims differ in strength.
+
+    A composite says a combination is unique and none of its members are. Leaking
+    a member into the single list makes the grain axis verify a claim the author
+    never wrote, and reconcile propose a `unique` test on a column that is not.
+    """
+
+    declarations = _source(case, tmp_path).declared_definitions()
+
+    if "composite_keys" in case:
+        seen = sorted(
+            (key.model, tuple(key.columns))
+            for key in declarations.declared_composite_keys
+        )
+        expected = sorted(
+            (entry["model"], tuple(entry["columns"]))
+            for entry in case["composite_keys"]
+        )
+        assert seen == expected, f"{case['id']}: composite keys {seen} != {expected}"
+
+    if "single_keys" in case:
+        seen = sorted(
+            (key.model, key.column) for key in declarations.declared_keys if key.unique
+        )
+        expected = sorted(
+            (entry["model"], entry["column"]) for entry in case["single_keys"]
+        )
+        assert seen == expected, f"{case['id']}: single keys {seen} != {expected}"
+
+
+@declaring("relationships")
+def test_the_declared_relationships_keep_every_ordered_pair(
+    case: dict[str, Any], tmp_path: Path
+) -> None:
+    declared = _source(case, tmp_path).declared_definitions().declared_relationships
+
+    seen = sorted(
+        (r.model, r.to_model, tuple(tuple(p) for p in r.column_pairs)) for r in declared
+    )
+    expected = sorted(
+        (
+            entry["model"],
+            entry["to_model"],
+            tuple(tuple(pair) for pair in entry["pairs"]),
+        )
+        for entry in case["relationships"]
+    )
+
+    assert seen == expected, f"{case['id']}: relationships {seen} != {expected}"
+
+
+def test_a_warning_retains_the_document_it_warns_about() -> None:
+    """The severity distinction, asserted rather than left to the manifest.
+
+    An error and a warning are not two strengths of the same verdict. An error
+    means dex could not read the document; a warning means it read it and has
+    something to say. A warning that dropped the document would silently narrow
+    the layer, and the narrowing would look like a layer the author never wrote.
+    """
+
+    case = next(c for c in CASES if c["id"] == "target_key_coverage_warns")
+
+    assert all(d["severity"] == "warning" for d in case["diagnostics"])
+    assert case["semantic_models"], (
+        "the case has to assert what survives, or it is asserting that a warning "
+        "is quiet rather than that it is non-fatal"
+    )
+
+
+def test_the_three_document_suffixes_read_identically(tmp_path: Path) -> None:
+    """Equivalent semantics, from three byte-different serializations.
+
+    The three fixtures are deliberately not each other's pretty-printer output:
+    one is block YAML, one is flow YAML with a different key order, one is JSON.
+    Reading them the same is a statement about the reader rather than about the
+    files.
+    """
+
+    def read(name: str) -> tuple[list[str], dict[str, Any]]:
+        root = tmp_path / name.replace(".", "_")
+        root.mkdir()
+        shutil.copyfile(DOCUMENTS / name, root / name)
+        view = OssieSemanticLayer(root, [name], connector="duckdb").semantic_catalog()
+        return [d.definition for d in view.dimensions], dict(view.physical_columns)
+
+    first = read("minimal.ossie.yaml")
+    assert first == read("minimal.ossie.yml")
+    assert first == read("minimal.ossie.json")
+
+
+def test_every_case_names_documents_that_exist_and_every_document_a_case(
+    tmp_path: Path,
+) -> None:
+    """The corpus and the manifest are one artifact, and this keeps them one.
+
+    A case naming a document that was renamed away is a case that silently stops
+    asserting. A document no case names is worse: it looks like reviewed coverage
+    and is not read by anything, so an upgrade that changes its verdict changes
+    nothing anybody sees.
+    """
+
+    on_disk = {path.name for path in DOCUMENTS.iterdir() if path.is_file()}
+    named = {name for case in CASES for name in case["documents"]}
+
+    assert not (named - on_disk), (
+        f"cases name absent documents: {sorted(named - on_disk)}"
+    )
+    assert not (on_disk - named), (
+        f"documents no case reads: {sorted(on_disk - named)}. An unread fixture "
+        "looks like coverage and is not"
+    )
+
+    ids = [case["id"] for case in CASES]
+    assert len(ids) == len(set(ids)), "case ids must be unique: they are the handle"
+
+
+def test_the_manifest_pins_the_same_schema_the_loader_and_provenance_do() -> None:
+    """One pin, recorded in four places, checked in one.
+
+    The hash lives in the loader (what validation uses), in PROVENANCE.md (what a
+    reader is told), in this manifest (what the corpus was reviewed against), and
+    in the compatibility matrix (what a user is promised). Updating one and not
+    the others is the ordinary way a pin rots, and it rots silently because every
+    individual file still looks right.
+
+    This checks consistency. It cannot check that a human reviewed the upgrade,
+    and it should not be read as though it does.
+    """
+
+    manifest = _manifest()["schema"]
+    provenance = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "exmergo_dex_core"
+        / "ossie"
+        / "schema"
+        / "PROVENANCE.md"
+    ).read_text(encoding="utf-8")
+    matrix = (
+        Path(__file__).resolve().parents[4] / "references" / "ossie-compatibility.md"
+    ).read_text(encoding="utf-8")
+
+    assert manifest["sha256"] == SCHEMA_SHA256
+    assert schema_sha256() == SCHEMA_SHA256, "the bundled schema's bytes moved"
+
+    for document, label in ((provenance, "PROVENANCE.md"), (matrix, "the matrix")):
+        assert SCHEMA_SHA256 in document, f"{label} does not carry the pinned hash"
+        assert manifest["upstream_commit"] in document, (
+            f"{label} does not carry the pinned upstream commit"
+        )
+        assert manifest["declared_version"] in document, (
+            f"{label} does not carry the declared schema version"
+        )
+
+
+def test_the_matrix_names_every_case_the_corpus_holds() -> None:
+    """A matrix row is a promise, and a case id is the evidence behind it.
+
+    Naming the case in the matrix is what lets a reader check a claim rather than
+    take it, and it is what makes an upgrade's changed verdict land in the
+    document that made the promise.
+    """
+
+    matrix = (
+        Path(__file__).resolve().parents[4] / "references" / "ossie-compatibility.md"
+    ).read_text(encoding="utf-8")
+
+    missing = [case["id"] for case in CASES if case["id"] not in matrix]
+
+    assert not missing, f"the compatibility matrix names no case for: {missing}"

--- a/packages/dex-core/tests/ossie/test_metered_safety.py
+++ b/packages/dex-core/tests/ossie/test_metered_safety.py
@@ -1,0 +1,385 @@
+"""Native Ossie declarations under the cost guard, on a billed connector.
+
+Ossie contributes declared keys and relationships at confidence 1.0, and
+verifying one is a warehouse scan. That scan reaches the warehouse through the
+same admission, budget, and ledger machinery every other scan does, and this
+asserts it does rather than assuming it: a second, vendor-shaped route to the
+warehouse is exactly the shape a guard gets bypassed by.
+
+The parametrized detail lives here rather than in the safety spine, which carries
+the one-line command-level statement of each rule. Nothing here stubs `CostGate`,
+admission, reservations, or ledger settlement: the gate is built by
+`connect.new_cost_gate`, so what is under test is the wiring the engine uses.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exmergo_dex_core.config import DexConfig, save_config
+from exmergo_dex_core.engine import DexEngine
+from exmergo_dex_core.storage import FilesystemStore
+
+pytest.importorskip("google.cloud.bigquery")
+
+MB = 1024 * 1024
+
+#: Two relationships onto one shared parent, plus a composite one. The shared
+#: parent is what makes the batching assertion mean something: unbatched, a
+#: shared dimension pays the scan once per edge that joins it.
+DOCUMENT = """
+version: "0.2.0.dev0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: test-proj.shop.customers
+        primary_key: [id]
+        fields:
+          - name: id
+            expression:
+              dialects: [{dialect: BIGQUERY, expression: id}]
+          - name: email
+            expression:
+              dialects: [{dialect: BIGQUERY, expression: email}]
+      - name: events
+        source: test-proj.shop.events
+        primary_key: [id]
+        fields:
+          - name: id
+            expression:
+              dialects: [{dialect: BIGQUERY, expression: id}]
+    relationships:
+      - name: events_to_orders
+        from: events
+        to: orders
+        from_columns: [id]
+        to_columns: [id]
+      - name: orders_to_orders
+        from: orders
+        to: orders
+        from_columns: [id]
+        to_columns: [id]
+"""
+
+
+def _repo(root: Path) -> None:
+    (root / "layer.ossie.yaml").write_text(DOCUMENT, encoding="utf-8")
+    save_config(
+        DexConfig(
+            connector="bigquery",
+            bigquery={"project": "p"},
+            semantic={"vendor": "ossie", "ossie": {"files": ["layer.ossie.yaml"]}},
+            # The day's cap, decided once and committed, the way a project that
+            # has answered the one-time ask carries it. Without it every
+            # confirmed command below would refuse on that question instead of
+            # on the one under test.
+            budget={"session_ceiling": float(1024 * MB)},
+        ),
+        root,
+    )
+
+
+def _engine(fake_bq_client, root: Path, monkeypatch, **kwargs) -> DexEngine:
+    """An Ossie-configured engine whose one connection is the BigQuery fake.
+
+    The gate comes from ``connect.new_cost_gate`` rather than being constructed
+    here, so a change to how the engine admits work reaches this test.
+    """
+
+    import exmergo_dex_core.connect as connect_mod
+    from exmergo_dex_core.adapters.bigquery import BigQueryAdapter
+    from exmergo_dex_core.config import BigQueryTarget, load_config
+    from exmergo_dex_core.connect import new_cost_gate
+
+    config = load_config(root)
+    store = FilesystemStore(root)
+
+    def opener(**opened):
+        return BigQueryAdapter(
+            project="test-proj",
+            cost_gate=new_cost_gate(
+                "bigquery",
+                config,
+                store,
+                budget=opened.get("budget"),
+                confirmed=opened.get("confirmed", False),
+                command=opened.get("command"),
+            ),
+            target=BigQueryTarget(),
+            client=fake_bq_client,
+            principal_type="user",
+        )
+
+    monkeypatch.setattr(connect_mod, "open_adapter", opener)
+    return DexEngine(config=config, store=store, repo_root=str(root), **kwargs)
+
+
+def _aggregate_rows(sql: str) -> list[dict]:
+    """One row carrying every alias a profile or a batched overlap probe reads.
+
+    A confirmed verify profiles the relations first, so the resolver has to
+    answer both statement shapes. Indexed aliases rather than a fixed set,
+    because overlap probes are batched and one statement asks about several
+    joins at once.
+    """
+
+    row: dict[str, object] = {"n_total": 100}
+    for index in range(10):
+        row[f"nn_{index}"] = 100
+        row[f"nd_{index}"] = 100 if index == 0 else 40
+        row[f"mn_{index}"] = 1
+        row[f"mx_{index}"] = 100
+        row[f"d_{index}"] = 100
+        row[f"nonnull_fk_{index}"] = 100
+        row[f"orphans_{index}"] = 0
+    return [row]
+
+
+@pytest.fixture
+def ossie_bq(fake_bq_client, tmp_path, monkeypatch):
+    _repo(tmp_path)
+    fake_bq_client.row_resolver = _aggregate_rows
+
+    def build(**kwargs):
+        return _engine(fake_bq_client, tmp_path, monkeypatch, **kwargs)
+
+    return build
+
+
+def test_unconfirmed_declared_verification_executes_no_billed_statement(
+    ossie_bq, fake_bq_client
+):
+    """Free work is allowed; billed work is not. A dry run is the estimate, so
+    it is what the caller is being shown rather than something they paid for."""
+
+    from exmergo_dex_core import ConfirmationRequiredError
+
+    with ossie_bq() as engine, pytest.raises(ConfirmationRequiredError) as caught:
+        engine.relationships(verify=True, use_project=True)
+
+    assert caught.value.request.cost.estimate > 0
+    assert fake_bq_client.query_calls, "nothing was priced, so nothing was proven"
+    assert all(call.dry_run for call in fake_bq_client.query_calls)
+
+
+def test_an_insufficient_command_budget_prevents_the_scan(ossie_bq, fake_bq_client):
+    """Confirmation is not an override: an estimate past the ceiling refuses
+    first, however confirmed the caller is."""
+
+    from exmergo_dex_core.guards.cost_guard import OverCeilingError
+
+    with (
+        ossie_bq(confirmed=True, budget=1.0) as engine,
+        pytest.raises(OverCeilingError),
+    ):
+        engine.relationships(verify=True, use_project=True)
+
+    assert all(call.dry_run for call in fake_bq_client.query_calls)
+
+
+def test_an_insufficient_session_budget_prevents_the_scan(
+    ossie_bq, fake_bq_client, tmp_path
+):
+    """The day's cap binds a command whose own budget would have allowed it.
+
+    Booked against the ledger rather than against a counter in the process, so
+    spend a previous command already settled is spend this one cannot have.
+    """
+
+    from exmergo_dex_core.guards.cost_guard import OverCeilingError, utc_day_start
+
+    store = FilesystemStore(tmp_path)
+    store.append_spend_log(
+        {
+            "at": utc_day_start(),
+            "connector": "bigquery",
+            "command": "explore",
+            "entry": "settlement",
+            "billed_bytes": float(64 * MB),
+        }
+    )
+    save_config(
+        DexConfig(
+            connector="bigquery",
+            bigquery={"project": "p"},
+            semantic={"vendor": "ossie", "ossie": {"files": ["layer.ossie.yaml"]}},
+            budget={"session_ceiling": float(65 * MB)},
+        ),
+        tmp_path,
+    )
+
+    with (
+        ossie_bq(confirmed=True, budget=float(500 * MB)) as engine,
+        pytest.raises(OverCeilingError),
+    ):
+        engine.relationships(verify=True, use_project=True)
+
+    assert all(call.dry_run for call in fake_bq_client.query_calls)
+
+
+def test_a_confirmed_scan_is_server_capped_and_settles_in_the_ledger(
+    ossie_bq, fake_bq_client, tmp_path
+):
+    """The two halves of the same guarantee.
+
+    The ceiling is enforced by BigQuery itself through
+    ``maximum_bytes_billed``, so an estimate that turns out low is stopped by
+    the server rather than by dex noticing afterwards. And what it actually
+    billed is written to the ledger, which is what the next command's session
+    headroom is computed from.
+    """
+
+    with ossie_bq(confirmed=True, budget=float(500 * MB)) as engine:
+        engine.relationships(verify=True, use_project=True)
+
+    executed = [call for call in fake_bq_client.query_calls if not call.dry_run]
+    assert executed, "the confirmed scan executed nothing"
+    for call in executed:
+        assert call.job_config.maximum_bytes_billed, (
+            "an executed statement carried no server-side cap, so the ceiling "
+            "held only as long as the estimate did"
+        )
+
+    entries = [
+        json.loads(line)
+        for line in (tmp_path / ".dex" / "spend.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip()
+    ]
+    settled = [e for e in entries if e.get("entry") == "settlement"]
+    assert settled, f"the confirmed scan settled nothing in the ledger: {entries}"
+    assert all(e["connector"] == "bigquery" for e in settled)
+
+
+def test_the_priced_statements_and_the_executed_statements_are_one_set(
+    ossie_bq, fake_bq_client
+):
+    """Pricing N probes and issuing N+M under-reports spend before it happens,
+    which is the one thing the cost guard exists to prevent.
+
+    The document declares two edges onto one shared parent, so this also holds
+    the shared-table batching: grouped, a shared parent is read once rather than
+    once per edge, and the priced set has to be grouped the same way.
+    """
+
+    with ossie_bq(confirmed=True, budget=float(500 * MB)) as engine:
+        engine.relationships(verify=True, use_project=True)
+
+    priced = [call.sql for call in fake_bq_client.query_calls if call.dry_run]
+    executed = [call.sql for call in fake_bq_client.query_calls if not call.dry_run]
+
+    assert executed, "nothing executed, so the comparison asserts nothing"
+    assert set(executed) <= set(priced), (
+        "a statement was executed that was never priced: "
+        f"{sorted(set(executed) - set(priced))}"
+    )
+
+    def probes(statements: list[str]) -> set[str]:
+        return {sql for sql in statements if "nonnull_fk_0" in sql}
+
+    # Sets, not lists: one statement may legitimately be priced more than once
+    # (a free dry run costs nothing and the estimate is taken at more than one
+    # point). What may not differ is *which* statements the two halves name.
+    assert probes(executed), "no overlap probe ran, so batching is unasserted"
+    assert probes(executed) == probes(priced), (
+        "the overlap probes that ran and the overlap probes that were priced "
+        "are not the same statements, so the estimate described different work "
+        "than the run did"
+    )
+    assert len(probes(executed)) == 1, (
+        "the two declared edges share a parent relation and ran as "
+        f"{len(probes(executed))} statements. Grouped, a shared parent is read "
+        "once rather than once per edge, and splitting them here would mean the "
+        "estimate and the run agree only because both are wrong"
+    )
+
+
+def test_a_declared_edge_keeps_confidence_one_whatever_the_probe_measures(
+    ossie_bq, fake_bq_client
+):
+    """A measurement never revises a declaration's confidence.
+
+    The layer's author asserted the join. A probe that finds the parent largely
+    missing is a finding about the data, not evidence that the author did not
+    say what they said, and rewriting the confidence would erase the difference
+    between a declared edge and an inferred one.
+    """
+
+    fake_bq_client.row_resolver = lambda sql: [
+        {**_aggregate_rows(sql)[0], "orphans_0": 100, "orphans_1": 100}
+    ]
+
+    with ossie_bq(confirmed=True, budget=float(500 * MB)) as engine:
+        result = engine.relationships(verify=True, use_project=True)
+
+    declared = [
+        edge
+        for edge in result.relationships
+        if "ossie" in str(getattr(edge, "declared_by", "")).lower()
+        or getattr(edge, "confidence", 0) == 1.0
+    ]
+    assert declared, "no declared edge reached the result"
+    assert all(edge.confidence == 1.0 for edge in declared)
+
+
+def test_the_free_catalog_opens_no_warehouse_connection(ossie_bq, fake_bq_client):
+    """Reading the layer is reading files in the repository.
+
+    A catalog read that opened a connection would put a billed connector between
+    a caller and a question the repository already answers, and on a metered
+    warehouse that is a handshake nobody should be asked for.
+    """
+
+    with ossie_bq() as engine:
+        result = engine.semantic_list()
+
+    assert result.catalog.view.semantic_models
+    assert fake_bq_client.query_calls == []
+
+
+def test_a_project_only_snapshot_opens_no_warehouse_connection(
+    ossie_bq, fake_bq_client
+):
+    """`--project-only` re-fingerprints the repository and carries the warehouse
+    block forward. It deliberately preserves warehouse staleness rather than
+    laundering it into a fresh measurement, and a connection here would be that
+    laundering."""
+
+    with ossie_bq(confirmed=True, budget=float(500 * MB)) as engine:
+        engine.snapshot()
+        fake_bq_client.query_calls.clear()
+        engine.snapshot(project_only=True)
+
+    assert fake_bq_client.query_calls == []
+
+
+def test_cached_authoring_validation_runs_no_warehouse_query(
+    ossie_bq, fake_bq_client, tmp_path
+):
+    """Plan-time validation reads the exploration cache, never the warehouse.
+
+    Authoring is a repository edit. Reaching a billed warehouse to decide
+    whether a document may be written would put a cost handshake in front of a
+    write, which is a different command than the one the caller ran.
+    """
+
+    from exmergo_dex_core.transform.native_semantic import semantic_ossie
+    from exmergo_dex_core.transform.plans import EditKind, PlanEdit
+
+    content = (tmp_path / "layer.ossie.yaml").read_text(encoding="utf-8")
+    edit = PlanEdit(
+        path="layer.ossie.yaml",
+        kind=EditKind.SEMANTIC_DOCUMENT,
+        new_content=content + "\n# reviewed\n",
+    )
+
+    with ossie_bq() as engine:
+        fake_bq_client.query_calls.clear()
+        semantic_ossie(engine, "revise the layer", [edit], mode="plan")
+
+    assert fake_bq_client.query_calls == []

--- a/packages/dex-core/tests/ossie/test_project.py
+++ b/packages/dex-core/tests/ossie/test_project.py
@@ -1,4 +1,4 @@
-"""Native Ossie semantic-layer construction coverage."""
+"""Native Ossie semantic-source construction coverage."""
 
 from __future__ import annotations
 
@@ -14,17 +14,30 @@ from exmergo_dex_core.errors import (
     ProjectError,
     RepoRootRequiredError,
 )
-from exmergo_dex_core.ossie import OssieProject
+from exmergo_dex_core.ossie import OssieSemanticLayer
 from exmergo_dex_core.project_definitions import ProjectDefinitions
+from exmergo_dex_core.semantic_source import SemanticSourceContext
 
 from .conftest import document, model, reference_document, write
 
 
 def context(root: Path, *names: str, connector: str = "duckdb", **options):
-    return ProjectContext(
+    return SemanticSourceContext(
         repo_root=str(root),
         connector=connector,
         options={"files": list(names), **options},
+    )
+
+
+def project_context(root: Path, *names: str, connector: str = "duckdb"):
+    """The same coordinates shaped as a *project* context.
+
+    Only the negative tests need this: they prove the project resolver refuses
+    the name, and the resolver takes the project shape.
+    """
+
+    return ProjectContext(
+        repo_root=str(root), connector=connector, options={"files": list(names)}
     )
 
 
@@ -36,7 +49,7 @@ def test_ossie_is_not_a_shipped_project_format(repo: Path):
 
     assert "ossie" not in SHIPPED
     with pytest.raises(ConfigurationError, match="unknown project format"):
-        build_project("ossie", context(repo, "commerce.ossie.yaml"))
+        build_project("ossie", project_context(repo, "commerce.ossie.yaml"))
 
 
 def test_resolving_the_dbt_name_does_not_import_the_ossie_reader():
@@ -60,19 +73,21 @@ def test_resolving_the_dbt_name_does_not_import_the_ossie_reader():
     assert out.stdout.strip() == "False"
 
 
-def test_the_format_needs_a_repository(repo: Path):
+def test_the_source_needs_a_repository(repo: Path):
     with pytest.raises(RepoRootRequiredError, match="repo root"):
-        OssieProject.from_context(
-            ProjectContext(options={"files": ["commerce.ossie.yaml"]})
+        OssieSemanticLayer.from_context(
+            SemanticSourceContext(options={"files": ["commerce.ossie.yaml"]})
         )
 
 
-def test_an_option_the_format_cannot_honor_is_refused_by_name(repo: Path):
+def test_an_option_the_source_cannot_honor_is_refused_by_name(repo: Path):
     """Accepted-and-ignored is indistinguishable from honored, right up until
     dex is reading a different project than the configuration named."""
 
     with pytest.raises(ConfigurationError, match="documents"):
-        OssieProject.from_context(context(repo, "commerce.ossie.yaml", documents=["x"]))
+        OssieSemanticLayer.from_context(
+            context(repo, "commerce.ossie.yaml", documents=["x"])
+        )
 
 
 @pytest.mark.parametrize(
@@ -93,8 +108,10 @@ def test_bad_coordinates_are_refused_where_they_are_written(
     options = {} if files is None else {"files": files}
 
     with pytest.raises(ConfigurationError, match=expected):
-        OssieProject.from_context(
-            ProjectContext(repo_root=str(repo), connector="duckdb", options=options)
+        OssieSemanticLayer.from_context(
+            SemanticSourceContext(
+                repo_root=str(repo), connector="duckdb", options=options
+            )
         )
 
 
@@ -107,30 +124,121 @@ def test_construction_reads_nothing(tmp_path: Path):
     semantic-layer path.
     """
 
-    project = OssieProject.from_context(context(tmp_path, "absent.ossie.yaml"))
+    source = OssieSemanticLayer.from_context(context(tmp_path, "absent.ossie.yaml"))
 
-    assert project.files == ["absent.ossie.yaml"]
-
-
-# --- the tier --------------------------------------------------------------
+    assert source.files == ["absent.ossie.yaml"]
 
 
-def test_ossie_is_reached_as_a_semantic_layer_not_a_project(
-    repo: Path,
-):
-    """Claiming a tier structurally is claiming it to `maintain reconcile`.
+# --- the capabilities, and the tiers it deliberately does not reach ---------
 
-    Tier 2 needs a snapshot shape that can hold composite relationships and
-    dataset keys; tier 3 needs a preservation contract for writing documents
-    back. Both are separate work, and growing the methods early would tell
-    reconcile it may propose edits this format cannot apply.
+
+def test_the_source_answers_both_semantic_capabilities(repo: Path):
+    """A catalog to read and a fingerprint to compare, and nothing wider."""
+
+    from exmergo_dex_core.semantic_source import (
+        SemanticCatalogSource,
+        SemanticSnapshotSource,
+    )
+
+    source = OssieSemanticLayer.from_context(context(repo, "commerce.ossie.yaml"))
+
+    assert isinstance(source, SemanticCatalogSource)
+    assert isinstance(source, SemanticSnapshotSource)
+    assert source.semantic_catalog().semantic_models
+    assert source.semantic_layer().semantic_models
+
+
+def test_the_source_satisfies_no_project_tier(repo: Path):
+    """Claiming a tier structurally is claiming it to `maintain reconcile` and
+    to `transform apply`.
+
+    A transformation project owns a model graph, compilation, targets, and a
+    write surface into dbt's own files. Ossie owns none of those, so satisfying
+    even the narrowest tier would tell reconcile it may propose edits this
+    source cannot apply, and would let a repository be reasoned about as though
+    a document set were a model graph. The tiers are structural, so this is a
+    real risk rather than a documentation point: two vestigial members were all
+    it took before.
     """
 
-    project = OssieProject.from_context(context(repo, "commerce.ossie.yaml"))
+    from exmergo_dex_core.adapters.project import (
+        EditableProject,
+        ExploreProject,
+        MaintainProject,
+        PlacingProject,
+    )
 
-    assert project.semantic_catalog().semantic_models
-    with pytest.raises(ConfigurationError, match="unknown project format"):
-        build_project("ossie", context(repo, "commerce.ossie.yaml"))
+    source = OssieSemanticLayer.from_context(context(repo, "commerce.ossie.yaml"))
+
+    for tier in (ExploreProject, MaintainProject, EditableProject, PlacingProject):
+        assert not isinstance(source, tier), tier.__name__
+    assert not hasattr(source, "name")
+    assert not hasattr(source, "definitions")
+    assert not hasattr(source, "transform_layer")
+
+
+def test_the_runtime_layer_satisfies_no_project_tier(repo: Path):
+    """The same for the object the explore surface holds, which wraps the
+    reader and would otherwise inherit the question."""
+
+    from exmergo_dex_core.adapters.project import (
+        EditableProject,
+        ExploreProject,
+        MaintainProject,
+        PlacingProject,
+    )
+    from exmergo_dex_core.config import DexConfig, save_config
+    from exmergo_dex_core.engine import DexEngine
+    from exmergo_dex_core.explore.semantic import resolve_semantic_layer
+
+    save_config(
+        DexConfig(
+            connector="duckdb",
+            semantic={"vendor": "ossie", "ossie": {"files": ["commerce.ossie.yaml"]}},
+        ),
+        repo,
+    )
+    layer = resolve_semantic_layer(DexEngine.from_repo(str(repo)), local=True)
+
+    for tier in (ExploreProject, MaintainProject, EditableProject, PlacingProject):
+        assert not isinstance(layer, tier), tier.__name__
+
+
+def test_no_semantic_route_builds_its_source_through_the_project_factory(
+    repo: Path, monkeypatch
+):
+    """The construction path is the thing this issue moved, so it is the thing
+    a regression would move back.
+
+    Spying on the factory rather than grepping for an import: a route that
+    reached it through a helper, or through the engine's own project accessor,
+    would satisfy a grep and still be building a semantic source as a project.
+    """
+
+    from exmergo_dex_core.adapters import project_resolver
+    from exmergo_dex_core.config import DexConfig, save_config
+    from exmergo_dex_core.engine import DexEngine
+
+    save_config(
+        DexConfig(
+            connector="duckdb",
+            semantic={"vendor": "ossie", "ossie": {"files": ["commerce.ossie.yaml"]}},
+        ),
+        repo,
+    )
+
+    def refuse(*args, **kwargs):
+        raise AssertionError("a semantic source was built through the project factory")
+
+    monkeypatch.setattr(project_resolver, "build_project", refuse)
+    monkeypatch.setattr(project_resolver, "construct_project", refuse)
+
+    engine = DexEngine.from_repo(str(repo))
+    source = engine.semantic_catalog_source()
+
+    assert source.semantic_catalog().semantic_models
+    assert source.semantic_layer().semantic_models
+    assert source.declared_definitions().declared_keys
 
 
 @pytest.mark.parametrize(
@@ -164,9 +272,9 @@ def test_definitions_never_raises_whatever_the_documents_are(tmp_path: Path, sab
     """
 
     sabotage(tmp_path)
-    project = OssieProject.from_context(context(tmp_path, "commerce.ossie.yaml"))
+    source = OssieSemanticLayer.from_context(context(tmp_path, "commerce.ossie.yaml"))
 
-    definitions = project.definitions()
+    definitions = source.declared_definitions()
 
     assert isinstance(definitions, ProjectDefinitions)
     assert definitions.declared_keys == []
@@ -192,10 +300,10 @@ def test_definitions_degrades_with_a_note_when_the_extra_is_absent(
             raise ImportError("no validator")
         return real(name, *args, **kwargs)
 
-    project = OssieProject.from_context(context(repo, "commerce.ossie.yaml"))
+    source = OssieSemanticLayer.from_context(context(repo, "commerce.ossie.yaml"))
     monkeypatch.setattr(builtins, "__import__", refuse)
 
-    definitions = project.definitions()
+    definitions = source.declared_definitions()
 
     assert definitions.declared_keys == []
     assert any("exmergo-dex-core[ossie]" in note for note in definitions.notes)
@@ -203,30 +311,21 @@ def test_definitions_degrades_with_a_note_when_the_extra_is_absent(
 
 def test_the_catalog_channel_refuses_a_document_it_cannot_read(tmp_path: Path):
     (tmp_path / "broken.ossie.yaml").write_text("a: [1,\n", encoding="utf-8")
-    project = OssieProject.from_context(context(tmp_path, "broken.ossie.yaml"))
+    source = OssieSemanticLayer.from_context(context(tmp_path, "broken.ossie.yaml"))
 
     with pytest.raises(ProjectError, match="could not be read"):
-        project.semantic_catalog()
+        source.semantic_catalog()
 
 
-def test_reading_the_same_project_twice_agrees(repo: Path):
+def test_reading_the_same_source_twice_agrees(repo: Path):
     """Rules out a read that consumes, which surfaces as a second command
     mysteriously seeing less than the first."""
 
-    project = OssieProject.from_context(context(repo, "commerce.ossie.yaml"))
+    source = OssieSemanticLayer.from_context(context(repo, "commerce.ossie.yaml"))
 
-    assert project.definitions() == project.definitions()
-    first, second = project.semantic_catalog(), project.semantic_catalog()
+    assert source.declared_definitions() == source.declared_definitions()
+    first, second = source.semantic_catalog(), source.semantic_catalog()
     assert [m.name for m in first.metrics] == [m.name for m in second.metrics]
-
-
-def test_the_name_identifies_the_format_and_not_the_instance(repo: Path, tmp_path):
-    """A name that varies per instance is a name a registry cannot resolve."""
-
-    one = OssieProject.from_context(context(repo, "commerce.ossie.yaml"))
-    two = OssieProject.from_context(context(tmp_path, "other.ossie.yaml"))
-
-    assert one.name == two.name == "ossie"
 
 
 # --- semantic configuration -------------------------------------------------
@@ -241,7 +340,7 @@ def test_semantic_configuration_builds_the_catalog(repo: Path):
     def catalog_of(config: dict) -> list[str]:
         save_config(DexConfig(**config), repo)
         engine = DexEngine.from_repo(str(repo))
-        view = engine.semantic_catalog_format().semantic_catalog()
+        view = engine.semantic_catalog_source().semantic_catalog()
         return [m.name for m in view.semantic_models]
 
     beside_dbt = catalog_of(
@@ -300,7 +399,7 @@ def test_the_connector_reaches_the_semantic_layer(repo: Path):
 
     layer = resolve_semantic_layer(DexEngine.from_repo(str(repo)))
 
-    assert layer._project.connector == "clickhouse"
+    assert layer._source.connector == "clickhouse"
     # ClickHouse relations are two parts, so a three-part source is not one.
     semantic_models = layer.list_definitions().view.semantic_models
     assert all(model.relation is None for model in semantic_models)
@@ -327,10 +426,10 @@ def test_several_documents_are_read_as_one_layer(tmp_path: Path):
     ]
     write(tmp_path, "two.ossie.json", second)
 
-    project = OssieProject.from_context(
+    source = OssieSemanticLayer.from_context(
         context(tmp_path, "one.ossie.yaml", "two.ossie.json")
     )
-    names = [m.name for m in project.semantic_catalog().semantic_models]
+    names = [m.name for m in source.semantic_catalog().semantic_models]
 
     assert "commerce.orders" in names
     assert "logistics.shipments" in names
@@ -343,7 +442,8 @@ def test_a_json_document_reads_identically_to_its_yaml_twin(tmp_path: Path):
     )
 
     def names(name: str) -> list[str]:
-        view = OssieProject.from_context(context(tmp_path, name)).semantic_catalog()
+        source = OssieSemanticLayer.from_context(context(tmp_path, name))
+        view = source.semantic_catalog()
         return [d.name for d in view.dimensions]
 
     assert names("a.ossie.yaml") == names("b.ossie.json")

--- a/packages/dex-core/tests/test_packaging.py
+++ b/packages/dex-core/tests/test_packaging.py
@@ -16,6 +16,7 @@ them, and CI runs them because a broken install is a broken release.
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -1324,9 +1325,9 @@ def test_selecting_ossie_without_its_extra_refuses_by_name(wheel: str):
 
     done = _run_isolated(
         wheel,
-        "from exmergo_dex_core.ossie import OssieProject, OssieDependencyError\n"
-        "from exmergo_dex_core.adapters.project import ProjectContext\n"
-        "p = OssieProject.from_context(ProjectContext(\n"
+        "from exmergo_dex_core.ossie import OssieSemanticLayer, OssieDependencyError\n"
+        "from exmergo_dex_core.semantic_source import SemanticSourceContext\n"
+        "p = OssieSemanticLayer.from_context(SemanticSourceContext(\n"
         "    repo_root='.', connector='duckdb',\n"
         "    options={'files': ['a.ossie.yaml']}))\n"
         "try:\n"
@@ -1336,9 +1337,251 @@ def test_selecting_ossie_without_its_extra_refuses_by_name(wheel: str):
         "    print('refused')\n"
         "else:\n"
         "    raise AssertionError('read a document with no validator installed')\n"
-        "# Tier 1 degrades instead, because explore runs on raw warehouses.\n"
-        "assert p.definitions().notes\n",
+        "# The declaration channel degrades instead, because explore runs on\n"
+        "# raw warehouses where a semantic layer is absent.\n"
+        "assert p.declared_definitions().notes\n",
     )
 
     assert done.returncode == 0, done.stderr
     assert done.stdout.strip() == "refused"
+
+
+# --- the Ossie install boundary, from an actual wheel --------------------------
+#
+# `[ossie]` exists so a repository whose semantic layer is native documents can
+# install a validator and nothing else. Every assertion below is about what that
+# install can and cannot do, run against a real wheel in a real isolated
+# environment, because the boundary is a packaging property and an in-process
+# import probe cannot see it.
+
+OSSIE_DOCUMENT = """version: "0.2.0.dev0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: demo.main.orders
+        primary_key: [order_id]
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id
+          - name: net_total
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_total - discount
+"""
+
+OSSIE_CONFIG = """connector: duckdb
+semantic:
+  vendor: ossie
+  ossie:
+    files:
+      - layer.ossie.yaml
+"""
+
+
+def _ossie_repo(tmp_path: Path) -> Path:
+    """A repository whose only project is a native semantic layer."""
+
+    root = tmp_path / "ossie_repo"
+    (root / ".dex").mkdir(parents=True)
+    (root / "layer.ossie.yaml").write_text(OSSIE_DOCUMENT, encoding="utf-8")
+    (root / ".dex" / "config.yml").write_text(OSSIE_CONFIG, encoding="utf-8")
+    return root
+
+
+def test_a_base_install_imports_no_reader_and_no_optional_dependency(wheel: str):
+    """The floor the extras are measured against.
+
+    A base install is pydantic and pyyaml. A module that eagerly imported the
+    schema validator, the dialect engine, dbt, or MetricFlow would break
+    `import exmergo_dex_core` on an install that has none of them, and the
+    failure would land at import rather than at the command that needed it.
+    """
+
+    done = _run_isolated(
+        wheel,
+        "import exmergo_dex_core, sys\n"
+        "watched = ('jsonschema', 'sqlglot', 'dbt', 'metricflow')\n"
+        "print(sorted({m.split('.')[0] for m in sys.modules "
+        "if m.startswith(watched)}))\n"
+        "assert 'exmergo_dex_core.ossie' not in sys.modules\n",
+    )
+
+    assert done.returncode == 0, done.stderr
+    assert done.stdout.strip() == "[]"
+
+
+def test_the_ossie_extra_catalogs_a_document_without_the_dialect_engine(
+    wheel: str, tmp_path: Path
+):
+    """Reading a layer is the thing `[ossie]` exists for, so the assertion is
+    that it reads one rather than that it imports.
+
+    An optional dependency can be loaded after import time, so an import probe
+    alone would pass an implementation that reached for sqlglot on the first
+    document it was handed.
+    """
+
+    root = _ossie_repo(tmp_path)
+    done = _run_isolated(
+        wheel,
+        "import sys, json\n"
+        "from exmergo_dex_core.engine import DexEngine\n"
+        f"engine = DexEngine.from_repo({str(root)!r})\n"
+        "view = engine.semantic_catalog_source().semantic_catalog()\n"
+        "assert [m.name for m in view.semantic_models] == ['shop.orders'], view\n"
+        "assert view.physical_columns == "
+        "{'orders__order_id': ('demo.main.orders', 'order_id')}, "
+        "view.physical_columns\n"
+        "assert any('sqlglot' in note or 'sql' in note.lower() "
+        "for note in view.notes), view.notes\n"
+        "print(sorted({m.split('.')[0] for m in sys.modules "
+        "if m.startswith(('sqlglot', 'dbt', 'metricflow'))}))\n",
+        extras=["ossie"],
+    )
+
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert done.stdout.strip() == "[]"
+
+
+def test_the_ossie_extra_plans_and_applies_a_document(wheel: str, tmp_path: Path):
+    """The command that install exists to run has to run on that install.
+
+    Native authoring reaches `transform apply`, which is a dbt-shaped verb, and
+    routing it through the dbt authoring surface would make a minimal Ossie
+    install unable to apply the plan it just made. This is the assertion that
+    holds the two apart, and it goes through the CLI because the router is where
+    the coupling lives.
+    """
+
+    root = _ossie_repo(tmp_path)
+    edits = root / "edits.json"
+    edits.write_text(
+        json.dumps(
+            {
+                "edits": [
+                    {
+                        "path": "layer.ossie.yaml",
+                        "content": OSSIE_DOCUMENT + "\n# reviewed\n",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    done = _run_isolated(
+        wheel,
+        "import sys, io, json, contextlib\n"
+        "from exmergo_dex_core.cli import main\n"
+        "def run(argv):\n"
+        "    out = io.StringIO()\n"
+        "    with contextlib.redirect_stdout(out):\n"
+        "        code = main(argv)\n"
+        "    payload = json.loads(out.getvalue())\n"
+        "    assert payload['status'] == 'ok', payload\n"
+        "    return payload\n"
+        f"root = {str(root)!r}\n"
+        "run(['--repo-root', root, 'semantic', 'ossie', 'plan', 'revise',\n"
+        f"     '--edits-file', {str(edits)!r}])\n"
+        "run(['--repo-root', root, 'transform', 'apply'])\n"
+        "import pathlib\n"
+        "written = pathlib.Path(root, 'layer.ossie.yaml').read_text()\n"
+        "assert written.endswith('# reviewed\\n'), written[-40:]\n"
+        "print(sorted({m.split('.')[0] for m in sys.modules "
+        "if m.startswith(('sqlglot', 'dbt', 'metricflow'))}))\n",
+        extras=["ossie"],
+    )
+
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert done.stdout.strip() == "[]", (
+        "applying a native semantic plan pulled a dbt-shaped dependency, so the "
+        "minimal Ossie install cannot apply the plan it can make"
+    )
+
+
+def test_the_ossie_and_sql_extras_together_check_expression_syntax(
+    wheel: str, tmp_path: Path
+):
+    """The third validation layer, which rides on `[sql]`.
+
+    With it, a malformed SQL expression is a diagnostic. Without it, the layer
+    does not run and says so. The difference between the two is what stops a
+    skipped check from reading as a passed one.
+    """
+
+    root = tmp_path / "bad_sql"
+    (root / ".dex").mkdir(parents=True)
+    (root / ".dex" / "config.yml").write_text(OSSIE_CONFIG, encoding="utf-8")
+    (root / "layer.ossie.yaml").write_text(
+        OSSIE_DOCUMENT.replace("order_total - discount", "SELECT FROM WHERE ,"),
+        encoding="utf-8",
+    )
+
+    probe = (
+        "from exmergo_dex_core.ossie.loader import load_documents\n"
+        f"loaded = load_documents({str(root)!r}, ['layer.ossie.yaml'], "
+        "connector='duckdb')\n"
+        "print(sorted({d.rule for d in loaded.diagnostics}))\n"
+    )
+
+    with_sql = _run_isolated(wheel, probe, extras=["ossie", "sql"])
+    without_sql = _run_isolated(wheel, probe, extras=["ossie"])
+
+    assert with_sql.returncode == 0, with_sql.stderr
+    assert "sql_syntax" in with_sql.stdout, with_sql.stdout
+    assert without_sql.returncode == 0, without_sql.stderr
+    assert "sql_unavailable" in without_sql.stdout, without_sql.stdout
+    assert "sql_syntax" not in without_sql.stdout, (
+        "a skipped check reported a verdict it did not reach"
+    )
+
+
+def test_a_dbt_read_pulls_in_neither_ossie_nor_its_validator(wheel: str):
+    """The other direction, which is the one that would make an existing dbt
+    deployment depend on a draft interchange schema."""
+
+    done = _run_isolated(
+        wheel,
+        "import sys\n"
+        "from exmergo_dex_core.adapters.project import DbtProject\n"
+        "DbtProject('.', None).definitions()\n"
+        "assert 'exmergo_dex_core.ossie' not in sys.modules\n"
+        "print(sorted({m.split('.')[0] for m in sys.modules "
+        "if m.startswith('jsonschema')}))\n",
+        extras=["sql"],
+    )
+
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert done.stdout.strip() == "[]"
+
+
+def test_the_semantic_source_contract_needs_only_a_test_runner(wheel: str):
+    """Same floor as the other three shipped contracts, and the floor is the
+    point: an implementer runs the suite against their own source without
+    installing a warehouse client, a dialect engine, or either semantic extra.
+
+    The cheapest way for this to acquire a heavier floor is for one assertion to
+    start building something that parses SQL, which is why it is asserted rather
+    than reviewed.
+    """
+
+    done = _run_isolated(
+        wheel,
+        "import sys\n"
+        "from exmergo_dex_core import semantic_source_conformance as c\n"
+        "assert c.SemanticCatalogSourceContract\n"
+        "assert c.SemanticDeclarationContract\n"
+        "assert c.SemanticFingerprintContract\n"
+        "assert c.SemanticSourceFactoryContract\n"
+        "print(sorted({m.split('.')[0] for m in sys.modules "
+        "if m.startswith(('sqlglot', 'metricflow', 'httpx', 'jsonschema'))}))\n",
+        extras=["semantic-conformance"],
+    )
+
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert done.stdout.strip() == "[]"

--- a/packages/dex-core/tests/test_safety_spine.py
+++ b/packages/dex-core/tests/test_safety_spine.py
@@ -6035,7 +6035,7 @@ def test_ossie_pii_linkage_exists_only_for_a_direct_column_on_a_real_relation(
 
     _ossie_repo(tmp_path, _OSSIE_DOCUMENT)
     view = (
-        DexEngine.from_repo(str(tmp_path)).semantic_catalog_format().semantic_catalog()
+        DexEngine.from_repo(str(tmp_path)).semantic_catalog_source().semantic_catalog()
     )
 
     assert view.physical_columns == {
@@ -6071,7 +6071,7 @@ def test_ossie_reads_are_confined_to_the_repository(tmp_path):
     from pydantic import ValidationError
 
     from exmergo_dex_core.config import DexConfig
-    from exmergo_dex_core.ossie import OssieProject
+    from exmergo_dex_core.ossie import OssieSemanticLayer
 
     outside = tmp_path.parent / "escape.ossie.yaml"
     outside.write_text("version: '0.2.0.dev0'\nsemantic_model: []\n", encoding="utf-8")
@@ -6091,8 +6091,8 @@ def test_ossie_reads_are_confined_to_the_repository(tmp_path):
     # caller that built its coordinates without going through config at all.
     # Confinement is a safety property, so it is checked where the file is
     # opened rather than only where the path is written.
-    escaping = OssieProject(repo, ["../escape.ossie.yaml"], connector="duckdb")
-    definitions = escaping.definitions()
+    escaping = OssieSemanticLayer(repo, ["../escape.ossie.yaml"], connector="duckdb")
+    definitions = escaping.declared_definitions()
 
     assert definitions.model_relations == {}
     assert any("outside the repository" in note for note in definitions.notes)
@@ -6118,6 +6118,262 @@ def test_ossie_never_executes_a_metric_query_it_cannot_price(tmp_path):
 
     with pytest.raises(SemanticBackendError, match="not a portable query runtime"):
         backend.query(SemanticQuery(metrics=["anything"]))
+
+
+def _ossie_billed_repo(root, *, session_ceiling: float | None = None) -> None:
+    """An Ossie layer over the BigQuery fake's own tables.
+
+    The relations are the fixture's, so a declared join is one the fake can
+    actually be asked about. Both edges point at one shared parent, which is what
+    makes the batched probe a single statement rather than one per edge.
+    """
+
+    from exmergo_dex_core.config import DexConfig, save_config
+
+    (root / "billed.ossie.yaml").write_text(
+        """
+version: "0.2.0.dev0"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: test-proj.shop.customers
+        primary_key: [id]
+        fields:
+          - name: id
+            expression:
+              dialects: [{dialect: BIGQUERY, expression: id}]
+      - name: events
+        source: test-proj.shop.events
+        primary_key: [id]
+        fields:
+          - name: id
+            expression:
+              dialects: [{dialect: BIGQUERY, expression: id}]
+    relationships:
+      - name: events_to_orders
+        from: events
+        to: orders
+        from_columns: [id]
+        to_columns: [id]
+      - name: orders_to_orders
+        from: orders
+        to: orders
+        from_columns: [id]
+        to_columns: [id]
+""",
+        encoding="utf-8",
+    )
+    save_config(
+        DexConfig(
+            connector="bigquery",
+            bigquery={"project": "p"},
+            semantic={"vendor": "ossie", "ossie": {"files": ["billed.ossie.yaml"]}},
+            budget=(
+                {} if session_ceiling is None else {"session_ceiling": session_ceiling}
+            ),
+        ),
+        root,
+    )
+
+
+def _ossie_billed_engine(fake_bq_client, root, monkeypatch, **kwargs):
+    """The Ossie repo, opened through the gate the engine really builds.
+
+    ``connect.new_cost_gate`` rather than a hand-rolled ``CostGate``: a
+    vendor-shaped second route to the warehouse is exactly the shape a guard gets
+    bypassed by, so what is under test has to be the wiring, not a stand-in.
+    """
+
+    import exmergo_dex_core.connect as connect_mod
+    from exmergo_dex_core.adapters.bigquery import BigQueryAdapter
+    from exmergo_dex_core.config import BigQueryTarget, load_config
+    from exmergo_dex_core.connect import new_cost_gate
+
+    config = load_config(root)
+    store = FilesystemStore(root)
+
+    def opener(**opened):
+        return BigQueryAdapter(
+            project="test-proj",
+            cost_gate=new_cost_gate(
+                "bigquery",
+                config,
+                store,
+                budget=opened.get("budget"),
+                confirmed=opened.get("confirmed", False),
+                command=opened.get("command"),
+            ),
+            target=BigQueryTarget(),
+            client=fake_bq_client,
+            principal_type="user",
+        )
+
+    monkeypatch.setattr(connect_mod, "open_adapter", opener)
+    return DexEngine(config=config, store=store, repo_root=str(root), **kwargs)
+
+
+def _billed_rows(sql: str) -> list[dict]:
+    values: dict[str, object] = {"n_total": 100}
+    for i in range(10):
+        values[f"nn_{i}"] = 100
+        values[f"nd_{i}"] = 100 if i == 0 else 40
+        values[f"mn_{i}"] = 1
+        values[f"mx_{i}"] = 100
+        values[f"d_{i}"] = 100
+        values[f"nonnull_fk_{i}"] = 100
+        values[f"orphans_{i}"] = 0
+    return [values]
+
+
+def test_unconfirmed_ossie_verification_executes_no_billed_statement(
+    fake_bq_client, tmp_path, monkeypatch
+):
+    """Family 2: a declaration is not an authorization to scan.
+
+    Ossie contributes declared joins at confidence 1.0, and measuring one is a
+    warehouse scan like any other. Free metadata and the dry run that produces
+    the estimate are allowed; nothing billed runs before the caller says so.
+    """
+
+    from exmergo_dex_core import ConfirmationRequiredError
+
+    _ossie_billed_repo(tmp_path)
+    fake_bq_client.row_resolver = _billed_rows
+    engine = _ossie_billed_engine(fake_bq_client, tmp_path, monkeypatch)
+
+    with engine, pytest.raises(ConfirmationRequiredError) as caught:
+        engine.relationships(verify=True, use_project=True)
+
+    assert caught.value.request.cost.estimate > 0
+    assert fake_bq_client.query_calls
+    assert all(call.dry_run for call in fake_bq_client.query_calls)
+
+
+def test_a_confirmed_ossie_scan_is_server_capped_and_reaches_the_ledger(
+    fake_bq_client, tmp_path, monkeypatch
+):
+    """Family 2, the other half: the ceiling binds at the server and the spend
+    is recorded, so the next command's headroom is computed from what this one
+    actually billed rather than from what it estimated."""
+
+    _ossie_billed_repo(tmp_path, session_ceiling=float(1024 * 1024 * 1024))
+    fake_bq_client.row_resolver = _billed_rows
+    engine = _ossie_billed_engine(
+        fake_bq_client,
+        tmp_path,
+        monkeypatch,
+        confirmed=True,
+        budget=float(500 * 1024 * 1024),
+    )
+
+    with engine:
+        engine.relationships(verify=True, use_project=True)
+
+    executed = [c for c in fake_bq_client.query_calls if not c.dry_run]
+    assert executed
+    assert all(c.job_config.maximum_bytes_billed for c in executed)
+
+    ledger = (tmp_path / ".dex" / "spend.jsonl").read_text(encoding="utf-8")
+    assert any(
+        json.loads(line).get("entry") == "settlement"
+        for line in ledger.splitlines()
+        if line.strip()
+    ), ledger
+
+
+def test_reading_an_ossie_layer_opens_no_warehouse_connection(
+    fake_bq_client, tmp_path, monkeypatch
+):
+    """Family 2: the layer is files in the repository, so reading it costs
+    nothing and must not put a cost handshake in front of a free question.
+
+    Three reads that must all stay free: the catalog, plan-time validation
+    (which adjudicates against the exploration cache), and a project-only
+    snapshot, which re-fingerprints the repository and deliberately carries
+    warehouse staleness forward rather than laundering it into a measurement.
+    """
+
+    from exmergo_dex_core.transform.native_semantic import semantic_ossie
+    from exmergo_dex_core.transform.plans import EditKind, PlanEdit
+
+    _ossie_billed_repo(tmp_path, session_ceiling=float(1024 * 1024 * 1024))
+    fake_bq_client.row_resolver = _billed_rows
+    engine = _ossie_billed_engine(fake_bq_client, tmp_path, monkeypatch)
+    content = (tmp_path / "billed.ossie.yaml").read_text(encoding="utf-8")
+
+    with engine:
+        assert engine.semantic_list().catalog.view.semantic_models
+        semantic_ossie(
+            engine,
+            "revise the layer",
+            [
+                PlanEdit(
+                    path="billed.ossie.yaml",
+                    kind=EditKind.SEMANTIC_DOCUMENT,
+                    new_content=content + "\n# reviewed\n",
+                )
+            ],
+            mode="plan",
+        )
+
+    assert fake_bq_client.query_calls == []
+
+
+def test_a_post_plan_symlink_cannot_move_an_ossie_write_out_of_the_repository(
+    tmp_path, capsys
+):
+    """Family 4 + 3: the write surface is decided at apply time, not at plan time.
+
+    A plan names a configured document, and between planning and applying that
+    document becomes a symlink pointing somewhere else. Checking containment
+    only when the plan was stored would write the authored bytes through the
+    link, and the file that changed would be one no diff ever showed.
+    """
+
+    _ossie_repo(tmp_path, _OSSIE_DOCUMENT)
+    outside = tmp_path.parent / "escaped.ossie.yaml"
+    outside.write_text("version: '0.2.0.dev0'\nsemantic_model: []\n", encoding="utf-8")
+    before = outside.read_bytes()
+
+    edits = tmp_path / "symlink-edits.json"
+    edits.write_text(
+        json.dumps(
+            {
+                "edits": [
+                    {
+                        "path": "layer.ossie.yaml",
+                        "content": _OSSIE_DOCUMENT + "\n# reviewed\n",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    planned = _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "semantic",
+            "ossie",
+            "plan",
+            "revise the layer",
+            "--edits-file",
+            str(edits),
+        ],
+        capsys,
+    )
+    assert planned["status"] == "ok", planned
+
+    target = tmp_path / "layer.ossie.yaml"
+    target.unlink()
+    target.symlink_to(outside)
+
+    applied = _run(["--repo-root", str(tmp_path), "transform", "apply"], capsys)
+
+    assert applied["status"] == "error", applied
+    assert "outside the repository" in " ".join(applied["errors"]), applied
+    assert outside.read_bytes() == before
 
 
 # --- The programmatic API is bound by the same spine as the CLI ----------------

--- a/references/command-contract.md
+++ b/references/command-contract.md
@@ -639,7 +639,8 @@ never told. The documents are named in `semantic.ossie.files`, including for an
 Ossie-only repository. They are confined to the repository, and selecting Ossie
 without the `[ossie]` extra refuses and names it. dex pins the Ossie schema by
 content hash rather than by the version string the document carries. See
-`references/semantic-layer.md`.
+`references/semantic-layer.md`, and `references/ossie-compatibility.md` for what
+dex accepts, checks, links, and declines to claim under that pin.
 
 `list` costs no warehouse query on either backend, and neither does the reverse
 lookup, which inverts the dimension list each metric already carries rather than

--- a/references/ossie-compatibility.md
+++ b/references/ossie-compatibility.md
@@ -1,0 +1,209 @@
+# Apache Ossie compatibility
+
+What dex accepts from a native [Apache Ossie](https://github.com/apache/ossie)
+(incubating) document, what it checks, what it makes of what it read, and what it
+does not claim. Read it beside
+[Native Apache Ossie](semantic-layer.md#native-apache-ossie-vendor-ossie), which
+describes how to configure and use the layer; this page is the compatibility
+statement behind it.
+
+Every row here is backed by a case in the reviewed corpus at
+`packages/dex-core/tests/ossie/fixtures/`, named by its case id. The corpus runs
+offline against the bundled schema, and an automated test refuses a claim on this
+page whose case does not exist.
+
+## The pinned schema
+
+dex vendors the upstream schema verbatim and pins it by content hash. Nothing at
+runtime needs a checkout of Apache Ossie.
+
+| | |
+|---|---|
+| Upstream | <https://github.com/apache/ossie> |
+| Commit | `b5da5d66f0da4a0cd3388d52201dbf5523221a77` |
+| Path | `core-spec/ossie-schema.json` |
+| SHA-256 | `27aab111647b1e8d2229a2413e4682e459f43edc62e0eaadd497317754089e42` |
+| Declared spec version | `0.2.0.dev0` |
+| License | Apache License 2.0 |
+
+The pin is on content and not on the version string, because the schema declares
+`version` as a constant that upstream does not move when the schema changes. The
+same hash appears in the loader, in the bundled
+`exmergo_dex_core/ossie/schema/PROVENANCE.md`, in the corpus manifest, and in the
+table above; an offline test asserts all four agree.
+
+## Required extras
+
+| capability | extra | absent |
+|---|---|---|
+| read, validate structure and integrity, catalog, snapshot, author | `[ossie]` (`jsonschema`) | refused by name; there is no weaker validator to fall back to |
+| check that a SQL expression parses | `[sql]` (`sqlglot`), which every connector extra already brings | a named skipped-validation note on the document, never a silent pass |
+
+`[ossie]` deliberately does not pull `[sql]`. Structure and integrity decide
+whether a document is readable at all and are pure plus one validator; expression
+syntax is a third layer that rides on a dependency a warehouse install already
+has.
+
+## What is accepted
+
+| behavior | verdict | cases |
+|---|---|---|
+| `.ossie.yaml`, `.ossie.yml`, `.ossie.json` | equivalent semantics, whichever serialization | `minimal_yaml`, `minimal_yml`, `minimal_json` |
+| several configured documents | compose into one layer | `compose_two_documents` |
+| a YAML `---` stream inside one configured file | refused: one configured file is one document | `yaml_stream_in_one_file` |
+| a document naming a semantic model another file already names | refused | `duplicate_model_across_files` |
+
+## What is checked, and how hard
+
+Three severities, and they are not three strengths of one verdict. An **error**
+means dex could not read the document, which is then absent from the layer. A
+**warning** means dex read it and has something to say about what it found. A
+**note** means dex read it and is saying what it did not check.
+
+| check | severity | origin | cases |
+|---|---|---|---|
+| bytes are not parseable | error | dex | `unparseable` |
+| a configured file holding a YAML `---` stream | error | dex | `yaml_stream_in_one_file` |
+| the document's own `version` is not the pinned constant | error | pinned schema | `wrong_version` |
+| a structural key the schema does not define | error | pinned schema | `unknown_structural_key` |
+| a dialect token the pinned schema's enum does not define | error | pinned schema | `post_pin_thoughtspot_is_refused` |
+| two datasets, fields, or metrics sharing a name in one model | error | upstream integrity | `duplicate_names_within_a_document` |
+| a relationship endpoint the model does not declare | error | upstream integrity | `relationship_endpoint_missing` |
+| a semantic-model name declared in two configured files | error | dex | `duplicate_model_across_files` |
+| a relationship whose two column arrays differ in length | error | dex | `relationship_arity_unequal` |
+| a relationship target whose declared key does not cover the join | warning | upstream integrity | `target_key_coverage_warns` |
+| expressions in a non-SQL dialect were not parsed | note | dex | `non_sql_dialects_are_metadata` |
+
+Two of those are dex's own rules rather than upstream's, marked accordingly in
+the corpus manifest and worth carrying upstream: cross-file semantic-model
+uniqueness, and equal arity between a relationship's two column arrays. The
+schema constrains both arrays but not their lengths against each other, and a
+relationship whose sides differ in arity has no complete tuple to join on.
+
+**What validation proves, and what it does not.** There is no external validator
+here the way `dbt parse` is for dbt: neither `apache-ossie` nor
+`apache-ossie-dbt` is published, and there is no Ossie runtime to load a document
+into. A document that passes is schema-valid and internally consistent. That is
+not a claim that any consumer can execute it, and no dex surface says otherwise.
+
+## Which expression dex reads
+
+An Ossie field or metric may declare one expression per dialect, and the enum
+mixes SQL dialects with expression languages that are not SQL. Selection is
+deterministic:
+
+1. the active connector's own Ossie dialect, where the document declares one;
+2. otherwise `ANSI_SQL`;
+3. otherwise the first supported SQL dialect in declaration order.
+
+Four of dex's seven connectors (DuckDB, Postgres, Redshift, ClickHouse) have no
+token in Ossie's enum. They fall to `ANSI_SQL` rather than to something close,
+because a wrong dialect is a worse answer than the portable one. Every declared
+expression is preserved whichever one dex reads. Cases:
+`dialect_selection`, `dialect_selection_falls_back_to_portable`.
+
+`MDX`, `TABLEAU` and `MAQL` are preserved verbatim, never parsed, never a source
+of a physical column, and never reported as SQL-validated. A bare token in MAQL
+that looks like a column identifier means something else entirely, so reading one
+would be worse than reading none. Case: `non_sql_dialects_are_metadata`.
+
+## The physical link, and therefore the PII gate
+
+A field resolves to a warehouse column only when **both** conditions hold: the
+dataset's source is a relation this connector can address, and the field's
+selected expression is a bare identifier. Everything else carries no column.
+
+| shape | links | why |
+|---|---|---|
+| a bare identifier on a `database.schema.table` source | yes | the only shape where the column is stated rather than inferred |
+| a computed expression | no | there is no single column behind it |
+| a quoted identifier | no | quoting is the author asserting a spelling dex would have to fold |
+| a qualified `dataset.column` expression | no | the qualifier names a dataset, not the relation dex would address |
+| a field declaring only non-SQL dialects | no | dex does not read those languages |
+| a query-valued source | no | Ossie documents a source as a relation **or** a query with no portable discriminator, and a query read as a relation reaches the gate as a relation that does not exist |
+| a source that is not addressable on this connector | no | opaque rather than guessed at |
+
+Case: `physical_linkage_is_direct_only`, which asserts the resulting link table by
+equality rather than containment. A link too few costs a screening; a link too
+many screens the wrong column and reports the verdict as evidence-backed.
+
+PII linkage follows exactly this table. A dimension dex cannot resolve to a
+column is screened by the name heuristic and says so, rather than being screened
+against a column that is not behind it.
+
+## Keys, relationships, snapshots, and authoring
+
+| capability | supported | cases |
+|---|---|---|
+| a primary key, and further independent `unique_keys` beside it | yes, kept as separate claims | `keys_and_relationships` |
+| a composite grain of three or more columns, in declared order | yes, and no member leaks into the single-key list | `keys_and_relationships` |
+| a relationship whose two sides are spelled differently | yes, both sides retained | `keys_and_relationships` |
+| a composite relationship as one ordered tuple | yes, verified as a complete tuple and never one pair at a time | `adversarial_composite` |
+| `maintain snapshot` baseline over the layer | yes | `drift_baseline` |
+| free definition, key, and relationship drift against that baseline | yes | `drift_baseline`, `drift_changed` |
+| `semantic ossie define\|update\|plan`, applied with `transform apply` | yes, confined to the exact paths in `semantic.ossie.files` | see [Authoring native documents](semantic-layer.md#authoring-native-documents) |
+
+`adversarial_composite` is the case worth reading. Its child tuples are
+`(1, 10, 100)` and `(2, 20, 200)`, its parent tuples `(1, 20, 200)` and
+`(2, 10, 100)`. Every column overlaps independently, so a probe that measures one
+column at a time reports a healthy join three times over; no complete tuple
+matches, so the join finds nothing. The two sides are named differently so that
+copying one side's columns onto the other cannot pass.
+
+## What Ossie does not carry, declared rather than absent
+
+These are properties of the format, not of how far the implementation got, and
+they arrive in the catalog's `unavailable` block rather than as empty fields a
+caller would read as facts about the layer.
+
+| absent | consequence |
+|---|---|
+| measures | every declared field of a measure is unavailable; metrics are expressions rather than compositions over measures |
+| entities | the layer's joins are explicit relationships, so there is no entity graph and no entity label |
+| metric-to-dimension groupability | `explore semantic list --for-dimension` refuses by name rather than answering "no metric can be grouped that way", which would be a false statement about the layer |
+| a portable query runtime | `explore semantic query` and `explore semantic values` refuse: Ossie defines no filter grammar, no join planning, and no execution semantics, so dex has nothing to render a governed statement from |
+| a hosted deployment | `--api` is refused; a hosted Ossie would be some vendor's service speaking its own protocol, which is a different vendor rather than a second deployment of this one |
+
+Ossie is a semantic layer and never a transformation project. `project.format:
+ossie` is refused rather than translated, and the reader satisfies none of the
+project tiers: it owns no model graph, no compilation, no targets, and no dbt
+write surface. A repository may have dbt beside Ossie, Ossie alone, or dbt alone.
+
+## What dex does not claim
+
+- **No converter interoperability.** dex reads Ossie documents; it does not
+  convert them to or from another semantic format, and says nothing about what
+  another tool would make of one.
+- **No execution assurance.** A document that validates here is schema-valid and
+  internally consistent. Whether any engine can execute it is a separate
+  question dex has no basis to answer.
+- **Missing SQL validation is disclosed, not passed.** Without `[sql]` the
+  expression layer does not run and the document says so. That note is the
+  absence of a check, not a check that succeeded.
+- **A warning is not a partial refusal.** A document that warns is read in full.
+
+## Known deltas from upstream's current schema
+
+Upstream moves; the pin does not, until somebody moves it deliberately.
+
+| delta | effect under this pin |
+|---|---|
+| upstream [added the `THOUGHTSPOT` dialect](https://github.com/apache/ossie/commit/211ce662c2e122e3410ad6c737248e9516a06d3b) after the pinned commit | a document declaring it is refused, since the pinned enum does not define it. Case: `post_pin_thoughtspot_is_refused` |
+| dex requires a semantic-model name to be unique across configured files | upstream validates one document at a time and has no cross-file rule |
+| dex requires a relationship's two column arrays to have equal length | upstream's schema constrains each array but not their lengths against each other |
+
+## Upgrading the pin
+
+1. Copy the new `core-spec/ossie-schema.json` in verbatim.
+2. Update the commit, hash, and declared version in `PROVENANCE.md`, in
+   `SCHEMA_SHA256` in `exmergo_dex_core/ossie/loader.py`, in the corpus
+   manifest's `schema:` block, and in the table on this page.
+3. Run the corpus. **Read every case whose verdict moved**, decide for each one
+   whether the new verdict is what upstream now intends, and record it in the
+   changelog with the behavior it changes.
+4. Update the tables on this page for anything that moved, and re-check the
+   known-deltas list: a delta upstream has adopted stops being a delta.
+
+Updating the hash alone is not an upgrade. The offline test checks that the four
+places agree with each other; it cannot check that anybody read the diff, and it
+should not be quoted as though it did.

--- a/references/project.md
+++ b/references/project.md
@@ -51,6 +51,17 @@ as well as tier 3. Its three methods are `load()`, `edit_path()` and
 what `explore semantic list --local` reads. It is described under
 [Reading the semantic layer twice](#reading-the-semantic-layer-twice-for-two-different-questions).
 
+It is here because a *dbt project* happens to hold a semantic layer, not because
+a semantic layer is a project. A repository can have a layer and no
+transformation project at all, and one that does is configured on the semantic
+axis (`semantic.vendor`) and built through
+`exmergo_dex_core.semantic_source`, which checks that what it built can answer a
+catalog and checks nothing else. Nothing on this page applies to it: it owns no
+model graph, no compilation, no targets, and no write surface into dbt's files,
+and it satisfies none of the tiers below. See
+[the semantic layer reference](semantic-layer.md) for that axis and its own
+conformance contracts.
+
 Both are beside rather than on a tier because these protocols are
 `runtime_checkable`: a method added to a tier would demote every format that has not
 implemented it yet, so `tier_of` would start answering 2 where it answered 3 and the
@@ -672,7 +683,7 @@ project:
 
 | Name | Example | For |
 |---|---|---|
-| shipped | `dbt`, `ossie` | dex's own formats, and never shadowable by anything installed |
+| shipped | `dbt` | dex's own formats, and never shadowable by anything installed |
 | dotted path | `mypkg.projects:my_project` | a factory reachable by import, with no packaging work |
 | entry point | `acme` | a name an installed distribution registered under `exmergo_dex_core.projects` |
 

--- a/references/semantic-layer.md
+++ b/references/semantic-layer.md
@@ -581,6 +581,11 @@ with multi-dialect expressions, explicit relationships, and expression metrics.
 dex reads native `.ossie.yaml`, `.ossie.yml` and `.ossie.json` documents from the
 repository, with no dbt project and no MetricFlow anywhere in the path.
 
+What dex accepts, checks, links, and declines to claim is written out row by row
+in [Apache Ossie compatibility](ossie-compatibility.md), with the pinned schema
+hash and a named corpus case behind each claim. This section is how to use the
+layer; that one is what it promises.
+
 It is **catalog-first**, and that is a statement about the format rather than
 about how far the implementation got. Ossie specifies interchange metadata and
 not a portable query runtime: no filter grammar, no join planning, no execution
@@ -681,7 +686,9 @@ itself is what checks it.
 
 The upstream commit, the hash, and the upgrade procedure are recorded beside the
 schema in the installed package, at
-`exmergo_dex_core/ossie/schema/PROVENANCE.md`.
+`exmergo_dex_core/ossie/schema/PROVENANCE.md`, and the deltas between the pin and
+upstream's current schema are listed in
+[Apache Ossie compatibility](ossie-compatibility.md).
 
 **State the assurance boundary plainly.** There is no external validator here the
 way `dbt parse` is for dbt: neither `apache-ossie` nor `apache-ossie-dbt` is
@@ -876,7 +883,55 @@ carries the PII gate's own column lookup; caps that count what they cut and leav
 the catalog they were given alone; `filter_refs` answering or declining without
 raising; and a values request for a PII-flagged dimension refused.
 
-dex binds its own two backends to it in
+### The source, as distinct from the backend
+
+A backend answers a catalog at runtime. A **semantic source** is what supplies
+the layer it answers from, and for a file-backed one that is a different set of
+promises: what the documents declare, what a drift baseline reduces them to, and
+what construction may and may not do. Those live in
+`exmergo_dex_core.semantic_source_conformance`, under the same
+`[semantic-conformance]` extra:
+
+```python
+from exmergo_dex_core.semantic_source_conformance import (
+    SemanticCatalogSourceContract,
+    SemanticDeclarationContract,
+    SemanticFingerprintContract,
+    SemanticSourceFactoryContract,
+)
+
+
+class TestMySource(
+    SemanticSourceFactoryContract,
+    SemanticDeclarationContract,
+    SemanticFingerprintContract,
+    SemanticCatalogSourceContract,
+):
+    def build_source(self, context): ...
+    def empty_source_context(self): ...
+    def a_source_declaring_a_unique_key(self): ...
+```
+
+Four contracts because a source may legitimately answer only some of them, and
+declining one is an answer rather than a shortfall: a source with no drift
+fingerprint is complete, and `maintain` reports the absence itself.
+
+The assertions are the same ones the project contracts in
+`exmergo_dex_core.adapters.conformance` run, extracted rather than copied, and
+those contracts compose these. A project format and a semantic source make the
+same promises about a layer through differently named methods, and one behaviour
+asserted in two places is one behaviour that can disagree with itself. dex binds
+Ossie to all four in `tests/ossie/test_conformance.py` and dbt reaches the same
+assertions through its project binding.
+
+**A semantic source is never a project**, and the contracts are structured so
+that satisfying these buys none of the project tiers. A transformation project
+owns a model graph, compilation, targets, and a write surface;
+`SemanticCatalogSource` and `SemanticSnapshotSource` in
+`exmergo_dex_core.semantic_source` are one method each and inherit nothing from
+`ExploreProject`.
+
+dex binds its own two backends to the runtime contract in
 `tests/explore/test_semantic_conformance.py`, three times: `--local` with
 MetricFlow resolving the join graph, `--local` with no resolver (the declared
 single-hop read), and `--api` against a transport reproducing the dbt Cloud API's

--- a/ruff.toml
+++ b/ruff.toml
@@ -41,9 +41,16 @@ ignore = ["UP042"]
 # The semantic edit-target conformance contract also ships for reuse and uses
 # pytest assertions for the same reason (S101).
 "packages/dex-core/src/exmergo_dex_core/edits_conformance.py" = ["S101"]
-# The semantic-backend conformance contract, third of the three, same reason and
-# same idiom (S101).
+# The semantic-backend conformance contract, same reason and same idiom (S101).
 "packages/dex-core/src/exmergo_dex_core/explore/semantic/conformance.py" = ["S101"]
+# The semantic-source conformance contract, same again. B017 rides along because
+# one assertion is that construction refuses an unknown option *somehow*: which
+# exception type a source raises is its own business, and pinning one here would
+# make the contract dictate an implementation detail it has no view on.
+"packages/dex-core/src/exmergo_dex_core/semantic_source_conformance.py" = [
+  "S101",
+  "B017",
+]
 # The skill wrappers shell out to the pinned dex CLI by design; the command is
 # a fixed path plus an argv passthrough, not untrusted input (S603). The engine
 # is reached by exec rather than a spawn, so the wrapper does not sit waiting on


### PR DESCRIPTION
Closes #413

## Why

Ossie was already absent from the shipped project registry, and
`project.format: ossie` was already refused. But only the explore route built the
reader directly. Every other consumer went through the project factory:

- `config.SEMANTIC_PROJECT_FORMATS` named a dotted factory path,
- `DexEngine.semantic_catalog_format()` built it with a `ProjectContext` through
  `build_project()`,
- `construct_project()` then enforced `isinstance(project, ExploreProject)`.

That check is why `OssieSemanticLayer` carried a `name` attribute and a
`definitions()` alias. Both existed only to get past a tier floor meant for
formats that own a model graph. So `maintain snapshot`, native semantic
planning, and semantic apply all still depended on Ossie pretending to be a
transformation project, and `maintain`'s snapshot route selected on
`MaintainProject`, which those two vestigial members were half of.

Removing the aliases alone would have broken those three routes silently: the
`isinstance` check would simply stop matching, and an Ossie-only repository would
have lost its semantic baseline with nothing raising. The construction path had
to move first.

## What changed

### A semantic-source seam

New `exmergo_dex_core/semantic_source.py`, a leaf module beside
`semantic_catalog.py`:

- `SemanticSourceContext`: repository, connector, and the vendor's own
  coordinates. No transformation-project directory, deliberately.
- `SemanticCatalogSource`: one method, `semantic_catalog()`.
- `SemanticSnapshotSource`: one method, `semantic_layer()`.
- `resolve_semantic_source_factory` / `construct_semantic_source` /
  `build_semantic_source`, mirroring the project resolver's shape and failure
  vocabulary but checking `SemanticCatalogSource` rather than `ExploreProject`.

`DexEngine.semantic_catalog_source()` is the canonical accessor;
`semantic_catalog_format()` forwards to it with corrected typing.
`SEMANTIC_PROJECT_FORMATS` is renamed `SEMANTIC_SOURCE_FACTORIES`.

Two capabilities rather than a tier ladder, because declining the second is an
answer: a source with no drift fingerprint is complete, not partial.

### Ossie stops being a project

`OssieSemanticLayer` loses `name`, `definitions()`, the `OssieProject` alias, and
`transform_layer()`; `ossie/snapshot.py` loses its transform-fingerprint helper.
It keeps `declared_definitions()`, `semantic_catalog()`, `semantic_layer()`, and
the three authoring methods, and `from_context` now takes a
`SemanticSourceContext`.

`maintain/commands.py` asks for `SemanticSnapshotSource` instead of
`MaintainProject`. `LocalOssieLayer.from_engine` routes through the engine
accessor rather than calling the constructor directly, so there is one
construction path and its coordinates are validated on every route rather than on
two of three.

The reader now satisfies none of `ExploreProject`, `MaintainProject`,
`EditableProject` or `PlacingProject`, and that is asserted rather than
documented. A separate test spies on `build_project`/`construct_project` and
fails if any semantic route reaches them.

`transform_layer: null` in an Ossie-only snapshot is the visible result: a
document set declares no build step, so there is nothing for a transform
baseline to be a baseline of, and the honest answer is now the one that comes
back.

### Conformance at the right boundary

New shipped `exmergo_dex_core/semantic_source_conformance.py`, under the existing
`[semantic-conformance]` extra: `SemanticSourceFactoryContract`,
`SemanticDeclarationContract`, `SemanticFingerprintContract`,
`SemanticCatalogSourceContract`.

The assertions are **extracted from the project contracts, not copied**, and
`adapters/conformance.py` now composes them through its existing hooks. A project
format and a semantic source make the same promises about a layer through
differently named methods, so one override
(`declarations_of`) reconciles `definitions()` with `declared_definitions()` and
there is one implementation of each shared rule. dbt's binding is unchanged and
gained one assertion (the unreadable-source degradation, which it now implements
with an uncompiled project).

Ossie's binding drops the four project-tier contracts and picks up the four
source contracts. `SemanticEditTargetContract` is unchanged.

The runtime `SemanticBackendContract` gained four layer-independent assertions:
descriptor-to-payload agreement, a declared gap naming a real field of a real
kind, a declared gap not being contradicted by content in the same payload, and
shape checks on `declared_relationships()` and `declared_keys()`. The
reference-layer `SemanticCatalogContract` stays bound to dbt only, since Ossie
has no entities, measures or metric groupability to answer it with;
manufacturing them to pass would invent a layer the author never wrote. That
applicability boundary is written down in the compatibility matrix rather than
left as a gap to rediscover.

The two long-standing Ossie skips remain and remain explained: dimension rows are
scoped per declaration, and the layer declares no ratio metric.

### A reviewed corpus and a compatibility matrix

`tests/ossie/fixtures/` holds 22 native documents plus `cases.yaml`, which says
what each one means: expected diagnostic rules and severities, whether each rule
comes from the pinned schema, upstream's integrity judgment or a dex restriction,
and expected physical links, key tuples and relationship pairs.

Expectations are authored, not captured. Two were wrong when first written and
the code was right: the parse-failure rule is `malformed` rather than
`unreadable`, and `non_sql_dialect` is a note rather than a warning. Both were
corrected in the manifest with the reasoning, which is the corpus doing its job.

`references/ossie-compatibility.md` states the same ground for a reader, with the
pin, the required extras, a named case behind every claim, and what dex does not
claim (no converter interoperability, no execution assurance, missing SQL
validation disclosed rather than passed). Known deltas include upstream's
post-pin `THOUGHTSPOT` dialect, refused under this pin.

An offline test asserts the loader constant, `PROVENANCE.md`, the corpus manifest
and the matrix carry one hash, that every matrix claim names a case that exists,
and that no fixture goes unread. It checks consistency; it cannot check that a
human read an upgrade diff, and says so.

### Safety and installation

Four command-level entries in the safety spine, plus nine parametrized ones in a
new `tests/ossie/test_metered_safety.py`. All go through
`connect.new_cost_gate`, so what is under test is the wiring the engine uses;
nothing stubs `CostGate`, admission, reservations, or ledger settlement.

They cover: unconfirmed verification executes no billed statement; an
insufficient command budget and an insufficient session budget each prevent the
scan; a confirmed scan carries `maximum_bytes_billed` and settles in the ledger;
the priced and executed overlap probes are the same statements and shared-parent
edges batch into one; a declared edge keeps confidence 1.0 whatever the probe
measures; the catalog, cached authoring validation and a project-only snapshot
open no connection; and a post-plan symlink cannot move a write out of the
repository.

Six wheel-backed packaging tests. `tests/ossie/test_boundaries.py`'s import probe
now reports third-party prefixes too, not just `exmergo_dex_core`, which is where
the heavier dependency would actually arrive.

### One defect those tests found

`transform apply` refused a native semantic plan on an install carrying only
`[ossie]`. The CLI asserted the dialect engine before dispatching every authoring
verb, and `transform.commands` imported it eagerly through `.semantic` and
`.validate`, so that install could author a plan it could never apply, which is
the one command it exists to run.

Fixed at the import boundary rather than by duplicating apply: the two
dialect-engine imports in `transform.commands` are reached at the point of use,
and the router reads the stored plan's edit target and asserts the dialect engine
only for plans that author SQL. It fails toward asserting it, so an apply that
cannot resolve a plan still refuses with the message it always did.

## Verification

Full suite: **3,714 passed, 120 skipped**, including the 27 packaging tests that
build a real wheel and install it into isolated environments. Ruff lint, Ruff
format, the em-dash prose check and `git diff --check` all pass.

Two live sessions.

**DuckDB**, a fresh `demo` warehouse and a two-document native layer over it:
catalog and narrowing; the four refusals (`--for-dimension`, `semantic query`,
`semantic values`, `--api`); declarations reaching profile, relationships,
map and diagram, with the composite edge measured as a complete tuple and
rendered as paired columns; snapshot with `transform_layer: null`; author and
apply, byte-identical to reviewed content; free definition drift; an invalid
cached reference refused before storage; a stale multi-file apply leaving both
files untouched; a declared composite grain caught at high severity; and the same
layer beside a minimal dbt project, where dbt supplies the transform layer and
Ossie the semantic one in one snapshot.

**BigQuery**, read-only against `bigquery-public-data.samples.shakespeare`,
nothing created or mutated, at an agreed 1 GiB per command and 10 GiB session
ceiling. The catalog is free on a metered connector. The profile measured the
grain, which is what made the deliberately invalid key declaration wrong on
evidence rather than on a hunch: 32,780 distinct `word` values over 164,656 rows.
Unconfirmed runs returned estimates and spent nothing; `--confirm` past the
ceiling was refused rather than honored; the confirmed grain check caught the
invalid composite with its measurement (122,833 distinct combinations over
164,656 rows). Total settled 62,914,560 bytes, and every figure the envelopes
reported equals its ledger settlements exactly. Cached authoring validation left
the ledger byte-identical.

One gap, named rather than papered over: `explore map` and
`explore relationships` price the whole source allowlist, and BigQuery's
allowlist granularity is the dataset, so on a public dataset holding
`natality`, `wikipedia` and `trigrams` both estimate 87 GB and the session
ceiling refuses them. The ceiling was not raised. Map annotations and the diagram
are therefore verified on DuckDB and by the offline suite, not on BigQuery; the
metered half of the declaration channel is covered on BigQuery through
`maintain grain`, which takes an object scope.

## Not in scope

The schema pin is unchanged. No semantic execution, no converters, no upgrade to
the workflow documentation that #414 covers, and no upstream contributions.
