### PR TITLE
SCRUM-1292-Fix classify_content misreading MetricFlow filter grammar

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`classify_content` read a metric filter's `Dimension`/`TimeDimension`/
+  `Entity` calls as an unrecognized macro, so a metric with a filter was
+  never `declarative`** ([#445]). Those three names are MetricFlow's own
+  filter grammar: they dispatch into the semantic layer's resolution against
+  definitions the project already declares, not into a macro the repository
+  wrote, so treating them as an unknown `macro_call` reached the executable
+  verdict on a premise that never held for them. `classify.py` now consults
+  `metricflow_dialect.FILTER_CALLEES`, the same module `#357` already made the
+  owner of this grammar, rather than re-deriving it. The reference is still
+  reported (a new `semantic_ref` signal) so a host applying its own policy
+  keeps the evidence; a filter calling a macro the project actually defines is
+  untouched and still classifies executable, and a document carrying both a
+  filter and a hook is still executable, since execution still outranks
+  everything else in `_verdict`. The exception is scoped to the value of a
+  `filter` key under `metrics[...]` specifically, not the callee name
+  everywhere it appears and not every `filter` key: a repository macro that
+  happens to be named `Dimension` and is called from a description or any
+  other field is still repository-controlled code and still classifies
+  `macro_call`/executable, and so is a `filter` key outside `metrics[...]`
+  (`models[].config.filter`, say), which names no MetricFlow grammar at all.
+  A new `classify-filtered-metric` conformance vector covers it. Also
+  clarified, no behavior change: `Grounding.
+  completeness` docstring now says explicitly that "complete" means every
+  reference was named statically, not that every named reference resolves to
+  something that exists.
+
 ## [1.12.0] - 2026-09-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.12.1] - 2026-09-09
+
 ### Fixed
 
 - **`classify_content` read a metric filter's `Dimension`/`TimeDimension`/

--- a/packages/dex-core/src/exmergo_dex_core/host/vectors/classify-filtered-metric.json
+++ b/packages/dex-core/src/exmergo_dex_core/host/vectors/classify-filtered-metric.json
@@ -1,0 +1,25 @@
+{
+  "name": "classify-filtered-metric",
+  "contract": "classification",
+  "description": "A metric filter naming a dimension through MetricFlow's own grammar. Dimension('...') dispatches into the semantic layer's resolution against definitions the project already declares, not into a macro the repository wrote, so the verdict is declarative and the reference is still reported as a signal.",
+  "payload": {
+    "path": "models/marts/live_sessions.yml",
+    "content": "metrics:\n  - name: live_sessions\n    label: Live sessions\n    type: simple\n    type_params:\n      measure:\n        name: session_count\n        filter: \"{{ Dimension('session__is_deleted') }} = false\"\n"
+  },
+  "expect": {
+    "artifact_class": "declarative",
+    "result": {
+      "path": "models/marts/live_sessions.yml",
+      "artifact_class": "declarative",
+      "basis": "content",
+      "parsed": true,
+      "signals": [
+        {
+          "signal": "semantic_ref",
+          "where": "metrics[0].type_params.measure.filter: line 1",
+          "detail": "Dimension(session__is_deleted)"
+        }
+      ]
+    }
+  }
+}

--- a/packages/dex-core/src/exmergo_dex_core/metricflow_dialect.py
+++ b/packages/dex-core/src/exmergo_dex_core/metricflow_dialect.py
@@ -61,6 +61,16 @@ STANDARD_GRAINS = (
 _DIMENSION_REF = re.compile(r"(?:Time)?Dimension\(\s*['\"]([^'\"]+)['\"]")
 _ENTITY_REF = re.compile(r"Entity\(\s*['\"]([^'\"]+)['\"]")
 
+#: The callee names this filter grammar recognizes. A call by one of these
+#: names dispatches into the semantic layer's own resolution against
+#: definitions the project already declares (a dimension or entity the layer
+#: knows about), not into a macro the repository wrote. Exported so a reader
+#: outside this module (`transform.classify`) has one place to ask "is this
+#: MetricFlow's own vocabulary" rather than re-deriving the grammar; keep this
+#: in step with `_DIMENSION_REF`/`_ENTITY_REF` above, which recognize the same
+#: three names.
+FILTER_CALLEES = frozenset({"Dimension", "TimeDimension", "Entity"})
+
 
 def filter_refs(clauses: list[str]) -> list[str]:
     """Every dimension and entity token a set of Jinja filter clauses names.

--- a/packages/dex-core/src/exmergo_dex_core/transform/classify.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/classify.py
@@ -40,6 +40,7 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, Field
 
+from .. import metricflow_dialect
 from ..dbt_project import jinja_regions
 from ..edits import Edit, EditOp
 
@@ -156,12 +157,21 @@ class ArtifactClassification(BaseModel):
         }
 
 
-def _jinja_signals(content: str, *, where_prefix: str = "") -> list[ArtifactSignal]:
+def _jinja_signals(
+    content: str, *, where_prefix: str = "", in_filter: bool = False
+) -> list[ArtifactSignal]:
     """Every executable signal the jinja in ``content`` carries.
 
     A region with no call at all is still a signal (``jinja_expression``): the
     content's meaning depends on a value dex cannot see, which is the same problem
     for a host as a macro call and a worse one to leave silent.
+
+    ``in_filter`` narrows the MetricFlow-callee exception to exactly the
+    context that grammar is defined for: the value of a ``filter`` key. A
+    repository macro that happens to be named ``Dimension`` and is called from
+    anywhere else (a description, a config value) is still a macro the
+    repository wrote, and reporting it as ``macro_call`` is the correct,
+    unnarrowed answer there.
     """
 
     signals: list[ArtifactSignal] = []
@@ -203,6 +213,21 @@ def _jinja_signals(content: str, *, where_prefix: str = "") -> list[ArtifactSign
                 signals.append(ArtifactSignal(signal="run_query", where=where))
             elif call.callee == "statement":
                 signals.append(ArtifactSignal(signal="statement_block", where=where))
+            elif in_filter and call.callee in metricflow_dialect.FILTER_CALLEES:
+                # A metric filter's own grammar, not a macro the repository
+                # wrote: `Dimension`/`TimeDimension`/`Entity` dispatch into the
+                # semantic layer's resolution against definitions the project
+                # already declares. Still reported, because a host applying
+                # its own policy wants the reference even where it did not
+                # decide the class.
+                token = call.args[0] if call.args and call.args[0] else None
+                signals.append(
+                    ArtifactSignal(
+                        signal="semantic_ref",
+                        where=where,
+                        detail=f"{call.callee}({token})" if token else call.callee,
+                    )
+                )
             elif call.callee not in _DECLARATIVE_CALLEES:
                 signals.append(
                     ArtifactSignal(signal="macro_call", where=where, detail=call.callee)
@@ -212,6 +237,24 @@ def _jinja_signals(content: str, *, where_prefix: str = "") -> list[ArtifactSign
         elif region.kind == "expression" and not callees:
             signals.append(ArtifactSignal(signal="jinja_expression", where=where))
     return signals
+
+
+def _in_filter_clause(path: str) -> bool:
+    """Whether ``path`` names the value of a ``filter`` key under a metric (or
+    an item of a list under one): a metric's own filter, its measure's,
+    ratio's, or an input metric's, and nothing wider.
+
+    ``metrics[...]`` anchors this to where MetricFlow's filter grammar is
+    actually defined. A ``filter`` key elsewhere, ``models[0].config.filter``
+    for instance, names no such grammar: it is not MetricFlow's, dex does not
+    know what it means, and treating it as one would narrow past what #445
+    asks for.
+    """
+
+    if not path.startswith("metrics["):
+        return False
+    stripped = re.sub(r"\[\d+\]$", "", path)
+    return stripped.endswith(".filter")
 
 
 def _walk_yaml(node: Any, path: str, signals: list[ArtifactSignal]) -> None:
@@ -230,7 +273,11 @@ def _walk_yaml(node: Any, path: str, signals: list[ArtifactSignal]) -> None:
             _walk_yaml(item, f"{path}[{i}]", signals)
     elif isinstance(node, str):
         if "{{" in node or "{%" in node:
-            signals.extend(_jinja_signals(node, where_prefix=f"{path}: "))
+            signals.extend(
+                _jinja_signals(
+                    node, where_prefix=f"{path}: ", in_filter=_in_filter_clause(path)
+                )
+            )
         elif _RUN_OPERATION.search(node):
             signals.append(ArtifactSignal(signal="run_operation", where=path))
 

--- a/packages/dex-core/src/exmergo_dex_core/transform/grounding.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/grounding.py
@@ -139,6 +139,15 @@ class GroundingBinding(BaseModel):
 class Grounding(BaseModel):
     """A plan's dependencies, and how much of the answer is finished."""
 
+    # "complete" means every reference in the plan was named statically: no
+    # entry in `unresolved` and nothing in `limits`. It is not a claim that
+    # every named reference resolves to something that exists. `ref(var('x'))`
+    # is unresolved (dex could not read the name at all) and lowers this to
+    # "partial"; `ref('no_such_model')` is named successfully and stays a
+    # `GroundedDependency` with `relation=None`, which does not move this
+    # field. A caller that wants "this plan's build has something to run"
+    # reads `dependencies[].relation` (or `relations`) per entry, not this
+    # field alone.
     completeness: str = "unresolved"
     dependencies: list[GroundedDependency] = Field(default_factory=list)
     relations: list[str] = Field(default_factory=list)

--- a/packages/dex-core/tests/transform/test_classify.py
+++ b/packages/dex-core/tests/transform/test_classify.py
@@ -55,6 +55,16 @@ models:
 """
 )
 
+FILTERED_METRIC = """metrics:
+  - name: live_sessions
+    label: Live sessions
+    type: simple
+    type_params:
+      measure:
+        name: session_count
+        filter: "{{ Dimension('session__is_deleted') }} = false"
+"""
+
 
 def signals(result) -> set[str]:
     return {s.signal for s in result.signals}
@@ -76,6 +86,121 @@ def test_a_semantic_declaration_beside_a_hook_is_executable():
     # The finding is located where a reviewer will open the file.
     where = next(s.where for s in result.signals if s.signal == "post_hook")
     assert where.endswith("config.post-hook")
+
+
+def test_a_metric_filters_dimension_reference_is_declarative():
+    """`Dimension('...')` dispatches into the semantic layer's own resolution
+    against definitions the project already declares, not into a macro the
+    repository wrote (#445), so it must not read the same as an unknown call."""
+
+    result = classify_content(FILTERED_METRIC, path="models/live_sessions.yml")
+    assert result.artifact_class is ArtifactClass.DECLARATIVE
+    # Still reported: a host applying its own policy wants the reference even
+    # where it did not decide the class.
+    assert "semantic_ref" in signals(result)
+    assert "macro_call" not in signals(result)
+    detail = next(s.detail for s in result.signals if s.signal == "semantic_ref")
+    assert detail == "Dimension(session__is_deleted)"
+
+
+@pytest.mark.parametrize(
+    ("callee", "args"),
+    [
+        ("Dimension", "'session__is_deleted'"),
+        ("TimeDimension", "'metric_time', 'day'"),
+        ("Entity", "'session'"),
+    ],
+)
+def test_every_metricflow_filter_callee_is_declarative(callee, args):
+    """The narrowing covers all three names the vendor's grammar defines, not
+    just the one in the report."""
+
+    content = FILTERED_METRIC.replace(
+        "Dimension('session__is_deleted')", f"{callee}({args})"
+    )
+    result = classify_content(content, path="models/live_sessions.yml")
+    assert result.artifact_class is ArtifactClass.DECLARATIVE
+    assert "semantic_ref" in signals(result)
+
+
+def test_a_filtered_metric_beside_a_hook_is_still_executable():
+    """The stronger-verdict rule is untouched: what changes is only whether a
+    bare dimension reference is evidence of repository-controlled execution."""
+
+    hooked = (
+        FILTERED_METRIC
+        + """
+models:
+  - name: sessions
+    config:
+      post-hook: "select 1"
+"""
+    )
+    result = classify_content(hooked, path="models/live_sessions.yml")
+    assert result.artifact_class is ArtifactClass.EXECUTABLE
+    assert {"semantic_ref", "post_hook"} <= signals(result)
+
+
+def test_a_metric_filter_calling_a_repository_macro_is_still_executable():
+    """The narrowing is to the vendor's own vocabulary, not to filters in
+    general: a macro the project defines is still repository-controlled code."""
+
+    content = FILTERED_METRIC.replace(
+        "Dimension('session__is_deleted')", "my_custom_macro('x')"
+    )
+    result = classify_content(content, path="models/live_sessions.yml")
+    assert result.artifact_class is ArtifactClass.EXECUTABLE
+    assert "macro_call" in signals(result)
+    detail = next(s.detail for s in result.signals if s.signal == "macro_call")
+    assert detail == "my_custom_macro"
+
+
+def test_unparseable_content_with_a_dimension_like_call_stays_unknown():
+    """The new callee narrowing must not weaken the never-declarative-on-
+    silence guarantee: unparseable content is unknown regardless of what it
+    contains."""
+
+    result = classify_content("a: [1, 2\n  Dimension('x')\n", path="models/x.yml")
+    assert result.artifact_class is ArtifactClass.UNKNOWN
+    assert result.parsed is False
+
+
+def test_a_repository_macro_named_dimension_outside_a_filter_is_still_a_macro_call():
+    """The narrowing is scoped to the ``filter:`` value MetricFlow's grammar
+    actually defines, not to the callee name everywhere it appears (#445
+    review). A project is free to define its own macro called ``Dimension``;
+    calling it from a description is calling repository-controlled code, and
+    must classify the same as any other unrecognized macro."""
+
+    content = """version: 2
+models:
+  - name: things
+    description: "{{ Dimension('not_a_real_filter') }}"
+"""
+    result = classify_content(content, path="models/things.yml")
+    assert result.artifact_class is ArtifactClass.EXECUTABLE
+    assert "macro_call" in signals(result)
+    assert "semantic_ref" not in signals(result)
+    detail = next(s.detail for s in result.signals if s.signal == "macro_call")
+    assert detail == "Dimension"
+
+
+def test_a_filter_key_outside_metrics_is_still_a_macro_call():
+    """The narrowing is anchored to ``metrics[...]``, where MetricFlow's
+    filter grammar is actually defined, not to the bare key name ``filter``
+    (#445 review). ``models[].config.filter`` names no such grammar; dex does
+    not know what it means and must not read it as a semantic reference."""
+
+    content = """version: 2
+models:
+  - name: things
+    config:
+      filter: "{{ Dimension('not_metricflow') }}"
+"""
+    result = classify_content(content, path="models/things.yml")
+    assert result.artifact_class is ArtifactClass.EXECUTABLE
+    assert "macro_call" in signals(result)
+    assert "semantic_ref" not in signals(result)
 
 
 def test_a_grant_is_authority_bearing():

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -65,7 +65,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.12.0"
+DEX_CORE_VERSION = "1.12.1"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -65,7 +65,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.12.0"
+DEX_CORE_VERSION = "1.12.1"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -65,7 +65,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.12.0"
+DEX_CORE_VERSION = "1.12.1"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
Closes #445: `classify_content` read MetricFlow's own filter grammar
(`Dimension`/`TimeDimension`/`Entity`) as an unrecognized macro call, so any
metric with a filter classified `executable` instead of `declarative`, the
narrowing is real and specific, not a general softening of the classifier.

- **Root cause**: `_jinja_signals`' callee loop had no branch for these three
  names, so they fell through to the generic `macro_call` signal, which is in
  `EXECUTABLE_SIGNALS`. But these names dispatch into the semantic layer's own
  resolution against definitions the project already declares, not into a
  macro the repository wrote , the same distinction `_DECLARATIVE_CALLEES`
  already draws for `ref`/`source`/`var`/etc.

- **Fix**: `metricflow_dialect.py` (already the owner of this grammar since
  #357) exports `FILTER_CALLEES = frozenset({"Dimension", "TimeDimension",
  "Entity"})`. `classify.py` consults it rather than re-deriving the names.
  A match produces a new `semantic_ref` signal , still reported, per the
  module's own "a signal is reported even when it did not decide the class"
  principle — but `semantic_ref` is not in `EXECUTABLE_SIGNALS`, so it no
  longer flips the verdict.

- **Scoped twice, through review**: the exception only applies when the call
  sits inside a `filter` key's value, *and* that key is under `metrics[...]`.
  Two false-safe boundaries this closes:
  - A repository macro that happens to be named `Dimension`, called from a
    `description` or any other field, still classifies `macro_call`/executable.
  - A `filter` key outside `metrics[...]` (`models[].config.filter`, say)
    names no MetricFlow grammar at all and still classifies
    `macro_call`/executable.

  Both were caught in review and are now regression-tested.

- **Untouched, by design**: a filter calling a macro the project actually
  defines still classifies executable (the narrowing is to the vendor's
  vocabulary, not to filters in general); a document with both a filter and a
  `post-hook` is still executable (execution still outranks everything else in
  `_verdict`); unparseable content is still `UNKNOWN`, never `declarative`.

- **Adjacent, lower-stakes item from the same issue**: `Grounding.
  completeness`'s docstring now says explicitly that "complete" means every
  reference was named statically, not that every named reference resolves to
  something that exists — a documentation clarification only, no behavior
  change, as the issue itself specified.

## Testing

- 8 new tests in `tests/transform/test_classify.py`: all three callees
  declarative, still executable beside a hook, a project-defined macro in a
  filter still executable, unparseable content still unknown, and the two
  false-safe boundary regressions from review (macro named `Dimension`
  outside a filter; `filter` key outside `metrics[...]`).
- New `classify-filtered-metric` conformance vector in
  `host/vectors/`, exercised by the existing
  `test_each_classification_vector_still_classifies_the_way_it_says`
  (its expected output was generated by running the real classifier, not
  hand-written).
- `tests/transform/test_classify.py` + `tests/test_host_contract.py`: 57
  passed. Wider `tests/transform/` + `tests/test_host_contract.py` sweep:
  747 passed, 0 failed.
- Ruff check/format clean, no em-dashes.