### PR TITLE
SCRUM-1293-maintain verify: report column contract drift on built relations

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dex",
   "description": "Analytics engineering for Claude Code and any agent: data warehouse exploration, dbt transformation and semantic modeling, and schema-drift maintenance on dbt.",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "author": {
     "name": "Exmergo, Inc.",
     "email": "support@exmergo.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **`maintain verify` reports a built relation whose columns diverge from its
+  declared schema.yml contract** ([#230]). For every selected model that
+  declares columns, the model's actual built columns (read free, from
+  `adapter.table_metadata`, the same schema-only lookup `missing_relation_
+  findings` already uses) are compared against the compiled manifest's own
+  declared set, in both directions, plus a type check where a type is
+  declared. A documented column the relation does not have is a real defect
+  (`column_missing`, high severity); an undocumented column is a
+  documentation gap (`column_undeclared`, low); a type that disagrees ranks
+  between the two (`column_type_mismatch`, medium). A model with no
+  `columns:` entry at all reports nothing per model, and how many such
+  models were considered is named once at the summary level rather than
+  repeated per model.
+
+  Shares its comparison logic with #214's plan-time check rather than
+  duplicating it: `dbt_project.column_contract_divergence` is the one set-math
+  primitive both `transform plan`'s authored-SELECT-list comparison and this
+  built-relation comparison call, differing only in where each side's names
+  and types come from (a static SELECT list carries no type information at
+  all, so #214's call into it never resolves a type mismatch). A project
+  that does not compile suppresses this the same way it already suppresses
+  build-status and no-relation findings, since a finding computed from an
+  untrustworthy manifest is not a finding at all. `maintain verify <object>`
+  narrows the check to the object named, the same as the command's other
+  finding classes: a model outside the request is neither read against the
+  warehouse nor named in the summary notes, and its finding now carries the
+  model name as its identifier like every other finding class here already
+  does, so a scoped request actually keeps it.
+
 ## [1.12.1] - 2026-09-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+## [1.12.2] - 2026-09-09
+
 ### Fixed
 
 - **`explore map` now carries the `pii_overrides` mismatch warning that

--- a/packages/dex-core/src/exmergo_dex_core/dbt_project.py
+++ b/packages/dex-core/src/exmergo_dex_core/dbt_project.py
@@ -1145,6 +1145,41 @@ def strip_relation_quoting(relation: str) -> str:
     return ".".join(part for part in parts if part)
 
 
+def column_contract_divergence(
+    declared: dict[str, str | None], actual: dict[str, str | None]
+) -> tuple[list[str], list[str], list[tuple[str, str, str]]]:
+    """A declared column contract against what actually exists, in both
+    directions, plus type mismatches where both sides state one.
+
+    Shared between `transform plan`'s authored-SELECT-list comparison
+    (#214) and `maintain verify`'s built-relation comparison (#230): both
+    reduce to the same set math over a model's declared and actual columns,
+    and only differ in where each side's names and types come from.
+
+    ``declared``/``actual`` are column name (already lowercased by the
+    caller) -> its type, or ``None`` where the caller has no type for that
+    side -- a plan-time SELECT list names no types at all, so #214's caller
+    never passes one. Returns ``(missing, extra, mismatched)``: names in
+    ``declared`` and not ``actual``, names in ``actual`` and not
+    ``declared``, and ``(name, declared_type, actual_type)`` for a name both
+    sides state with a type that disagrees. A name whose type is absent on
+    either side is not a mismatch: absence is not evidence of a difference.
+    """
+
+    missing = sorted(set(declared) - set(actual))
+    extra = sorted(set(actual) - set(declared))
+    mismatched: list[tuple[str, str, str]] = []
+    for name in sorted(set(declared) & set(actual)):
+        declared_type, actual_type = declared[name], actual[name]
+        if (
+            declared_type
+            and actual_type
+            and declared_type.lower() != actual_type.lower()
+        ):
+            mismatched.append((name, declared_type, actual_type))
+    return missing, extra, mismatched
+
+
 def _parse_relation_ref(value: Any) -> str | None:
     """A ``ref('x')`` / ``source('a', 'b')`` argument as a referable name."""
 

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -715,22 +715,24 @@ def cmd_grain(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
 def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
     """Is the project correct right now, with no baseline required (#224).
 
-    Two finding classes. Build-status gaps (#225) read the compiled manifest
+    Three finding classes. Build-status gaps (#225) read the compiled manifest
     and the last run's ``run_results.json`` (failed nodes, nodes skipped by a
     failed parent), plus models the project declares that have no relation in
-    the warehouse. Row population (#226) reads each model's compiled SQL for
-    the relation it is built from and compares the two row counts, reporting a
-    model that lost rows with nothing in its SQL to account for it, or one that
-    fanned out on a join.
+    the warehouse. Column contract (#230) compares a built relation's actual
+    columns against what its schema.yml declares, both directions, plus a type
+    check where a type is declared. Row population (#226) reads each model's
+    compiled SQL for the relation it is built from and compares the two row
+    counts, reporting a model that lost rows with nothing in its SQL to
+    account for it, or one that fanned out on a join.
 
     Free wherever the answer is free, which is most of it: the manifest read
-    touches no connection, the relation check and the row counts read cheap
-    object metadata, and on a connector with no cost gate the counts are made
-    exact because doing so bills nothing. Only the counts a warehouse keeps no
-    metadata for cost anything, and those are offered rather than taken: the
-    envelope returns its free findings as the complete answer they are, with
-    the scan priced beside them, exactly as `maintain check` and
-    `maintain semantic` do.
+    touches no connection, the relation check, the column contract, and the
+    row counts all read cheap object metadata, and on a connector with no cost
+    gate the row counts are made exact because doing so bills nothing. Only
+    the row counts a warehouse keeps no metadata for cost anything, and those
+    are offered rather than taken: the envelope returns its free findings as
+    the complete answer they are, with the scan priced beside them, exactly as
+    `maintain check` and `maintain semantic` do.
 
     A project that does not compile is reported first and suppresses every
     other check here, since a finding computed from a manifest a broken
@@ -748,6 +750,7 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
             suppressed={
                 "build_status": str(exc),
                 "no_relation": str(exc),
+                "column_contract": str(exc),
                 "compile": str(exc),
             },
             warnings=[f"maintain verify needs a dbt project: {exc}"],
@@ -764,11 +767,12 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
                 "build_status": reason,
                 "no_relation": reason,
                 "row_population": reason,
+                "column_contract": reason,
             },
             warnings=[
-                "build-status, no-relation and row-population findings "
-                "suppressed: the project does not compile, so its manifest "
-                "cannot be trusted"
+                "build-status, no-relation, row-population and column-contract "
+                "findings suppressed: the project does not compile, so its "
+                "manifest cannot be trusted"
             ],
         )
         return result
@@ -781,12 +785,23 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
         suppressed["build_status"] = build_notes[0]
 
     definitions = engine.project_format().definitions()
+    wanted = (
+        {
+            name.strip().lower()
+            for raw in objects
+            for name in raw.split(",")
+            if name.strip()
+        }
+        if objects
+        else None
+    )
     cost = None
     adapter = None
     offer = None
     if not definitions.present:
         suppressed["no_relation"] = "no dbt project found"
         suppressed["row_population"] = "no dbt project found"
+        suppressed["column_contract"] = "no dbt project found"
     else:
         model_relations = {
             name: relation
@@ -798,6 +813,7 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
         except DexError as exc:
             suppressed["no_relation"] = f"warehouse unreachable: {exc}"
             suppressed["row_population"] = f"warehouse unreachable: {exc}"
+            suppressed["column_contract"] = f"warehouse unreachable: {exc}"
         else:
             cost = command_args.preflight_cost(adapter)
             live = adapter.list_objects()
@@ -807,6 +823,13 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
                     model_relations, [o.identifier for o in live], already
                 )
             )
+            column_findings, column_warnings, column_reason = _column_contract(
+                project_dir, adapter, model_relations, live, scope=wanted
+            )
+            findings.extend(column_findings)
+            warnings.extend(column_warnings)
+            if column_reason is not None:
+                suppressed["column_contract"] = column_reason
             row_findings, row_warnings, row_reason, offer = _row_population(
                 engine, adapter, project_dir, live
             )
@@ -815,13 +838,7 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
             if row_reason is not None:
                 suppressed["row_population"] = row_reason
 
-    if objects:
-        wanted = {
-            name.strip().lower()
-            for raw in objects
-            for name in raw.split(",")
-            if name.strip()
-        }
+    if wanted:
         findings = [f for f in findings if (f.identifier or "").lower() in wanted]
 
     result = VerifyResult(
@@ -837,6 +854,45 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
         result.pending_offer = offer
         return result
     return result if adapter is None else command_args.stamp_spend(result, adapter)
+
+
+def _column_contract(project_dir, adapter, model_relations, live, *, scope=None):
+    """The column-contract half of `maintain verify`, end to end (#230).
+
+    No cost decision in it at all, unlike row population beside it: both
+    sides are metadata (the compiled manifest's own declared columns, and
+    ``adapter.table_metadata``'s schema lookup), so there is nothing to
+    price and nothing to offer. Returns ``(findings, notes, suppressed_
+    reason)``, the same shape :func:`_row_population` returns minus the
+    offer it has no use for.
+
+    ``scope`` is the same lowered object-name set `verify()` filters its
+    findings down to afterward. Passed through here too so a scoped call
+    considers only the requested models in the first place: the metadata
+    lookup a model outside the scope would cost, and the summary notes
+    naming models the caller never asked about, both go away rather than
+    running and then being discarded by that later filter.
+    """
+
+    declared_by_model, undeclared, plan_notes = verify_mod.column_contract_plan(
+        project_dir, scope=scope
+    )
+    if not declared_by_model and not undeclared:
+        reason = (
+            plan_notes[0]
+            if plan_notes
+            else "no model in the project declares columns in schema.yml"
+        )
+        return [], plan_notes, reason
+
+    findings, finding_notes = verify_mod.column_contract_findings(
+        adapter,
+        declared_by_model,
+        model_relations,
+        [o.identifier for o in live],
+        undeclared,
+    )
+    return findings, plan_notes + finding_notes, None
 
 
 def _row_population(engine: DexEngine, adapter, project_dir, live):

--- a/packages/dex-core/src/exmergo_dex_core/maintain/verify.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/verify.py
@@ -1,21 +1,25 @@
 """maintain verify: a baseline-free sweep answering "is this project correct
 right now", as opposed to drift's "what changed since the baseline" (#224).
 
-Two finding classes live here. Build-status gaps (#225) read the compiled
+Three finding classes live here. Build-status gaps (#225) read the compiled
 manifest and the last run's ``run_results.json``: failed nodes, nodes skipped
 by a failed parent, models with no relation, and a project that does not
-compile. Row population (#226) reads each model's compiled SQL to find the
-relation it is built *from*, and compares the two row counts: a model holding
-materially fewer rows than its driving parent, with nothing in its SQL that
-would account for the shortfall, has lost rows silently, and one holding
-materially more has fanned out on a join.
+compile. Column contract (#230) compares a built relation's actual columns
+against what its schema.yml declares, in both directions, plus a type check
+where a type is declared. Row population (#226) reads each model's compiled
+SQL to find the relation it is built *from*, and compares the two row counts:
+a model holding materially fewer rows than its driving parent, with nothing
+in its SQL that would account for the shortfall, has lost rows silently, and
+one holding materially more has fanned out on a join.
 
-Detection is pure and reads only artifacts already on disk. The one exception is
-:func:`relation_counts`, which is where the warehouse is touched at all, and it
-is separate for that reason: it decides between the catalog's free metadata, a
-free count, and a count that has to be paid for and is therefore offered rather
-than taken. Keeping that decision in one place is what lets every other function
-here be judged on artifacts alone.
+Detection is pure and reads only artifacts already on disk, with two
+exceptions, both metadata-only and free on every connector rather than a
+scan: the column contract's own ``adapter.table_metadata`` read, and
+:func:`relation_counts`, which is where a warehouse *scan* can happen at all
+and is separate for that reason: it decides between the catalog's free
+metadata, a free count, and a count that has to be paid for and is therefore
+offered rather than taken. Keeping that decision in one place is what lets
+every other function here be judged on artifacts (or free metadata) alone.
 """
 
 from __future__ import annotations
@@ -251,6 +255,196 @@ def missing_relation_findings(
             )
         )
     return findings
+
+
+# --- column contract: a built relation against its declared schema.yml ---------
+
+
+def column_contract_plan(
+    project_dir: Path, *, scope: set[str] | None = None
+) -> tuple[dict[str, dict[str, str | None]], int, list[str]]:
+    """Every selected model's declared column contract, from the compiled
+    manifest, plus how many considered models declare none at all (#230).
+
+    Read from the manifest rather than by re-parsing schema.yml, the way
+    #214's plan-time comparison has to: dbt already reduces every declared
+    column (and its ``data_type``, when one is declared) into each model
+    node's own ``columns``, and a compiled manifest is exactly what this
+    command needs a build to have produced already for its other two finding
+    classes. ``scope`` narrows which models are even considered, so a model
+    outside it is neither checked nor counted toward the undeclared total,
+    the same rule :func:`row_population_plan` follows. Compared lowercase on
+    both sides: the caller here is `maintain verify`'s own ``objects``
+    argument, already lowered before it reaches this function, and a model
+    name is conventionally lowercase already, so this never narrows past
+    what an exact-case match would.
+
+    Returns ``(declared_by_model, undeclared_count, notes)``. A model with no
+    ``columns:`` entry contributes to the count and nothing to the mapping:
+    it has no contract to compare, which is a fact about the project rather
+    than a finding about any one model, so it is named once at the summary
+    level (#230's acceptance) rather than repeated per model. ``notes`` names
+    the one condition that stops this from running at all, the same way
+    :func:`row_population_plan` does for its own manifest read.
+    """
+
+    nodes = _manifest_nodes(project_dir)
+    if nodes is None:
+        return (
+            {},
+            0,
+            [
+                "no compiled manifest found; run `dbt compile` or `dbt build` "
+                "for column-contract findings"
+            ],
+        )
+
+    declared_by_model: dict[str, dict[str, str | None]] = {}
+    undeclared = 0
+    for node in nodes.values():
+        if not isinstance(node, dict) or node.get("resource_type") != "model":
+            continue
+        name = node.get("name")
+        if not (isinstance(name, str) and name):
+            continue
+        if scope is not None and name.lower() not in scope:
+            continue
+        columns = node.get("columns")
+        if not isinstance(columns, dict) or not columns:
+            undeclared += 1
+            continue
+        declared_by_model[name] = {
+            str(column_name): (
+                column["data_type"]
+                if isinstance(column, dict) and isinstance(column.get("data_type"), str)
+                else None
+            )
+            for column_name, column in columns.items()
+            if isinstance(column_name, str)
+        }
+    return declared_by_model, undeclared, []
+
+
+def column_contract_findings(
+    adapter,
+    declared_by_model: dict[str, dict[str, str | None]],
+    model_relations: dict[str, str],
+    live_identifiers: list[str],
+    undeclared: int,
+) -> tuple[list[DriftFinding], list[str]]:
+    """A built relation's actual columns against what its schema.yml declares,
+    in both directions, plus a type check where a type is declared (#230).
+
+    Two-directional and deliberately asymmetric in severity, per the issue's
+    own framing: a documented column the relation does not have is a real
+    defect (``high``, someone reading the docs to write a query gets a
+    column that is not there), and an undocumented column is a
+    documentation gap (``low``). A type disagreement ranks between the two:
+    the column exists on both sides, so nothing is missing, but a reader
+    trusting the declared type gets the wrong one.
+
+    Free on every connector: both sides come from metadata dex already has
+    to read for this command's other checks (the manifest) or reads no
+    differently than :func:`missing_relation_findings` does
+    (``adapter.table_metadata``, a schema lookup, never a scan).
+
+    A model with no relation in the warehouse, or an ambiguous one, is named
+    in the notes rather than silently skipped: the no-relation finding
+    already explains the missing-entirely case, so naming it again here
+    would only be additive if the model resolved ambiguously, which is worth
+    knowing about but does not deserve its own high-severity finding.
+    """
+
+    from ..dbt_project import column_contract_divergence
+
+    findings: list[DriftFinding] = []
+    unchecked: list[str] = []
+    for model, declared in sorted(declared_by_model.items()):
+        relation = model_relations.get(model)
+        if relation is None:
+            continue
+        matches = match_identifier(relation, live_identifiers)
+        if len(matches) != 1:
+            unchecked.append(model)
+            continue
+
+        declared_lower = {name.lower(): dtype for name, dtype in declared.items()}
+        _meta, columns = adapter.table_metadata(matches[0])
+        actual_lower = {column.name.lower(): column.data_type for column in columns}
+        missing, extra, mismatched = column_contract_divergence(
+            declared_lower, actual_lower
+        )
+
+        if missing:
+            findings.append(
+                DriftFinding(
+                    axis="build",
+                    code="column_missing",
+                    identifier=model,
+                    severity="high",
+                    detail=(
+                        f"'{model}' declares column(s) {', '.join(missing)} in "
+                        "schema.yml that the built relation does not have"
+                    ),
+                    data={"model": model, "columns": missing},
+                )
+            )
+        if extra:
+            findings.append(
+                DriftFinding(
+                    axis="build",
+                    code="column_undeclared",
+                    identifier=model,
+                    severity="low",
+                    detail=(
+                        f"'{model}' builds column(s) {', '.join(extra)} that "
+                        "schema.yml does not declare"
+                    ),
+                    data={"model": model, "columns": extra},
+                )
+            )
+        if mismatched:
+            findings.append(
+                DriftFinding(
+                    axis="build",
+                    code="column_type_mismatch",
+                    identifier=model,
+                    severity="medium",
+                    detail=(
+                        f"'{model}' declares "
+                        + ", ".join(
+                            f"{name} as {declared_type}"
+                            for name, declared_type, _ in mismatched
+                        )
+                        + " in schema.yml, but the built relation has "
+                        + ", ".join(
+                            f"{name} as {actual_type}"
+                            for name, _, actual_type in mismatched
+                        )
+                    ),
+                    data={
+                        "model": model,
+                        "mismatches": [
+                            {"column": name, "declared": d, "actual": a}
+                            for name, d, a in mismatched
+                        ],
+                    },
+                )
+            )
+
+    notes: list[str] = []
+    if unchecked:
+        notes.append(
+            "the column contract was not checked for "
+            + ", ".join(sorted(unchecked))
+            + ": no single relation in the warehouse matched"
+        )
+    if undeclared:
+        notes.append(
+            f"{undeclared} model(s) considered declare no columns in "
+            "schema.yml, so the column contract was not checked for them"
+        )
+    return findings, notes
 
 
 # --- row population: a model against the relation it is built from -------------

--- a/packages/dex-core/src/exmergo_dex_core/transform/plans.py
+++ b/packages/dex-core/src/exmergo_dex_core/transform/plans.py
@@ -856,6 +856,8 @@ def column_contract_warnings(edits: list[PlanEdit], view: DbtProjectView) -> lis
             if columns:
                 declared_by_model[entry["name"]] = columns
 
+    from ..dbt_project import column_contract_divergence
+
     warnings: list[str] = []
     for edit in edits:
         if (
@@ -868,7 +870,7 @@ def column_contract_warnings(edits: list[PlanEdit], view: DbtProjectView) -> lis
         declared = declared_by_model.get(model)
         if not declared:
             continue
-        declared_lower = {c.lower() for c in declared}
+        declared_lower = {c.lower(): None for c in declared}
 
         produced = select_columns(edit.new_content)
         if produced is None:
@@ -880,13 +882,17 @@ def column_contract_warnings(edits: list[PlanEdit], view: DbtProjectView) -> lis
             )
             continue
 
-        missing = sorted(declared_lower - produced)
+        # No type info on either side here: a SELECT list names no types at
+        # all, so this call never resolves a mismatch, only the two name-only
+        # directions.
+        missing, extra, _mismatched = column_contract_divergence(
+            declared_lower, dict.fromkeys(produced)
+        )
         if missing:
             warnings.append(
                 f"{edit.path}: schema.yml declares column(s) {', '.join(missing)} "
                 f"for {model} that the SELECT list does not produce"
             )
-        extra = sorted(produced - declared_lower)
         if extra:
             warnings.append(
                 f"{edit.path}: the SELECT list produces column(s) "

--- a/packages/dex-core/tests/maintain/test_verify.py
+++ b/packages/dex-core/tests/maintain/test_verify.py
@@ -13,6 +13,8 @@ import pytest
 from exmergo_dex_core.maintain import verify as verify_mod
 from exmergo_dex_core.maintain.verify import (
     build_status_findings,
+    column_contract_findings,
+    column_contract_plan,
     compile_check,
     missing_relation_findings,
 )
@@ -191,6 +193,153 @@ def test_a_model_already_explained_by_a_build_status_finding_is_not_repeated():
     assert findings == []
 
 
+# --- column_contract_plan / column_contract_findings: pure (#230) --------------
+
+
+class _ColumnAdapter:
+    """Just ``table_metadata``, keyed by identifier."""
+
+    def __init__(self, columns_by_identifier: dict[str, list[tuple[str, str]]]):
+        self._columns = columns_by_identifier
+
+    def table_metadata(self, identifier: str):
+        cols = [
+            types.SimpleNamespace(name=name, data_type=data_type)
+            for name, data_type in self._columns[identifier]
+        ]
+        return types.SimpleNamespace(identifier=identifier), cols
+
+
+def _node_with_columns(name: str, columns: dict[str, str | None]) -> dict:
+    return {
+        "name": name,
+        "resource_type": "model",
+        "columns": {
+            col_name: ({"data_type": data_type} if data_type else {})
+            for col_name, data_type in columns.items()
+        },
+    }
+
+
+def test_no_manifest_is_a_note_not_a_finding(tmp_path: Path):
+    declared, undeclared, notes = column_contract_plan(tmp_path)
+    assert declared == {}
+    assert undeclared == 0
+    assert notes and "no compiled manifest found" in notes[0]
+
+
+def test_a_model_with_no_columns_key_counts_as_undeclared(tmp_path: Path):
+    _write_artifacts(
+        tmp_path,
+        nodes={
+            "model.p.a": {"name": "a", "resource_type": "model"},
+            "model.p.b": _node_with_columns("b", {"id": "INTEGER"}),
+        },
+        results=[],
+    )
+    declared, undeclared, notes = column_contract_plan(tmp_path)
+    assert notes == []
+    assert undeclared == 1
+    assert set(declared) == {"b"}
+    assert declared["b"] == {"id": "INTEGER"}
+
+
+def test_a_column_with_no_declared_type_maps_to_none(tmp_path: Path):
+    _write_artifacts(
+        tmp_path,
+        nodes={"model.p.a": _node_with_columns("a", {"id": None})},
+        results=[],
+    )
+    declared, _undeclared, _notes = column_contract_plan(tmp_path)
+    assert declared["a"] == {"id": None}
+
+
+def test_a_missing_declared_column_is_reported_high_severity():
+    findings, notes = column_contract_findings(
+        _ColumnAdapter({"db.main.a": [("id", "INTEGER")]}),
+        declared_by_model={"a": {"id": "INTEGER", "email": "VARCHAR"}},
+        model_relations={"a": "db.main.a"},
+        live_identifiers=["db.main.a"],
+        undeclared=0,
+    )
+    assert notes == []
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.code == "column_missing"
+    assert finding.identifier == "a"
+    assert finding.severity == "high"
+    assert "email" in finding.detail
+    assert finding.data == {"model": "a", "columns": ["email"]}
+
+
+def test_an_undeclared_column_is_reported_low_severity():
+    findings, _notes = column_contract_findings(
+        _ColumnAdapter({"db.main.a": [("id", "INTEGER"), ("extra", "VARCHAR")]}),
+        declared_by_model={"a": {"id": "INTEGER"}},
+        model_relations={"a": "db.main.a"},
+        live_identifiers=["db.main.a"],
+        undeclared=0,
+    )
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.code == "column_undeclared"
+    assert finding.severity == "low"
+    assert "extra" in finding.detail
+
+
+def test_a_declared_type_that_disagrees_is_a_medium_severity_mismatch():
+    findings, _notes = column_contract_findings(
+        _ColumnAdapter({"db.main.a": [("id", "VARCHAR")]}),
+        declared_by_model={"a": {"id": "INTEGER"}},
+        model_relations={"a": "db.main.a"},
+        live_identifiers=["db.main.a"],
+        undeclared=0,
+    )
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.code == "column_type_mismatch"
+    assert finding.severity == "medium"
+    assert finding.data["mismatches"] == [
+        {"column": "id", "declared": "INTEGER", "actual": "VARCHAR"}
+    ]
+
+
+def test_a_matching_contract_reports_nothing():
+    findings, _notes = column_contract_findings(
+        _ColumnAdapter({"db.main.a": [("id", "INTEGER")]}),
+        declared_by_model={"a": {"id": "INTEGER"}},
+        model_relations={"a": "db.main.a"},
+        live_identifiers=["db.main.a"],
+        undeclared=0,
+    )
+    assert findings == []
+
+
+def test_undeclared_models_are_named_once_at_the_summary_level_not_per_model():
+    findings, notes = column_contract_findings(
+        _ColumnAdapter({"db.main.a": [("id", "INTEGER")]}),
+        declared_by_model={"a": {"id": "INTEGER"}},
+        model_relations={"a": "db.main.a"},
+        live_identifiers=["db.main.a"],
+        undeclared=3,
+    )
+    assert findings == []
+    assert len(notes) == 1
+    assert "3 model(s)" in notes[0]
+
+
+def test_a_model_with_no_matching_relation_is_named_in_notes_not_a_finding():
+    findings, notes = column_contract_findings(
+        _ColumnAdapter({}),
+        declared_by_model={"a": {"id": "INTEGER"}},
+        model_relations={"a": "db.main.a"},
+        live_identifiers=[],
+        undeclared=0,
+    )
+    assert findings == []
+    assert notes and "a" in notes[0]
+
+
 # --- compile_check: wraps shadow_parse -------------------------------------------
 
 
@@ -350,6 +499,132 @@ def test_verify_reports_a_model_with_no_relation_end_to_end(
     assert "no_relation" not in payload["data"]["suppressed"]
 
 
+def test_verify_reports_a_missing_declared_column_end_to_end(
+    maintain_repo, _assume_the_project_compiles
+):
+    """#230: schema.yml declares a column the real, built ``stg_orders``
+    relation does not have. Free on every connector: no ``--confirm`` needed,
+    both sides are metadata."""
+
+    _write_artifacts(
+        maintain_repo.project_dir,
+        nodes={
+            "model.maintain_test.stg_orders": _node_with_columns(
+                "stg_orders",
+                {
+                    "order_id": "INTEGER",
+                    "customer_id": "INTEGER",
+                    "amount": "DOUBLE",
+                    "status": "VARCHAR",
+                    "ordered_at": "DATE",
+                    "region": "VARCHAR",
+                },
+            )
+            | {"relation_name": '"warehouse"."main"."stg_orders"'}
+        },
+        results=[],
+    )
+    rc, payload = maintain_repo.dex("maintain", "verify")
+    assert rc == 0 and payload["status"] == "ok", payload
+    findings = [f for f in payload["data"]["findings"] if f["code"] == "column_missing"]
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "high"
+    assert "region" in findings[0]["detail"]
+    assert "column_contract" not in payload["data"]["suppressed"]
+
+
+def test_verify_scoped_by_object_name_keeps_the_column_finding(
+    maintain_repo, _assume_the_project_compiles
+):
+    """`maintain verify <object>` narrows the column contract to the object
+    named, both ways: the named model's finding survives, and a request for
+    an unrelated name checks nothing (no finding, no "unchecked" note about
+    a model that was never in scope to begin with)."""
+
+    _write_artifacts(
+        maintain_repo.project_dir,
+        nodes={
+            "model.maintain_test.stg_orders": _node_with_columns(
+                "stg_orders",
+                {
+                    "order_id": "INTEGER",
+                    "customer_id": "INTEGER",
+                    "amount": "DOUBLE",
+                    "status": "VARCHAR",
+                    "ordered_at": "DATE",
+                    "region": "VARCHAR",
+                },
+            )
+            | {"relation_name": '"warehouse"."main"."stg_orders"'}
+        },
+        results=[],
+    )
+    rc, payload = maintain_repo.dex("maintain", "verify", "stg_orders")
+    assert rc == 0 and payload["status"] == "ok", payload
+    findings = [f for f in payload["data"]["findings"] if f["code"] == "column_missing"]
+    assert len(findings) == 1
+    assert findings[0]["identifier"] == "stg_orders"
+
+    rc, payload = maintain_repo.dex("maintain", "verify", "customers")
+    assert rc == 0 and payload["status"] == "ok", payload
+    assert payload["data"]["findings"] == []
+    assert not any("stg_orders" in w for w in payload["warnings"])
+
+
+def test_verify_reports_an_undeclared_column_end_to_end(
+    maintain_repo, _assume_the_project_compiles
+):
+    """#230's other direction, at lower severity: the built relation has
+    columns schema.yml never declared."""
+
+    _write_artifacts(
+        maintain_repo.project_dir,
+        nodes={
+            "model.maintain_test.stg_orders": _node_with_columns(
+                "stg_orders", {"order_id": "INTEGER", "customer_id": "INTEGER"}
+            )
+            | {"relation_name": '"warehouse"."main"."stg_orders"'}
+        },
+        results=[],
+    )
+    rc, payload = maintain_repo.dex("maintain", "verify")
+    assert rc == 0 and payload["status"] == "ok", payload
+    findings = [
+        f for f in payload["data"]["findings"] if f["code"] == "column_undeclared"
+    ]
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "low"
+    for name in ("amount", "status", "ordered_at"):
+        assert name in findings[0]["detail"]
+
+
+def test_verify_reports_no_columns_declared_once_at_summary_level(
+    maintain_repo, _assume_the_project_compiles
+):
+    """#230's third acceptance bullet: a model with no schema.yml entry
+    reports nothing per model, and the gap is named once, not per model."""
+
+    _write_artifacts(
+        maintain_repo.project_dir,
+        nodes={
+            "model.maintain_test.stg_orders": {
+                "name": "stg_orders",
+                "resource_type": "model",
+                "relation_name": '"warehouse"."main"."stg_orders"',
+            }
+        },
+        results=[],
+    )
+    rc, payload = maintain_repo.dex("maintain", "verify")
+    assert rc == 0 and payload["status"] == "ok", payload
+    assert [
+        f
+        for f in payload["data"]["findings"]
+        if f["code"] in ("column_missing", "column_undeclared", "column_type_mismatch")
+    ] == []
+    assert any("declare no columns" in w for w in payload["warnings"])
+
+
 def test_verify_reports_a_compile_failure_first_and_suppresses_the_rest(
     maintain_repo, monkeypatch: pytest.MonkeyPatch
 ):
@@ -386,6 +661,7 @@ def test_verify_reports_a_compile_failure_first_and_suppresses_the_rest(
         "build_status",
         "no_relation",
         "row_population",
+        "column_contract",
     }
 
 

--- a/skills/explore/scripts/run.py
+++ b/skills/explore/scripts/run.py
@@ -65,7 +65,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.12.1"
+DEX_CORE_VERSION = "1.12.2"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/maintain/scripts/run.py
+++ b/skills/maintain/scripts/run.py
@@ -65,7 +65,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.12.1"
+DEX_CORE_VERSION = "1.12.2"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset

--- a/skills/transform/scripts/run.py
+++ b/skills/transform/scripts/run.py
@@ -65,7 +65,7 @@ from pathlib import Path
 # Rewritten by scripts/prepare_release.sh to the tagged version. The connector
 # extra is deliberately NOT part of this pin: it is chosen at runtime (see
 # _resolve_connector), so a release artifact is connector-neutral.
-DEX_CORE_VERSION = "1.12.1"
+DEX_CORE_VERSION = "1.12.2"
 
 # Connector id -> packaging extra. The engine's connector ids and the pyproject
 # extras share names, so this is the identity set today. An unknown or unset


### PR DESCRIPTION
Closes #230

- `maintain verify` now reports a built relation whose columns diverge from
  its declared schema.yml contract: a missing declared column (`column_missing`,
  high), an undeclared extra column (`column_undeclared`, low), and a type
  mismatch where both sides declare one (`column_type_mismatch`, medium). A
  model with no `columns:` entry reports nothing per model; how many such
  models were considered is named once at the summary level (#230's
  acceptance criteria).
- Shares its comparison logic with #214's plan-time check rather than
  duplicating it: `dbt_project.column_contract_divergence` is the one
  set-math primitive both `transform plan`'s authored-SELECT-list comparison
  and this built-relation comparison call, differing only in where each
  side's names and types come from.
- Suppressed the same way build-status and no-relation findings already are
  when the project doesn't compile, the warehouse is unreachable, or there's
  no dbt project.
- `maintain verify <object>` now actually scopes the column contract to the
  object named, instead of computing it for every model and discarding the
  rest: the plan-level read is narrowed up front, and the finding's
  identifier is now the model name (matching every other finding class in
  this module) instead of the warehouse-qualified relation name, which
  previously meant a scoped request silently returned zero column findings.

## Test plan
- [x] `tests/maintain/test_verify.py` — 58 passed (10 pure unit tests for
      `column_contract_plan`/`column_contract_findings`, 4 end-to-end tests
      including the new object-scoping regression test, plus the
      pre-existing compile-failure suppression test updated for the new key)
- [x] `tests/transform/test_plan.py -k column` — #214's existing 6 tests
      still pass unchanged after refactoring it onto the shared primitive
- [x] Full regression sweep: `tests/maintain/ tests/transform/` — 997 passed
- [x] `ruff check` / `ruff format` clean on all touched files
- [x] Zero em-dashes in code, tests, and CHANGELOG