### PR TITLE
`explore map` carries the `pii_overrides` mismatch warning that `explore profile` already emits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,6 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
   the `pii_overrides` prefix reads one contract. No new result field: the
   issue names a `MapResult` field for orphaned entries as the better shape
   for a host, and that is a larger downstream-visible change than this one.
-  Downstream-visible in the sense of the release-notes label: a consumer
-  that stores or compares `map`'s envelope will see warnings it did not
-  before, and only when an override is already orphaned.
 
 ## [1.12.1] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`explore map` now carries the `pii_overrides` mismatch warning that
+  `explore profile` already emitted** ([#448]). `_override_mismatches` warns
+  when an exact entry names a column its table does not have, or a pattern
+  entry's scope matches profiled tables and none carries the named column;
+  `profile` was its only caller, and `map` built its own `warnings[]` from
+  carry-forward, `--verify` and overlap warnings alone. A host that schedules
+  `map` and runs `profile` by hand therefore had no scheduled run that could
+  say a column rename had left an override pointing at nothing: the override
+  silently stopped clearing, the renamed column came back under the
+  classifier's default flag, and the one command that said so was the one
+  nothing scheduled. `map` now extends its warnings with the same call over
+  the composed set (fresh and carried profiles alike), placed after the
+  overlap warning and before the result is built, so both entry forms reach
+  `map`'s `warnings[]` with the text `profile` uses and a host matching on
+  the `pii_overrides` prefix reads one contract. No new result field: the
+  issue names a `MapResult` field for orphaned entries as the better shape
+  for a host, and that is a larger downstream-visible change than this one.
+  Downstream-visible in the sense of the release-notes label: a consumer
+  that stores or compares `map`'s envelope will see warnings it did not
+  before, and only when an override is already orphaned.
+
 ## [1.12.1] - 2026-09-09
 
 ### Fixed

--- a/packages/dex-core/src/exmergo_dex_core/explore/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/explore/commands.py
@@ -2329,6 +2329,12 @@ def map(
     )
     if overlap_warning:
         warnings.append(overlap_warning)
+    # The same sentence `profile` emits when a `pii_overrides` entry names a
+    # column the profiled table does not have (issue #448). `map` is the
+    # command a host schedules, so this is where a rename that orphaned an
+    # override gets seen; over the composed set, fresh and carried alike, so
+    # a cache hit does not hide it.
+    warnings.extend(_override_mismatches(datasets, config.pii_overrides))
 
     # Same ordering the payload's own selection uses: rank first, identifier
     # second. Two orderings derived from one cache inside one envelope would be a

--- a/packages/dex-core/tests/explore/test_explore.py
+++ b/packages/dex-core/tests/explore/test_explore.py
@@ -1917,3 +1917,26 @@ def test_map_stays_silent_when_the_pii_override_applies(
     person = {c.name: c for c in hosts.columns}["name"]
     assert person.pii is None
     assert person.pii_overridden == "name", "the audit trail"
+
+
+def test_map_still_warns_when_every_profile_is_a_cache_hit(
+    tpch_names_duckdb: Path, tmp_path: Path, capsys
+):
+    """The scheduled case: the second nightly `map` re-scans nothing, and the
+    orphaned override has to be reported from the carried profiles, or a host
+    hears it exactly once and never again."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_exact_override(repo, "tpch_names.main.hosts.nmae")
+
+    _, first = _map_warnings(tpch_names_duckdb, repo, capsys)
+    payload, second = _map_warnings(tpch_names_duckdb, repo, capsys)
+
+    assert payload["data"]["profiled_count"] == 0, "the second run scanned nothing"
+    assert payload["data"]["cache_hit_count"] >= 1
+    orphaned = [w for w in second if "matches no column" in w]
+    assert orphaned == [w for w in first if "matches no column" in w], (
+        "the same warning, from carried profiles"
+    )
+    assert len(orphaned) == 1, orphaned

--- a/packages/dex-core/tests/explore/test_explore.py
+++ b/packages/dex-core/tests/explore/test_explore.py
@@ -22,7 +22,7 @@ from exmergo_dex_core.cache import (
     ValueDomain,
 )
 from exmergo_dex_core.cli import main
-from exmergo_dex_core.config import DexConfig, save_config
+from exmergo_dex_core.config import DexConfig, PIIOverride, save_config
 from exmergo_dex_core.dbt_project import DeclaredCompositeKey, ProjectDefinitions
 from exmergo_dex_core.explore import summary
 from exmergo_dex_core.explore.commands import _annotate_grain, _merged_hints
@@ -1830,3 +1830,90 @@ def test_the_semantic_read_survives_a_project_with_no_compiled_layer(
 
     assert data["objects"], "the map still describes the warehouse"
     assert all(o["semantic_models"] == [] for o in data["objects"])
+
+
+# --- pii_overrides mismatch warnings reach `map`, not only `profile`: issue #448
+
+
+def _write_exact_override(repo: Path, entry: str) -> None:
+    save_config(DexConfig(pii_overrides=[PIIOverride(column=entry)]), repo)
+
+
+def _write_pattern_override(repo: Path, column_name: str, scope: str) -> None:
+    save_config(
+        DexConfig(pii_overrides=[PIIOverride(column_name=column_name, scope=scope)]),
+        repo,
+    )
+
+
+def _map_warnings(db: Path, repo: Path, capsys) -> tuple[dict, list[str]]:
+    payload = _run(
+        ["explore", "map", "--path", str(db), "--repo-root", str(repo)], capsys
+    )
+    return payload, payload["warnings"]
+
+
+def test_map_warns_when_a_pii_override_entry_matches_no_column(
+    tpch_names_duckdb: Path, tmp_path: Path, capsys
+):
+    """`profile` already says an exact `pii_overrides` entry names a column the
+    table does not have. `map` is the command a host schedules, so the same
+    sentence has to reach its `warnings[]` or a rename goes unnoticed."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_exact_override(repo, "tpch_names.main.hosts.nmae")
+
+    payload, warnings = _map_warnings(tpch_names_duckdb, repo, capsys)
+
+    assert any(
+        "pii_overrides entry 'tpch_names.main.hosts.nmae' matches no column" in w
+        for w in warnings
+    ), warnings
+    # A typo clears nothing: the person-name column is still flagged in the cache.
+    hosts = next(
+        d
+        for d in FilesystemStore(repo).load_cache().datasets
+        if d.identifier == "tpch_names.main.hosts"
+    )
+    assert {c.name: c for c in hosts.columns}["name"].pii is not None
+    assert payload["data"]["pii_column_count"] >= 1
+
+
+def test_map_warns_when_a_pii_override_pattern_matches_no_column(
+    tpch_names_duckdb: Path, tmp_path: Path, capsys
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_pattern_override(repo, "nmae", "tpch_names.main.*")
+
+    _, warnings = _map_warnings(tpch_names_duckdb, repo, capsys)
+
+    assert any(
+        "pii_overrides pattern entry (column_name='nmae', scope='tpch_names.main.*') "
+        "matches no column named 'nmae'" in w
+        for w in warnings
+    ), warnings
+
+
+def test_map_stays_silent_when_the_pii_override_applies(
+    tpch_names_duckdb: Path, tmp_path: Path, capsys
+):
+    """The negative arm: an override that names a real column produces no
+    mismatch warning on `map`, and the column it names is cleared."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_exact_override(repo, "tpch_names.main.hosts.name")
+
+    _, warnings = _map_warnings(tpch_names_duckdb, repo, capsys)
+
+    assert not [w for w in warnings if "pii_overrides" in w], warnings
+    hosts = next(
+        d
+        for d in FilesystemStore(repo).load_cache().datasets
+        if d.identifier == "tpch_names.main.hosts"
+    )
+    person = {c.name: c for c in hosts.columns}["name"]
+    assert person.pii is None
+    assert person.pii_overridden == "name", "the audit trail"


### PR DESCRIPTION
## What this changes

`_override_mismatches` warns when an exact `pii_overrides` entry names a column its table does not have, or a pattern entry's scope matches profiled tables and none of them carries the named column. `profile` was its only caller (`explore/commands.py`, the `warnings=` argument of its result). `map` profiles the same datasets but built its own `warnings[]` from carry-forward, `--verify` and overlap warnings alone, so a host that schedules `map` and runs `profile` by hand had no scheduled run that could say a column rename had left an override pointing at nothing. The override silently stopped clearing, the renamed column came back under the classifier's default flag, and the one command that said so was the one nothing scheduled.

### The fix

`map` now extends its warnings with the same call, over the composed set (fresh and carried profiles alike, so a cache hit does not hide it), placed after the overlap warning and before `MapResult` is built. Both entry forms reach `map`'s `warnings[]` with the text `profile` uses, so a host matching on the `pii_overrides` prefix reads one contract. One statement plus a comment in `explore/commands.py`.

### The tests

Three tests on the `tpch_names_duckdb` fixture in `tests/explore/test_explore.py`: an exact entry naming a column the table lacks warns on `map` and clears nothing (the `hosts.name` flag survives in the cache); a pattern entry naming a column no matched table carries warns; an entry naming a real column produces no such warning and clears the column with its `pii_overridden` audit trail. The two positive arms fail on the previous tree, which is the reproducer from the issue.

### Not in this change

A `MapResult` field naming the orphaned entries, the way `conflicts` names disagreeing declarations. The issue calls it the better shape for a host; it is a larger downstream-visible change than the one-line extension that closes the gap, and is left for a maintainer's call. `explore relationships` also profiles the full inventory and builds its own `warnings[]` without this call; it is not the command a host schedules, so it is left as it was rather than widened past the issue.

Under the criterion in `.github/release.yml`, this qualifies as `downstream-visible`: a consumer that stores or compares `map`'s envelope will see warnings it did not before, and only when an override is already orphaned. I cannot apply the label from a fork, so it is stated here.

## Related issues

Closes #448.

## Checklist

- [x] Tests pass (`uv run pytest` in `packages/dex-core`)
- [x] Eval scoring-core tests pass (`uvx pytest evals`): 36 pass locally; the six `evals/tests/test_wrapper.py` cases that monkeypatch `PosixPath` cannot run on Windows (`cannot instantiate 'PosixPath' on your system`), fail identically on `main` here, and are untouched by this change, so the ubuntu CI job is the arbiter for them
- [x] If a safety path is touched, the spine still holds: read-only against data, cost-guarded, PII flagged not surfaced, propose-don't-impose (no safety path is touched; the change adds a warning string and reads no data)
- [x] PR title is ready for release notes; applicable release-note labels and upgrade guidance are included (label stated above, cannot be applied from a fork; no upgrade step)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Prose is em-dash free (checked in CI)
- [x] No credentials, secrets, or raw warehouse rows in code, tests, or fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
