### PR TITLE
SCRUM-1079-maintain verify: report a built relation whose grain is not unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ tag releases both in lockstep, so entries below are keyed by the engine version.
 
 ## [Unreleased]
 
+### Added
+
+- **`maintain verify` reports a built relation whose grain is not unique**
+  ([#229]). For every selected model, the intended grain is determined from a
+  declared `unique` test, a declared composite `unique_combination_of_columns`
+  (checked only when no single-column test exists for the model), or a
+  semantic model's declared primary entity (checked only when neither dbt
+  test exists), each verified with a real distinct-count scan against the
+  built relation. A model with no declaration at all falls to a free naming
+  heuristic instead: an `id`/`<entity>_id`-shaped column is checked with an
+  approximate distinct count first, escalating to an exact scan only when
+  already close to unique, so a column nowhere near unique is reported
+  straight from the cheap approximate count rather than paying for an exact
+  scan to confirm what is already obvious. A broken grain reports
+  `grain_broken` with the duplicate count; a model whose true grain the
+  heuristic could not find (a composite with no declaration, say) is named
+  once in the summary notes as unknown, never reported broken; a proven
+  unique grain reports nothing. The finding's `exact` flag is honest about
+  which of the two: `True` for every declared check and every heuristic
+  check the near-unique escalation reached, `False` only for the one case a
+  verdict rests on the approximate count alone.
+
 ## [1.12.2] - 2026-09-09
 
 ### Fixed

--- a/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/commands.py
@@ -715,7 +715,7 @@ def cmd_grain(args: argparse.Namespace, engine: DexEngine) -> env.Envelope:
 def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
     """Is the project correct right now, with no baseline required (#224).
 
-    Three finding classes. Build-status gaps (#225) read the compiled manifest
+    Four finding classes. Build-status gaps (#225) read the compiled manifest
     and the last run's ``run_results.json`` (failed nodes, nodes skipped by a
     failed parent), plus models the project declares that have no relation in
     the warehouse. Column contract (#230) compares a built relation's actual
@@ -723,7 +723,10 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
     check where a type is declared. Row population (#226) reads each model's
     compiled SQL for the relation it is built from and compares the two row
     counts, reporting a model that lost rows with nothing in its SQL to
-    account for it, or one that fanned out on a join.
+    account for it, or one that fanned out on a join. Grain (#229) checks that
+    a model's intended grain -- a declared unique test, a semantic model's
+    declared primary entity, or (absent either) a free naming guess -- still
+    holds one row per key in the built relation.
 
     Free wherever the answer is free, which is most of it: the manifest read
     touches no connection, the relation check, the column contract, and the
@@ -751,6 +754,7 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
                 "build_status": str(exc),
                 "no_relation": str(exc),
                 "column_contract": str(exc),
+                "grain": str(exc),
                 "compile": str(exc),
             },
             warnings=[f"maintain verify needs a dbt project: {exc}"],
@@ -768,11 +772,12 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
                 "no_relation": reason,
                 "row_population": reason,
                 "column_contract": reason,
+                "grain": reason,
             },
             warnings=[
-                "build-status, no-relation, row-population and column-contract "
-                "findings suppressed: the project does not compile, so its "
-                "manifest cannot be trusted"
+                "build-status, no-relation, row-population, column-contract "
+                "and grain findings suppressed: the project does not compile, "
+                "so its manifest cannot be trusted"
             ],
         )
         return result
@@ -802,6 +807,7 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
         suppressed["no_relation"] = "no dbt project found"
         suppressed["row_population"] = "no dbt project found"
         suppressed["column_contract"] = "no dbt project found"
+        suppressed["grain"] = "no dbt project found"
     else:
         model_relations = {
             name: relation
@@ -814,6 +820,7 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
             suppressed["no_relation"] = f"warehouse unreachable: {exc}"
             suppressed["row_population"] = f"warehouse unreachable: {exc}"
             suppressed["column_contract"] = f"warehouse unreachable: {exc}"
+            suppressed["grain"] = f"warehouse unreachable: {exc}"
         else:
             cost = command_args.preflight_cost(adapter)
             live = adapter.list_objects()
@@ -830,6 +837,13 @@ def verify(engine: DexEngine, objects: list[str] | None = None) -> VerifyResult:
             warnings.extend(column_warnings)
             if column_reason is not None:
                 suppressed["column_contract"] = column_reason
+            grain_findings, grain_warnings, grain_reason = _grain_contract(
+                adapter, definitions, model_relations, live, scope=wanted
+            )
+            findings.extend(grain_findings)
+            warnings.extend(grain_warnings)
+            if grain_reason is not None:
+                suppressed["grain"] = grain_reason
             row_findings, row_warnings, row_reason, offer = _row_population(
                 engine, adapter, project_dir, live
             )
@@ -893,6 +907,37 @@ def _column_contract(project_dir, adapter, model_relations, live, *, scope=None)
         undeclared,
     )
     return findings, plan_notes + finding_notes, None
+
+
+def _grain_contract(adapter, definitions, model_relations, live, *, scope=None):
+    """The grain half of `maintain verify`, end to end (#229).
+
+    No cost decision of its own, unlike row population beside it: a declared
+    grain's exact check and the naming heuristic's escalation are both
+    bounded-and-deliberate by the adapter's own contract (see
+    ``verify.py``'s module docstring), not a scan this command doses out with
+    a handshake the way row population's ``COUNT(*)`` is. Always attempts
+    every selected model, declared or not, so there is no "nothing to check"
+    reason to report the way column contract has for a project with no
+    ``columns:`` blocks at all -- a model's grain is either declared,
+    guessable by name, or reported unknown, and all three are `grain_
+    findings`'s own job to sort out.
+    """
+
+    scoped_models = (
+        {name for name in model_relations if name.lower() in scope}
+        if scope is not None
+        else set(model_relations)
+    )
+    declared = verify_mod.grain_plan(definitions, scope=scope)
+    findings, notes = verify_mod.grain_findings(
+        adapter,
+        declared,
+        model_relations,
+        [o.identifier for o in live],
+        scoped_models,
+    )
+    return findings, notes, None
 
 
 def _row_population(engine: DexEngine, adapter, project_dir, live):

--- a/packages/dex-core/src/exmergo_dex_core/maintain/verify.py
+++ b/packages/dex-core/src/exmergo_dex_core/maintain/verify.py
@@ -1,7 +1,7 @@
 """maintain verify: a baseline-free sweep answering "is this project correct
 right now", as opposed to drift's "what changed since the baseline" (#224).
 
-Three finding classes live here. Build-status gaps (#225) read the compiled
+Four finding classes live here. Build-status gaps (#225) read the compiled
 manifest and the last run's ``run_results.json``: failed nodes, nodes skipped
 by a failed parent, models with no relation, and a project that does not
 compile. Column contract (#230) compares a built relation's actual columns
@@ -10,16 +10,23 @@ where a type is declared. Row population (#226) reads each model's compiled
 SQL to find the relation it is built *from*, and compares the two row counts:
 a model holding materially fewer rows than its driving parent, with nothing
 in its SQL that would account for the shortfall, has lost rows silently, and
-one holding materially more has fanned out on a join.
+one holding materially more has fanned out on a join. Grain (#229) checks
+that a model's intended grain -- a declared ``unique`` test, a semantic
+model's declared primary entity, or (absent either) a free naming heuristic
+-- still holds one row per key in the built relation.
 
-Detection is pure and reads only artifacts already on disk, with two
-exceptions, both metadata-only and free on every connector rather than a
-scan: the column contract's own ``adapter.table_metadata`` read, and
-:func:`relation_counts`, which is where a warehouse *scan* can happen at all
-and is separate for that reason: it decides between the catalog's free
-metadata, a free count, and a count that has to be paid for and is therefore
-offered rather than taken. Keeping that decision in one place is what lets
-every other function here be judged on artifacts (or free metadata) alone.
+Detection is pure and reads only artifacts already on disk, with three
+exceptions, all metadata-only or bounded-and-deliberate by the adapter's own
+contract rather than an open-ended scan: the column contract's own
+``adapter.table_metadata`` read, the grain check's ``adapter.
+exact_distinct_counts``/``distinct_combination_counts`` (called only on a
+declared or already-near-unique key, never speculatively across a table), and
+:func:`relation_counts`, which is where an open-ended warehouse *scan* can
+happen at all and is separate for that reason: it decides between the
+catalog's free metadata, a free count, and a count that has to be paid for
+and is therefore offered rather than taken. Keeping that decision in one
+place is what lets every other function here be judged on artifacts (or free,
+bounded metadata) alone.
 """
 
 from __future__ import annotations
@@ -31,8 +38,10 @@ from pathlib import Path
 
 from ..cache import match_identifier
 from ..dbt_project import strip_relation_quoting
+from ..explore.profile import NEAR_UNIQUE_RATIO
+from ..explore.relationships import entity_of, is_id_shaped
 from ..transform.build import shadow_parse
-from .drift import DriftFinding
+from .drift import DriftFinding, _grain_severity
 
 #: dbt's own run_results.json status strings that mean the node did not build.
 _FAILURE_STATUSES = frozenset({"error", "fail"})
@@ -443,6 +452,365 @@ def column_contract_findings(
         notes.append(
             f"{undeclared} model(s) considered declare no columns in "
             "schema.yml, so the column contract was not checked for them"
+        )
+    return findings, notes
+
+
+# --- grain: a built relation against its intended one-row-per-entity key -------
+
+
+@dataclass(frozen=True)
+class GrainCandidate:
+    """One model's intended grain, and where the claim came from (#229).
+
+    ``source`` is one of ``"unique_test"`` (a single column dbt's own
+    ``unique``/``data_tests: unique`` declares), ``"unique_test_composite"``
+    (``unique_combination_of_columns``, checked only when no single-column
+    test exists for the same model: a column-level test is the narrower,
+    more specific claim), ``"primary_entity"`` (a semantic model's declared
+    grain, checked only when neither dbt test exists: a real declaration, but
+    one MetricFlow's modeling layer makes rather than a test dbt itself
+    verifies), or ``"heuristic"`` (no declaration at all; a free naming guess,
+    see :func:`_heuristic_candidate`).
+    """
+
+    columns: list[str]
+    source: str
+
+
+def grain_plan(
+    definitions, *, scope: set[str] | None = None
+) -> dict[str, list[GrainCandidate]]:
+    """Every selected model's declared grain, straight from ``ProjectDefinitions``
+    (#229) -- no manifest walk of its own, unlike every other plan function
+    here: a declared unique test, a declared composite unique combination, and
+    a semantic model's primary entity are already fully resolved there (the
+    same object :func:`~exmergo_dex_core.maintain.commands.verify` already
+    reads for ``model_relations``), so re-deriving any of it from
+    ``target/manifest.json`` directly would only duplicate what
+    ``dbt_project.py``'s own readers already did.
+
+    A model absent from the returned mapping declares no grain at all by any
+    of the three sources; the findings step's own free naming heuristic and
+    "grain unknown" reporting cover it from there, since both need a live
+    relation's actual columns, which ``ProjectDefinitions`` does not carry.
+
+    Priority is per model, not per candidate: every column independently
+    declared ``unique`` is checked (a model can have more than one, each its
+    own claim); a declared composite is checked only when the model has no
+    single-column unique test; the primary entity is checked only when the
+    model has neither. A model can therefore only ever produce candidates
+    from one of the three sources, never a mix.
+
+    ``scope`` is compared lowercase, the same convention
+    :func:`column_contract_plan` follows and for the same reason: the caller
+    is `maintain verify`'s own ``objects`` argument, already lowered.
+    """
+
+    by_model: dict[str, list[GrainCandidate]] = {}
+    for key in definitions.declared_keys:
+        if not key.unique:
+            continue
+        if scope is not None and key.model.lower() not in scope:
+            continue
+        by_model.setdefault(key.model, []).append(
+            GrainCandidate(columns=[key.column], source="unique_test")
+        )
+    for combo in definitions.declared_composite_keys:
+        if combo.model in by_model:
+            continue
+        if scope is not None and combo.model.lower() not in scope:
+            continue
+        by_model.setdefault(combo.model, []).append(
+            GrainCandidate(columns=list(combo.columns), source="unique_test_composite")
+        )
+    for model, column in definitions.primary_entities.items():
+        if model in by_model:
+            continue
+        if scope is not None and model.lower() not in scope:
+            continue
+        by_model[model] = [GrainCandidate(columns=[column], source="primary_entity")]
+    return by_model
+
+
+_GRAIN_SOURCE_PHRASE = {
+    "unique_test": "declares",
+    "unique_test_composite": "declares the combination of",
+    "primary_entity": "declares as its semantic layer's primary entity",
+    "heuristic": "has no declared grain, but appears (by column name) to intend",
+}
+
+
+def _grain_broken_finding(
+    model: str,
+    columns: list[str],
+    row_count: int,
+    distinct_count: int,
+    *,
+    exact: bool,
+    source: str,
+    min_rows: int,
+) -> DriftFinding:
+    duplicates = row_count - distinct_count
+    severity, extra_data, note_suffix = _grain_severity(row_count, min_rows)
+    approx = "" if exact else "approximately "
+    columns_text = " and ".join(columns) if len(columns) < 3 else ", ".join(columns)
+    unique_word = "unique" if len(columns) == 1 else "jointly unique"
+    return DriftFinding(
+        axis="grain",
+        code="grain_broken",
+        identifier=model,
+        column=columns[0] if len(columns) == 1 else None,
+        severity=severity,
+        exact=exact,
+        detail=(
+            f"'{model}' {_GRAIN_SOURCE_PHRASE[source]} {columns_text} "
+            f"{unique_word}, but the built relation has {approx}{duplicates} "
+            f"duplicate row(s){note_suffix}"
+        ),
+        data={
+            "model": model,
+            "columns": columns,
+            "duplicate_count": duplicates,
+            "source": source,
+            **extra_data,
+        },
+    )
+
+
+def _declared_grain_findings(
+    adapter,
+    model: str,
+    identifier: str,
+    candidates: list[GrainCandidate],
+    min_rows: int,
+) -> tuple[list[DriftFinding], bool]:
+    """Check every declared candidate for one model. Returns ``(findings,
+    unchecked)``: ``unchecked`` is True when a composite candidate could not
+    be measured at all (a metered adapter declining an unaffordable scan,
+    per :meth:`Adapter.distinct_combination_counts`'s own contract), which is
+    a caveat for the caller's notes, not a clean bill of health."""
+
+    meta, _columns = adapter.table_metadata(identifier)
+    row_count = meta.row_count
+    if row_count is None:
+        return [], True
+
+    findings: list[DriftFinding] = []
+    unchecked = False
+
+    singles = [c for c in candidates if len(c.columns) == 1]
+    if singles:
+        counts = adapter.exact_distinct_counts(
+            identifier, [c.columns[0] for c in singles]
+        )
+        for c in singles:
+            distinct = counts.get(c.columns[0])
+            if distinct is None:
+                unchecked = True
+                continue
+            if distinct >= row_count:
+                continue
+            findings.append(
+                _grain_broken_finding(
+                    model,
+                    c.columns,
+                    row_count,
+                    distinct,
+                    exact=True,
+                    source=c.source,
+                    min_rows=min_rows,
+                )
+            )
+
+    for c in candidates:
+        if len(c.columns) == 1:
+            continue
+        result = adapter.distinct_combination_counts(identifier, [c.columns])
+        distinct = result.get(tuple(c.columns))
+        if distinct is None:
+            unchecked = True
+            continue
+        if distinct >= row_count:
+            continue
+        findings.append(
+            _grain_broken_finding(
+                model,
+                c.columns,
+                row_count,
+                distinct,
+                exact=True,
+                source=c.source,
+                min_rows=min_rows,
+            )
+        )
+
+    return findings, unchecked
+
+
+def _heuristic_candidate(adapter, model: str, identifier: str, min_rows: int):
+    """The free naming heuristic (#229): no declared grain at all, so this
+    looks for a column named ``id``/``<entity>_id`` or otherwise
+    :func:`~exmergo_dex_core.explore.relationships.is_id_shaped`, the same
+    shape :func:`~exmergo_dex_core.explore.relationships.detect_grain` prefers
+    -- but unlike that function, never trusts a naming match as proof by
+    itself. A guess from a name alone is the weakest of the three sources,
+    so it earns the cheapest possible check first: an approximate distinct
+    count, already free metadata this command reads for column contract.
+    Only a column that already looks near-unique in that approximate count
+    is worth a real (still cheap, single-column) exact scan to turn a guess
+    into a proof; a column nowhere close to unique is reported straight from
+    the approximate count instead, honestly marked ``exact=False``, since
+    escalating would only confirm what the approximation already made clear.
+
+    Returns ``(finding_or_None, reason)`` where ``reason`` is ``None`` (clean
+    or a finding was produced), ``"unknown"`` (no column even looked like a
+    key), or ``"unsupported"`` (the adapter cannot run the check this needs).
+    """
+
+    meta, columns = adapter.table_metadata(identifier)
+    row_count = meta.row_count
+    entity = entity_of(identifier.rsplit(".", 1)[-1])
+    named = (f"{entity}_id", f"{entity}id", "id")
+    candidate = next((c for c in columns if c.name.lower() in named), None)
+    if candidate is None:
+        candidate = next((c for c in columns if is_id_shaped(c.name)), None)
+    if candidate is None:
+        return None, "unknown"
+    if row_count is None:
+        return None, "unsupported"
+
+    aggregates_fn = getattr(adapter, "column_aggregates", None)
+    if aggregates_fn is None:
+        return None, "unsupported"
+    aggregates = aggregates_fn(identifier, [candidate])
+    agg = next((a for a in aggregates if a.name == candidate.name), None)
+    if agg is None or agg.distinct_count is None:
+        return None, "unsupported"
+    if agg.null_fraction not in (0.0, None):
+        # A key candidate with nulls is not a key: disqualified, not proven.
+        return None, "unknown"
+
+    non_null = round((1 - (agg.null_fraction or 0.0)) * row_count)
+    if non_null and agg.distinct_count >= NEAR_UNIQUE_RATIO * non_null:
+        exact_fn = getattr(adapter, "exact_distinct_counts", None)
+        if exact_fn is not None:
+            exact_counts = exact_fn(identifier, [candidate.name])
+            distinct = exact_counts.get(candidate.name)
+            if distinct is not None:
+                if distinct >= row_count:
+                    return None, None
+                return (
+                    _grain_broken_finding(
+                        model,
+                        [candidate.name],
+                        row_count,
+                        distinct,
+                        exact=True,
+                        source="heuristic",
+                        min_rows=min_rows,
+                    ),
+                    None,
+                )
+    if agg.distinct_count >= row_count:
+        return None, None
+    return (
+        _grain_broken_finding(
+            model,
+            [candidate.name],
+            row_count,
+            agg.distinct_count,
+            exact=False,
+            source="heuristic",
+            min_rows=min_rows,
+        ),
+        None,
+    )
+
+
+def grain_findings(
+    adapter,
+    declared: dict[str, list[GrainCandidate]],
+    model_relations: dict[str, str],
+    live_identifiers: list[str],
+    all_models: set[str],
+    *,
+    min_rows: int = 100,
+) -> tuple[list[DriftFinding], list[str]]:
+    """A built relation's grain against what the project declares (or, absent
+    any declaration, a free naming guess), for every selected model (#229).
+
+    A declared source (unique test, composite, or primary entity) is checked
+    directly with an exact scan: the declaration itself is the justification
+    for spending on verification, the same reasoning ``maintain grain``'s own
+    ``declared_composite_checks`` already rests on. Only a model with no
+    declaration at all falls to the heuristic, which is free-first and
+    escalates to exact only when already close (see
+    :func:`_heuristic_candidate`) -- so a ``grain_broken`` finding's ``exact``
+    flag is always True except in exactly that one approximate-verdict case,
+    honestly naming the one place this check ever reports from a guess.
+
+    An unknown grain and a broken one are reported through different
+    channels on purpose (the issue's own framing): a broken grain is a
+    ``DriftFinding``; an unknown one is named once in ``notes`` rather than
+    given a finding of its own, since "dex could not tell" is not itself a
+    defect in the project.
+    """
+
+    findings: list[DriftFinding] = []
+    ambiguous: list[str] = []
+    unchecked: list[str] = []
+    unknown: list[str] = []
+
+    for model in sorted(all_models):
+        relation = model_relations.get(model)
+        if relation is None:
+            # missing_relation_findings already reports this model; nothing
+            # about its grain belongs in a second, unrelated finding class.
+            continue
+        matches = match_identifier(relation, live_identifiers)
+        if len(matches) != 1:
+            ambiguous.append(model)
+            continue
+        identifier = matches[0]
+
+        candidates = declared.get(model)
+        if candidates:
+            model_findings, was_unchecked = _declared_grain_findings(
+                adapter, model, identifier, candidates, min_rows
+            )
+            findings.extend(model_findings)
+            if was_unchecked:
+                unchecked.append(model)
+            continue
+
+        finding, reason = _heuristic_candidate(adapter, model, identifier, min_rows)
+        if finding is not None:
+            findings.append(finding)
+        elif reason == "unknown":
+            unknown.append(model)
+        elif reason == "unsupported":
+            unchecked.append(model)
+
+    notes: list[str] = []
+    if ambiguous:
+        notes.append(
+            "the grain was not checked for "
+            + ", ".join(sorted(ambiguous))
+            + ": no single relation in the warehouse matched"
+        )
+    if unchecked:
+        notes.append(
+            "the grain could not be measured for "
+            + ", ".join(sorted(unchecked))
+            + ": the connector could not run the distinct-count scan this needs"
+        )
+    if unknown:
+        notes.append(
+            "the grain could not be determined for "
+            + ", ".join(sorted(unknown))
+            + ": no declared unique test, no declared primary entity, and no "
+            "id-shaped column was found"
         )
     return findings, notes
 

--- a/packages/dex-core/tests/maintain/test_verify.py
+++ b/packages/dex-core/tests/maintain/test_verify.py
@@ -340,6 +340,284 @@ def test_a_model_with_no_matching_relation_is_named_in_notes_not_a_finding():
     assert notes and "a" in notes[0]
 
 
+# --- grain_plan / grain_findings: pure (#229) -----------------------------------
+
+
+class _GrainAdapter:
+    """A fake adapter exposing exactly the grain-check surface: schema-only
+    metadata, exact distinct counts (single-column and combination), and
+    approximate column aggregates."""
+
+    def __init__(
+        self,
+        *,
+        row_counts: dict[str, int],
+        columns: dict[str, list[str]],
+        exact: dict[str, dict[str, int]] | None = None,
+        combos: dict[str, dict[tuple[str, ...], int]] | None = None,
+        approx: dict[str, dict[str, tuple[int, float | None]]] | None = None,
+    ):
+        self._row_counts = row_counts
+        self._columns = columns
+        self._exact = exact or {}
+        self._combos = combos or {}
+        self._approx = approx or {}
+
+    def table_metadata(self, identifier: str):
+        cols = [types.SimpleNamespace(name=name) for name in self._columns[identifier]]
+        meta = types.SimpleNamespace(
+            identifier=identifier, row_count=self._row_counts[identifier]
+        )
+        return meta, cols
+
+    def exact_distinct_counts(self, identifier: str, columns: list[str]):
+        return {
+            col: count
+            for col, count in self._exact.get(identifier, {}).items()
+            if col in columns
+        }
+
+    def distinct_combination_counts(
+        self, identifier: str, combinations: list[list[str]]
+    ):
+        wanted = {tuple(combo) for combo in combinations}
+        return {
+            combo: count
+            for combo, count in self._combos.get(identifier, {}).items()
+            if combo in wanted
+        }
+
+    def column_aggregates(self, identifier: str, columns):
+        result = []
+        for col in columns:
+            entry = self._approx.get(identifier, {}).get(col.name)
+            if entry is None:
+                continue
+            distinct_count, null_fraction = entry
+            result.append(
+                types.SimpleNamespace(
+                    name=col.name,
+                    distinct_count=distinct_count,
+                    null_fraction=null_fraction,
+                )
+            )
+        return result
+
+
+def _defs(*, keys=(), composites=(), primary=None):
+    from exmergo_dex_core.dbt_project import (
+        DeclaredCompositeKey,
+        DeclaredKey,
+        ProjectDefinitions,
+    )
+
+    return ProjectDefinitions(
+        present=True,
+        declared_keys=[
+            DeclaredKey(model=model, column=column, unique=unique, source="manifest")
+            for model, column, unique in keys
+        ],
+        declared_composite_keys=[
+            DeclaredCompositeKey(model=model, columns=list(columns), source="manifest")
+            for model, columns in composites
+        ],
+        primary_entities=dict(primary or {}),
+    )
+
+
+def test_grain_plan_prefers_a_declared_unique_test_over_a_primary_entity():
+    defs = _defs(
+        keys=[("a", "id", True)],
+        primary=[("a", "other_col")],
+    )
+    declared = verify_mod.grain_plan(defs)
+    assert len(declared["a"]) == 1
+    assert declared["a"][0].source == "unique_test"
+    assert declared["a"][0].columns == ["id"]
+
+
+def test_grain_plan_falls_back_to_a_composite_when_no_single_column_test_exists():
+    defs = _defs(composites=[("a", ["order_id", "line_no"])], primary=[("a", "id")])
+    declared = verify_mod.grain_plan(defs)
+    assert len(declared["a"]) == 1
+    assert declared["a"][0].source == "unique_test_composite"
+    assert declared["a"][0].columns == ["order_id", "line_no"]
+
+
+def test_grain_plan_falls_back_to_the_primary_entity_when_nothing_is_declared():
+    defs = _defs(primary=[("a", "order_id")])
+    declared = verify_mod.grain_plan(defs)
+    assert declared["a"] == [
+        verify_mod.GrainCandidate(columns=["order_id"], source="primary_entity")
+    ]
+
+
+def test_grain_plan_checks_every_independently_declared_unique_column():
+    defs = _defs(keys=[("a", "id", True), ("a", "email", True), ("a", "note", False)])
+    declared = verify_mod.grain_plan(defs)
+    assert {c.columns[0] for c in declared["a"]} == {"id", "email"}
+
+
+def test_grain_plan_scope_is_lowercase_like_column_contract_plan():
+    defs = _defs(keys=[("a", "id", True), ("b", "id", True)])
+    declared = verify_mod.grain_plan(defs, scope={"a"})
+    assert set(declared) == {"a"}
+
+
+def test_grain_plan_reports_nothing_for_a_model_with_no_declaration():
+    defs = _defs(keys=[("a", "id", True)])
+    declared = verify_mod.grain_plan(defs)
+    assert "b" not in declared
+
+
+def test_a_declared_unique_key_with_duplicates_is_reported():
+    adapter = _GrainAdapter(
+        row_counts={"db.main.a": 200},
+        columns={"db.main.a": ["id"]},
+        exact={"db.main.a": {"id": 199}},
+    )
+    findings, notes = verify_mod.grain_findings(
+        adapter,
+        {"a": [verify_mod.GrainCandidate(columns=["id"], source="unique_test")]},
+        {"a": "db.main.a"},
+        ["db.main.a"],
+        {"a"},
+    )
+    assert notes == []
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.code == "grain_broken"
+    assert finding.identifier == "a"
+    assert finding.exact is True
+    assert finding.data["duplicate_count"] == 1
+    assert finding.severity == "high"
+
+
+def test_a_declared_composite_with_duplicates_is_reported():
+    adapter = _GrainAdapter(
+        row_counts={"db.main.a": 10},
+        columns={"db.main.a": ["order_id", "line_no"]},
+        combos={"db.main.a": {("order_id", "line_no"): 8}},
+    )
+    findings, notes = verify_mod.grain_findings(
+        adapter,
+        {
+            "a": [
+                verify_mod.GrainCandidate(
+                    columns=["order_id", "line_no"], source="unique_test_composite"
+                )
+            ]
+        },
+        {"a": "db.main.a"},
+        ["db.main.a"],
+        {"a"},
+    )
+    assert notes == []
+    assert len(findings) == 1
+    assert findings[0].data["duplicate_count"] == 2
+    assert findings[0].data["columns"] == ["order_id", "line_no"]
+
+
+def test_a_proven_unique_declared_grain_reports_nothing():
+    adapter = _GrainAdapter(
+        row_counts={"db.main.a": 10},
+        columns={"db.main.a": ["id"]},
+        exact={"db.main.a": {"id": 10}},
+    )
+    findings, notes = verify_mod.grain_findings(
+        adapter,
+        {"a": [verify_mod.GrainCandidate(columns=["id"], source="unique_test")]},
+        {"a": "db.main.a"},
+        ["db.main.a"],
+        {"a"},
+    )
+    assert findings == []
+    assert notes == []
+
+
+def test_a_composite_the_heuristic_cannot_find_is_reported_unknown_not_broken():
+    # No declared source at all, and no id-shaped column exists: the model's
+    # true grain may well be a composite, but the free naming heuristic never
+    # invents one, so this must come back as "unknown", never "broken".
+    adapter = _GrainAdapter(
+        row_counts={"db.main.a": 10},
+        columns={"db.main.a": ["status", "amount"]},
+    )
+    findings, notes = verify_mod.grain_findings(
+        adapter, {}, {"a": "db.main.a"}, ["db.main.a"], {"a"}
+    )
+    assert findings == []
+    assert any("could not be determined" in n and "a" in n for n in notes)
+
+
+def test_the_heuristic_escalates_a_near_unique_id_shaped_column_to_an_exact_check():
+    adapter = _GrainAdapter(
+        row_counts={"db.main.a": 100},
+        columns={"db.main.a": ["order_id", "status"]},
+        approx={"db.main.a": {"order_id": (99, 0.0)}},
+        exact={"db.main.a": {"order_id": 98}},
+    )
+    findings, notes = verify_mod.grain_findings(
+        adapter, {}, {"a": "db.main.a"}, ["db.main.a"], {"a"}
+    )
+    assert notes == []
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.exact is True
+    assert finding.data["duplicate_count"] == 2
+    assert finding.data["source"] == "heuristic"
+
+
+def test_the_heuristic_reports_a_clearly_broken_grain_from_the_approximate_count():
+    # Far below near-unique, so this is reported straight from the
+    # approximate count rather than paying for an exact scan to confirm
+    # what is already obvious -- honestly marked exact=False.
+    adapter = _GrainAdapter(
+        row_counts={"db.main.a": 100},
+        columns={"db.main.a": ["order_id"]},
+        approx={"db.main.a": {"order_id": (40, 0.0)}},
+    )
+    findings, notes = verify_mod.grain_findings(
+        adapter, {}, {"a": "db.main.a"}, ["db.main.a"], {"a"}
+    )
+    assert notes == []
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.exact is False
+    assert finding.data["duplicate_count"] == 60
+    assert "approximately" in finding.detail
+
+
+def test_the_heuristic_skips_a_column_with_nulls_as_a_key_candidate():
+    adapter = _GrainAdapter(
+        row_counts={"db.main.a": 100},
+        columns={"db.main.a": ["order_id"]},
+        approx={"db.main.a": {"order_id": (95, 0.1)}},
+    )
+    findings, notes = verify_mod.grain_findings(
+        adapter, {}, {"a": "db.main.a"}, ["db.main.a"], {"a"}
+    )
+    assert findings == []
+    assert any("could not be determined" in n for n in notes)
+
+
+def test_grain_is_not_checked_for_an_ambiguous_relation_match():
+    adapter = _GrainAdapter(row_counts={}, columns={})
+    findings, notes = verify_mod.grain_findings(
+        adapter, {}, {"a": "db.main.a"}, [], {"a"}
+    )
+    assert findings == []
+    assert any("was not checked" in n and "a" in n for n in notes)
+
+
+def test_a_model_with_no_relation_is_silently_skipped():
+    # missing_relation_findings already reports this; grain adds nothing.
+    adapter = _GrainAdapter(row_counts={}, columns={})
+    findings, notes = verify_mod.grain_findings(adapter, {}, {}, [], {"a"})
+    assert findings == []
+    assert notes == []
+
+
 # --- compile_check: wraps shadow_parse -------------------------------------------
 
 
@@ -625,6 +903,136 @@ def test_verify_reports_no_columns_declared_once_at_summary_level(
     assert any("declare no columns" in w for w in payload["warnings"])
 
 
+def _unique_test_node(model_unique_id: str, column: str) -> dict:
+    """A compiled ``unique`` test node, the shape ``_declared_from_manifest``
+    reads: ``attached_node`` names the model this test belongs to."""
+
+    return {
+        "resource_type": "test",
+        "test_metadata": {"name": "unique", "kwargs": {"column_name": column}},
+        "attached_node": model_unique_id,
+    }
+
+
+def test_verify_reports_a_broken_grain_from_the_declared_primary_entity(
+    maintain_repo, _assume_the_project_compiles
+):
+    """#229: `stg_orders` has no unique test in this manifest, so its
+    semantic layer's declared primary entity (`order_id`, read straight from
+    the project's own real semantic YAML, since there is no compiled
+    semantic manifest here) is what stands in as the intended grain."""
+
+    maintain_repo.sql("UPDATE stg_orders SET order_id = 1 WHERE order_id = 2")
+    _write_artifacts(
+        maintain_repo.project_dir,
+        nodes={
+            "model.maintain_test.stg_orders": {
+                "name": "stg_orders",
+                "resource_type": "model",
+                "relation_name": '"warehouse"."main"."stg_orders"',
+            }
+        },
+        results=[],
+    )
+    rc, payload = maintain_repo.dex("maintain", "verify")
+    assert rc == 0 and payload["status"] == "ok", payload
+    findings = [f for f in payload["data"]["findings"] if f["code"] == "grain_broken"]
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["identifier"] == "stg_orders"
+    assert finding["data"]["source"] == "primary_entity"
+    assert finding["data"]["duplicate_count"] == 1
+    assert finding["exact"] is True
+
+
+def test_verify_reports_a_broken_grain_from_a_declared_unique_test(
+    maintain_repo, _assume_the_project_compiles
+):
+    """#229's first acceptance bullet: a declared unique key with duplicates
+    is reported with a count. A unique test in the manifest outranks the
+    semantic layer's primary entity for the same model and column."""
+
+    maintain_repo.sql("UPDATE stg_orders SET order_id = 1 WHERE order_id = 2")
+    _write_artifacts(
+        maintain_repo.project_dir,
+        nodes={
+            "model.maintain_test.stg_orders": {
+                "name": "stg_orders",
+                "resource_type": "model",
+                "relation_name": '"warehouse"."main"."stg_orders"',
+            },
+            "test.maintain_test.unique_stg_orders_order_id": _unique_test_node(
+                "model.maintain_test.stg_orders", "order_id"
+            ),
+        },
+        results=[],
+    )
+    rc, payload = maintain_repo.dex("maintain", "verify")
+    assert rc == 0 and payload["status"] == "ok", payload
+    findings = [f for f in payload["data"]["findings"] if f["code"] == "grain_broken"]
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["data"]["source"] == "unique_test"
+    assert finding["data"]["duplicate_count"] == 1
+    assert finding["severity"] == "high"
+
+
+def test_verify_reports_nothing_for_a_proven_unique_grain_end_to_end(
+    maintain_repo, _assume_the_project_compiles
+):
+    """#229's third acceptance bullet: a model with a proven unique grain
+    reports nothing, even though a real distinct-count scan ran."""
+
+    _write_artifacts(
+        maintain_repo.project_dir,
+        nodes={
+            "model.maintain_test.stg_orders": {
+                "name": "stg_orders",
+                "resource_type": "model",
+                "relation_name": '"warehouse"."main"."stg_orders"',
+            },
+            "test.maintain_test.unique_stg_orders_order_id": _unique_test_node(
+                "model.maintain_test.stg_orders", "order_id"
+            ),
+        },
+        results=[],
+    )
+    rc, payload = maintain_repo.dex("maintain", "verify")
+    assert rc == 0 and payload["status"] == "ok", payload
+    assert [f for f in payload["data"]["findings"] if f["code"] == "grain_broken"] == []
+    assert "grain" not in payload["data"]["suppressed"]
+
+
+def test_verify_finds_a_broken_grain_via_the_naming_heuristic_end_to_end(
+    maintain_repo, _assume_the_project_compiles
+):
+    """#229's proposal: a model with no declared unique test and no semantic
+    entity still gets checked, via the free ``id``-shaped naming guess, using
+    the real ``customers`` table (a genuine warehouse object with no dbt
+    model wrapping it in this manifest)."""
+
+    maintain_repo.sql("UPDATE customers SET id = 1 WHERE id = 2")
+    _write_artifacts(
+        maintain_repo.project_dir,
+        nodes={
+            "model.maintain_test.dim_customers": {
+                "name": "dim_customers",
+                "resource_type": "model",
+                "relation_name": '"warehouse"."main"."customers"',
+            }
+        },
+        results=[],
+    )
+    rc, payload = maintain_repo.dex("maintain", "verify")
+    assert rc == 0 and payload["status"] == "ok", payload
+    findings = [f for f in payload["data"]["findings"] if f["code"] == "grain_broken"]
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["identifier"] == "dim_customers"
+    assert finding["data"]["source"] == "heuristic"
+    assert finding["data"]["duplicate_count"] == 1
+
+
 def test_verify_reports_a_compile_failure_first_and_suppresses_the_rest(
     maintain_repo, monkeypatch: pytest.MonkeyPatch
 ):
@@ -662,6 +1070,7 @@ def test_verify_reports_a_compile_failure_first_and_suppresses_the_rest(
         "no_relation",
         "row_population",
         "column_contract",
+        "grain",
     }
 
 


### PR DESCRIPTION
## Summary
- `maintain verify` now reports a built relation whose grain is not unique: for every selected model, the intended grain is determined from a declared `unique` test, a declared composite `unique_combination_of_columns` (checked only when the model has no single-column test), or a semantic model's declared primary entity (checked only when neither dbt test exists), each verified with a real `exact_distinct_counts`/`distinct_combination_counts` scan against the built relation.
- A model with no declaration at all falls to a free naming heuristic: an `id`/`<entity>_id`-shaped column is checked with an approximate distinct count first (`adapter.column_aggregates`), escalating to an exact scan only when already near-unique (mirroring `explore/profile.py`'s own escalation pattern) — a column nowhere near unique is reported straight from the cheap approximate count instead of paying for an exact scan to confirm what's already obvious.
- A broken grain reports `grain_broken` with the duplicate count; a model whose true grain the heuristic couldn't find (a composite with no declaration, say) is named once in the summary notes as unknown, never reported broken; a proven unique grain reports nothing.
- The finding's `exact` flag is honest: `True` for every declared check and every heuristic check the near-unique escalation reached, `False` only for the one case a verdict rests on the raw approximate count alone.
- Wired into `maintain verify`'s existing suppression machinery (`_grain_contract` wrapper in `commands.py`), consistent with build-status/row-population/column-contract: suppressed the same way when the project doesn't compile, the warehouse is unreachable, or there's no dbt project.

## Acceptance criteria
- [x] A model with a declared unique key that has duplicates is reported with a count.
- [x] A model whose grain is a composite the heuristic did not find is reported as unknown, never as broken.
- [x] A model with a proven unique grain reports nothing.
- [x] The finding carries the `exact` flag honestly when the verdict rests on an approximate distinct count.

## Test plan
- [x] 12 new pure unit tests covering `grain_plan`'s declared-source priority (unique test > composite > primary entity) and scope filtering, plus `grain_findings`'s declared-check, heuristic-escalation, approximate-verdict, disqualified-candidate, unknown, and ambiguous-relation paths
- [x] 4 new end-to-end tests through the real DuckDB `maintain_repo` fixture: the primary-entity path (real semantic YAML fallback), the declared-unique-test path (constructed manifest test node, outranking the primary entity for the same model), the clean/proven-unique path, and the naming-heuristic path (a plain warehouse table with no dbt test or semantic declaration)
- [x] `tests/maintain/test_verify.py` — 77/77 passed
- [x] Full regression sweep: `tests/maintain/ tests/transform/ tests/explore/` — 1849 passed, 30 skipped (pre-existing, unrelated), 0 failed
- [x] `ruff check` / `ruff format` clean on all touched files
- [x] Zero em-dashes in code, tests, and CHANGELOG
